### PR TITLE
test(instance): update scratch storage test with instance max capacity

### DIFF
--- a/internal/services/instance/server_test.go
+++ b/internal/services/instance/server_test.go
@@ -2414,14 +2414,14 @@ func TestAccServer_ScratchStorage(t *testing.T) {
 			{
 				Config: `
 					resource "scaleway_instance_volume" "main" {
-						size_in_gb = 20
+						size_in_gb = 1600
 						type = "scratch"
 						zone = "fr-par-2"
 					}
 			
 					resource "scaleway_instance_server" "main" {
 						name = "test-acc-server-scratch"
-						type = "H100-1-80G"
+						type = "L40S-1-48G"
 						image = "ubuntu_jammy_gpu_os_12"
 						state = "stopped"
 						zone = "fr-par-2"
@@ -2432,10 +2432,10 @@ func TestAccServer_ScratchStorage(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					instancechecks.IsServerPresent(tt, "scaleway_instance_server.main"),
 					instancechecks.IsVolumePresent(tt, "scaleway_instance_volume.main"),
-					resource.TestCheckResourceAttr("scaleway_instance_server.main", "type", "H100-1-80G"),
+					resource.TestCheckResourceAttr("scaleway_instance_server.main", "type", "L40S-1-48G"),
 					resource.TestCheckResourceAttr("scaleway_instance_server.main", "image", "ubuntu_jammy_gpu_os_12"),
 					resource.TestCheckResourceAttrPair("scaleway_instance_server.main", "additional_volume_ids.0", "scaleway_instance_volume.main", "id"),
-					resource.TestCheckResourceAttr("scaleway_instance_volume.main", "size_in_gb", "20"),
+					resource.TestCheckResourceAttr("scaleway_instance_volume.main", "size_in_gb", "1600"),
 				),
 			},
 		},

--- a/internal/services/instance/testdata/server-scratch-storage.cassette.yaml
+++ b/internal/services/instance/testdata/server-scratch-storage.cassette.yaml
@@ -1,1428 +1,1428 @@
 ---
 version: 2
 interactions:
-- id: 0
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 123
-    host: api.scaleway.com
-    body: "{\"name\":\"tf-vol-lucid-shannon\",\"project\":\"fa1e3217-dc80-42ac-85c3-3f034b78b552\",\"volume_type\":\"scratch\",\"size\":20000000000}"
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/volumes
-    method: POST
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 424
-    body: "{\"volume\": {\"id\": \"46673d86-c393-4205-8112-e54064d54310\", \"name\": \"tf-vol-lucid-shannon\", \"volume_type\": \"scratch\", \"organization\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"project\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"server\": null, \"size\": 20000000000, \"state\": \"available\", \"creation_date\": \"2025-12-05T13:09:36.607979+00:00\", \"modification_date\": \"2025-12-05T13:09:36.607979+00:00\", \"tags\": [], \"zone\": \"fr-par-2\"}}"
-    headers:
-      Content-Length:
-      - "424"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Dec 2025 13:09:36 GMT
-      Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-2/volumes/46673d86-c393-4205-8112-e54064d54310
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      X-Request-Id:
-      - d0fbeeca-67eb-48f1-8d2c-01fc2a5db053
-    status: 201 Created
-    code: 201
-    duration: 286.433739ms
-- id: 1
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/volumes/46673d86-c393-4205-8112-e54064d54310
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 424
-    body: "{\"volume\": {\"id\": \"46673d86-c393-4205-8112-e54064d54310\", \"name\": \"tf-vol-lucid-shannon\", \"volume_type\": \"scratch\", \"organization\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"project\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"server\": null, \"size\": 20000000000, \"state\": \"available\", \"creation_date\": \"2025-12-05T13:09:36.607979+00:00\", \"modification_date\": \"2025-12-05T13:09:36.607979+00:00\", \"tags\": [], \"zone\": \"fr-par-2\"}}"
-    headers:
-      Content-Length:
-      - "424"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Dec 2025 13:09:36 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      X-Request-Id:
-      - 623ec6ae-ca4c-4ade-b73e-ba321216c564
-    status: 200 OK
-    code: 200
-    duration: 56.331603ms
-- id: 2
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/volumes/46673d86-c393-4205-8112-e54064d54310
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 424
-    body: "{\"volume\": {\"id\": \"46673d86-c393-4205-8112-e54064d54310\", \"name\": \"tf-vol-lucid-shannon\", \"volume_type\": \"scratch\", \"organization\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"project\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"server\": null, \"size\": 20000000000, \"state\": \"available\", \"creation_date\": \"2025-12-05T13:09:36.607979+00:00\", \"modification_date\": \"2025-12-05T13:09:36.607979+00:00\", \"tags\": [], \"zone\": \"fr-par-2\"}}"
-    headers:
-      Content-Length:
-      - "424"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Dec 2025 13:09:36 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      X-Request-Id:
-      - 6e139437-2109-4c13-9070-a4b7fcbd76f8
-    status: 200 OK
-    code: 200
-    duration: 216.325117ms
-- id: 3
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    form:
-      page:
-      - "1"
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/products/servers?page=1
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 40317
-    body: "{\"servers\": {\"B300-SXM-8-288G\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 224, \"ram\": 4123168604160, \"gpu\": 8, \"gpu_info\": {\"gpu_manufacturer\": \"NVIDIA\", \"gpu_name\": \"B300-SXM\", \"gpu_memory\": 309237645312}, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": 24000000000000, \"monthly_price\": 43800.0, \"hourly_price\": 60.0, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 16}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 20000000000, \"sum_internet_bandwidth\": 20000000000, \"interfaces\": [{\"internal_bandwidth\": 20000000000, \"internet_bandwidth\": 20000000000}]}, \"block_bandwidth\": 5242880000, \"end_of_service\": false}, \"BASIC2-A16C-32G\": {\"alt_names\": [], \"arch\": \"arm64\", \"ncpus\": 16, \"ram\": 34359738368, \"gpu\": 0, \"gpu_info\": null, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": null, \"monthly_price\": 150.89, \"hourly_price\": 0.2067, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 0}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 1600000000, \"sum_internet_bandwidth\": 1600000000, \"interfaces\": [{\"internal_bandwidth\": 1600000000, \"internet_bandwidth\": 1600000000}]}, \"block_bandwidth\": 503316480, \"end_of_service\": false}, \"BASIC2-A16C-64G\": {\"alt_names\": [], \"arch\": \"arm64\", \"ncpus\": 16, \"ram\": 68719476736, \"gpu\": 0, \"gpu_info\": null, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": null, \"monthly_price\": 201.19, \"hourly_price\": 0.2756, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 0}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 1600000000, \"sum_internet_bandwidth\": 1600000000, \"interfaces\": [{\"internal_bandwidth\": 1600000000, \"internet_bandwidth\": 1600000000}]}, \"block_bandwidth\": 503316480, \"end_of_service\": false}, \"BASIC2-A2C-4G\": {\"alt_names\": [], \"arch\": \"arm64\", \"ncpus\": 2, \"ram\": 4294967296, \"gpu\": 0, \"gpu_info\": null, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": null, \"monthly_price\": 16.79, \"hourly_price\": 0.023, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 0}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 200000000, \"sum_internet_bandwidth\": 200000000, \"interfaces\": [{\"internal_bandwidth\": 200000000, \"internet_bandwidth\": 200000000}]}, \"block_bandwidth\": 83886080, \"end_of_service\": false}, \"BASIC2-A2C-8G\": {\"alt_names\": [], \"arch\": \"arm64\", \"ncpus\": 2, \"ram\": 8589934592, \"gpu\": 0, \"gpu_info\": null, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": null, \"monthly_price\": 25.19, \"hourly_price\": 0.0345, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 0}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 200000000, \"sum_internet_bandwidth\": 200000000, \"interfaces\": [{\"internal_bandwidth\": 200000000, \"internet_bandwidth\": 200000000}]}, \"block_bandwidth\": 83886080, \"end_of_service\": false}, \"BASIC2-A4C-16G\": {\"alt_names\": [], \"arch\": \"arm64\", \"ncpus\": 4, \"ram\": 17179869184, \"gpu\": 0, \"gpu_info\": null, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": null, \"monthly_price\": 50.3, \"hourly_price\": 0.0689, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 0}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 400000000, \"sum_internet_bandwidth\": 400000000, \"interfaces\": [{\"internal_bandwidth\": 400000000, \"internet_bandwidth\": 400000000}]}, \"block_bandwidth\": 125829120, \"end_of_service\": false}, \"BASIC2-A4C-8G\": {\"alt_names\": [], \"arch\": \"arm64\", \"ncpus\": 4, \"ram\": 8589934592, \"gpu\": 0, \"gpu_info\": null, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": null, \"monthly_price\": 37.74, \"hourly_price\": 0.0517, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 0}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 400000000, \"sum_internet_bandwidth\": 400000000, \"interfaces\": [{\"internal_bandwidth\": 400000000, \"internet_bandwidth\": 400000000}]}, \"block_bandwidth\": 125829120, \"end_of_service\": false}, \"BASIC2-A8C-16G\": {\"alt_names\": [], \"arch\": \"arm64\", \"ncpus\": 8, \"ram\": 17179869184, \"gpu\": 0, \"gpu_info\": null, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": null, \"monthly_price\": 75.48, \"hourly_price\": 0.1034, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 0}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 800000000, \"sum_internet_bandwidth\": 800000000, \"interfaces\": [{\"internal_bandwidth\": 800000000, \"internet_bandwidth\": 800000000}]}, \"block_bandwidth\": 251658240, \"end_of_service\": false}, \"BASIC2-A8C-32G\": {\"alt_names\": [], \"arch\": \"arm64\", \"ncpus\": 8, \"ram\": 34359738368, \"gpu\": 0, \"gpu_info\": null, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": null, \"monthly_price\": 100.59, \"hourly_price\": 0.1378, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 0}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 800000000, \"sum_internet_bandwidth\": 800000000, \"interfaces\": [{\"internal_bandwidth\": 800000000, \"internet_bandwidth\": 800000000}]}, \"block_bandwidth\": 251658240, \"end_of_service\": false}, \"COPARM1-16C-64G\": {\"alt_names\": [], \"arch\": \"arm64\", \"ncpus\": 16, \"ram\": 68719476736, \"gpu\": 0, \"gpu_info\": null, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": null, \"monthly_price\": 252.14, \"hourly_price\": 0.3454, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 0}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 1600000000, \"sum_internet_bandwidth\": 1600000000, \"interfaces\": [{\"internal_bandwidth\": 1600000000, \"internet_bandwidth\": 1600000000}]}, \"block_bandwidth\": 671088640, \"end_of_service\": false}, \"COPARM1-2C-8G\": {\"alt_names\": [], \"arch\": \"arm64\", \"ncpus\": 2, \"ram\": 8589934592, \"gpu\": 0, \"gpu_info\": null, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": null, \"monthly_price\": 31.1, \"hourly_price\": 0.0426, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 0}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 200000000, \"sum_internet_bandwidth\": 200000000, \"interfaces\": [{\"internal_bandwidth\": 200000000, \"internet_bandwidth\": 200000000}]}, \"block_bandwidth\": 83886080, \"end_of_service\": false}, \"COPARM1-32C-128G\": {\"alt_names\": [], \"arch\": \"arm64\", \"ncpus\": 32, \"ram\": 137438953472, \"gpu\": 0, \"gpu_info\": null, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": null, \"monthly_price\": 506.26, \"hourly_price\": 0.6935, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 0}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 3200000000, \"sum_internet_bandwidth\": 3200000000, \"interfaces\": [{\"internal_bandwidth\": 3200000000, \"internet_bandwidth\": 3200000000}]}, \"block_bandwidth\": 1342177280, \"end_of_service\": false}, \"COPARM1-4C-16G\": {\"alt_names\": [], \"arch\": \"arm64\", \"ncpus\": 4, \"ram\": 17179869184, \"gpu\": 0, \"gpu_info\": null, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": null, \"monthly_price\": 62.56, \"hourly_price\": 0.0857, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 0}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 400000000, \"sum_internet_bandwidth\": 400000000, \"interfaces\": [{\"internal_bandwidth\": 400000000, \"internet_bandwidth\": 400000000}]}, \"block_bandwidth\": 167772160, \"end_of_service\": false}, \"COPARM1-8C-32G\": {\"alt_names\": [], \"arch\": \"arm64\", \"ncpus\": 8, \"ram\": 34359738368, \"gpu\": 0, \"gpu_info\": null, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": null, \"monthly_price\": 125.85, \"hourly_price\": 0.1724, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 0}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 800000000, \"sum_internet_bandwidth\": 800000000, \"interfaces\": [{\"internal_bandwidth\": 800000000, \"internet_bandwidth\": 800000000}]}, \"block_bandwidth\": 335544320, \"end_of_service\": false}, \"DEV1-L\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 4, \"ram\": 8589934592, \"gpu\": 0, \"gpu_info\": null, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 80000000000}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 1000000000, \"max_size\": 800000000000}}, \"scratch_storage_max_size\": null, \"monthly_price\": 30.66, \"hourly_price\": 0.042, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": true, \"private_network\": 8, \"max_file_systems\": 0}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 400000000, \"sum_internet_bandwidth\": 400000000, \"interfaces\": [{\"internal_bandwidth\": 400000000, \"internet_bandwidth\": 400000000}]}, \"block_bandwidth\": 209715200, \"end_of_service\": false}, \"DEV1-M\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 3, \"ram\": 4294967296, \"gpu\": 0, \"gpu_info\": null, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 40000000000}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 1000000000, \"max_size\": 800000000000}}, \"scratch_storage_max_size\": null, \"monthly_price\": 14.454, \"hourly_price\": 0.0198, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": true, \"private_network\": 8, \"max_file_systems\": 0}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 300000000, \"sum_internet_bandwidth\": 300000000, \"interfaces\": [{\"internal_bandwidth\": 300000000, \"internet_bandwidth\": 300000000}]}, \"block_bandwidth\": 157286400, \"end_of_service\": false}, \"DEV1-S\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 2, \"ram\": 2147483648, \"gpu\": 0, \"gpu_info\": null, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 20000000000}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 1000000000, \"max_size\": 800000000000}}, \"scratch_storage_max_size\": null, \"monthly_price\": 6.424, \"hourly_price\": 0.0088, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": true, \"private_network\": 8, \"max_file_systems\": 0}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 200000000, \"sum_internet_bandwidth\": 200000000, \"interfaces\": [{\"internal_bandwidth\": 200000000, \"internet_bandwidth\": 200000000}]}, \"block_bandwidth\": 104857600, \"end_of_service\": false}, \"DEV1-XL\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 4, \"ram\": 12884901888, \"gpu\": 0, \"gpu_info\": null, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 120000000000}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 1000000000, \"max_size\": 800000000000}}, \"scratch_storage_max_size\": null, \"monthly_price\": 46.5734, \"hourly_price\": 0.06378, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": true, \"private_network\": 8, \"max_file_systems\": 0}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 500000000, \"sum_internet_bandwidth\": 500000000, \"interfaces\": [{\"internal_bandwidth\": 500000000, \"internet_bandwidth\": 500000000}]}, \"block_bandwidth\": 262144000, \"end_of_service\": false}, \"GP1-L\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 32, \"ram\": 137438953472, \"gpu\": 0, \"gpu_info\": null, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 600000000000}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 1000000000, \"max_size\": 800000000000}}, \"scratch_storage_max_size\": null, \"monthly_price\": 554.07, \"hourly_price\": 0.759, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": true, \"private_network\": 8, \"max_file_systems\": 0}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 5000000000, \"sum_internet_bandwidth\": 5000000000, \"interfaces\": [{\"internal_bandwidth\": 5000000000, \"internet_bandwidth\": 5000000000}]}, \"block_bandwidth\": 1073741824, \"end_of_service\": false}, \"GP1-M\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 16, \"ram\": 68719476736, \"gpu\": 0, \"gpu_info\": null, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 600000000000}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 1000000000, \"max_size\": 800000000000}}, \"scratch_storage_max_size\": null, \"monthly_price\": 274.48, \"hourly_price\": 0.376, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": true, \"private_network\": 8, \"max_file_systems\": 0}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 1500000000, \"sum_internet_bandwidth\": 1500000000, \"interfaces\": [{\"internal_bandwidth\": 1500000000, \"internet_bandwidth\": 1500000000}]}, \"block_bandwidth\": 838860800, \"end_of_service\": false}, \"GP1-S\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 8, \"ram\": 34359738368, \"gpu\": 0, \"gpu_info\": null, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 300000000000}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 1000000000, \"max_size\": 800000000000}}, \"scratch_storage_max_size\": null, \"monthly_price\": 136.51, \"hourly_price\": 0.187, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": true, \"private_network\": 8, \"max_file_systems\": 0}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 800000000, \"sum_internet_bandwidth\": 800000000, \"interfaces\": [{\"internal_bandwidth\": 800000000, \"internet_bandwidth\": 800000000}]}, \"block_bandwidth\": 524288000, \"end_of_service\": false}, \"GP1-XL\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 48, \"ram\": 274877906944, \"gpu\": 0, \"gpu_info\": null, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 600000000000}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 1000000000, \"max_size\": 800000000000}}, \"scratch_storage_max_size\": null, \"monthly_price\": 1197.93, \"hourly_price\": 1.641, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": true, \"private_network\": 8, \"max_file_systems\": 0}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 10000000000, \"sum_internet_bandwidth\": 10000000000, \"interfaces\": [{\"internal_bandwidth\": 10000000000, \"internet_bandwidth\": 10000000000}]}, \"block_bandwidth\": 2147483648, \"end_of_service\": false}, \"GP1-XS\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 4, \"ram\": 17179869184, \"gpu\": 0, \"gpu_info\": null, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 150000000000}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 1000000000, \"max_size\": 800000000000}}, \"scratch_storage_max_size\": null, \"monthly_price\": 66.43, \"hourly_price\": 0.091, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": true, \"private_network\": 8, \"max_file_systems\": 0}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 500000000, \"sum_internet_bandwidth\": 500000000, \"interfaces\": [{\"internal_bandwidth\": 500000000, \"internet_bandwidth\": 500000000}]}, \"block_bandwidth\": 314572800, \"end_of_service\": false}, \"GPU-3070-S\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 8, \"ram\": 17179869184, \"gpu\": 1, \"gpu_info\": {\"gpu_manufacturer\": \"NVIDIA\", \"gpu_name\": \"RTX-3070\", \"gpu_memory\": 8589934592}, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": null, \"monthly_price\": 715.4, \"hourly_price\": 0.98, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 0}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 2500000000, \"sum_internet_bandwidth\": 2500000000, \"interfaces\": [{\"internal_bandwidth\": 2500000000, \"internet_bandwidth\": 2500000000}]}, \"block_bandwidth\": 1048576000, \"end_of_service\": false}, \"H100-1-80G\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 24, \"ram\": 257698037760, \"gpu\": 1, \"gpu_info\": {\"gpu_manufacturer\": \"NVIDIA\", \"gpu_name\": \"H100-PCIe\", \"gpu_memory\": 85899345920}, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": 3000000000000, \"monthly_price\": 1992.9, \"hourly_price\": 2.73, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 2}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 10000000000, \"sum_internet_bandwidth\": 10000000000, \"interfaces\": [{\"internal_bandwidth\": 10000000000, \"internet_bandwidth\": 10000000000}]}, \"block_bandwidth\": 2097152000, \"end_of_service\": false}, \"H100-1-M\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 24, \"ram\": 257698037760, \"gpu\": 1, \"gpu_info\": {\"gpu_manufacturer\": \"NVIDIA\", \"gpu_name\": \"H100-PCIe\", \"gpu_memory\": 85899345920}, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": 3000000000000, \"monthly_price\": 3066.0, \"hourly_price\": 4.2, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 2}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 10000000000, \"sum_internet_bandwidth\": 10000000000, \"interfaces\": [{\"internal_bandwidth\": 10000000000, \"internet_bandwidth\": 10000000000}]}, \"block_bandwidth\": 2097152000, \"end_of_service\": false}, \"H100-2-80G\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 48, \"ram\": 515396075520, \"gpu\": 2, \"gpu_info\": {\"gpu_manufacturer\": \"NVIDIA\", \"gpu_name\": \"H100-PCIe\", \"gpu_memory\": 85899345920}, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": 6000000000000, \"monthly_price\": 3985.8, \"hourly_price\": 5.46, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 4}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 20000000000, \"sum_internet_bandwidth\": 20000000000, \"interfaces\": [{\"internal_bandwidth\": 20000000000, \"internet_bandwidth\": 20000000000}]}, \"block_bandwidth\": 4194304000, \"end_of_service\": false}, \"H100-2-M\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 48, \"ram\": 515396075520, \"gpu\": 2, \"gpu_info\": {\"gpu_manufacturer\": \"NVIDIA\", \"gpu_name\": \"H100-PCIe\", \"gpu_memory\": 85899345920}, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": 6000000000000, \"monthly_price\": 6132.0, \"hourly_price\": 8.4, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 4}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 20000000000, \"sum_internet_bandwidth\": 20000000000, \"interfaces\": [{\"internal_bandwidth\": 20000000000, \"internet_bandwidth\": 20000000000}]}, \"block_bandwidth\": 4194304000, \"end_of_service\": false}, \"H100-SXM-2-80G\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 32, \"ram\": 257698037760, \"gpu\": 2, \"gpu_info\": {\"gpu_manufacturer\": \"NVIDIA\", \"gpu_name\": \"H100-SXM\", \"gpu_memory\": 85899345920}, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": 3200000000000, \"monthly_price\": 4393.14, \"hourly_price\": 6.018, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 4}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 20000000000, \"sum_internet_bandwidth\": 20000000000, \"interfaces\": [{\"internal_bandwidth\": 20000000000, \"internet_bandwidth\": 20000000000}]}, \"block_bandwidth\": 5242880000, \"end_of_service\": false}, \"H100-SXM-4-80G\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 64, \"ram\": 515396075520, \"gpu\": 4, \"gpu_info\": {\"gpu_manufacturer\": \"NVIDIA\", \"gpu_name\": \"H100-SXM\", \"gpu_memory\": 85899345920}, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": 6400000000000, \"monthly_price\": 8475.3, \"hourly_price\": 11.61, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 8}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 20000000000, \"sum_internet_bandwidth\": 20000000000, \"interfaces\": [{\"internal_bandwidth\": 20000000000, \"internet_bandwidth\": 20000000000}]}, \"block_bandwidth\": 5242880000, \"end_of_service\": false}, \"H100-SXM-8-80G\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 128, \"ram\": 1030792151040, \"gpu\": 8, \"gpu_info\": {\"gpu_manufacturer\": \"NVIDIA\", \"gpu_name\": \"H100-SXM\", \"gpu_memory\": 85899345920}, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": 12800000000000, \"monthly_price\": 16810.44, \"hourly_price\": 23.028, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 16}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 20000000000, \"sum_internet_bandwidth\": 20000000000, \"interfaces\": [{\"internal_bandwidth\": 20000000000, \"internet_bandwidth\": 20000000000}]}, \"block_bandwidth\": 5242880000, \"end_of_service\": false}, \"L4-1-24G\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 8, \"ram\": 51539607552, \"gpu\": 1, \"gpu_info\": {\"gpu_manufacturer\": \"NVIDIA\", \"gpu_name\": \"L4\", \"gpu_memory\": 25769803776}, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": null, \"monthly_price\": 547.5, \"hourly_price\": 0.75, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 2}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 2500000000, \"sum_internet_bandwidth\": 2500000000, \"interfaces\": [{\"internal_bandwidth\": 2500000000, \"internet_bandwidth\": 2500000000}]}, \"block_bandwidth\": 1048576000, \"end_of_service\": false}, \"L4-2-24G\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 16, \"ram\": 103079215104, \"gpu\": 2, \"gpu_info\": {\"gpu_manufacturer\": \"NVIDIA\", \"gpu_name\": \"L4\", \"gpu_memory\": 25769803776}, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": null, \"monthly_price\": 1095.0, \"hourly_price\": 1.5, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 4}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 5000000000, \"sum_internet_bandwidth\": 5000000000, \"interfaces\": [{\"internal_bandwidth\": 5000000000, \"internet_bandwidth\": 5000000000}]}, \"block_bandwidth\": 1572864000, \"end_of_service\": false}, \"L4-4-24G\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 32, \"ram\": 206158430208, \"gpu\": 4, \"gpu_info\": {\"gpu_manufacturer\": \"NVIDIA\", \"gpu_name\": \"L4\", \"gpu_memory\": 25769803776}, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": null, \"monthly_price\": 2190.0, \"hourly_price\": 3.0, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 8}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 10000000000, \"sum_internet_bandwidth\": 10000000000, \"interfaces\": [{\"internal_bandwidth\": 10000000000, \"internet_bandwidth\": 10000000000}]}, \"block_bandwidth\": 2621440000, \"end_of_service\": false}, \"L4-8-24G\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 64, \"ram\": 412316860416, \"gpu\": 8, \"gpu_info\": {\"gpu_manufacturer\": \"NVIDIA\", \"gpu_name\": \"L4\", \"gpu_memory\": 25769803776}, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": null, \"monthly_price\": 4380.0, \"hourly_price\": 6.0, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 16}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 20000000000, \"sum_internet_bandwidth\": 20000000000, \"interfaces\": [{\"internal_bandwidth\": 20000000000, \"internet_bandwidth\": 20000000000}]}, \"block_bandwidth\": 5242880000, \"end_of_service\": false}, \"L40S-1-48G\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 8, \"ram\": 103079215104, \"gpu\": 1, \"gpu_info\": {\"gpu_manufacturer\": \"NVIDIA\", \"gpu_name\": \"L40S\", \"gpu_memory\": 51539607552}, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": 1600000000000, \"monthly_price\": 1022.0, \"hourly_price\": 1.4, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 2}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 2500000000, \"sum_internet_bandwidth\": 2500000000, \"interfaces\": [{\"internal_bandwidth\": 2500000000, \"internet_bandwidth\": 2500000000}]}, \"block_bandwidth\": 1048576000, \"end_of_service\": false}, \"L40S-2-48G\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 16, \"ram\": 206158430208, \"gpu\": 2, \"gpu_info\": {\"gpu_manufacturer\": \"NVIDIA\", \"gpu_name\": \"L40S\", \"gpu_memory\": 51539607552}, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": 3200000000000, \"monthly_price\": 2044.0, \"hourly_price\": 2.8, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 4}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 5000000000, \"sum_internet_bandwidth\": 5000000000, \"interfaces\": [{\"internal_bandwidth\": 5000000000, \"internet_bandwidth\": 5000000000}]}, \"block_bandwidth\": 1572864000, \"end_of_service\": false}, \"L40S-4-48G\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 32, \"ram\": 412316860416, \"gpu\": 4, \"gpu_info\": {\"gpu_manufacturer\": \"NVIDIA\", \"gpu_name\": \"L40S\", \"gpu_memory\": 51539607552}, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": 6400000000000, \"monthly_price\": 4088.0, \"hourly_price\": 5.6, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 8}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 10000000000, \"sum_internet_bandwidth\": 10000000000, \"interfaces\": [{\"internal_bandwidth\": 10000000000, \"internet_bandwidth\": 10000000000}]}, \"block_bandwidth\": 2621440000, \"end_of_service\": false}, \"L40S-8-48G\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 64, \"ram\": 824633720832, \"gpu\": 8, \"gpu_info\": {\"gpu_manufacturer\": \"NVIDIA\", \"gpu_name\": \"L40S\", \"gpu_memory\": 51539607552}, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": 12800000000000, \"monthly_price\": 8176.0, \"hourly_price\": 11.2, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 16}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 20000000000, \"sum_internet_bandwidth\": 20000000000, \"interfaces\": [{\"internal_bandwidth\": 20000000000, \"internet_bandwidth\": 20000000000}]}, \"block_bandwidth\": 5242880000, \"end_of_service\": false}, \"PLAY2-MICRO\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 4, \"ram\": 8589934592, \"gpu\": 0, \"gpu_info\": null, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": null, \"monthly_price\": 39.42, \"hourly_price\": 0.054, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 0}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 400000000, \"sum_internet_bandwidth\": 400000000, \"interfaces\": [{\"internal_bandwidth\": 400000000, \"internet_bandwidth\": 400000000}]}, \"block_bandwidth\": 167772160, \"end_of_service\": false}, \"PLAY2-NANO\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 2, \"ram\": 4294967296, \"gpu\": 0, \"gpu_info\": null, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": null, \"monthly_price\": 19.71, \"hourly_price\": 0.027, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 0}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 200000000, \"sum_internet_bandwidth\": 200000000, \"interfaces\": [{\"internal_bandwidth\": 200000000, \"internet_bandwidth\": 200000000}]}, \"block_bandwidth\": 83886080, \"end_of_service\": false}, \"PLAY2-PICO\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 1, \"ram\": 2147483648, \"gpu\": 0, \"gpu_info\": null, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": null, \"monthly_price\": 10.22, \"hourly_price\": 0.014, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 0}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 100000000, \"sum_internet_bandwidth\": 100000000, \"interfaces\": [{\"internal_bandwidth\": 100000000, \"internet_bandwidth\": 100000000}]}, \"block_bandwidth\": 41943040, \"end_of_service\": false}, \"POP2-16C-64G\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 16, \"ram\": 68719476736, \"gpu\": 0, \"gpu_info\": null, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": null, \"monthly_price\": 430.7, \"hourly_price\": 0.59, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 4}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 3200000000, \"sum_internet_bandwidth\": 3200000000, \"interfaces\": [{\"internal_bandwidth\": 3200000000, \"internet_bandwidth\": 3200000000}]}, \"block_bandwidth\": 3355443200, \"end_of_service\": false}, \"POP2-16C-64G-WIN\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 16, \"ram\": 68719476736, \"gpu\": 0, \"gpu_info\": null, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": null, \"monthly_price\": 1063.391, \"hourly_price\": 1.4567, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 0}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 3200000000, \"sum_internet_bandwidth\": 3200000000, \"interfaces\": [{\"internal_bandwidth\": 3200000000, \"internet_bandwidth\": 3200000000}]}, \"block_bandwidth\": 3355443200, \"end_of_service\": false}, \"POP2-2C-8G\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 2, \"ram\": 8589934592, \"gpu\": 0, \"gpu_info\": null, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": null, \"monthly_price\": 53.66, \"hourly_price\": 0.0735, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 1}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 400000000, \"sum_internet_bandwidth\": 400000000, \"interfaces\": [{\"internal_bandwidth\": 400000000, \"internet_bandwidth\": 400000000}]}, \"block_bandwidth\": 419430400, \"end_of_service\": false}, \"POP2-2C-8G-WIN\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 2, \"ram\": 8589934592, \"gpu\": 0, \"gpu_info\": null, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": null, \"monthly_price\": 133.079, \"hourly_price\": 0.1823, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 0}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 400000000, \"sum_internet_bandwidth\": 400000000, \"interfaces\": [{\"internal_bandwidth\": 400000000, \"internet_bandwidth\": 400000000}]}, \"block_bandwidth\": 419430400, \"end_of_service\": false}, \"POP2-32C-128G\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 32, \"ram\": 137438953472, \"gpu\": 0, \"gpu_info\": null, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": null, \"monthly_price\": 861.4, \"hourly_price\": 1.18, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 8}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 6400000000, \"sum_internet_bandwidth\": 6400000000, \"interfaces\": [{\"internal_bandwidth\": 6400000000, \"internet_bandwidth\": 6400000000}]}, \"block_bandwidth\": 5905580032, \"end_of_service\": false}, \"POP2-32C-128G-WIN\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 32, \"ram\": 137438953472, \"gpu\": 0, \"gpu_info\": null, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": null, \"monthly_price\": 2126.709, \"hourly_price\": 2.9133, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 0}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 6400000000, \"sum_internet_bandwidth\": 6400000000, \"interfaces\": [{\"internal_bandwidth\": 6400000000, \"internet_bandwidth\": 6400000000}]}, \"block_bandwidth\": 5905580032, \"end_of_service\": false}, \"POP2-48C-192G\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 48, \"ram\": 206158430208, \"gpu\": 0, \"gpu_info\": null, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": null, \"monthly_price\": 1274.4, \"hourly_price\": 1.77, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 12}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 9600000000, \"sum_internet_bandwidth\": 9600000000, \"interfaces\": [{\"internal_bandwidth\": 9600000000, \"internet_bandwidth\": 9600000000}]}, \"block_bandwidth\": 5905580032, \"end_of_service\": false}, \"POP2-4C-16G\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 4, \"ram\": 17179869184, \"gpu\": 0, \"gpu_info\": null, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": null, \"monthly_price\": 107.31, \"hourly_price\": 0.147, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 1}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 800000000, \"sum_internet_bandwidth\": 800000000, \"interfaces\": [{\"internal_bandwidth\": 800000000, \"internet_bandwidth\": 800000000}]}, \"block_bandwidth\": 838860800, \"end_of_service\": false}}}"
-    headers:
-      Content-Length:
-      - "40317"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Dec 2025 13:09:37 GMT
-      Link:
-      - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>; rel="last"
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      X-Request-Id:
-      - f5fa0ec5-0f65-4a30-aa05-329dec2e14a9
-      X-Total-Count:
-      - "77"
-    status: 200 OK
-    code: 200
-    duration: 77.577099ms
-- id: 4
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    form:
-      page:
-      - "2"
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/products/servers?page=2
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 21046
-    body: "{\"servers\": {\"POP2-4C-16G-WIN\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 4, \"ram\": 17179869184, \"gpu\": 0, \"gpu_info\": null, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": null, \"monthly_price\": 265.501, \"hourly_price\": 0.3637, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 0}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 800000000, \"sum_internet_bandwidth\": 800000000, \"interfaces\": [{\"internal_bandwidth\": 800000000, \"internet_bandwidth\": 800000000}]}, \"block_bandwidth\": 838860800, \"end_of_service\": false}, \"POP2-64C-256G\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 64, \"ram\": 274877906944, \"gpu\": 0, \"gpu_info\": null, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": null, \"monthly_price\": 1715.5, \"hourly_price\": 2.35, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 16}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 12800000000, \"sum_internet_bandwidth\": 12800000000, \"interfaces\": [{\"internal_bandwidth\": 12800000000, \"internet_bandwidth\": 12800000000}]}, \"block_bandwidth\": 5905580032, \"end_of_service\": false}, \"POP2-8C-32G\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 8, \"ram\": 34359738368, \"gpu\": 0, \"gpu_info\": null, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": null, \"monthly_price\": 211.7, \"hourly_price\": 0.29, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 2}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 1600000000, \"sum_internet_bandwidth\": 1600000000, \"interfaces\": [{\"internal_bandwidth\": 1600000000, \"internet_bandwidth\": 1600000000}]}, \"block_bandwidth\": 1677721600, \"end_of_service\": false}, \"POP2-8C-32G-WIN\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 8, \"ram\": 34359738368, \"gpu\": 0, \"gpu_info\": null, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": null, \"monthly_price\": 528.009, \"hourly_price\": 0.7233, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 0}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 1600000000, \"sum_internet_bandwidth\": 1600000000, \"interfaces\": [{\"internal_bandwidth\": 1600000000, \"internet_bandwidth\": 1600000000}]}, \"block_bandwidth\": 1677721600, \"end_of_service\": false}, \"POP2-HC-16C-32G\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 16, \"ram\": 34359738368, \"gpu\": 0, \"gpu_info\": null, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": null, \"monthly_price\": 310.69, \"hourly_price\": 0.4256, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 4}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 3200000000, \"sum_internet_bandwidth\": 3200000000, \"interfaces\": [{\"internal_bandwidth\": 3200000000, \"internet_bandwidth\": 3200000000}]}, \"block_bandwidth\": 3355443200, \"end_of_service\": false}, \"POP2-HC-2C-4G\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 2, \"ram\": 4294967296, \"gpu\": 0, \"gpu_info\": null, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": null, \"monthly_price\": 38.84, \"hourly_price\": 0.0532, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 1}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 400000000, \"sum_internet_bandwidth\": 400000000, \"interfaces\": [{\"internal_bandwidth\": 400000000, \"internet_bandwidth\": 400000000}]}, \"block_bandwidth\": 419430400, \"end_of_service\": false}, \"POP2-HC-32C-64G\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 32, \"ram\": 68719476736, \"gpu\": 0, \"gpu_info\": null, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": null, \"monthly_price\": 621.38, \"hourly_price\": 0.8512, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 8}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 6400000000, \"sum_internet_bandwidth\": 6400000000, \"interfaces\": [{\"internal_bandwidth\": 6400000000, \"internet_bandwidth\": 6400000000}]}, \"block_bandwidth\": 5905580032, \"end_of_service\": false}, \"POP2-HC-48C-96G\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 48, \"ram\": 103079215104, \"gpu\": 0, \"gpu_info\": null, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": null, \"monthly_price\": 914.4, \"hourly_price\": 1.27, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 12}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 9600000000, \"sum_internet_bandwidth\": 9600000000, \"interfaces\": [{\"internal_bandwidth\": 9600000000, \"internet_bandwidth\": 9600000000}]}, \"block_bandwidth\": 5905580032, \"end_of_service\": false}, \"POP2-HC-4C-8G\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 4, \"ram\": 8589934592, \"gpu\": 0, \"gpu_info\": null, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": null, \"monthly_price\": 77.67, \"hourly_price\": 0.1064, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 1}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 800000000, \"sum_internet_bandwidth\": 800000000, \"interfaces\": [{\"internal_bandwidth\": 800000000, \"internet_bandwidth\": 800000000}]}, \"block_bandwidth\": 838860800, \"end_of_service\": false}, \"POP2-HC-64C-128G\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 64, \"ram\": 137438953472, \"gpu\": 0, \"gpu_info\": null, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": null, \"monthly_price\": 1242.75, \"hourly_price\": 1.7024, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 16}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 12800000000, \"sum_internet_bandwidth\": 12800000000, \"interfaces\": [{\"internal_bandwidth\": 12800000000, \"internet_bandwidth\": 12800000000}]}, \"block_bandwidth\": 5905580032, \"end_of_service\": false}, \"POP2-HC-8C-16G\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 8, \"ram\": 17179869184, \"gpu\": 0, \"gpu_info\": null, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": null, \"monthly_price\": 155.34, \"hourly_price\": 0.2128, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 2}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 1600000000, \"sum_internet_bandwidth\": 1600000000, \"interfaces\": [{\"internal_bandwidth\": 1600000000, \"internet_bandwidth\": 1600000000}]}, \"block_bandwidth\": 1677721600, \"end_of_service\": false}, \"POP2-HM-16C-128G\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 16, \"ram\": 137438953472, \"gpu\": 0, \"gpu_info\": null, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": null, \"monthly_price\": 601.52, \"hourly_price\": 0.824, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 4}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 3200000000, \"sum_internet_bandwidth\": 3200000000, \"interfaces\": [{\"internal_bandwidth\": 3200000000, \"internet_bandwidth\": 3200000000}]}, \"block_bandwidth\": 3355443200, \"end_of_service\": false}, \"POP2-HM-2C-16G\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 2, \"ram\": 17179869184, \"gpu\": 0, \"gpu_info\": null, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": null, \"monthly_price\": 75.19, \"hourly_price\": 0.103, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 2}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 400000000, \"sum_internet_bandwidth\": 400000000, \"interfaces\": [{\"internal_bandwidth\": 400000000, \"internet_bandwidth\": 400000000}]}, \"block_bandwidth\": 419430400, \"end_of_service\": false}, \"POP2-HM-32C-256G\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 32, \"ram\": 274877906944, \"gpu\": 0, \"gpu_info\": null, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": null, \"monthly_price\": 1203.04, \"hourly_price\": 1.648, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 8}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 6400000000, \"sum_internet_bandwidth\": 6400000000, \"interfaces\": [{\"internal_bandwidth\": 6400000000, \"internet_bandwidth\": 6400000000}]}, \"block_bandwidth\": 5905580032, \"end_of_service\": false}, \"POP2-HM-48C-384G\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 48, \"ram\": 412316860416, \"gpu\": 0, \"gpu_info\": null, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": null, \"monthly_price\": 1778.4, \"hourly_price\": 2.47, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 12}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 9600000000, \"sum_internet_bandwidth\": 9600000000, \"interfaces\": [{\"internal_bandwidth\": 9600000000, \"internet_bandwidth\": 9600000000}]}, \"block_bandwidth\": 5905580032, \"end_of_service\": false}, \"POP2-HM-4C-32G\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 4, \"ram\": 34359738368, \"gpu\": 0, \"gpu_info\": null, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": null, \"monthly_price\": 150.38, \"hourly_price\": 0.206, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 1}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 800000000, \"sum_internet_bandwidth\": 800000000, \"interfaces\": [{\"internal_bandwidth\": 800000000, \"internet_bandwidth\": 800000000}]}, \"block_bandwidth\": 838860800, \"end_of_service\": false}, \"POP2-HM-64C-512G\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 64, \"ram\": 549755813888, \"gpu\": 0, \"gpu_info\": null, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": null, \"monthly_price\": 2406.08, \"hourly_price\": 3.296, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 16}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 12800000000, \"sum_internet_bandwidth\": 12800000000, \"interfaces\": [{\"internal_bandwidth\": 12800000000, \"internet_bandwidth\": 12800000000}]}, \"block_bandwidth\": 5905580032, \"end_of_service\": false}, \"POP2-HM-8C-64G\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 8, \"ram\": 68719476736, \"gpu\": 0, \"gpu_info\": null, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": null, \"monthly_price\": 300.76, \"hourly_price\": 0.412, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 2}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 1600000000, \"sum_internet_bandwidth\": 1600000000, \"interfaces\": [{\"internal_bandwidth\": 1600000000, \"internet_bandwidth\": 1600000000}]}, \"block_bandwidth\": 1677721600, \"end_of_service\": false}, \"POP2-HN-10\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 4, \"ram\": 8589934592, \"gpu\": 0, \"gpu_info\": null, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": null, \"monthly_price\": 530.29, \"hourly_price\": 0.7264, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 1}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 10000000000, \"sum_internet_bandwidth\": 10000000000, \"interfaces\": [{\"internal_bandwidth\": 10000000000, \"internet_bandwidth\": 10000000000}]}, \"block_bandwidth\": 838860800, \"end_of_service\": false}, \"POP2-HN-3\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 2, \"ram\": 4294967296, \"gpu\": 0, \"gpu_info\": null, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": null, \"monthly_price\": 186.49, \"hourly_price\": 0.2554, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 1}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 3000000000, \"sum_internet_bandwidth\": 3000000000, \"interfaces\": [{\"internal_bandwidth\": 3000000000, \"internet_bandwidth\": 3000000000}]}, \"block_bandwidth\": 419430400, \"end_of_service\": false}, \"POP2-HN-5\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 4, \"ram\": 8589934592, \"gpu\": 0, \"gpu_info\": null, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": null, \"monthly_price\": 330.29, \"hourly_price\": 0.4524, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 1}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 5000000000, \"sum_internet_bandwidth\": 5000000000, \"interfaces\": [{\"internal_bandwidth\": 5000000000, \"internet_bandwidth\": 5000000000}]}, \"block_bandwidth\": 838860800, \"end_of_service\": false}, \"PRO2-L\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 32, \"ram\": 137438953472, \"gpu\": 0, \"gpu_info\": null, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": null, \"monthly_price\": 640.21, \"hourly_price\": 0.877, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 0}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 6000000000, \"sum_internet_bandwidth\": 6000000000, \"interfaces\": [{\"internal_bandwidth\": 6000000000, \"internet_bandwidth\": 6000000000}]}, \"block_bandwidth\": 2097152000, \"end_of_service\": false}, \"PRO2-M\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 16, \"ram\": 68719476736, \"gpu\": 0, \"gpu_info\": null, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": null, \"monthly_price\": 319.74, \"hourly_price\": 0.438, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 0}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 3000000000, \"sum_internet_bandwidth\": 3000000000, \"interfaces\": [{\"internal_bandwidth\": 3000000000, \"internet_bandwidth\": 3000000000}]}, \"block_bandwidth\": 1048576000, \"end_of_service\": false}, \"PRO2-S\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 8, \"ram\": 34359738368, \"gpu\": 0, \"gpu_info\": null, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": null, \"monthly_price\": 159.87, \"hourly_price\": 0.219, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 0}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 1500000000, \"sum_internet_bandwidth\": 1500000000, \"interfaces\": [{\"internal_bandwidth\": 1500000000, \"internet_bandwidth\": 1500000000}]}, \"block_bandwidth\": 524288000, \"end_of_service\": false}, \"PRO2-XS\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 4, \"ram\": 17179869184, \"gpu\": 0, \"gpu_info\": null, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": null, \"monthly_price\": 80.3, \"hourly_price\": 0.11, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 0}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 700000000, \"sum_internet_bandwidth\": 700000000, \"interfaces\": [{\"internal_bandwidth\": 700000000, \"internet_bandwidth\": 700000000}]}, \"block_bandwidth\": 262144000, \"end_of_service\": false}, \"PRO2-XXS\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 2, \"ram\": 8589934592, \"gpu\": 0, \"gpu_info\": null, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 0}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 0, \"max_size\": 0}}, \"scratch_storage_max_size\": null, \"monthly_price\": 40.15, \"hourly_price\": 0.055, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": false, \"private_network\": 8, \"max_file_systems\": 0}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 350000000, \"sum_internet_bandwidth\": 350000000, \"interfaces\": [{\"internal_bandwidth\": 350000000, \"internet_bandwidth\": 350000000}]}, \"block_bandwidth\": 131072000, \"end_of_service\": false}, \"RENDER-S\": {\"alt_names\": [], \"arch\": \"x86_64\", \"ncpus\": 10, \"ram\": 45097156608, \"gpu\": 1, \"gpu_info\": {\"gpu_manufacturer\": \"NVIDIA\", \"gpu_name\": \"P100\", \"gpu_memory\": 17179869184}, \"mig_profile\": null, \"volumes_constraint\": {\"min_size\": 0, \"max_size\": 400000000000}, \"per_volume_constraint\": {\"l_ssd\": {\"min_size\": 1000000000, \"max_size\": 800000000000}}, \"scratch_storage_max_size\": null, \"monthly_price\": 891.33, \"hourly_price\": 1.221, \"capabilities\": {\"boot_types\": [\"local\", \"rescue\"], \"placement_groups\": true, \"block_storage\": true, \"hot_snapshots_local_volume\": true, \"private_network\": 8, \"max_file_systems\": 0}, \"network\": {\"ipv6_support\": true, \"sum_internal_bandwidth\": 2000000000, \"sum_internet_bandwidth\": 2000000000, \"interfaces\": [{\"internal_bandwidth\": 2000000000, \"internet_bandwidth\": 2000000000}]}, \"block_bandwidth\": 2147483648, \"end_of_service\": false}}}"
-    headers:
-      Content-Length:
-      - "21046"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Dec 2025 13:09:37 GMT
-      Link:
-      - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>; rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      X-Request-Id:
-      - 8b8f8834-ace5-491f-a792-3c5c4782e1c9
-      X-Total-Count:
-      - "77"
-    status: 200 OK
-    code: 200
-    duration: 167.763406ms
-- id: 5
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/volumes/46673d86-c393-4205-8112-e54064d54310
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 424
-    body: "{\"volume\": {\"id\": \"46673d86-c393-4205-8112-e54064d54310\", \"name\": \"tf-vol-lucid-shannon\", \"volume_type\": \"scratch\", \"organization\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"project\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"server\": null, \"size\": 20000000000, \"state\": \"available\", \"creation_date\": \"2025-12-05T13:09:36.607979+00:00\", \"modification_date\": \"2025-12-05T13:09:36.607979+00:00\", \"tags\": [], \"zone\": \"fr-par-2\"}}"
-    headers:
-      Content-Length:
-      - "424"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Dec 2025 13:09:37 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      X-Request-Id:
-      - ae1f3bb9-ca7e-4b85-aa67-491ae3b3c97c
-    status: 200 OK
-    code: 200
-    duration: 65.493446ms
-- id: 6
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    form:
-      image_label:
-      - ubuntu_jammy_gpu_os_12
-      order_by:
-      - type_asc
-      type:
-      - instance_sbs
-      zone:
-      - fr-par-2
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_jammy_gpu_os_12&order_by=type_asc&type=instance_sbs&zone=fr-par-2
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 536
-    body: "{\"local_images\":[{\"id\":\"f3431c05-e917-4bf0-b9db-9d4c14716a5e\", \"arch\":\"x86_64\", \"zone\":\"fr-par-2\", \"compatible_commercial_types\":[\"L4-1-24G\", \"L4-2-24G\", \"L4-4-24G\", \"L4-8-24G\", \"L40S-1-48G\", \"L40S-2-48G\", \"L40S-4-48G\", \"L40S-8-48G\", \"RENDER-S\", \"GPU-3070-S\", \"H100-1-M\", \"H100-2-M\", \"H100-1-80G\", \"H100-2-80G\", \"H100-SXM-1-80G\", \"H100-SXM-2-80G\", \"H100-SXM-4-80G\", \"H100-SXM-8-80G\", \"B300-SXM-1-288G\", \"B300-SXM-2-288G\", \"B300-SXM-4-288G\", \"B300-SXM-8-288G\"], \"label\":\"ubuntu_jammy_gpu_os_12\", \"type\":\"instance_sbs\"}], \"total_count\":1}"
-    headers:
-      Content-Length:
-      - "536"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Dec 2025 13:09:37 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      X-Request-Id:
-      - 3e4335ae-2ce2-4095-abdf-ee168688c08c
-    status: 200 OK
-    code: 200
-    duration: 203.970965ms
-- id: 7
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 383
-    host: api.scaleway.com
-    body: "{\"name\":\"test-acc-server-scratch\",\"dynamic_ip_required\":false,\"commercial_type\":\"H100-1-80G\",\"image\":\"f3431c05-e917-4bf0-b9db-9d4c14716a5e\",\"volumes\":{\"0\":{\"boot\":false},\"1\":{\"id\":\"46673d86-c393-4205-8112-e54064d54310\",\"name\":\"tf-vol-lucid-shannon\"}},\"boot_type\":\"local\",\"project\":\"fa1e3217-dc80-42ac-85c3-3f034b78b552\",\"tags\":[\"terraform-test\",\"scaleway_instance_server\",\"scratch\"]}"
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers
-    method: POST
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 2322
-    body: "{\"server\": {\"id\": \"3f0c9280-b4fb-4e58-9dab-df62551756d4\", \"name\": \"test-acc-server-scratch\", \"arch\": \"x86_64\", \"commercial_type\": \"H100-1-80G\", \"boot_type\": \"local\", \"organization\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"project\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"hostname\": \"test-acc-server-scratch\", \"image\": {\"id\": \"f3431c05-e917-4bf0-b9db-9d4c14716a5e\", \"name\": \"Ubuntu Jammy GPU OS 12 passthrough\", \"organization\": \"51b656e3-4865-41e8-adbc-0c45bdd780db\", \"project\": \"51b656e3-4865-41e8-adbc-0c45bdd780db\", \"root_volume\": {\"volume_type\": \"sbs_snapshot\", \"id\": \"43d3942a-890e-4bae-b657-a776667db001\", \"size\": 0, \"name\": \"\"}, \"extra_volumes\": {}, \"public\": true, \"arch\": \"x86_64\", \"creation_date\": \"2025-10-20T14:33:32.134908+00:00\", \"modification_date\": \"2025-10-20T14:33:32.134908+00:00\", \"default_bootscript\": null, \"from_server\": \"\", \"state\": \"available\", \"tags\": [], \"zone\": \"fr-par-2\"}, \"volumes\": {\"0\": {\"boot\": false, \"volume_type\": \"sbs_volume\", \"id\": \"83613205-86bc-414d-9b2c-62e86df29cc8\", \"state\": \"available\", \"zone\": \"fr-par-2\"}, \"1\": {\"boot\": false, \"id\": \"46673d86-c393-4205-8112-e54064d54310\", \"name\": \"tf-vol-lucid-shannon\", \"volume_type\": \"scratch\", \"organization\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"project\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"server\": {\"id\": \"3f0c9280-b4fb-4e58-9dab-df62551756d4\", \"name\": \"test-acc-server-scratch\"}, \"size\": 20000000000, \"state\": \"available\", \"creation_date\": \"2025-12-05T13:09:36.607979+00:00\", \"modification_date\": \"2025-12-05T13:09:37.688702+00:00\", \"tags\": [], \"zone\": \"fr-par-2\"}}, \"tags\": [\"terraform-test\", \"scaleway_instance_server\", \"scratch\"], \"state\": \"stopped\", \"protected\": false, \"state_detail\": \"\", \"public_ip\": null, \"public_ips\": [], \"mac_address\": \"de:00:00:95:80:cd\", \"routed_ip_enabled\": true, \"ipv6\": null, \"extra_networks\": [], \"dynamic_ip_required\": false, \"enable_ipv6\": false, \"private_ip\": null, \"creation_date\": \"2025-12-05T13:09:37.688702+00:00\", \"modification_date\": \"2025-12-05T13:09:37.688702+00:00\", \"bootscript\": null, \"security_group\": {\"id\": \"22961510-2391-4fc7-83bd-d4c9d2d5c7fd\", \"name\": \"Default security group\"}, \"location\": null, \"maintenances\": [], \"allowed_actions\": [\"poweron\", \"backup\"], \"placement_group\": null, \"private_nics\": [], \"zone\": \"fr-par-2\", \"filesystems\": [], \"end_of_service\": false}}"
-    headers:
-      Content-Length:
-      - "2322"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Dec 2025 13:09:38 GMT
-      Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/3f0c9280-b4fb-4e58-9dab-df62551756d4
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      X-Request-Id:
-      - f7e646f8-03bf-4f37-bbcc-33700a7b4ee5
-    status: 201 Created
-    code: 201
-    duration: 542.59547ms
-- id: 8
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/3f0c9280-b4fb-4e58-9dab-df62551756d4
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 2322
-    body: "{\"server\": {\"id\": \"3f0c9280-b4fb-4e58-9dab-df62551756d4\", \"name\": \"test-acc-server-scratch\", \"arch\": \"x86_64\", \"commercial_type\": \"H100-1-80G\", \"boot_type\": \"local\", \"organization\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"project\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"hostname\": \"test-acc-server-scratch\", \"image\": {\"id\": \"f3431c05-e917-4bf0-b9db-9d4c14716a5e\", \"name\": \"Ubuntu Jammy GPU OS 12 passthrough\", \"organization\": \"51b656e3-4865-41e8-adbc-0c45bdd780db\", \"project\": \"51b656e3-4865-41e8-adbc-0c45bdd780db\", \"root_volume\": {\"volume_type\": \"sbs_snapshot\", \"id\": \"43d3942a-890e-4bae-b657-a776667db001\", \"size\": 0, \"name\": \"\"}, \"extra_volumes\": {}, \"public\": true, \"arch\": \"x86_64\", \"creation_date\": \"2025-10-20T14:33:32.134908+00:00\", \"modification_date\": \"2025-10-20T14:33:32.134908+00:00\", \"default_bootscript\": null, \"from_server\": \"\", \"state\": \"available\", \"tags\": [], \"zone\": \"fr-par-2\"}, \"volumes\": {\"0\": {\"boot\": false, \"volume_type\": \"sbs_volume\", \"id\": \"83613205-86bc-414d-9b2c-62e86df29cc8\", \"state\": \"available\", \"zone\": \"fr-par-2\"}, \"1\": {\"boot\": false, \"id\": \"46673d86-c393-4205-8112-e54064d54310\", \"name\": \"tf-vol-lucid-shannon\", \"volume_type\": \"scratch\", \"organization\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"project\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"server\": {\"id\": \"3f0c9280-b4fb-4e58-9dab-df62551756d4\", \"name\": \"test-acc-server-scratch\"}, \"size\": 20000000000, \"state\": \"available\", \"creation_date\": \"2025-12-05T13:09:36.607979+00:00\", \"modification_date\": \"2025-12-05T13:09:37.688702+00:00\", \"tags\": [], \"zone\": \"fr-par-2\"}}, \"tags\": [\"terraform-test\", \"scaleway_instance_server\", \"scratch\"], \"state\": \"stopped\", \"protected\": false, \"state_detail\": \"\", \"public_ip\": null, \"public_ips\": [], \"mac_address\": \"de:00:00:95:80:cd\", \"routed_ip_enabled\": true, \"ipv6\": null, \"extra_networks\": [], \"dynamic_ip_required\": false, \"enable_ipv6\": false, \"private_ip\": null, \"creation_date\": \"2025-12-05T13:09:37.688702+00:00\", \"modification_date\": \"2025-12-05T13:09:37.688702+00:00\", \"bootscript\": null, \"security_group\": {\"id\": \"22961510-2391-4fc7-83bd-d4c9d2d5c7fd\", \"name\": \"Default security group\"}, \"location\": null, \"maintenances\": [], \"allowed_actions\": [\"poweron\", \"backup\"], \"placement_group\": null, \"private_nics\": [], \"zone\": \"fr-par-2\", \"filesystems\": [], \"end_of_service\": false}}"
-    headers:
-      Content-Length:
-      - "2322"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Dec 2025 13:09:38 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      X-Request-Id:
-      - 8e66943e-48c5-4e8b-84a2-c38b76e62695
-    status: 200 OK
-    code: 200
-    duration: 268.608696ms
-- id: 9
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/3f0c9280-b4fb-4e58-9dab-df62551756d4
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 2322
-    body: "{\"server\": {\"id\": \"3f0c9280-b4fb-4e58-9dab-df62551756d4\", \"name\": \"test-acc-server-scratch\", \"arch\": \"x86_64\", \"commercial_type\": \"H100-1-80G\", \"boot_type\": \"local\", \"organization\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"project\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"hostname\": \"test-acc-server-scratch\", \"image\": {\"id\": \"f3431c05-e917-4bf0-b9db-9d4c14716a5e\", \"name\": \"Ubuntu Jammy GPU OS 12 passthrough\", \"organization\": \"51b656e3-4865-41e8-adbc-0c45bdd780db\", \"project\": \"51b656e3-4865-41e8-adbc-0c45bdd780db\", \"root_volume\": {\"volume_type\": \"sbs_snapshot\", \"id\": \"43d3942a-890e-4bae-b657-a776667db001\", \"size\": 0, \"name\": \"\"}, \"extra_volumes\": {}, \"public\": true, \"arch\": \"x86_64\", \"creation_date\": \"2025-10-20T14:33:32.134908+00:00\", \"modification_date\": \"2025-10-20T14:33:32.134908+00:00\", \"default_bootscript\": null, \"from_server\": \"\", \"state\": \"available\", \"tags\": [], \"zone\": \"fr-par-2\"}, \"volumes\": {\"0\": {\"boot\": false, \"volume_type\": \"sbs_volume\", \"id\": \"83613205-86bc-414d-9b2c-62e86df29cc8\", \"state\": \"available\", \"zone\": \"fr-par-2\"}, \"1\": {\"boot\": false, \"id\": \"46673d86-c393-4205-8112-e54064d54310\", \"name\": \"tf-vol-lucid-shannon\", \"volume_type\": \"scratch\", \"organization\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"project\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"server\": {\"id\": \"3f0c9280-b4fb-4e58-9dab-df62551756d4\", \"name\": \"test-acc-server-scratch\"}, \"size\": 20000000000, \"state\": \"available\", \"creation_date\": \"2025-12-05T13:09:36.607979+00:00\", \"modification_date\": \"2025-12-05T13:09:37.688702+00:00\", \"tags\": [], \"zone\": \"fr-par-2\"}}, \"tags\": [\"terraform-test\", \"scaleway_instance_server\", \"scratch\"], \"state\": \"stopped\", \"protected\": false, \"state_detail\": \"\", \"public_ip\": null, \"public_ips\": [], \"mac_address\": \"de:00:00:95:80:cd\", \"routed_ip_enabled\": true, \"ipv6\": null, \"extra_networks\": [], \"dynamic_ip_required\": false, \"enable_ipv6\": false, \"private_ip\": null, \"creation_date\": \"2025-12-05T13:09:37.688702+00:00\", \"modification_date\": \"2025-12-05T13:09:37.688702+00:00\", \"bootscript\": null, \"security_group\": {\"id\": \"22961510-2391-4fc7-83bd-d4c9d2d5c7fd\", \"name\": \"Default security group\"}, \"location\": null, \"maintenances\": [], \"allowed_actions\": [\"poweron\", \"backup\"], \"placement_group\": null, \"private_nics\": [], \"zone\": \"fr-par-2\", \"filesystems\": [], \"end_of_service\": false}}"
-    headers:
-      Content-Length:
-      - "2322"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Dec 2025 13:09:38 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      X-Request-Id:
-      - cdb88fb3-682e-407e-9c88-e941d90d5e51
-    status: 200 OK
-    code: 200
-    duration: 271.55409ms
-- id: 10
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/3f0c9280-b4fb-4e58-9dab-df62551756d4
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 2322
-    body: "{\"server\": {\"id\": \"3f0c9280-b4fb-4e58-9dab-df62551756d4\", \"name\": \"test-acc-server-scratch\", \"arch\": \"x86_64\", \"commercial_type\": \"H100-1-80G\", \"boot_type\": \"local\", \"organization\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"project\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"hostname\": \"test-acc-server-scratch\", \"image\": {\"id\": \"f3431c05-e917-4bf0-b9db-9d4c14716a5e\", \"name\": \"Ubuntu Jammy GPU OS 12 passthrough\", \"organization\": \"51b656e3-4865-41e8-adbc-0c45bdd780db\", \"project\": \"51b656e3-4865-41e8-adbc-0c45bdd780db\", \"root_volume\": {\"volume_type\": \"sbs_snapshot\", \"id\": \"43d3942a-890e-4bae-b657-a776667db001\", \"size\": 0, \"name\": \"\"}, \"extra_volumes\": {}, \"public\": true, \"arch\": \"x86_64\", \"creation_date\": \"2025-10-20T14:33:32.134908+00:00\", \"modification_date\": \"2025-10-20T14:33:32.134908+00:00\", \"default_bootscript\": null, \"from_server\": \"\", \"state\": \"available\", \"tags\": [], \"zone\": \"fr-par-2\"}, \"volumes\": {\"0\": {\"boot\": false, \"volume_type\": \"sbs_volume\", \"id\": \"83613205-86bc-414d-9b2c-62e86df29cc8\", \"state\": \"available\", \"zone\": \"fr-par-2\"}, \"1\": {\"boot\": false, \"id\": \"46673d86-c393-4205-8112-e54064d54310\", \"name\": \"tf-vol-lucid-shannon\", \"volume_type\": \"scratch\", \"organization\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"project\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"server\": {\"id\": \"3f0c9280-b4fb-4e58-9dab-df62551756d4\", \"name\": \"test-acc-server-scratch\"}, \"size\": 20000000000, \"state\": \"available\", \"creation_date\": \"2025-12-05T13:09:36.607979+00:00\", \"modification_date\": \"2025-12-05T13:09:37.688702+00:00\", \"tags\": [], \"zone\": \"fr-par-2\"}}, \"tags\": [\"terraform-test\", \"scaleway_instance_server\", \"scratch\"], \"state\": \"stopped\", \"protected\": false, \"state_detail\": \"\", \"public_ip\": null, \"public_ips\": [], \"mac_address\": \"de:00:00:95:80:cd\", \"routed_ip_enabled\": true, \"ipv6\": null, \"extra_networks\": [], \"dynamic_ip_required\": false, \"enable_ipv6\": false, \"private_ip\": null, \"creation_date\": \"2025-12-05T13:09:37.688702+00:00\", \"modification_date\": \"2025-12-05T13:09:37.688702+00:00\", \"bootscript\": null, \"security_group\": {\"id\": \"22961510-2391-4fc7-83bd-d4c9d2d5c7fd\", \"name\": \"Default security group\"}, \"location\": null, \"maintenances\": [], \"allowed_actions\": [\"poweron\", \"backup\"], \"placement_group\": null, \"private_nics\": [], \"zone\": \"fr-par-2\", \"filesystems\": [], \"end_of_service\": false}}"
-    headers:
-      Content-Length:
-      - "2322"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Dec 2025 13:09:38 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      X-Request-Id:
-      - ad43f88b-4bd9-4ba8-be56-d2aa197888eb
-    status: 200 OK
-    code: 200
-    duration: 270.923206ms
-- id: 11
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/volumes/83613205-86bc-414d-9b2c-62e86df29cc8
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 143
-    body: "{\"type\": \"not_found\", \"message\": \"resource is not found\", \"resource\": \"instance_volume\", \"resource_id\": \"83613205-86bc-414d-9b2c-62e86df29cc8\"}"
-    headers:
-      Content-Length:
-      - "143"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Dec 2025 13:09:38 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      X-Request-Id:
-      - 7ce23a2d-317e-48a3-9b47-23219ebb072f
-    status: 404 Not Found
-    code: 404
-    duration: 27.477826ms
-- id: 12
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-2/volumes/83613205-86bc-414d-9b2c-62e86df29cc8
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 711
-    body: "{\"id\":\"83613205-86bc-414d-9b2c-62e86df29cc8\", \"name\":\"Ubuntu Jammy GPU OS 12 passthrough_sbs_volume_0\", \"type\":\"sbs_5k\", \"size\":20000000000, \"project_id\":\"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"created_at\":\"2025-12-05T13:09:37.791053Z\", \"updated_at\":\"2025-12-05T13:09:37.791053Z\", \"references\":[{\"id\":\"d76724e8-5f8e-4094-adf6-e49990578dec\", \"product_resource_type\":\"instance_server\", \"product_resource_id\":\"3f0c9280-b4fb-4e58-9dab-df62551756d4\", \"created_at\":\"2025-12-05T13:09:37.791053Z\", \"type\":\"exclusive\", \"status\":\"attached\"}], \"parent_snapshot_id\":\"43d3942a-890e-4bae-b657-a776667db001\", \"status\":\"in_use\", \"tags\":[], \"specs\":{\"perf_iops\":5000, \"class\":\"sbs\"}, \"last_detached_at\":null, \"zone\":\"fr-par-2\"}"
-    headers:
-      Content-Length:
-      - "711"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Dec 2025 13:09:38 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      X-Request-Id:
-      - 1fa1f8d5-2e3f-4817-8f1c-534807b2171d
-    status: 200 OK
-    code: 200
-    duration: 55.584631ms
-- id: 13
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/3f0c9280-b4fb-4e58-9dab-df62551756d4/user_data
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 17
-    body: "{\"user_data\": []}"
-    headers:
-      Content-Length:
-      - "17"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Dec 2025 13:09:39 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      X-Request-Id:
-      - 16f89394-772e-445c-ad1b-98d3e72c4e0f
-    status: 200 OK
-    code: 200
-    duration: 186.039925ms
-- id: 14
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/3f0c9280-b4fb-4e58-9dab-df62551756d4/private_nics
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 20
-    body: "{\"private_nics\": []}"
-    headers:
-      Content-Length:
-      - "20"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Dec 2025 13:09:39 GMT
-      Link:
-      - </servers/3f0c9280-b4fb-4e58-9dab-df62551756d4/private_nics?page=0&per_page=50&>; rel="last"
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      X-Request-Id:
-      - 4ba1ab37-6e92-48f6-b1bf-7b8419e05881
-      X-Total-Count:
-      - "0"
-    status: 200 OK
-    code: 200
-    duration: 50.336487ms
-- id: 15
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/3f0c9280-b4fb-4e58-9dab-df62551756d4
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 2368
-    body: "{\"server\": {\"id\": \"3f0c9280-b4fb-4e58-9dab-df62551756d4\", \"name\": \"test-acc-server-scratch\", \"arch\": \"x86_64\", \"commercial_type\": \"H100-1-80G\", \"boot_type\": \"local\", \"organization\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"project\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"hostname\": \"test-acc-server-scratch\", \"image\": {\"id\": \"f3431c05-e917-4bf0-b9db-9d4c14716a5e\", \"name\": \"Ubuntu Jammy GPU OS 12 passthrough\", \"organization\": \"51b656e3-4865-41e8-adbc-0c45bdd780db\", \"project\": \"51b656e3-4865-41e8-adbc-0c45bdd780db\", \"root_volume\": {\"volume_type\": \"sbs_snapshot\", \"id\": \"43d3942a-890e-4bae-b657-a776667db001\", \"size\": 0, \"name\": \"\"}, \"extra_volumes\": {}, \"public\": true, \"arch\": \"x86_64\", \"creation_date\": \"2025-10-20T14:33:32.134908+00:00\", \"modification_date\": \"2025-10-20T14:33:32.134908+00:00\", \"default_bootscript\": null, \"from_server\": \"\", \"state\": \"available\", \"tags\": [], \"zone\": \"fr-par-2\"}, \"volumes\": {\"0\": {\"boot\": false, \"volume_type\": \"sbs_volume\", \"id\": \"83613205-86bc-414d-9b2c-62e86df29cc8\", \"state\": \"available\", \"zone\": \"fr-par-2\"}, \"1\": {\"boot\": false, \"id\": \"46673d86-c393-4205-8112-e54064d54310\", \"name\": \"tf-vol-lucid-shannon\", \"volume_type\": \"scratch\", \"organization\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"project\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"server\": {\"id\": \"3f0c9280-b4fb-4e58-9dab-df62551756d4\", \"name\": \"test-acc-server-scratch\"}, \"size\": 20000000000, \"state\": \"available\", \"creation_date\": \"2025-12-05T13:09:36.607979+00:00\", \"modification_date\": \"2025-12-05T13:09:37.688702+00:00\", \"tags\": [], \"zone\": \"fr-par-2\"}}, \"tags\": [\"terraform-test\", \"scaleway_instance_server\", \"scratch\"], \"state\": \"stopped\", \"protected\": false, \"state_detail\": \"\", \"public_ip\": null, \"public_ips\": [], \"mac_address\": \"de:00:00:95:80:cd\", \"routed_ip_enabled\": true, \"ipv6\": null, \"extra_networks\": [], \"dynamic_ip_required\": false, \"enable_ipv6\": false, \"private_ip\": null, \"creation_date\": \"2025-12-05T13:09:37.688702+00:00\", \"modification_date\": \"2025-12-05T13:09:37.688702+00:00\", \"bootscript\": null, \"security_group\": {\"id\": \"22961510-2391-4fc7-83bd-d4c9d2d5c7fd\", \"name\": \"Default security group\"}, \"location\": null, \"maintenances\": [], \"allowed_actions\": [\"poweron\", \"backup\"], \"placement_group\": null, \"private_nics\": [], \"zone\": \"fr-par-2\", \"filesystems\": [], \"end_of_service\": false, \"admin_password_encryption_ssh_key_id\": null}}"
-    headers:
-      Content-Length:
-      - "2368"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Dec 2025 13:09:39 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      X-Request-Id:
-      - ba2bfd9d-9c11-470f-9382-e0efec96208d
-    status: 200 OK
-    code: 200
-    duration: 237.904468ms
-- id: 16
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/volumes/46673d86-c393-4205-8112-e54064d54310
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 501
-    body: "{\"volume\": {\"id\": \"46673d86-c393-4205-8112-e54064d54310\", \"name\": \"tf-vol-lucid-shannon\", \"volume_type\": \"scratch\", \"organization\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"project\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"server\": {\"id\": \"3f0c9280-b4fb-4e58-9dab-df62551756d4\", \"name\": \"test-acc-server-scratch\"}, \"size\": 20000000000, \"state\": \"available\", \"creation_date\": \"2025-12-05T13:09:36.607979+00:00\", \"modification_date\": \"2025-12-05T13:09:37.688702+00:00\", \"tags\": [], \"zone\": \"fr-par-2\"}}"
-    headers:
-      Content-Length:
-      - "501"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Dec 2025 13:09:39 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      X-Request-Id:
-      - 17f5f921-3d54-49f1-bd67-e4b93e7b9fbd
-    status: 200 OK
-    code: 200
-    duration: 179.467256ms
-- id: 17
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/volumes/46673d86-c393-4205-8112-e54064d54310
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 501
-    body: "{\"volume\": {\"id\": \"46673d86-c393-4205-8112-e54064d54310\", \"name\": \"tf-vol-lucid-shannon\", \"volume_type\": \"scratch\", \"organization\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"project\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"server\": {\"id\": \"3f0c9280-b4fb-4e58-9dab-df62551756d4\", \"name\": \"test-acc-server-scratch\"}, \"size\": 20000000000, \"state\": \"available\", \"creation_date\": \"2025-12-05T13:09:36.607979+00:00\", \"modification_date\": \"2025-12-05T13:09:37.688702+00:00\", \"tags\": [], \"zone\": \"fr-par-2\"}}"
-    headers:
-      Content-Length:
-      - "501"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Dec 2025 13:09:40 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      X-Request-Id:
-      - 13db2a02-112f-4409-b132-2ae566af0848
-    status: 200 OK
-    code: 200
-    duration: 121.466193ms
-- id: 18
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/3f0c9280-b4fb-4e58-9dab-df62551756d4
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 2368
-    body: "{\"server\": {\"id\": \"3f0c9280-b4fb-4e58-9dab-df62551756d4\", \"name\": \"test-acc-server-scratch\", \"arch\": \"x86_64\", \"commercial_type\": \"H100-1-80G\", \"boot_type\": \"local\", \"organization\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"project\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"hostname\": \"test-acc-server-scratch\", \"image\": {\"id\": \"f3431c05-e917-4bf0-b9db-9d4c14716a5e\", \"name\": \"Ubuntu Jammy GPU OS 12 passthrough\", \"organization\": \"51b656e3-4865-41e8-adbc-0c45bdd780db\", \"project\": \"51b656e3-4865-41e8-adbc-0c45bdd780db\", \"root_volume\": {\"volume_type\": \"sbs_snapshot\", \"id\": \"43d3942a-890e-4bae-b657-a776667db001\", \"size\": 0, \"name\": \"\"}, \"extra_volumes\": {}, \"public\": true, \"arch\": \"x86_64\", \"creation_date\": \"2025-10-20T14:33:32.134908+00:00\", \"modification_date\": \"2025-10-20T14:33:32.134908+00:00\", \"default_bootscript\": null, \"from_server\": \"\", \"state\": \"available\", \"tags\": [], \"zone\": \"fr-par-2\"}, \"volumes\": {\"0\": {\"boot\": false, \"volume_type\": \"sbs_volume\", \"id\": \"83613205-86bc-414d-9b2c-62e86df29cc8\", \"state\": \"available\", \"zone\": \"fr-par-2\"}, \"1\": {\"boot\": false, \"id\": \"46673d86-c393-4205-8112-e54064d54310\", \"name\": \"tf-vol-lucid-shannon\", \"volume_type\": \"scratch\", \"organization\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"project\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"server\": {\"id\": \"3f0c9280-b4fb-4e58-9dab-df62551756d4\", \"name\": \"test-acc-server-scratch\"}, \"size\": 20000000000, \"state\": \"available\", \"creation_date\": \"2025-12-05T13:09:36.607979+00:00\", \"modification_date\": \"2025-12-05T13:09:37.688702+00:00\", \"tags\": [], \"zone\": \"fr-par-2\"}}, \"tags\": [\"terraform-test\", \"scaleway_instance_server\", \"scratch\"], \"state\": \"stopped\", \"protected\": false, \"state_detail\": \"\", \"public_ip\": null, \"public_ips\": [], \"mac_address\": \"de:00:00:95:80:cd\", \"routed_ip_enabled\": true, \"ipv6\": null, \"extra_networks\": [], \"dynamic_ip_required\": false, \"enable_ipv6\": false, \"private_ip\": null, \"creation_date\": \"2025-12-05T13:09:37.688702+00:00\", \"modification_date\": \"2025-12-05T13:09:37.688702+00:00\", \"bootscript\": null, \"security_group\": {\"id\": \"22961510-2391-4fc7-83bd-d4c9d2d5c7fd\", \"name\": \"Default security group\"}, \"location\": null, \"maintenances\": [], \"allowed_actions\": [\"poweron\", \"backup\"], \"placement_group\": null, \"private_nics\": [], \"zone\": \"fr-par-2\", \"filesystems\": [], \"end_of_service\": false, \"admin_password_encryption_ssh_key_id\": null}}"
-    headers:
-      Content-Length:
-      - "2368"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Dec 2025 13:09:40 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      X-Request-Id:
-      - 3d306d42-1a7e-4b25-bd2f-9f3a507f01cc
-    status: 200 OK
-    code: 200
-    duration: 222.50768ms
-- id: 19
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/volumes/83613205-86bc-414d-9b2c-62e86df29cc8
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 143
-    body: "{\"type\": \"not_found\", \"message\": \"resource is not found\", \"resource\": \"instance_volume\", \"resource_id\": \"83613205-86bc-414d-9b2c-62e86df29cc8\"}"
-    headers:
-      Content-Length:
-      - "143"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Dec 2025 13:09:40 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      X-Request-Id:
-      - 306aaa88-a4a2-4d5a-aef9-a59c9a83ceaf
-    status: 404 Not Found
-    code: 404
-    duration: 27.081052ms
-- id: 20
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-2/volumes/83613205-86bc-414d-9b2c-62e86df29cc8
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 711
-    body: "{\"id\":\"83613205-86bc-414d-9b2c-62e86df29cc8\", \"name\":\"Ubuntu Jammy GPU OS 12 passthrough_sbs_volume_0\", \"type\":\"sbs_5k\", \"size\":20000000000, \"project_id\":\"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"created_at\":\"2025-12-05T13:09:37.791053Z\", \"updated_at\":\"2025-12-05T13:09:37.791053Z\", \"references\":[{\"id\":\"d76724e8-5f8e-4094-adf6-e49990578dec\", \"product_resource_type\":\"instance_server\", \"product_resource_id\":\"3f0c9280-b4fb-4e58-9dab-df62551756d4\", \"created_at\":\"2025-12-05T13:09:37.791053Z\", \"type\":\"exclusive\", \"status\":\"attached\"}], \"parent_snapshot_id\":\"43d3942a-890e-4bae-b657-a776667db001\", \"status\":\"in_use\", \"tags\":[], \"specs\":{\"perf_iops\":5000, \"class\":\"sbs\"}, \"last_detached_at\":null, \"zone\":\"fr-par-2\"}"
-    headers:
-      Content-Length:
-      - "711"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Dec 2025 13:09:40 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      X-Request-Id:
-      - 4ed6cde9-91ae-44fd-905a-5215c0e68135
-    status: 200 OK
-    code: 200
-    duration: 54.170288ms
-- id: 21
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/3f0c9280-b4fb-4e58-9dab-df62551756d4/user_data
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 17
-    body: "{\"user_data\": []}"
-    headers:
-      Content-Length:
-      - "17"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Dec 2025 13:09:40 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      X-Request-Id:
-      - ae4e7853-92af-4d5d-b190-d924f626032b
-    status: 200 OK
-    code: 200
-    duration: 84.854106ms
-- id: 22
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/3f0c9280-b4fb-4e58-9dab-df62551756d4/private_nics
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 20
-    body: "{\"private_nics\": []}"
-    headers:
-      Content-Length:
-      - "20"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Dec 2025 13:09:40 GMT
-      Link:
-      - </servers/3f0c9280-b4fb-4e58-9dab-df62551756d4/private_nics?page=0&per_page=50&>; rel="last"
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      X-Request-Id:
-      - eea4adbf-308c-458b-b375-a9598e1ab33d
-      X-Total-Count:
-      - "0"
-    status: 200 OK
-    code: 200
-    duration: 101.002242ms
-- id: 23
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/3f0c9280-b4fb-4e58-9dab-df62551756d4
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 2322
-    body: "{\"server\": {\"id\": \"3f0c9280-b4fb-4e58-9dab-df62551756d4\", \"name\": \"test-acc-server-scratch\", \"arch\": \"x86_64\", \"commercial_type\": \"H100-1-80G\", \"boot_type\": \"local\", \"organization\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"project\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"hostname\": \"test-acc-server-scratch\", \"image\": {\"id\": \"f3431c05-e917-4bf0-b9db-9d4c14716a5e\", \"name\": \"Ubuntu Jammy GPU OS 12 passthrough\", \"organization\": \"51b656e3-4865-41e8-adbc-0c45bdd780db\", \"project\": \"51b656e3-4865-41e8-adbc-0c45bdd780db\", \"root_volume\": {\"volume_type\": \"sbs_snapshot\", \"id\": \"43d3942a-890e-4bae-b657-a776667db001\", \"size\": 0, \"name\": \"\"}, \"extra_volumes\": {}, \"public\": true, \"arch\": \"x86_64\", \"creation_date\": \"2025-10-20T14:33:32.134908+00:00\", \"modification_date\": \"2025-10-20T14:33:32.134908+00:00\", \"default_bootscript\": null, \"from_server\": \"\", \"state\": \"available\", \"tags\": [], \"zone\": \"fr-par-2\"}, \"volumes\": {\"0\": {\"boot\": false, \"volume_type\": \"sbs_volume\", \"id\": \"83613205-86bc-414d-9b2c-62e86df29cc8\", \"state\": \"available\", \"zone\": \"fr-par-2\"}, \"1\": {\"boot\": false, \"id\": \"46673d86-c393-4205-8112-e54064d54310\", \"name\": \"tf-vol-lucid-shannon\", \"volume_type\": \"scratch\", \"organization\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"project\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"server\": {\"id\": \"3f0c9280-b4fb-4e58-9dab-df62551756d4\", \"name\": \"test-acc-server-scratch\"}, \"size\": 20000000000, \"state\": \"available\", \"creation_date\": \"2025-12-05T13:09:36.607979+00:00\", \"modification_date\": \"2025-12-05T13:09:37.688702+00:00\", \"tags\": [], \"zone\": \"fr-par-2\"}}, \"tags\": [\"terraform-test\", \"scaleway_instance_server\", \"scratch\"], \"state\": \"stopped\", \"protected\": false, \"state_detail\": \"\", \"public_ip\": null, \"public_ips\": [], \"mac_address\": \"de:00:00:95:80:cd\", \"routed_ip_enabled\": true, \"ipv6\": null, \"extra_networks\": [], \"dynamic_ip_required\": false, \"enable_ipv6\": false, \"private_ip\": null, \"creation_date\": \"2025-12-05T13:09:37.688702+00:00\", \"modification_date\": \"2025-12-05T13:09:37.688702+00:00\", \"bootscript\": null, \"security_group\": {\"id\": \"22961510-2391-4fc7-83bd-d4c9d2d5c7fd\", \"name\": \"Default security group\"}, \"location\": null, \"maintenances\": [], \"allowed_actions\": [\"poweron\", \"backup\"], \"placement_group\": null, \"private_nics\": [], \"zone\": \"fr-par-2\", \"filesystems\": [], \"end_of_service\": false}}"
-    headers:
-      Content-Length:
-      - "2322"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Dec 2025 13:09:40 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      X-Request-Id:
-      - 601ec0b0-a3fc-4049-9309-8c877fc4ff08
-    status: 200 OK
-    code: 200
-    duration: 217.604533ms
-- id: 24
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/3f0c9280-b4fb-4e58-9dab-df62551756d4
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 2322
-    body: "{\"server\": {\"id\": \"3f0c9280-b4fb-4e58-9dab-df62551756d4\", \"name\": \"test-acc-server-scratch\", \"arch\": \"x86_64\", \"commercial_type\": \"H100-1-80G\", \"boot_type\": \"local\", \"organization\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"project\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"hostname\": \"test-acc-server-scratch\", \"image\": {\"id\": \"f3431c05-e917-4bf0-b9db-9d4c14716a5e\", \"name\": \"Ubuntu Jammy GPU OS 12 passthrough\", \"organization\": \"51b656e3-4865-41e8-adbc-0c45bdd780db\", \"project\": \"51b656e3-4865-41e8-adbc-0c45bdd780db\", \"root_volume\": {\"volume_type\": \"sbs_snapshot\", \"id\": \"43d3942a-890e-4bae-b657-a776667db001\", \"size\": 0, \"name\": \"\"}, \"extra_volumes\": {}, \"public\": true, \"arch\": \"x86_64\", \"creation_date\": \"2025-10-20T14:33:32.134908+00:00\", \"modification_date\": \"2025-10-20T14:33:32.134908+00:00\", \"default_bootscript\": null, \"from_server\": \"\", \"state\": \"available\", \"tags\": [], \"zone\": \"fr-par-2\"}, \"volumes\": {\"0\": {\"boot\": false, \"volume_type\": \"sbs_volume\", \"id\": \"83613205-86bc-414d-9b2c-62e86df29cc8\", \"state\": \"available\", \"zone\": \"fr-par-2\"}, \"1\": {\"boot\": false, \"id\": \"46673d86-c393-4205-8112-e54064d54310\", \"name\": \"tf-vol-lucid-shannon\", \"volume_type\": \"scratch\", \"organization\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"project\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"server\": {\"id\": \"3f0c9280-b4fb-4e58-9dab-df62551756d4\", \"name\": \"test-acc-server-scratch\"}, \"size\": 20000000000, \"state\": \"available\", \"creation_date\": \"2025-12-05T13:09:36.607979+00:00\", \"modification_date\": \"2025-12-05T13:09:37.688702+00:00\", \"tags\": [], \"zone\": \"fr-par-2\"}}, \"tags\": [\"terraform-test\", \"scaleway_instance_server\", \"scratch\"], \"state\": \"stopped\", \"protected\": false, \"state_detail\": \"\", \"public_ip\": null, \"public_ips\": [], \"mac_address\": \"de:00:00:95:80:cd\", \"routed_ip_enabled\": true, \"ipv6\": null, \"extra_networks\": [], \"dynamic_ip_required\": false, \"enable_ipv6\": false, \"private_ip\": null, \"creation_date\": \"2025-12-05T13:09:37.688702+00:00\", \"modification_date\": \"2025-12-05T13:09:37.688702+00:00\", \"bootscript\": null, \"security_group\": {\"id\": \"22961510-2391-4fc7-83bd-d4c9d2d5c7fd\", \"name\": \"Default security group\"}, \"location\": null, \"maintenances\": [], \"allowed_actions\": [\"poweron\", \"backup\"], \"placement_group\": null, \"private_nics\": [], \"zone\": \"fr-par-2\", \"filesystems\": [], \"end_of_service\": false}}"
-    headers:
-      Content-Length:
-      - "2322"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Dec 2025 13:09:41 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      X-Request-Id:
-      - ffd2d27a-055d-4c3f-81de-148e82ac8578
-    status: 200 OK
-    code: 200
-    duration: 100.008158ms
-- id: 25
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-2/volumes/83613205-86bc-414d-9b2c-62e86df29cc8
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 711
-    body: "{\"id\":\"83613205-86bc-414d-9b2c-62e86df29cc8\", \"name\":\"Ubuntu Jammy GPU OS 12 passthrough_sbs_volume_0\", \"type\":\"sbs_5k\", \"size\":20000000000, \"project_id\":\"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"created_at\":\"2025-12-05T13:09:37.791053Z\", \"updated_at\":\"2025-12-05T13:09:37.791053Z\", \"references\":[{\"id\":\"d76724e8-5f8e-4094-adf6-e49990578dec\", \"product_resource_type\":\"instance_server\", \"product_resource_id\":\"3f0c9280-b4fb-4e58-9dab-df62551756d4\", \"created_at\":\"2025-12-05T13:09:37.791053Z\", \"type\":\"exclusive\", \"status\":\"attached\"}], \"parent_snapshot_id\":\"43d3942a-890e-4bae-b657-a776667db001\", \"status\":\"in_use\", \"tags\":[], \"specs\":{\"perf_iops\":5000, \"class\":\"sbs\"}, \"last_detached_at\":null, \"zone\":\"fr-par-2\"}"
-    headers:
-      Content-Length:
-      - "711"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Dec 2025 13:09:41 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      X-Request-Id:
-      - 044be1c6-0a83-4939-82c2-47dda9cb125f
-    status: 200 OK
-    code: 200
-    duration: 99.255986ms
-- id: 26
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 20
-    host: api.scaleway.com
-    body: "{\"action\":\"poweron\"}"
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/3f0c9280-b4fb-4e58-9dab-df62551756d4/action
-    method: POST
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 357
-    body: "{\"task\": {\"id\": \"68721725-5ecd-4366-a063-b4a53c551d30\", \"description\": \"server_batch_poweron\", \"status\": \"pending\", \"href_from\": \"/servers/3f0c9280-b4fb-4e58-9dab-df62551756d4/action\", \"href_result\": \"/servers/3f0c9280-b4fb-4e58-9dab-df62551756d4\", \"started_at\": \"2025-12-05T13:09:41.324592+00:00\", \"terminated_at\": null, \"progress\": 0, \"zone\": \"fr-par-2\"}}"
-    headers:
-      Content-Length:
-      - "357"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Dec 2025 13:09:41 GMT
-      Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-2/tasks/68721725-5ecd-4366-a063-b4a53c551d30
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      X-Request-Id:
-      - 03c6ece6-30fa-4a8b-b0c6-79ec8237c6b7
-    status: 202 Accepted
-    code: 202
-    duration: 210.778521ms
-- id: 27
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/3f0c9280-b4fb-4e58-9dab-df62551756d4
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 2390
-    body: "{\"server\": {\"id\": \"3f0c9280-b4fb-4e58-9dab-df62551756d4\", \"name\": \"test-acc-server-scratch\", \"arch\": \"x86_64\", \"commercial_type\": \"H100-1-80G\", \"boot_type\": \"local\", \"organization\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"project\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"hostname\": \"test-acc-server-scratch\", \"image\": {\"id\": \"f3431c05-e917-4bf0-b9db-9d4c14716a5e\", \"name\": \"Ubuntu Jammy GPU OS 12 passthrough\", \"organization\": \"51b656e3-4865-41e8-adbc-0c45bdd780db\", \"project\": \"51b656e3-4865-41e8-adbc-0c45bdd780db\", \"root_volume\": {\"volume_type\": \"sbs_snapshot\", \"id\": \"43d3942a-890e-4bae-b657-a776667db001\", \"size\": 0, \"name\": \"\"}, \"extra_volumes\": {}, \"public\": true, \"arch\": \"x86_64\", \"creation_date\": \"2025-10-20T14:33:32.134908+00:00\", \"modification_date\": \"2025-10-20T14:33:32.134908+00:00\", \"default_bootscript\": null, \"from_server\": \"\", \"state\": \"available\", \"tags\": [], \"zone\": \"fr-par-2\"}, \"volumes\": {\"0\": {\"boot\": false, \"volume_type\": \"sbs_volume\", \"id\": \"83613205-86bc-414d-9b2c-62e86df29cc8\", \"state\": \"available\", \"zone\": \"fr-par-2\"}, \"1\": {\"boot\": false, \"id\": \"46673d86-c393-4205-8112-e54064d54310\", \"name\": \"tf-vol-lucid-shannon\", \"volume_type\": \"scratch\", \"organization\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"project\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"server\": {\"id\": \"3f0c9280-b4fb-4e58-9dab-df62551756d4\", \"name\": \"test-acc-server-scratch\"}, \"size\": 20000000000, \"state\": \"available\", \"creation_date\": \"2025-12-05T13:09:36.607979+00:00\", \"modification_date\": \"2025-12-05T13:09:37.688702+00:00\", \"tags\": [], \"zone\": \"fr-par-2\"}}, \"tags\": [\"terraform-test\", \"scaleway_instance_server\", \"scratch\"], \"state\": \"starting\", \"protected\": false, \"state_detail\": \"allocating node\", \"public_ip\": null, \"public_ips\": [], \"mac_address\": \"de:00:00:95:80:cd\", \"routed_ip_enabled\": true, \"ipv6\": null, \"extra_networks\": [], \"dynamic_ip_required\": false, \"enable_ipv6\": false, \"private_ip\": null, \"creation_date\": \"2025-12-05T13:09:37.688702+00:00\", \"modification_date\": \"2025-12-05T13:09:41.173699+00:00\", \"bootscript\": null, \"security_group\": {\"id\": \"22961510-2391-4fc7-83bd-d4c9d2d5c7fd\", \"name\": \"Default security group\"}, \"location\": null, \"maintenances\": [], \"allowed_actions\": [\"stop_in_place\", \"backup\"], \"placement_group\": null, \"private_nics\": [], \"zone\": \"fr-par-2\", \"filesystems\": [], \"end_of_service\": false, \"admin_password_encryption_ssh_key_id\": null}}"
-    headers:
-      Content-Length:
-      - "2390"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Dec 2025 13:09:41 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      X-Request-Id:
-      - 4c64b335-1246-4e8b-8865-43775820ab31
-    status: 200 OK
-    code: 200
-    duration: 94.435306ms
-- id: 28
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/3f0c9280-b4fb-4e58-9dab-df62551756d4
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 2446
-    body: "{\"server\": {\"id\": \"3f0c9280-b4fb-4e58-9dab-df62551756d4\", \"name\": \"test-acc-server-scratch\", \"arch\": \"x86_64\", \"commercial_type\": \"H100-1-80G\", \"boot_type\": \"local\", \"organization\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"project\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"hostname\": \"test-acc-server-scratch\", \"image\": {\"id\": \"f3431c05-e917-4bf0-b9db-9d4c14716a5e\", \"name\": \"Ubuntu Jammy GPU OS 12 passthrough\", \"organization\": \"51b656e3-4865-41e8-adbc-0c45bdd780db\", \"project\": \"51b656e3-4865-41e8-adbc-0c45bdd780db\", \"root_volume\": {\"volume_type\": \"sbs_snapshot\", \"id\": \"43d3942a-890e-4bae-b657-a776667db001\", \"size\": 0, \"name\": \"\"}, \"extra_volumes\": {}, \"public\": true, \"arch\": \"x86_64\", \"creation_date\": \"2025-10-20T14:33:32.134908+00:00\", \"modification_date\": \"2025-10-20T14:33:32.134908+00:00\", \"default_bootscript\": null, \"from_server\": \"\", \"state\": \"available\", \"tags\": [], \"zone\": \"fr-par-2\"}, \"volumes\": {\"0\": {\"boot\": false, \"volume_type\": \"sbs_volume\", \"id\": \"83613205-86bc-414d-9b2c-62e86df29cc8\", \"state\": \"available\", \"zone\": \"fr-par-2\"}, \"1\": {\"boot\": false, \"id\": \"46673d86-c393-4205-8112-e54064d54310\", \"name\": \"tf-vol-lucid-shannon\", \"volume_type\": \"scratch\", \"organization\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"project\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"server\": {\"id\": \"3f0c9280-b4fb-4e58-9dab-df62551756d4\", \"name\": \"test-acc-server-scratch\"}, \"size\": 20000000000, \"state\": \"available\", \"creation_date\": \"2025-12-05T13:09:36.607979+00:00\", \"modification_date\": \"2025-12-05T13:09:37.688702+00:00\", \"tags\": [], \"zone\": \"fr-par-2\"}}, \"tags\": [\"terraform-test\", \"scaleway_instance_server\", \"scratch\"], \"state\": \"starting\", \"protected\": false, \"state_detail\": \"provisioning node\", \"public_ip\": null, \"public_ips\": [], \"mac_address\": \"de:00:00:95:80:cd\", \"routed_ip_enabled\": true, \"ipv6\": null, \"extra_networks\": [], \"dynamic_ip_required\": false, \"enable_ipv6\": false, \"private_ip\": null, \"creation_date\": \"2025-12-05T13:09:37.688702+00:00\", \"modification_date\": \"2025-12-05T13:09:41.173699+00:00\", \"bootscript\": null, \"security_group\": {\"id\": \"22961510-2391-4fc7-83bd-d4c9d2d5c7fd\", \"name\": \"Default security group\"}, \"location\": {\"zone_id\": \"fr-par-2\", \"platform_id\": \"30\", \"cluster_id\": \"39\", \"hypervisor_id\": \"101\", \"node_id\": \"2\"}, \"maintenances\": [], \"allowed_actions\": [\"stop_in_place\", \"backup\"], \"placement_group\": null, \"private_nics\": [], \"zone\": \"fr-par-2\", \"filesystems\": [], \"end_of_service\": false}}"
-    headers:
-      Content-Length:
-      - "2446"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Dec 2025 13:09:46 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      X-Request-Id:
-      - e39d813f-a81e-4871-8128-671e96fbea88
-    status: 200 OK
-    code: 200
-    duration: 216.243516ms
-- id: 29
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/3f0c9280-b4fb-4e58-9dab-df62551756d4
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 2446
-    body: "{\"server\": {\"id\": \"3f0c9280-b4fb-4e58-9dab-df62551756d4\", \"name\": \"test-acc-server-scratch\", \"arch\": \"x86_64\", \"commercial_type\": \"H100-1-80G\", \"boot_type\": \"local\", \"organization\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"project\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"hostname\": \"test-acc-server-scratch\", \"image\": {\"id\": \"f3431c05-e917-4bf0-b9db-9d4c14716a5e\", \"name\": \"Ubuntu Jammy GPU OS 12 passthrough\", \"organization\": \"51b656e3-4865-41e8-adbc-0c45bdd780db\", \"project\": \"51b656e3-4865-41e8-adbc-0c45bdd780db\", \"root_volume\": {\"volume_type\": \"sbs_snapshot\", \"id\": \"43d3942a-890e-4bae-b657-a776667db001\", \"size\": 0, \"name\": \"\"}, \"extra_volumes\": {}, \"public\": true, \"arch\": \"x86_64\", \"creation_date\": \"2025-10-20T14:33:32.134908+00:00\", \"modification_date\": \"2025-10-20T14:33:32.134908+00:00\", \"default_bootscript\": null, \"from_server\": \"\", \"state\": \"available\", \"tags\": [], \"zone\": \"fr-par-2\"}, \"volumes\": {\"0\": {\"boot\": false, \"volume_type\": \"sbs_volume\", \"id\": \"83613205-86bc-414d-9b2c-62e86df29cc8\", \"state\": \"available\", \"zone\": \"fr-par-2\"}, \"1\": {\"boot\": false, \"id\": \"46673d86-c393-4205-8112-e54064d54310\", \"name\": \"tf-vol-lucid-shannon\", \"volume_type\": \"scratch\", \"organization\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"project\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"server\": {\"id\": \"3f0c9280-b4fb-4e58-9dab-df62551756d4\", \"name\": \"test-acc-server-scratch\"}, \"size\": 20000000000, \"state\": \"available\", \"creation_date\": \"2025-12-05T13:09:36.607979+00:00\", \"modification_date\": \"2025-12-05T13:09:37.688702+00:00\", \"tags\": [], \"zone\": \"fr-par-2\"}}, \"tags\": [\"terraform-test\", \"scaleway_instance_server\", \"scratch\"], \"state\": \"starting\", \"protected\": false, \"state_detail\": \"provisioning node\", \"public_ip\": null, \"public_ips\": [], \"mac_address\": \"de:00:00:95:80:cd\", \"routed_ip_enabled\": true, \"ipv6\": null, \"extra_networks\": [], \"dynamic_ip_required\": false, \"enable_ipv6\": false, \"private_ip\": null, \"creation_date\": \"2025-12-05T13:09:37.688702+00:00\", \"modification_date\": \"2025-12-05T13:09:41.173699+00:00\", \"bootscript\": null, \"security_group\": {\"id\": \"22961510-2391-4fc7-83bd-d4c9d2d5c7fd\", \"name\": \"Default security group\"}, \"location\": {\"zone_id\": \"fr-par-2\", \"platform_id\": \"30\", \"cluster_id\": \"39\", \"hypervisor_id\": \"101\", \"node_id\": \"2\"}, \"maintenances\": [], \"allowed_actions\": [\"stop_in_place\", \"backup\"], \"placement_group\": null, \"private_nics\": [], \"zone\": \"fr-par-2\", \"filesystems\": [], \"end_of_service\": false}}"
-    headers:
-      Content-Length:
-      - "2446"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Dec 2025 13:09:51 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      X-Request-Id:
-      - d51feab0-0193-439e-b0f3-4af68810d233
-    status: 200 OK
-    code: 200
-    duration: 110.219816ms
-- id: 30
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/3f0c9280-b4fb-4e58-9dab-df62551756d4
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 2492
-    body: "{\"server\": {\"id\": \"3f0c9280-b4fb-4e58-9dab-df62551756d4\", \"name\": \"test-acc-server-scratch\", \"arch\": \"x86_64\", \"commercial_type\": \"H100-1-80G\", \"boot_type\": \"local\", \"organization\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"project\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"hostname\": \"test-acc-server-scratch\", \"image\": {\"id\": \"f3431c05-e917-4bf0-b9db-9d4c14716a5e\", \"name\": \"Ubuntu Jammy GPU OS 12 passthrough\", \"organization\": \"51b656e3-4865-41e8-adbc-0c45bdd780db\", \"project\": \"51b656e3-4865-41e8-adbc-0c45bdd780db\", \"root_volume\": {\"volume_type\": \"sbs_snapshot\", \"id\": \"43d3942a-890e-4bae-b657-a776667db001\", \"size\": 0, \"name\": \"\"}, \"extra_volumes\": {}, \"public\": true, \"arch\": \"x86_64\", \"creation_date\": \"2025-10-20T14:33:32.134908+00:00\", \"modification_date\": \"2025-10-20T14:33:32.134908+00:00\", \"default_bootscript\": null, \"from_server\": \"\", \"state\": \"available\", \"tags\": [], \"zone\": \"fr-par-2\"}, \"volumes\": {\"0\": {\"boot\": false, \"volume_type\": \"sbs_volume\", \"id\": \"83613205-86bc-414d-9b2c-62e86df29cc8\", \"state\": \"available\", \"zone\": \"fr-par-2\"}, \"1\": {\"boot\": false, \"id\": \"46673d86-c393-4205-8112-e54064d54310\", \"name\": \"tf-vol-lucid-shannon\", \"volume_type\": \"scratch\", \"organization\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"project\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"server\": {\"id\": \"3f0c9280-b4fb-4e58-9dab-df62551756d4\", \"name\": \"test-acc-server-scratch\"}, \"size\": 20000000000, \"state\": \"available\", \"creation_date\": \"2025-12-05T13:09:36.607979+00:00\", \"modification_date\": \"2025-12-05T13:09:37.688702+00:00\", \"tags\": [], \"zone\": \"fr-par-2\"}}, \"tags\": [\"terraform-test\", \"scaleway_instance_server\", \"scratch\"], \"state\": \"starting\", \"protected\": false, \"state_detail\": \"provisioning node\", \"public_ip\": null, \"public_ips\": [], \"mac_address\": \"de:00:00:95:80:cd\", \"routed_ip_enabled\": true, \"ipv6\": null, \"extra_networks\": [], \"dynamic_ip_required\": false, \"enable_ipv6\": false, \"private_ip\": null, \"creation_date\": \"2025-12-05T13:09:37.688702+00:00\", \"modification_date\": \"2025-12-05T13:09:41.173699+00:00\", \"bootscript\": null, \"security_group\": {\"id\": \"22961510-2391-4fc7-83bd-d4c9d2d5c7fd\", \"name\": \"Default security group\"}, \"location\": {\"zone_id\": \"fr-par-2\", \"platform_id\": \"30\", \"cluster_id\": \"39\", \"hypervisor_id\": \"101\", \"node_id\": \"2\"}, \"maintenances\": [], \"allowed_actions\": [\"stop_in_place\", \"backup\"], \"placement_group\": null, \"private_nics\": [], \"zone\": \"fr-par-2\", \"filesystems\": [], \"end_of_service\": false, \"admin_password_encryption_ssh_key_id\": null}}"
-    headers:
-      Content-Length:
-      - "2492"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Dec 2025 13:09:56 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      X-Request-Id:
-      - bc0e0dd8-6cd4-4625-a35f-4afdf3fc7bde
-    status: 200 OK
-    code: 200
-    duration: 97.406343ms
-- id: 31
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/3f0c9280-b4fb-4e58-9dab-df62551756d4
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 2477
-    body: "{\"server\": {\"id\": \"3f0c9280-b4fb-4e58-9dab-df62551756d4\", \"name\": \"test-acc-server-scratch\", \"arch\": \"x86_64\", \"commercial_type\": \"H100-1-80G\", \"boot_type\": \"local\", \"organization\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"project\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"hostname\": \"test-acc-server-scratch\", \"image\": {\"id\": \"f3431c05-e917-4bf0-b9db-9d4c14716a5e\", \"name\": \"Ubuntu Jammy GPU OS 12 passthrough\", \"organization\": \"51b656e3-4865-41e8-adbc-0c45bdd780db\", \"project\": \"51b656e3-4865-41e8-adbc-0c45bdd780db\", \"root_volume\": {\"volume_type\": \"sbs_snapshot\", \"id\": \"43d3942a-890e-4bae-b657-a776667db001\", \"size\": 0, \"name\": \"\"}, \"extra_volumes\": {}, \"public\": true, \"arch\": \"x86_64\", \"creation_date\": \"2025-10-20T14:33:32.134908+00:00\", \"modification_date\": \"2025-10-20T14:33:32.134908+00:00\", \"default_bootscript\": null, \"from_server\": \"\", \"state\": \"available\", \"tags\": [], \"zone\": \"fr-par-2\"}, \"volumes\": {\"0\": {\"boot\": false, \"volume_type\": \"sbs_volume\", \"id\": \"83613205-86bc-414d-9b2c-62e86df29cc8\", \"state\": \"available\", \"zone\": \"fr-par-2\"}, \"1\": {\"boot\": false, \"id\": \"46673d86-c393-4205-8112-e54064d54310\", \"name\": \"tf-vol-lucid-shannon\", \"volume_type\": \"scratch\", \"organization\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"project\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"server\": {\"id\": \"3f0c9280-b4fb-4e58-9dab-df62551756d4\", \"name\": \"test-acc-server-scratch\"}, \"size\": 20000000000, \"state\": \"available\", \"creation_date\": \"2025-12-05T13:09:36.607979+00:00\", \"modification_date\": \"2025-12-05T13:09:37.688702+00:00\", \"tags\": [], \"zone\": \"fr-par-2\"}}, \"tags\": [\"terraform-test\", \"scaleway_instance_server\", \"scratch\"], \"state\": \"running\", \"protected\": false, \"state_detail\": \"booting kernel\", \"public_ip\": null, \"public_ips\": [], \"mac_address\": \"de:00:00:95:80:cd\", \"routed_ip_enabled\": true, \"ipv6\": null, \"extra_networks\": [], \"dynamic_ip_required\": false, \"enable_ipv6\": false, \"private_ip\": null, \"creation_date\": \"2025-12-05T13:09:37.688702+00:00\", \"modification_date\": \"2025-12-05T13:09:58.264779+00:00\", \"bootscript\": null, \"security_group\": {\"id\": \"22961510-2391-4fc7-83bd-d4c9d2d5c7fd\", \"name\": \"Default security group\"}, \"location\": {\"zone_id\": \"fr-par-2\", \"platform_id\": \"30\", \"cluster_id\": \"39\", \"hypervisor_id\": \"101\", \"node_id\": \"2\"}, \"maintenances\": [], \"allowed_actions\": [\"poweroff\", \"terminate\", \"reboot\", \"stop_in_place\", \"backup\"], \"placement_group\": null, \"private_nics\": [], \"zone\": \"fr-par-2\", \"filesystems\": [], \"end_of_service\": false}}"
-    headers:
-      Content-Length:
-      - "2477"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Dec 2025 13:10:01 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      X-Request-Id:
-      - e8a2f6ea-f6eb-44eb-82b6-b450ba29962d
-    status: 200 OK
-    code: 200
-    duration: 103.964911ms
-- id: 32
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 22
-    host: api.scaleway.com
-    body: "{\"action\":\"terminate\"}"
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/3f0c9280-b4fb-4e58-9dab-df62551756d4/action
-    method: POST
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 353
-    body: "{\"task\": {\"id\": \"203a1d8a-2184-481d-b10f-28df4cb728e1\", \"description\": \"server_terminate\", \"status\": \"pending\", \"href_from\": \"/servers/3f0c9280-b4fb-4e58-9dab-df62551756d4/action\", \"href_result\": \"/servers/3f0c9280-b4fb-4e58-9dab-df62551756d4\", \"started_at\": \"2025-12-05T13:10:02.149138+00:00\", \"terminated_at\": null, \"progress\": 0, \"zone\": \"fr-par-2\"}}"
-    headers:
-      Content-Length:
-      - "353"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Dec 2025 13:10:02 GMT
-      Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-2/tasks/203a1d8a-2184-481d-b10f-28df4cb728e1
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      X-Request-Id:
-      - d89dd4d9-9954-4537-b184-2090e09199cf
-    status: 202 Accepted
-    code: 202
-    duration: 184.438034ms
-- id: 33
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/3f0c9280-b4fb-4e58-9dab-df62551756d4
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 2440
-    body: "{\"server\": {\"id\": \"3f0c9280-b4fb-4e58-9dab-df62551756d4\", \"name\": \"test-acc-server-scratch\", \"arch\": \"x86_64\", \"commercial_type\": \"H100-1-80G\", \"boot_type\": \"local\", \"organization\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"project\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"hostname\": \"test-acc-server-scratch\", \"image\": {\"id\": \"f3431c05-e917-4bf0-b9db-9d4c14716a5e\", \"name\": \"Ubuntu Jammy GPU OS 12 passthrough\", \"organization\": \"51b656e3-4865-41e8-adbc-0c45bdd780db\", \"project\": \"51b656e3-4865-41e8-adbc-0c45bdd780db\", \"root_volume\": {\"volume_type\": \"sbs_snapshot\", \"id\": \"43d3942a-890e-4bae-b657-a776667db001\", \"size\": 0, \"name\": \"\"}, \"extra_volumes\": {}, \"public\": true, \"arch\": \"x86_64\", \"creation_date\": \"2025-10-20T14:33:32.134908+00:00\", \"modification_date\": \"2025-10-20T14:33:32.134908+00:00\", \"default_bootscript\": null, \"from_server\": \"\", \"state\": \"available\", \"tags\": [], \"zone\": \"fr-par-2\"}, \"volumes\": {\"0\": {\"boot\": false, \"volume_type\": \"sbs_volume\", \"id\": \"83613205-86bc-414d-9b2c-62e86df29cc8\", \"state\": \"available\", \"zone\": \"fr-par-2\"}, \"1\": {\"boot\": false, \"id\": \"46673d86-c393-4205-8112-e54064d54310\", \"name\": \"tf-vol-lucid-shannon\", \"volume_type\": \"scratch\", \"organization\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"project\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"server\": {\"id\": \"3f0c9280-b4fb-4e58-9dab-df62551756d4\", \"name\": \"test-acc-server-scratch\"}, \"size\": 20000000000, \"state\": \"available\", \"creation_date\": \"2025-12-05T13:09:36.607979+00:00\", \"modification_date\": \"2025-12-05T13:09:37.688702+00:00\", \"tags\": [], \"zone\": \"fr-par-2\"}}, \"tags\": [\"terraform-test\", \"scaleway_instance_server\", \"scratch\"], \"state\": \"stopping\", \"protected\": false, \"state_detail\": \"terminating\", \"public_ip\": null, \"public_ips\": [], \"mac_address\": \"de:00:00:95:80:cd\", \"routed_ip_enabled\": true, \"ipv6\": null, \"extra_networks\": [], \"dynamic_ip_required\": false, \"enable_ipv6\": false, \"private_ip\": null, \"creation_date\": \"2025-12-05T13:09:37.688702+00:00\", \"modification_date\": \"2025-12-05T13:10:02.012305+00:00\", \"bootscript\": null, \"security_group\": {\"id\": \"22961510-2391-4fc7-83bd-d4c9d2d5c7fd\", \"name\": \"Default security group\"}, \"location\": {\"zone_id\": \"fr-par-2\", \"platform_id\": \"30\", \"cluster_id\": \"39\", \"hypervisor_id\": \"101\", \"node_id\": \"2\"}, \"maintenances\": [], \"allowed_actions\": [\"stop_in_place\", \"backup\"], \"placement_group\": null, \"private_nics\": [], \"zone\": \"fr-par-2\", \"filesystems\": [], \"end_of_service\": false}}"
-    headers:
-      Content-Length:
-      - "2440"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Dec 2025 13:10:02 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      X-Request-Id:
-      - 53bc5338-d591-443a-90c9-356f2c0a8890
-    status: 200 OK
-    code: 200
-    duration: 65.100262ms
-- id: 34
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/3f0c9280-b4fb-4e58-9dab-df62551756d4
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 2486
-    body: "{\"server\": {\"id\": \"3f0c9280-b4fb-4e58-9dab-df62551756d4\", \"name\": \"test-acc-server-scratch\", \"arch\": \"x86_64\", \"commercial_type\": \"H100-1-80G\", \"boot_type\": \"local\", \"organization\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"project\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"hostname\": \"test-acc-server-scratch\", \"image\": {\"id\": \"f3431c05-e917-4bf0-b9db-9d4c14716a5e\", \"name\": \"Ubuntu Jammy GPU OS 12 passthrough\", \"organization\": \"51b656e3-4865-41e8-adbc-0c45bdd780db\", \"project\": \"51b656e3-4865-41e8-adbc-0c45bdd780db\", \"root_volume\": {\"volume_type\": \"sbs_snapshot\", \"id\": \"43d3942a-890e-4bae-b657-a776667db001\", \"size\": 0, \"name\": \"\"}, \"extra_volumes\": {}, \"public\": true, \"arch\": \"x86_64\", \"creation_date\": \"2025-10-20T14:33:32.134908+00:00\", \"modification_date\": \"2025-10-20T14:33:32.134908+00:00\", \"default_bootscript\": null, \"from_server\": \"\", \"state\": \"available\", \"tags\": [], \"zone\": \"fr-par-2\"}, \"volumes\": {\"0\": {\"boot\": false, \"volume_type\": \"sbs_volume\", \"id\": \"83613205-86bc-414d-9b2c-62e86df29cc8\", \"state\": \"available\", \"zone\": \"fr-par-2\"}, \"1\": {\"boot\": false, \"id\": \"46673d86-c393-4205-8112-e54064d54310\", \"name\": \"tf-vol-lucid-shannon\", \"volume_type\": \"scratch\", \"organization\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"project\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"server\": {\"id\": \"3f0c9280-b4fb-4e58-9dab-df62551756d4\", \"name\": \"test-acc-server-scratch\"}, \"size\": 20000000000, \"state\": \"available\", \"creation_date\": \"2025-12-05T13:09:36.607979+00:00\", \"modification_date\": \"2025-12-05T13:09:37.688702+00:00\", \"tags\": [], \"zone\": \"fr-par-2\"}}, \"tags\": [\"terraform-test\", \"scaleway_instance_server\", \"scratch\"], \"state\": \"stopping\", \"protected\": false, \"state_detail\": \"terminating\", \"public_ip\": null, \"public_ips\": [], \"mac_address\": \"de:00:00:95:80:cd\", \"routed_ip_enabled\": true, \"ipv6\": null, \"extra_networks\": [], \"dynamic_ip_required\": false, \"enable_ipv6\": false, \"private_ip\": null, \"creation_date\": \"2025-12-05T13:09:37.688702+00:00\", \"modification_date\": \"2025-12-05T13:10:02.012305+00:00\", \"bootscript\": null, \"security_group\": {\"id\": \"22961510-2391-4fc7-83bd-d4c9d2d5c7fd\", \"name\": \"Default security group\"}, \"location\": {\"zone_id\": \"fr-par-2\", \"platform_id\": \"30\", \"cluster_id\": \"39\", \"hypervisor_id\": \"101\", \"node_id\": \"2\"}, \"maintenances\": [], \"allowed_actions\": [\"stop_in_place\", \"backup\"], \"placement_group\": null, \"private_nics\": [], \"zone\": \"fr-par-2\", \"filesystems\": [], \"end_of_service\": false, \"admin_password_encryption_ssh_key_id\": null}}"
-    headers:
-      Content-Length:
-      - "2486"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Dec 2025 13:10:07 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      X-Request-Id:
-      - 3a89d458-b9d2-4f49-a0ef-df5c7cb4524e
-    status: 200 OK
-    code: 200
-    duration: 102.926752ms
-- id: 35
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/3f0c9280-b4fb-4e58-9dab-df62551756d4
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 2440
-    body: "{\"server\": {\"id\": \"3f0c9280-b4fb-4e58-9dab-df62551756d4\", \"name\": \"test-acc-server-scratch\", \"arch\": \"x86_64\", \"commercial_type\": \"H100-1-80G\", \"boot_type\": \"local\", \"organization\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"project\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"hostname\": \"test-acc-server-scratch\", \"image\": {\"id\": \"f3431c05-e917-4bf0-b9db-9d4c14716a5e\", \"name\": \"Ubuntu Jammy GPU OS 12 passthrough\", \"organization\": \"51b656e3-4865-41e8-adbc-0c45bdd780db\", \"project\": \"51b656e3-4865-41e8-adbc-0c45bdd780db\", \"root_volume\": {\"volume_type\": \"sbs_snapshot\", \"id\": \"43d3942a-890e-4bae-b657-a776667db001\", \"size\": 0, \"name\": \"\"}, \"extra_volumes\": {}, \"public\": true, \"arch\": \"x86_64\", \"creation_date\": \"2025-10-20T14:33:32.134908+00:00\", \"modification_date\": \"2025-10-20T14:33:32.134908+00:00\", \"default_bootscript\": null, \"from_server\": \"\", \"state\": \"available\", \"tags\": [], \"zone\": \"fr-par-2\"}, \"volumes\": {\"0\": {\"boot\": false, \"volume_type\": \"sbs_volume\", \"id\": \"83613205-86bc-414d-9b2c-62e86df29cc8\", \"state\": \"available\", \"zone\": \"fr-par-2\"}, \"1\": {\"boot\": false, \"id\": \"46673d86-c393-4205-8112-e54064d54310\", \"name\": \"tf-vol-lucid-shannon\", \"volume_type\": \"scratch\", \"organization\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"project\": \"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"server\": {\"id\": \"3f0c9280-b4fb-4e58-9dab-df62551756d4\", \"name\": \"test-acc-server-scratch\"}, \"size\": 20000000000, \"state\": \"available\", \"creation_date\": \"2025-12-05T13:09:36.607979+00:00\", \"modification_date\": \"2025-12-05T13:09:37.688702+00:00\", \"tags\": [], \"zone\": \"fr-par-2\"}}, \"tags\": [\"terraform-test\", \"scaleway_instance_server\", \"scratch\"], \"state\": \"stopping\", \"protected\": false, \"state_detail\": \"terminating\", \"public_ip\": null, \"public_ips\": [], \"mac_address\": \"de:00:00:95:80:cd\", \"routed_ip_enabled\": true, \"ipv6\": null, \"extra_networks\": [], \"dynamic_ip_required\": false, \"enable_ipv6\": false, \"private_ip\": null, \"creation_date\": \"2025-12-05T13:09:37.688702+00:00\", \"modification_date\": \"2025-12-05T13:10:02.012305+00:00\", \"bootscript\": null, \"security_group\": {\"id\": \"22961510-2391-4fc7-83bd-d4c9d2d5c7fd\", \"name\": \"Default security group\"}, \"location\": {\"zone_id\": \"fr-par-2\", \"platform_id\": \"30\", \"cluster_id\": \"39\", \"hypervisor_id\": \"101\", \"node_id\": \"2\"}, \"maintenances\": [], \"allowed_actions\": [\"stop_in_place\", \"backup\"], \"placement_group\": null, \"private_nics\": [], \"zone\": \"fr-par-2\", \"filesystems\": [], \"end_of_service\": false}}"
-    headers:
-      Content-Length:
-      - "2440"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Dec 2025 13:10:12 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      X-Request-Id:
-      - 22e2144b-e091-4b9b-ad1a-3732468991c7
-    status: 200 OK
-    code: 200
-    duration: 90.086178ms
-- id: 36
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/3f0c9280-b4fb-4e58-9dab-df62551756d4
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 143
-    body: "{\"type\": \"not_found\", \"message\": \"resource is not found\", \"resource\": \"instance_server\", \"resource_id\": \"3f0c9280-b4fb-4e58-9dab-df62551756d4\"}"
-    headers:
-      Content-Length:
-      - "143"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Dec 2025 13:10:17 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      X-Request-Id:
-      - 8e9e4d07-560b-43a4-a9dc-fd52eb961493
-    status: 404 Not Found
-    code: 404
-    duration: 48.785652ms
-- id: 37
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/volumes/83613205-86bc-414d-9b2c-62e86df29cc8
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 143
-    body: "{\"type\": \"not_found\", \"message\": \"resource is not found\", \"resource\": \"instance_volume\", \"resource_id\": \"83613205-86bc-414d-9b2c-62e86df29cc8\"}"
-    headers:
-      Content-Length:
-      - "143"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Dec 2025 13:10:17 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      X-Request-Id:
-      - 50a253e8-ff7c-4477-966a-7fd7416e15f4
-    status: 404 Not Found
-    code: 404
-    duration: 32.727056ms
-- id: 38
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-2/volumes/83613205-86bc-414d-9b2c-62e86df29cc8
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 504
-    body: "{\"id\":\"83613205-86bc-414d-9b2c-62e86df29cc8\", \"name\":\"Ubuntu Jammy GPU OS 12 passthrough_sbs_volume_0\", \"type\":\"sbs_5k\", \"size\":20000000000, \"project_id\":\"fa1e3217-dc80-42ac-85c3-3f034b78b552\", \"created_at\":\"2025-12-05T13:09:37.791053Z\", \"updated_at\":\"2025-12-05T13:10:14.150568Z\", \"references\":[], \"parent_snapshot_id\":\"43d3942a-890e-4bae-b657-a776667db001\", \"status\":\"available\", \"tags\":[], \"specs\":{\"perf_iops\":5000, \"class\":\"sbs\"}, \"last_detached_at\":\"2025-12-05T13:10:14.150568Z\", \"zone\":\"fr-par-2\"}"
-    headers:
-      Content-Length:
-      - "504"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Dec 2025 13:10:17 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      X-Request-Id:
-      - 1e3bfa52-0300-49bd-ba5a-4ec86002bb90
-    status: 200 OK
-    code: 200
-    duration: 48.574837ms
-- id: 39
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-2/volumes/83613205-86bc-414d-9b2c-62e86df29cc8
-    method: DELETE
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 0
-    body: ""
-    headers:
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Dec 2025 13:10:17 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      X-Request-Id:
-      - 0a73907c-0ac3-4efd-a9a5-2f8f44375fba
-    status: 204 No Content
-    code: 204
-    duration: 90.628504ms
-- id: 40
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/volumes/46673d86-c393-4205-8112-e54064d54310
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 143
-    body: "{\"type\": \"not_found\", \"message\": \"resource is not found\", \"resource\": \"instance_volume\", \"resource_id\": \"46673d86-c393-4205-8112-e54064d54310\"}"
-    headers:
-      Content-Length:
-      - "143"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Dec 2025 13:10:17 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      X-Request-Id:
-      - c84bfeea-7cb3-4f22-bb1e-7de73764ff3b
-    status: 404 Not Found
-    code: 404
-    duration: 26.585157ms
-- id: 41
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/3f0c9280-b4fb-4e58-9dab-df62551756d4
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 143
-    body: "{\"type\": \"not_found\", \"message\": \"resource is not found\", \"resource\": \"instance_server\", \"resource_id\": \"3f0c9280-b4fb-4e58-9dab-df62551756d4\"}"
-    headers:
-      Content-Length:
-      - "143"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Dec 2025 13:10:17 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      X-Request-Id:
-      - 1c287e52-824d-475a-a4c4-bdac18b071a5
-    status: 404 Not Found
-    code: 404
-    duration: 52.905118ms
-- id: 42
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/volumes/46673d86-c393-4205-8112-e54064d54310
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 143
-    body: "{\"type\": \"not_found\", \"message\": \"resource is not found\", \"resource\": \"instance_volume\", \"resource_id\": \"46673d86-c393-4205-8112-e54064d54310\"}"
-    headers:
-      Content-Length:
-      - "143"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Dec 2025 13:10:17 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      X-Request-Id:
-      - cc16a422-4770-47b6-8520-8d2529e3d0a5
-    status: 404 Not Found
-    code: 404
-    duration: 25.330635ms
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 124
+        host: api.scaleway.com
+        body: '{"name":"tf-vol-serene-moore","project":"105bdce1-64c0-48ab-899d-868455867ecf","volume_type":"scratch","size":1600000000000}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/volumes
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 445
+        body: '{"volume": {"id": "2f460ab5-ddc6-4992-b98e-01451bd69af6", "name": "tf-vol-serene-moore", "volume_type": "scratch", "export_uri": null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf", "server": null, "size": 1600000000000, "state": "available", "creation_date": "2026-01-13T13:41:49.344351+00:00", "modification_date": "2026-01-13T13:41:49.344351+00:00", "tags": [], "zone": "fr-par-2"}}'
+        headers:
+            Content-Length:
+                - "445"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 13 Jan 2026 13:41:49 GMT
+            Location:
+                - https://api.scaleway.com/instance/v1/zones/fr-par-2/volumes/2f460ab5-ddc6-4992-b98e-01451bd69af6
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 2ccfe761-a555-4500-b423-8e258b6aaa2a
+        status: 201 Created
+        code: 201
+        duration: 221.500275ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/volumes/2f460ab5-ddc6-4992-b98e-01451bd69af6
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 445
+        body: '{"volume": {"id": "2f460ab5-ddc6-4992-b98e-01451bd69af6", "name": "tf-vol-serene-moore", "volume_type": "scratch", "export_uri": null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf", "server": null, "size": 1600000000000, "state": "available", "creation_date": "2026-01-13T13:41:49.344351+00:00", "modification_date": "2026-01-13T13:41:49.344351+00:00", "tags": [], "zone": "fr-par-2"}}'
+        headers:
+            Content-Length:
+                - "445"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 13 Jan 2026 13:41:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 28ab061a-9ac6-4b4d-9daf-0cb3da41a611
+        status: 200 OK
+        code: 200
+        duration: 98.906627ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/volumes/2f460ab5-ddc6-4992-b98e-01451bd69af6
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 445
+        body: '{"volume": {"id": "2f460ab5-ddc6-4992-b98e-01451bd69af6", "name": "tf-vol-serene-moore", "volume_type": "scratch", "export_uri": null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf", "server": null, "size": 1600000000000, "state": "available", "creation_date": "2026-01-13T13:41:49.344351+00:00", "modification_date": "2026-01-13T13:41:49.344351+00:00", "tags": [], "zone": "fr-par-2"}}'
+        headers:
+            Content-Length:
+                - "445"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 13 Jan 2026 13:41:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 032e63b4-5b5c-48ac-8324-d75dc12c322b
+        status: 200 OK
+        code: 200
+        duration: 101.976765ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/products/servers?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 42203
+        body: '{"servers": {"B300-SXM-8-288G": {"alt_names": [], "arch": "x86_64", "ncpus": 224, "ram": 4123168604160, "gpu": 8, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "B300-SXM", "gpu_memory": 309237645312}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 24000000000000, "scratch_storage_max_volumes_count": 1, "monthly_price": 43800.0, "hourly_price": 60.0, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 20000000000, "sum_internet_bandwidth": 20000000000, "interfaces": [{"internal_bandwidth": 20000000000, "internet_bandwidth": 20000000000}]}, "block_bandwidth": 5242880000, "end_of_service": false}, "BASIC2-A16C-32G": {"alt_names": [], "arch": "arm64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 150.89, "hourly_price": 0.2067, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 503316480, "end_of_service": false}, "BASIC2-A16C-64G": {"alt_names": [], "arch": "arm64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 201.19, "hourly_price": 0.2756, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 503316480, "end_of_service": false}, "BASIC2-A2C-4G": {"alt_names": [], "arch": "arm64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 16.79, "hourly_price": 0.023, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 83886080, "end_of_service": false}, "BASIC2-A2C-8G": {"alt_names": [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 25.19, "hourly_price": 0.0345, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 83886080, "end_of_service": false}, "BASIC2-A4C-16G": {"alt_names": [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 50.3, "hourly_price": 0.0689, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 125829120, "end_of_service": false}, "BASIC2-A4C-8G": {"alt_names": [], "arch": "arm64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 37.74, "hourly_price": 0.0517, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 125829120, "end_of_service": false}, "BASIC2-A8C-16G": {"alt_names": [], "arch": "arm64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 75.48, "hourly_price": 0.1034, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 251658240, "end_of_service": false}, "BASIC2-A8C-32G": {"alt_names": [], "arch": "arm64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 100.59, "hourly_price": 0.1378, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 251658240, "end_of_service": false}, "COPARM1-16C-64G": {"alt_names": [], "arch": "arm64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 252.14, "hourly_price": 0.3454, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 671088640, "end_of_service": false}, "COPARM1-2C-8G": {"alt_names": [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 31.1, "hourly_price": 0.0426, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 83886080, "end_of_service": false}, "COPARM1-32C-128G": {"alt_names": [], "arch": "arm64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 506.26, "hourly_price": 0.6935, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 1342177280, "end_of_service": false}, "COPARM1-4C-16G": {"alt_names": [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 62.56, "hourly_price": 0.0857, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 167772160, "end_of_service": false}, "COPARM1-8C-32G": {"alt_names": [], "arch": "arm64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 125.85, "hourly_price": 0.1724, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 335544320, "end_of_service": false}, "DEV1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 80000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 30.66, "hourly_price": 0.042, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 209715200, "end_of_service": false}, "DEV1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 3, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 40000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 14.454, "hourly_price": 0.0198, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 300000000, "sum_internet_bandwidth": 300000000, "interfaces": [{"internal_bandwidth": 300000000, "internet_bandwidth": 300000000}]}, "block_bandwidth": 157286400, "end_of_service": false}, "DEV1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 20000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 6.424, "hourly_price": 0.0088, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 104857600, "end_of_service": false}, "DEV1-XL": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 12884901888, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 120000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 46.5734, "hourly_price": 0.06378, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 262144000, "end_of_service": false}, "GP1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 554.07, "hourly_price": 0.759, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]}, "block_bandwidth": 1073741824, "end_of_service": false}, "GP1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 274.48, "hourly_price": 0.376, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "GP1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 300000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 136.51, "hourly_price": 0.187, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 524288000, "end_of_service": false}, "GP1-XL": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1197.93, "hourly_price": 1.641, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]}, "block_bandwidth": 2147483648, "end_of_service": false}, "GP1-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 150000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 66.43, "hourly_price": 0.091, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 314572800, "end_of_service": false}, "GPU-3070-S": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 17179869184, "gpu": 1, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "RTX-3070", "gpu_memory": 8589934592}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 715.4, "hourly_price": 0.98, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 2500000000, "sum_internet_bandwidth": 2500000000, "interfaces": [{"internal_bandwidth": 2500000000, "internet_bandwidth": 2500000000}]}, "block_bandwidth": 1048576000, "end_of_service": false}, "H100-1-80G": {"alt_names": [], "arch": "x86_64", "ncpus": 24, "ram": 257698037760, "gpu": 1, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "H100-PCIe", "gpu_memory": 85899345920}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 3000000000000, "scratch_storage_max_volumes_count": 1, "monthly_price": 1992.9, "hourly_price": 2.73, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]}, "block_bandwidth": 2097152000, "end_of_service": false}, "H100-1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 24, "ram": 257698037760, "gpu": 1, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "H100-PCIe", "gpu_memory": 85899345920}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 3000000000000, "scratch_storage_max_volumes_count": 1, "monthly_price": 3066.0, "hourly_price": 4.2, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]}, "block_bandwidth": 2097152000, "end_of_service": false}, "H100-2-80G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 515396075520, "gpu": 2, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "H100-PCIe", "gpu_memory": 85899345920}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 6000000000000, "scratch_storage_max_volumes_count": 1, "monthly_price": 3985.8, "hourly_price": 5.46, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 20000000000, "sum_internet_bandwidth": 20000000000, "interfaces": [{"internal_bandwidth": 20000000000, "internet_bandwidth": 20000000000}]}, "block_bandwidth": 4194304000, "end_of_service": false}, "H100-2-M": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 515396075520, "gpu": 2, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "H100-PCIe", "gpu_memory": 85899345920}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 6000000000000, "scratch_storage_max_volumes_count": 1, "monthly_price": 6132.0, "hourly_price": 8.4, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 20000000000, "sum_internet_bandwidth": 20000000000, "interfaces": [{"internal_bandwidth": 20000000000, "internet_bandwidth": 20000000000}]}, "block_bandwidth": 4194304000, "end_of_service": false}, "H100-SXM-2-80G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 257698037760, "gpu": 2, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "H100-SXM", "gpu_memory": 85899345920}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 3200000000000, "scratch_storage_max_volumes_count": 1, "monthly_price": 4393.14, "hourly_price": 6.018, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 20000000000, "sum_internet_bandwidth": 20000000000, "interfaces": [{"internal_bandwidth": 20000000000, "internet_bandwidth": 20000000000}]}, "block_bandwidth": 5242880000, "end_of_service": false}, "H100-SXM-4-80G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 515396075520, "gpu": 4, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "H100-SXM", "gpu_memory": 85899345920}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 6400000000000, "scratch_storage_max_volumes_count": 1, "monthly_price": 8475.3, "hourly_price": 11.61, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 20000000000, "sum_internet_bandwidth": 20000000000, "interfaces": [{"internal_bandwidth": 20000000000, "internet_bandwidth": 20000000000}]}, "block_bandwidth": 5242880000, "end_of_service": false}, "H100-SXM-8-80G": {"alt_names": [], "arch": "x86_64", "ncpus": 128, "ram": 1030792151040, "gpu": 8, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "H100-SXM", "gpu_memory": 85899345920}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 12800000000000, "scratch_storage_max_volumes_count": 1, "monthly_price": 16810.44, "hourly_price": 23.028, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 20000000000, "sum_internet_bandwidth": 20000000000, "interfaces": [{"internal_bandwidth": 20000000000, "internet_bandwidth": 20000000000}]}, "block_bandwidth": 5242880000, "end_of_service": false}, "L4-1-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 51539607552, "gpu": 1, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 547.5, "hourly_price": 0.75, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 2500000000, "sum_internet_bandwidth": 2500000000, "interfaces": [{"internal_bandwidth": 2500000000, "internet_bandwidth": 2500000000}]}, "block_bandwidth": 1048576000, "end_of_service": false}, "L4-2-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 103079215104, "gpu": 2, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1095.0, "hourly_price": 1.5, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]}, "block_bandwidth": 1572864000, "end_of_service": false}, "L4-4-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 206158430208, "gpu": 4, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 2190.0, "hourly_price": 3.0, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]}, "block_bandwidth": 2621440000, "end_of_service": false}, "L4-8-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 412316860416, "gpu": 8, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 4380.0, "hourly_price": 6.0, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 20000000000, "sum_internet_bandwidth": 20000000000, "interfaces": [{"internal_bandwidth": 20000000000, "internet_bandwidth": 20000000000}]}, "block_bandwidth": 5242880000, "end_of_service": false}, "L40S-1-48G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 103079215104, "gpu": 1, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L40S", "gpu_memory": 51539607552}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 1600000000000, "scratch_storage_max_volumes_count": 1, "monthly_price": 1022.0, "hourly_price": 1.4, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 2500000000, "sum_internet_bandwidth": 2500000000, "interfaces": [{"internal_bandwidth": 2500000000, "internet_bandwidth": 2500000000}]}, "block_bandwidth": 1048576000, "end_of_service": false}, "L40S-2-48G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 206158430208, "gpu": 2, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L40S", "gpu_memory": 51539607552}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 3200000000000, "scratch_storage_max_volumes_count": 1, "monthly_price": 2044.0, "hourly_price": 2.8, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]}, "block_bandwidth": 1572864000, "end_of_service": false}, "L40S-4-48G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 412316860416, "gpu": 4, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L40S", "gpu_memory": 51539607552}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 6400000000000, "scratch_storage_max_volumes_count": 1, "monthly_price": 4088.0, "hourly_price": 5.6, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]}, "block_bandwidth": 2621440000, "end_of_service": false}, "L40S-8-48G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 824633720832, "gpu": 8, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L40S", "gpu_memory": 51539607552}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 12800000000000, "scratch_storage_max_volumes_count": 1, "monthly_price": 8176.0, "hourly_price": 11.2, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 20000000000, "sum_internet_bandwidth": 20000000000, "interfaces": [{"internal_bandwidth": 20000000000, "internet_bandwidth": 20000000000}]}, "block_bandwidth": 5242880000, "end_of_service": false}, "PLAY2-MICRO": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 39.42, "hourly_price": 0.054, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 167772160, "end_of_service": false}, "PLAY2-NANO": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 19.71, "hourly_price": 0.027, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 83886080, "end_of_service": false}, "PLAY2-PICO": {"alt_names": [], "arch": "x86_64", "ncpus": 1, "ram": 2147483648, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 10.22, "hourly_price": 0.014, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]}, "block_bandwidth": 41943040, "end_of_service": false}, "POP2-16C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 430.7, "hourly_price": 0.59, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-16C-64G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1063.391, "hourly_price": 1.4567, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-2C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 53.66, "hourly_price": 0.0735, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-2C-8G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 133.079, "hourly_price": 0.1823, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-32C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 861.4, "hourly_price": 1.18, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-32C-128G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 2126.709, "hourly_price": 2.9133, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-48C-192G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1274.4, "hourly_price": 1.77, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-4C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 107.31, "hourly_price": 0.147, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}}}'
+        headers:
+            Content-Length:
+                - "42203"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 13 Jan 2026 13:41:49 GMT
+            Link:
+                - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - df8661f7-2a9b-4d3a-80fb-363549c76d07
+            X-Total-Count:
+                - "77"
+        status: 200 OK
+        code: 200
+        duration: 70.162544ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "2"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/products/servers?page=2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 22045
+        body: '{"servers": {"POP2-4C-16G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 265.501, "hourly_price": 0.3637, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-64C-256G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1715.5, "hourly_price": 2.35, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-8C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 211.7, "hourly_price": 0.29, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-8C-32G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 528.009, "hourly_price": 0.7233, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HC-16C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 310.69, "hourly_price": 0.4256, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-HC-2C-4G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 38.84, "hourly_price": 0.0532, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HC-32C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 621.38, "hourly_price": 0.8512, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HC-48C-96G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 103079215104, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 914.4, "hourly_price": 1.27, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HC-4C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 77.67, "hourly_price": 0.1064, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HC-64C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1242.75, "hourly_price": 1.7024, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HC-8C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 155.34, "hourly_price": 0.2128, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HM-16C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 601.52, "hourly_price": 0.824, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-HM-2C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 75.19, "hourly_price": 0.103, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HM-32C-256G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1203.04, "hourly_price": 1.648, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HM-48C-384G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 412316860416, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1778.4, "hourly_price": 2.47, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HM-4C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 150.38, "hourly_price": 0.206, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HM-64C-512G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 549755813888, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 2406.08, "hourly_price": 3.296, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HM-8C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 300.76, "hourly_price": 0.412, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HN-10": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 530.29, "hourly_price": 0.7264, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HN-3": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 186.49, "hourly_price": 0.2554, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HN-5": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 330.29, "hourly_price": 0.4524, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "PRO2-L": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 640.21, "hourly_price": 0.877, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6000000000, "sum_internet_bandwidth": 6000000000, "interfaces": [{"internal_bandwidth": 6000000000, "internet_bandwidth": 6000000000}]}, "block_bandwidth": 2097152000, "end_of_service": false}, "PRO2-M": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 319.74, "hourly_price": 0.438, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]}, "block_bandwidth": 1048576000, "end_of_service": false}, "PRO2-S": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 159.87, "hourly_price": 0.219, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]}, "block_bandwidth": 524288000, "end_of_service": false}, "PRO2-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 80.3, "hourly_price": 0.11, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth": 700000000, "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth": 700000000}]}, "block_bandwidth": 262144000, "end_of_service": false}, "PRO2-XXS": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 40.15, "hourly_price": 0.055, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth": 350000000, "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth": 350000000}]}, "block_bandwidth": 131072000, "end_of_service": false}, "RENDER-S": {"alt_names": [], "arch": "x86_64", "ncpus": 10, "ram": 45097156608, "gpu": 1, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "P100", "gpu_memory": 17179869184}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 400000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 891.33, "hourly_price": 1.221, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 2000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth": 2000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 2147483648, "end_of_service": false}}}'
+        headers:
+            Content-Length:
+                - "22045"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 13 Jan 2026 13:41:49 GMT
+            Link:
+                - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>; rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - a8857b47-9f1f-4dda-abf0-3f0e089084d2
+            X-Total-Count:
+                - "77"
+        status: 200 OK
+        code: 200
+        duration: 52.125179ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/volumes/2f460ab5-ddc6-4992-b98e-01451bd69af6
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 445
+        body: '{"volume": {"id": "2f460ab5-ddc6-4992-b98e-01451bd69af6", "name": "tf-vol-serene-moore", "volume_type": "scratch", "export_uri": null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf", "server": null, "size": 1600000000000, "state": "available", "creation_date": "2026-01-13T13:41:49.344351+00:00", "modification_date": "2026-01-13T13:41:49.344351+00:00", "tags": [], "zone": "fr-par-2"}}'
+        headers:
+            Content-Length:
+                - "445"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 13 Jan 2026 13:41:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 00eb7a62-2275-4934-b5bd-38222f9d6fcb
+        status: 200 OK
+        code: 200
+        duration: 88.752165ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            image_label:
+                - ubuntu_jammy_gpu_os_12
+            order_by:
+                - type_asc
+            type:
+                - instance_sbs
+            zone:
+                - fr-par-2
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_jammy_gpu_os_12&order_by=type_asc&type=instance_sbs&zone=fr-par-2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 536
+        body: '{"local_images":[{"id":"f3431c05-e917-4bf0-b9db-9d4c14716a5e", "arch":"x86_64", "zone":"fr-par-2", "compatible_commercial_types":["L4-1-24G", "L4-2-24G", "L4-4-24G", "L4-8-24G", "L40S-1-48G", "L40S-2-48G", "L40S-4-48G", "L40S-8-48G", "RENDER-S", "GPU-3070-S", "H100-1-M", "H100-2-M", "H100-1-80G", "H100-2-80G", "H100-SXM-1-80G", "H100-SXM-2-80G", "H100-SXM-4-80G", "H100-SXM-8-80G", "B300-SXM-1-288G", "B300-SXM-2-288G", "B300-SXM-4-288G", "B300-SXM-8-288G"], "label":"ubuntu_jammy_gpu_os_12", "type":"instance_sbs"}], "total_count":1}'
+        headers:
+            Content-Length:
+                - "536"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 13 Jan 2026 13:41:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 1ad0653e-ff06-4e5a-9da5-55606e6ae69b
+        status: 200 OK
+        code: 200
+        duration: 52.34995ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 382
+        host: api.scaleway.com
+        body: '{"name":"test-acc-server-scratch","dynamic_ip_required":false,"commercial_type":"L40S-1-48G","image":"f3431c05-e917-4bf0-b9db-9d4c14716a5e","volumes":{"0":{"boot":false},"1":{"id":"2f460ab5-ddc6-4992-b98e-01451bd69af6","name":"tf-vol-serene-moore"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":["terraform-test","scaleway_instance_server","scratch"]}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 2414
+        body: '{"server": {"id": "a42e3a68-6562-42d1-98e7-c5b50180d8c2", "name": "test-acc-server-scratch", "arch": "x86_64", "commercial_type": "L40S-1-48G", "boot_type": "local", "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf", "hostname": "test-acc-server-scratch", "image": {"id": "f3431c05-e917-4bf0-b9db-9d4c14716a5e", "name": "Ubuntu Jammy GPU OS 12 passthrough", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "43d3942a-890e-4bae-b657-a776667db001", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-10-20T14:33:32.134908+00:00", "modification_date": "2025-10-20T14:33:32.134908+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-2"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "f091a98e-364d-4132-9f80-8adee7c8ae70", "state": "available", "zone": "fr-par-2"}, "1": {"boot": false, "id": "2f460ab5-ddc6-4992-b98e-01451bd69af6", "name": "tf-vol-serene-moore", "volume_type": "scratch", "export_uri": null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf", "server": {"id": "a42e3a68-6562-42d1-98e7-c5b50180d8c2", "name": "test-acc-server-scratch"}, "size": 1600000000000, "state": "available", "creation_date": "2026-01-13T13:41:49.344351+00:00", "modification_date": "2026-01-13T13:41:50.438626+00:00", "tags": [], "zone": "fr-par-2"}}, "tags": ["terraform-test", "scaleway_instance_server", "scratch"], "state": "stopped", "protected": false, "state_detail": "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:9d:6f:f7", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": false, "enable_ipv6": false, "private_ip": null, "creation_date": "2026-01-13T13:41:50.438626+00:00", "modification_date": "2026-01-13T13:41:50.438626+00:00", "bootscript": null, "security_group": {"id": "eaabb9f4-fbdf-4310-9cb6-4d42934b673a", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-2", "filesystems": [], "end_of_service": false, "dns": "a42e3a68-6562-42d1-98e7-c5b50180d8c2.pub.instances.scw.cloud"}}'
+        headers:
+            Content-Length:
+                - "2414"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 13 Jan 2026 13:41:50 GMT
+            Location:
+                - https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/a42e3a68-6562-42d1-98e7-c5b50180d8c2
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 466228b9-e954-4803-98cf-7e66131633be
+        status: 201 Created
+        code: 201
+        duration: 1.06179399s
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/a42e3a68-6562-42d1-98e7-c5b50180d8c2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 2414
+        body: '{"server": {"id": "a42e3a68-6562-42d1-98e7-c5b50180d8c2", "name": "test-acc-server-scratch", "arch": "x86_64", "commercial_type": "L40S-1-48G", "boot_type": "local", "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf", "hostname": "test-acc-server-scratch", "image": {"id": "f3431c05-e917-4bf0-b9db-9d4c14716a5e", "name": "Ubuntu Jammy GPU OS 12 passthrough", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "43d3942a-890e-4bae-b657-a776667db001", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-10-20T14:33:32.134908+00:00", "modification_date": "2025-10-20T14:33:32.134908+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-2"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "f091a98e-364d-4132-9f80-8adee7c8ae70", "state": "available", "zone": "fr-par-2"}, "1": {"boot": false, "id": "2f460ab5-ddc6-4992-b98e-01451bd69af6", "name": "tf-vol-serene-moore", "volume_type": "scratch", "export_uri": null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf", "server": {"id": "a42e3a68-6562-42d1-98e7-c5b50180d8c2", "name": "test-acc-server-scratch"}, "size": 1600000000000, "state": "available", "creation_date": "2026-01-13T13:41:49.344351+00:00", "modification_date": "2026-01-13T13:41:50.438626+00:00", "tags": [], "zone": "fr-par-2"}}, "tags": ["terraform-test", "scaleway_instance_server", "scratch"], "state": "stopped", "protected": false, "state_detail": "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:9d:6f:f7", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": false, "enable_ipv6": false, "private_ip": null, "creation_date": "2026-01-13T13:41:50.438626+00:00", "modification_date": "2026-01-13T13:41:50.438626+00:00", "bootscript": null, "security_group": {"id": "eaabb9f4-fbdf-4310-9cb6-4d42934b673a", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-2", "filesystems": [], "end_of_service": false, "dns": "a42e3a68-6562-42d1-98e7-c5b50180d8c2.pub.instances.scw.cloud"}}'
+        headers:
+            Content-Length:
+                - "2414"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 13 Jan 2026 13:41:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - bf8a0a69-ce6f-4285-bfbd-22ec62126901
+        status: 200 OK
+        code: 200
+        duration: 158.167889ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/a42e3a68-6562-42d1-98e7-c5b50180d8c2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 2414
+        body: '{"server": {"id": "a42e3a68-6562-42d1-98e7-c5b50180d8c2", "name": "test-acc-server-scratch", "arch": "x86_64", "commercial_type": "L40S-1-48G", "boot_type": "local", "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf", "hostname": "test-acc-server-scratch", "image": {"id": "f3431c05-e917-4bf0-b9db-9d4c14716a5e", "name": "Ubuntu Jammy GPU OS 12 passthrough", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "43d3942a-890e-4bae-b657-a776667db001", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-10-20T14:33:32.134908+00:00", "modification_date": "2025-10-20T14:33:32.134908+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-2"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "f091a98e-364d-4132-9f80-8adee7c8ae70", "state": "available", "zone": "fr-par-2"}, "1": {"boot": false, "id": "2f460ab5-ddc6-4992-b98e-01451bd69af6", "name": "tf-vol-serene-moore", "volume_type": "scratch", "export_uri": null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf", "server": {"id": "a42e3a68-6562-42d1-98e7-c5b50180d8c2", "name": "test-acc-server-scratch"}, "size": 1600000000000, "state": "available", "creation_date": "2026-01-13T13:41:49.344351+00:00", "modification_date": "2026-01-13T13:41:50.438626+00:00", "tags": [], "zone": "fr-par-2"}}, "tags": ["terraform-test", "scaleway_instance_server", "scratch"], "state": "stopped", "protected": false, "state_detail": "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:9d:6f:f7", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": false, "enable_ipv6": false, "private_ip": null, "creation_date": "2026-01-13T13:41:50.438626+00:00", "modification_date": "2026-01-13T13:41:50.438626+00:00", "bootscript": null, "security_group": {"id": "eaabb9f4-fbdf-4310-9cb6-4d42934b673a", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-2", "filesystems": [], "end_of_service": false, "dns": "a42e3a68-6562-42d1-98e7-c5b50180d8c2.pub.instances.scw.cloud"}}'
+        headers:
+            Content-Length:
+                - "2414"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 13 Jan 2026 13:41:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 9f0263b6-db14-442d-881b-af093e158527
+        status: 200 OK
+        code: 200
+        duration: 168.099313ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/a42e3a68-6562-42d1-98e7-c5b50180d8c2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 2414
+        body: '{"server": {"id": "a42e3a68-6562-42d1-98e7-c5b50180d8c2", "name": "test-acc-server-scratch", "arch": "x86_64", "commercial_type": "L40S-1-48G", "boot_type": "local", "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf", "hostname": "test-acc-server-scratch", "image": {"id": "f3431c05-e917-4bf0-b9db-9d4c14716a5e", "name": "Ubuntu Jammy GPU OS 12 passthrough", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "43d3942a-890e-4bae-b657-a776667db001", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-10-20T14:33:32.134908+00:00", "modification_date": "2025-10-20T14:33:32.134908+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-2"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "f091a98e-364d-4132-9f80-8adee7c8ae70", "state": "available", "zone": "fr-par-2"}, "1": {"boot": false, "id": "2f460ab5-ddc6-4992-b98e-01451bd69af6", "name": "tf-vol-serene-moore", "volume_type": "scratch", "export_uri": null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf", "server": {"id": "a42e3a68-6562-42d1-98e7-c5b50180d8c2", "name": "test-acc-server-scratch"}, "size": 1600000000000, "state": "available", "creation_date": "2026-01-13T13:41:49.344351+00:00", "modification_date": "2026-01-13T13:41:50.438626+00:00", "tags": [], "zone": "fr-par-2"}}, "tags": ["terraform-test", "scaleway_instance_server", "scratch"], "state": "stopped", "protected": false, "state_detail": "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:9d:6f:f7", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": false, "enable_ipv6": false, "private_ip": null, "creation_date": "2026-01-13T13:41:50.438626+00:00", "modification_date": "2026-01-13T13:41:50.438626+00:00", "bootscript": null, "security_group": {"id": "eaabb9f4-fbdf-4310-9cb6-4d42934b673a", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-2", "filesystems": [], "end_of_service": false, "dns": "a42e3a68-6562-42d1-98e7-c5b50180d8c2.pub.instances.scw.cloud"}}'
+        headers:
+            Content-Length:
+                - "2414"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 13 Jan 2026 13:41:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 7f339edc-32dc-47a5-ad99-0578ecccb2fd
+        status: 200 OK
+        code: 200
+        duration: 132.413862ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/volumes/f091a98e-364d-4132-9f80-8adee7c8ae70
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 143
+        body: '{"type": "not_found", "message": "resource is not found", "resource": "instance_volume", "resource_id": "f091a98e-364d-4132-9f80-8adee7c8ae70"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 13 Jan 2026 13:41:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - e387214e-be2c-43dd-acc9-0eb1064e90d9
+        status: 404 Not Found
+        code: 404
+        duration: 27.62781ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-2/volumes/f091a98e-364d-4132-9f80-8adee7c8ae70
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 711
+        body: '{"id":"f091a98e-364d-4132-9f80-8adee7c8ae70", "name":"Ubuntu Jammy GPU OS 12 passthrough_sbs_volume_0", "type":"sbs_5k", "size":20000000000, "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "created_at":"2026-01-13T13:41:50.617692Z", "updated_at":"2026-01-13T13:41:50.617692Z", "references":[{"id":"e671814a-f6bb-4b07-a501-5a3fd4a356be", "product_resource_type":"instance_server", "product_resource_id":"a42e3a68-6562-42d1-98e7-c5b50180d8c2", "created_at":"2026-01-13T13:41:50.617692Z", "type":"exclusive", "status":"attached"}], "parent_snapshot_id":"43d3942a-890e-4bae-b657-a776667db001", "status":"in_use", "tags":[], "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-2"}'
+        headers:
+            Content-Length:
+                - "711"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 13 Jan 2026 13:41:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - c33674b4-db83-4924-97ba-47bdd03c3b27
+        status: 200 OK
+        code: 200
+        duration: 88.656446ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/a42e3a68-6562-42d1-98e7-c5b50180d8c2/user_data
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 17
+        body: '{"user_data": []}'
+        headers:
+            Content-Length:
+                - "17"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 13 Jan 2026 13:41:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 7ade0118-513c-469e-8bfa-230268d087c1
+        status: 200 OK
+        code: 200
+        duration: 112.786807ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/a42e3a68-6562-42d1-98e7-c5b50180d8c2/private_nics
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 20
+        body: '{"private_nics": []}'
+        headers:
+            Content-Length:
+                - "20"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 13 Jan 2026 13:41:51 GMT
+            Link:
+                - </servers/a42e3a68-6562-42d1-98e7-c5b50180d8c2/private_nics?page=0&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 68f3eb5d-cb1e-40ef-831d-0c1c0f186412
+            X-Total-Count:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 105.515421ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/a42e3a68-6562-42d1-98e7-c5b50180d8c2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 2414
+        body: '{"server": {"id": "a42e3a68-6562-42d1-98e7-c5b50180d8c2", "name": "test-acc-server-scratch", "arch": "x86_64", "commercial_type": "L40S-1-48G", "boot_type": "local", "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf", "hostname": "test-acc-server-scratch", "image": {"id": "f3431c05-e917-4bf0-b9db-9d4c14716a5e", "name": "Ubuntu Jammy GPU OS 12 passthrough", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "43d3942a-890e-4bae-b657-a776667db001", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-10-20T14:33:32.134908+00:00", "modification_date": "2025-10-20T14:33:32.134908+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-2"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "f091a98e-364d-4132-9f80-8adee7c8ae70", "state": "available", "zone": "fr-par-2"}, "1": {"boot": false, "id": "2f460ab5-ddc6-4992-b98e-01451bd69af6", "name": "tf-vol-serene-moore", "volume_type": "scratch", "export_uri": null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf", "server": {"id": "a42e3a68-6562-42d1-98e7-c5b50180d8c2", "name": "test-acc-server-scratch"}, "size": 1600000000000, "state": "available", "creation_date": "2026-01-13T13:41:49.344351+00:00", "modification_date": "2026-01-13T13:41:50.438626+00:00", "tags": [], "zone": "fr-par-2"}}, "tags": ["terraform-test", "scaleway_instance_server", "scratch"], "state": "stopped", "protected": false, "state_detail": "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:9d:6f:f7", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": false, "enable_ipv6": false, "private_ip": null, "creation_date": "2026-01-13T13:41:50.438626+00:00", "modification_date": "2026-01-13T13:41:50.438626+00:00", "bootscript": null, "security_group": {"id": "eaabb9f4-fbdf-4310-9cb6-4d42934b673a", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-2", "filesystems": [], "end_of_service": false, "dns": "a42e3a68-6562-42d1-98e7-c5b50180d8c2.pub.instances.scw.cloud"}}'
+        headers:
+            Content-Length:
+                - "2414"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 13 Jan 2026 13:41:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - a1ff25c3-3f42-40df-9ea9-2ba428ebb576
+        status: 200 OK
+        code: 200
+        duration: 142.038161ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/volumes/2f460ab5-ddc6-4992-b98e-01451bd69af6
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 522
+        body: '{"volume": {"id": "2f460ab5-ddc6-4992-b98e-01451bd69af6", "name": "tf-vol-serene-moore", "volume_type": "scratch", "export_uri": null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf", "server": {"id": "a42e3a68-6562-42d1-98e7-c5b50180d8c2", "name": "test-acc-server-scratch"}, "size": 1600000000000, "state": "available", "creation_date": "2026-01-13T13:41:49.344351+00:00", "modification_date": "2026-01-13T13:41:50.438626+00:00", "tags": [], "zone": "fr-par-2"}}'
+        headers:
+            Content-Length:
+                - "522"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 13 Jan 2026 13:41:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 3e911f64-8260-48f6-b173-1fdf2add3024
+        status: 200 OK
+        code: 200
+        duration: 105.746193ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/volumes/2f460ab5-ddc6-4992-b98e-01451bd69af6
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 522
+        body: '{"volume": {"id": "2f460ab5-ddc6-4992-b98e-01451bd69af6", "name": "tf-vol-serene-moore", "volume_type": "scratch", "export_uri": null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf", "server": {"id": "a42e3a68-6562-42d1-98e7-c5b50180d8c2", "name": "test-acc-server-scratch"}, "size": 1600000000000, "state": "available", "creation_date": "2026-01-13T13:41:49.344351+00:00", "modification_date": "2026-01-13T13:41:50.438626+00:00", "tags": [], "zone": "fr-par-2"}}'
+        headers:
+            Content-Length:
+                - "522"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 13 Jan 2026 13:41:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - d9bfd29b-28bd-48fb-bed2-c9aedef10d4c
+        status: 200 OK
+        code: 200
+        duration: 114.793239ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/a42e3a68-6562-42d1-98e7-c5b50180d8c2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 2414
+        body: '{"server": {"id": "a42e3a68-6562-42d1-98e7-c5b50180d8c2", "name": "test-acc-server-scratch", "arch": "x86_64", "commercial_type": "L40S-1-48G", "boot_type": "local", "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf", "hostname": "test-acc-server-scratch", "image": {"id": "f3431c05-e917-4bf0-b9db-9d4c14716a5e", "name": "Ubuntu Jammy GPU OS 12 passthrough", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "43d3942a-890e-4bae-b657-a776667db001", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-10-20T14:33:32.134908+00:00", "modification_date": "2025-10-20T14:33:32.134908+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-2"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "f091a98e-364d-4132-9f80-8adee7c8ae70", "state": "available", "zone": "fr-par-2"}, "1": {"boot": false, "id": "2f460ab5-ddc6-4992-b98e-01451bd69af6", "name": "tf-vol-serene-moore", "volume_type": "scratch", "export_uri": null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf", "server": {"id": "a42e3a68-6562-42d1-98e7-c5b50180d8c2", "name": "test-acc-server-scratch"}, "size": 1600000000000, "state": "available", "creation_date": "2026-01-13T13:41:49.344351+00:00", "modification_date": "2026-01-13T13:41:50.438626+00:00", "tags": [], "zone": "fr-par-2"}}, "tags": ["terraform-test", "scaleway_instance_server", "scratch"], "state": "stopped", "protected": false, "state_detail": "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:9d:6f:f7", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": false, "enable_ipv6": false, "private_ip": null, "creation_date": "2026-01-13T13:41:50.438626+00:00", "modification_date": "2026-01-13T13:41:50.438626+00:00", "bootscript": null, "security_group": {"id": "eaabb9f4-fbdf-4310-9cb6-4d42934b673a", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-2", "filesystems": [], "end_of_service": false, "dns": "a42e3a68-6562-42d1-98e7-c5b50180d8c2.pub.instances.scw.cloud"}}'
+        headers:
+            Content-Length:
+                - "2414"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 13 Jan 2026 13:41:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 17f5a4da-ebd2-451a-be31-f4c820e79243
+        status: 200 OK
+        code: 200
+        duration: 167.741743ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/volumes/f091a98e-364d-4132-9f80-8adee7c8ae70
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 143
+        body: '{"type": "not_found", "message": "resource is not found", "resource": "instance_volume", "resource_id": "f091a98e-364d-4132-9f80-8adee7c8ae70"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 13 Jan 2026 13:41:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - e9518f0f-fcbc-4ff5-853a-ef00ddbf3a11
+        status: 404 Not Found
+        code: 404
+        duration: 32.04846ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-2/volumes/f091a98e-364d-4132-9f80-8adee7c8ae70
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 711
+        body: '{"id":"f091a98e-364d-4132-9f80-8adee7c8ae70", "name":"Ubuntu Jammy GPU OS 12 passthrough_sbs_volume_0", "type":"sbs_5k", "size":20000000000, "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "created_at":"2026-01-13T13:41:50.617692Z", "updated_at":"2026-01-13T13:41:50.617692Z", "references":[{"id":"e671814a-f6bb-4b07-a501-5a3fd4a356be", "product_resource_type":"instance_server", "product_resource_id":"a42e3a68-6562-42d1-98e7-c5b50180d8c2", "created_at":"2026-01-13T13:41:50.617692Z", "type":"exclusive", "status":"attached"}], "parent_snapshot_id":"43d3942a-890e-4bae-b657-a776667db001", "status":"in_use", "tags":[], "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-2"}'
+        headers:
+            Content-Length:
+                - "711"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 13 Jan 2026 13:41:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 0c7a4d31-9c13-4f16-b965-77f72cdd4362
+        status: 200 OK
+        code: 200
+        duration: 85.017672ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/a42e3a68-6562-42d1-98e7-c5b50180d8c2/user_data
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 17
+        body: '{"user_data": []}'
+        headers:
+            Content-Length:
+                - "17"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 13 Jan 2026 13:41:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 1a621a7c-0020-4a96-9b54-b022acadce1a
+        status: 200 OK
+        code: 200
+        duration: 113.032888ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/a42e3a68-6562-42d1-98e7-c5b50180d8c2/private_nics
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 20
+        body: '{"private_nics": []}'
+        headers:
+            Content-Length:
+                - "20"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 13 Jan 2026 13:41:52 GMT
+            Link:
+                - </servers/a42e3a68-6562-42d1-98e7-c5b50180d8c2/private_nics?page=0&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 6021164c-409a-48c6-8750-6b421628ff62
+            X-Total-Count:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 51.134822ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/a42e3a68-6562-42d1-98e7-c5b50180d8c2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 2414
+        body: '{"server": {"id": "a42e3a68-6562-42d1-98e7-c5b50180d8c2", "name": "test-acc-server-scratch", "arch": "x86_64", "commercial_type": "L40S-1-48G", "boot_type": "local", "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf", "hostname": "test-acc-server-scratch", "image": {"id": "f3431c05-e917-4bf0-b9db-9d4c14716a5e", "name": "Ubuntu Jammy GPU OS 12 passthrough", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "43d3942a-890e-4bae-b657-a776667db001", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-10-20T14:33:32.134908+00:00", "modification_date": "2025-10-20T14:33:32.134908+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-2"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "f091a98e-364d-4132-9f80-8adee7c8ae70", "state": "available", "zone": "fr-par-2"}, "1": {"boot": false, "id": "2f460ab5-ddc6-4992-b98e-01451bd69af6", "name": "tf-vol-serene-moore", "volume_type": "scratch", "export_uri": null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf", "server": {"id": "a42e3a68-6562-42d1-98e7-c5b50180d8c2", "name": "test-acc-server-scratch"}, "size": 1600000000000, "state": "available", "creation_date": "2026-01-13T13:41:49.344351+00:00", "modification_date": "2026-01-13T13:41:50.438626+00:00", "tags": [], "zone": "fr-par-2"}}, "tags": ["terraform-test", "scaleway_instance_server", "scratch"], "state": "stopped", "protected": false, "state_detail": "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:9d:6f:f7", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": false, "enable_ipv6": false, "private_ip": null, "creation_date": "2026-01-13T13:41:50.438626+00:00", "modification_date": "2026-01-13T13:41:50.438626+00:00", "bootscript": null, "security_group": {"id": "eaabb9f4-fbdf-4310-9cb6-4d42934b673a", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-2", "filesystems": [], "end_of_service": false, "dns": "a42e3a68-6562-42d1-98e7-c5b50180d8c2.pub.instances.scw.cloud"}}'
+        headers:
+            Content-Length:
+                - "2414"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 13 Jan 2026 13:41:53 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - f569c692-fe62-4883-ae46-8e8120136220
+        status: 200 OK
+        code: 200
+        duration: 83.664123ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/a42e3a68-6562-42d1-98e7-c5b50180d8c2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 2414
+        body: '{"server": {"id": "a42e3a68-6562-42d1-98e7-c5b50180d8c2", "name": "test-acc-server-scratch", "arch": "x86_64", "commercial_type": "L40S-1-48G", "boot_type": "local", "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf", "hostname": "test-acc-server-scratch", "image": {"id": "f3431c05-e917-4bf0-b9db-9d4c14716a5e", "name": "Ubuntu Jammy GPU OS 12 passthrough", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "43d3942a-890e-4bae-b657-a776667db001", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-10-20T14:33:32.134908+00:00", "modification_date": "2025-10-20T14:33:32.134908+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-2"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "f091a98e-364d-4132-9f80-8adee7c8ae70", "state": "available", "zone": "fr-par-2"}, "1": {"boot": false, "id": "2f460ab5-ddc6-4992-b98e-01451bd69af6", "name": "tf-vol-serene-moore", "volume_type": "scratch", "export_uri": null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf", "server": {"id": "a42e3a68-6562-42d1-98e7-c5b50180d8c2", "name": "test-acc-server-scratch"}, "size": 1600000000000, "state": "available", "creation_date": "2026-01-13T13:41:49.344351+00:00", "modification_date": "2026-01-13T13:41:50.438626+00:00", "tags": [], "zone": "fr-par-2"}}, "tags": ["terraform-test", "scaleway_instance_server", "scratch"], "state": "stopped", "protected": false, "state_detail": "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:9d:6f:f7", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": false, "enable_ipv6": false, "private_ip": null, "creation_date": "2026-01-13T13:41:50.438626+00:00", "modification_date": "2026-01-13T13:41:50.438626+00:00", "bootscript": null, "security_group": {"id": "eaabb9f4-fbdf-4310-9cb6-4d42934b673a", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-2", "filesystems": [], "end_of_service": false, "dns": "a42e3a68-6562-42d1-98e7-c5b50180d8c2.pub.instances.scw.cloud"}}'
+        headers:
+            Content-Length:
+                - "2414"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 13 Jan 2026 13:41:53 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 59d02917-a76d-4520-897b-8318348b5ef1
+        status: 200 OK
+        code: 200
+        duration: 164.083051ms
+    - id: 25
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-2/volumes/f091a98e-364d-4132-9f80-8adee7c8ae70
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 711
+        body: '{"id":"f091a98e-364d-4132-9f80-8adee7c8ae70", "name":"Ubuntu Jammy GPU OS 12 passthrough_sbs_volume_0", "type":"sbs_5k", "size":20000000000, "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "created_at":"2026-01-13T13:41:50.617692Z", "updated_at":"2026-01-13T13:41:50.617692Z", "references":[{"id":"e671814a-f6bb-4b07-a501-5a3fd4a356be", "product_resource_type":"instance_server", "product_resource_id":"a42e3a68-6562-42d1-98e7-c5b50180d8c2", "created_at":"2026-01-13T13:41:50.617692Z", "type":"exclusive", "status":"attached"}], "parent_snapshot_id":"43d3942a-890e-4bae-b657-a776667db001", "status":"in_use", "tags":[], "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-2"}'
+        headers:
+            Content-Length:
+                - "711"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 13 Jan 2026 13:41:53 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 50a6067f-b2d7-4017-9453-5d3f1da24c35
+        status: 200 OK
+        code: 200
+        duration: 92.161919ms
+    - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 20
+        host: api.scaleway.com
+        body: '{"action":"poweron"}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/a42e3a68-6562-42d1-98e7-c5b50180d8c2/action
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 357
+        body: '{"task": {"id": "a23c9898-e7bb-4804-877b-5aeefc3dcb8b", "description": "server_batch_poweron", "status": "pending", "href_from": "/servers/a42e3a68-6562-42d1-98e7-c5b50180d8c2/action", "href_result": "/servers/a42e3a68-6562-42d1-98e7-c5b50180d8c2", "started_at": "2026-01-13T13:41:53.635118+00:00", "terminated_at": null, "progress": 0, "zone": "fr-par-2"}}'
+        headers:
+            Content-Length:
+                - "357"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 13 Jan 2026 13:41:53 GMT
+            Location:
+                - https://api.scaleway.com/instance/v1/zones/fr-par-2/tasks/a23c9898-e7bb-4804-877b-5aeefc3dcb8b
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - a334ccb4-aee2-4d06-b7ec-ca8429378ea3
+        status: 202 Accepted
+        code: 202
+        duration: 294.891013ms
+    - id: 27
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/a42e3a68-6562-42d1-98e7-c5b50180d8c2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 2436
+        body: '{"server": {"id": "a42e3a68-6562-42d1-98e7-c5b50180d8c2", "name": "test-acc-server-scratch", "arch": "x86_64", "commercial_type": "L40S-1-48G", "boot_type": "local", "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf", "hostname": "test-acc-server-scratch", "image": {"id": "f3431c05-e917-4bf0-b9db-9d4c14716a5e", "name": "Ubuntu Jammy GPU OS 12 passthrough", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "43d3942a-890e-4bae-b657-a776667db001", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-10-20T14:33:32.134908+00:00", "modification_date": "2025-10-20T14:33:32.134908+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-2"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "f091a98e-364d-4132-9f80-8adee7c8ae70", "state": "available", "zone": "fr-par-2"}, "1": {"boot": false, "id": "2f460ab5-ddc6-4992-b98e-01451bd69af6", "name": "tf-vol-serene-moore", "volume_type": "scratch", "export_uri": null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf", "server": {"id": "a42e3a68-6562-42d1-98e7-c5b50180d8c2", "name": "test-acc-server-scratch"}, "size": 1600000000000, "state": "available", "creation_date": "2026-01-13T13:41:49.344351+00:00", "modification_date": "2026-01-13T13:41:50.438626+00:00", "tags": [], "zone": "fr-par-2"}}, "tags": ["terraform-test", "scaleway_instance_server", "scratch"], "state": "starting", "protected": false, "state_detail": "allocating node", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:9d:6f:f7", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": false, "enable_ipv6": false, "private_ip": null, "creation_date": "2026-01-13T13:41:50.438626+00:00", "modification_date": "2026-01-13T13:41:53.399521+00:00", "bootscript": null, "security_group": {"id": "eaabb9f4-fbdf-4310-9cb6-4d42934b673a", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-2", "filesystems": [], "end_of_service": false, "dns": "a42e3a68-6562-42d1-98e7-c5b50180d8c2.pub.instances.scw.cloud"}}'
+        headers:
+            Content-Length:
+                - "2436"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 13 Jan 2026 13:41:53 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - c73f3a76-1748-412f-a60e-650d19835c24
+        status: 200 OK
+        code: 200
+        duration: 181.79682ms
+    - id: 28
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/a42e3a68-6562-42d1-98e7-c5b50180d8c2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 2539
+        body: '{"server": {"id": "a42e3a68-6562-42d1-98e7-c5b50180d8c2", "name": "test-acc-server-scratch", "arch": "x86_64", "commercial_type": "L40S-1-48G", "boot_type": "local", "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf", "hostname": "test-acc-server-scratch", "image": {"id": "f3431c05-e917-4bf0-b9db-9d4c14716a5e", "name": "Ubuntu Jammy GPU OS 12 passthrough", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "43d3942a-890e-4bae-b657-a776667db001", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-10-20T14:33:32.134908+00:00", "modification_date": "2025-10-20T14:33:32.134908+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-2"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "f091a98e-364d-4132-9f80-8adee7c8ae70", "state": "available", "zone": "fr-par-2"}, "1": {"boot": false, "id": "2f460ab5-ddc6-4992-b98e-01451bd69af6", "name": "tf-vol-serene-moore", "volume_type": "scratch", "export_uri": null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf", "server": {"id": "a42e3a68-6562-42d1-98e7-c5b50180d8c2", "name": "test-acc-server-scratch"}, "size": 1600000000000, "state": "available", "creation_date": "2026-01-13T13:41:49.344351+00:00", "modification_date": "2026-01-13T13:41:50.438626+00:00", "tags": [], "zone": "fr-par-2"}}, "tags": ["terraform-test", "scaleway_instance_server", "scratch"], "state": "starting", "protected": false, "state_detail": "provisioning node", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:9d:6f:f7", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": false, "enable_ipv6": false, "private_ip": null, "creation_date": "2026-01-13T13:41:50.438626+00:00", "modification_date": "2026-01-13T13:41:53.399521+00:00", "bootscript": null, "security_group": {"id": "eaabb9f4-fbdf-4310-9cb6-4d42934b673a", "name": "Default security group"}, "location": {"zone_id": "fr-par-2", "platform_id": "30", "cluster_id": "16", "hypervisor_id": "1901", "node_id": "8"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-2", "filesystems": [], "end_of_service": false, "dns": "a42e3a68-6562-42d1-98e7-c5b50180d8c2.pub.instances.scw.cloud"}}'
+        headers:
+            Content-Length:
+                - "2539"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 13 Jan 2026 13:41:58 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - ba390747-eaa2-4205-a746-d8996e6cfecf
+        status: 200 OK
+        code: 200
+        duration: 96.663741ms
+    - id: 29
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/a42e3a68-6562-42d1-98e7-c5b50180d8c2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 2539
+        body: '{"server": {"id": "a42e3a68-6562-42d1-98e7-c5b50180d8c2", "name": "test-acc-server-scratch", "arch": "x86_64", "commercial_type": "L40S-1-48G", "boot_type": "local", "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf", "hostname": "test-acc-server-scratch", "image": {"id": "f3431c05-e917-4bf0-b9db-9d4c14716a5e", "name": "Ubuntu Jammy GPU OS 12 passthrough", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "43d3942a-890e-4bae-b657-a776667db001", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-10-20T14:33:32.134908+00:00", "modification_date": "2025-10-20T14:33:32.134908+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-2"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "f091a98e-364d-4132-9f80-8adee7c8ae70", "state": "available", "zone": "fr-par-2"}, "1": {"boot": false, "id": "2f460ab5-ddc6-4992-b98e-01451bd69af6", "name": "tf-vol-serene-moore", "volume_type": "scratch", "export_uri": null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf", "server": {"id": "a42e3a68-6562-42d1-98e7-c5b50180d8c2", "name": "test-acc-server-scratch"}, "size": 1600000000000, "state": "available", "creation_date": "2026-01-13T13:41:49.344351+00:00", "modification_date": "2026-01-13T13:41:50.438626+00:00", "tags": [], "zone": "fr-par-2"}}, "tags": ["terraform-test", "scaleway_instance_server", "scratch"], "state": "starting", "protected": false, "state_detail": "provisioning node", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:9d:6f:f7", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": false, "enable_ipv6": false, "private_ip": null, "creation_date": "2026-01-13T13:41:50.438626+00:00", "modification_date": "2026-01-13T13:41:53.399521+00:00", "bootscript": null, "security_group": {"id": "eaabb9f4-fbdf-4310-9cb6-4d42934b673a", "name": "Default security group"}, "location": {"zone_id": "fr-par-2", "platform_id": "30", "cluster_id": "16", "hypervisor_id": "1901", "node_id": "8"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-2", "filesystems": [], "end_of_service": false, "dns": "a42e3a68-6562-42d1-98e7-c5b50180d8c2.pub.instances.scw.cloud"}}'
+        headers:
+            Content-Length:
+                - "2539"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 13 Jan 2026 13:42:04 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 833a0221-f087-4b61-8616-c580f311969f
+        status: 200 OK
+        code: 200
+        duration: 93.574488ms
+    - id: 30
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/a42e3a68-6562-42d1-98e7-c5b50180d8c2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 2539
+        body: '{"server": {"id": "a42e3a68-6562-42d1-98e7-c5b50180d8c2", "name": "test-acc-server-scratch", "arch": "x86_64", "commercial_type": "L40S-1-48G", "boot_type": "local", "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf", "hostname": "test-acc-server-scratch", "image": {"id": "f3431c05-e917-4bf0-b9db-9d4c14716a5e", "name": "Ubuntu Jammy GPU OS 12 passthrough", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "43d3942a-890e-4bae-b657-a776667db001", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-10-20T14:33:32.134908+00:00", "modification_date": "2025-10-20T14:33:32.134908+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-2"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "f091a98e-364d-4132-9f80-8adee7c8ae70", "state": "available", "zone": "fr-par-2"}, "1": {"boot": false, "id": "2f460ab5-ddc6-4992-b98e-01451bd69af6", "name": "tf-vol-serene-moore", "volume_type": "scratch", "export_uri": null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf", "server": {"id": "a42e3a68-6562-42d1-98e7-c5b50180d8c2", "name": "test-acc-server-scratch"}, "size": 1600000000000, "state": "available", "creation_date": "2026-01-13T13:41:49.344351+00:00", "modification_date": "2026-01-13T13:41:50.438626+00:00", "tags": [], "zone": "fr-par-2"}}, "tags": ["terraform-test", "scaleway_instance_server", "scratch"], "state": "starting", "protected": false, "state_detail": "provisioning node", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:9d:6f:f7", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": false, "enable_ipv6": false, "private_ip": null, "creation_date": "2026-01-13T13:41:50.438626+00:00", "modification_date": "2026-01-13T13:41:53.399521+00:00", "bootscript": null, "security_group": {"id": "eaabb9f4-fbdf-4310-9cb6-4d42934b673a", "name": "Default security group"}, "location": {"zone_id": "fr-par-2", "platform_id": "30", "cluster_id": "16", "hypervisor_id": "1901", "node_id": "8"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-2", "filesystems": [], "end_of_service": false, "dns": "a42e3a68-6562-42d1-98e7-c5b50180d8c2.pub.instances.scw.cloud"}}'
+        headers:
+            Content-Length:
+                - "2539"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 13 Jan 2026 13:42:09 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - a6531697-ea62-4b47-b2ca-2cb9c9c9a867
+        status: 200 OK
+        code: 200
+        duration: 155.281195ms
+    - id: 31
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/a42e3a68-6562-42d1-98e7-c5b50180d8c2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 2570
+        body: '{"server": {"id": "a42e3a68-6562-42d1-98e7-c5b50180d8c2", "name": "test-acc-server-scratch", "arch": "x86_64", "commercial_type": "L40S-1-48G", "boot_type": "local", "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf", "hostname": "test-acc-server-scratch", "image": {"id": "f3431c05-e917-4bf0-b9db-9d4c14716a5e", "name": "Ubuntu Jammy GPU OS 12 passthrough", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "43d3942a-890e-4bae-b657-a776667db001", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-10-20T14:33:32.134908+00:00", "modification_date": "2025-10-20T14:33:32.134908+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-2"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "f091a98e-364d-4132-9f80-8adee7c8ae70", "state": "available", "zone": "fr-par-2"}, "1": {"boot": false, "id": "2f460ab5-ddc6-4992-b98e-01451bd69af6", "name": "tf-vol-serene-moore", "volume_type": "scratch", "export_uri": null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf", "server": {"id": "a42e3a68-6562-42d1-98e7-c5b50180d8c2", "name": "test-acc-server-scratch"}, "size": 1600000000000, "state": "available", "creation_date": "2026-01-13T13:41:49.344351+00:00", "modification_date": "2026-01-13T13:41:50.438626+00:00", "tags": [], "zone": "fr-par-2"}}, "tags": ["terraform-test", "scaleway_instance_server", "scratch"], "state": "running", "protected": false, "state_detail": "booting kernel", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:9d:6f:f7", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": false, "enable_ipv6": false, "private_ip": null, "creation_date": "2026-01-13T13:41:50.438626+00:00", "modification_date": "2026-01-13T13:42:10.164186+00:00", "bootscript": null, "security_group": {"id": "eaabb9f4-fbdf-4310-9cb6-4d42934b673a", "name": "Default security group"}, "location": {"zone_id": "fr-par-2", "platform_id": "30", "cluster_id": "16", "hypervisor_id": "1901", "node_id": "8"}, "maintenances": [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-2", "filesystems": [], "end_of_service": false, "dns": "a42e3a68-6562-42d1-98e7-c5b50180d8c2.pub.instances.scw.cloud"}}'
+        headers:
+            Content-Length:
+                - "2570"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 13 Jan 2026 13:42:14 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - b9f38571-44d6-400a-87be-c7375249f977
+        status: 200 OK
+        code: 200
+        duration: 84.395845ms
+    - id: 32
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 22
+        host: api.scaleway.com
+        body: '{"action":"terminate"}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/a42e3a68-6562-42d1-98e7-c5b50180d8c2/action
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 353
+        body: '{"task": {"id": "d70091ef-4e6d-4550-9da0-8d470d30e71f", "description": "server_terminate", "status": "pending", "href_from": "/servers/a42e3a68-6562-42d1-98e7-c5b50180d8c2/action", "href_result": "/servers/a42e3a68-6562-42d1-98e7-c5b50180d8c2", "started_at": "2026-01-13T13:42:14.539051+00:00", "terminated_at": null, "progress": 0, "zone": "fr-par-2"}}'
+        headers:
+            Content-Length:
+                - "353"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 13 Jan 2026 13:42:14 GMT
+            Location:
+                - https://api.scaleway.com/instance/v1/zones/fr-par-2/tasks/d70091ef-4e6d-4550-9da0-8d470d30e71f
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 473d8966-3f8a-4354-992c-a2d0213d6ea2
+        status: 202 Accepted
+        code: 202
+        duration: 292.108225ms
+    - id: 33
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/a42e3a68-6562-42d1-98e7-c5b50180d8c2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 2533
+        body: '{"server": {"id": "a42e3a68-6562-42d1-98e7-c5b50180d8c2", "name": "test-acc-server-scratch", "arch": "x86_64", "commercial_type": "L40S-1-48G", "boot_type": "local", "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf", "hostname": "test-acc-server-scratch", "image": {"id": "f3431c05-e917-4bf0-b9db-9d4c14716a5e", "name": "Ubuntu Jammy GPU OS 12 passthrough", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "43d3942a-890e-4bae-b657-a776667db001", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-10-20T14:33:32.134908+00:00", "modification_date": "2025-10-20T14:33:32.134908+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-2"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "f091a98e-364d-4132-9f80-8adee7c8ae70", "state": "available", "zone": "fr-par-2"}, "1": {"boot": false, "id": "2f460ab5-ddc6-4992-b98e-01451bd69af6", "name": "tf-vol-serene-moore", "volume_type": "scratch", "export_uri": null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf", "server": {"id": "a42e3a68-6562-42d1-98e7-c5b50180d8c2", "name": "test-acc-server-scratch"}, "size": 1600000000000, "state": "available", "creation_date": "2026-01-13T13:41:49.344351+00:00", "modification_date": "2026-01-13T13:41:50.438626+00:00", "tags": [], "zone": "fr-par-2"}}, "tags": ["terraform-test", "scaleway_instance_server", "scratch"], "state": "stopping", "protected": false, "state_detail": "terminating", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:9d:6f:f7", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": false, "enable_ipv6": false, "private_ip": null, "creation_date": "2026-01-13T13:41:50.438626+00:00", "modification_date": "2026-01-13T13:42:14.313349+00:00", "bootscript": null, "security_group": {"id": "eaabb9f4-fbdf-4310-9cb6-4d42934b673a", "name": "Default security group"}, "location": {"zone_id": "fr-par-2", "platform_id": "30", "cluster_id": "16", "hypervisor_id": "1901", "node_id": "8"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-2", "filesystems": [], "end_of_service": false, "dns": "a42e3a68-6562-42d1-98e7-c5b50180d8c2.pub.instances.scw.cloud"}}'
+        headers:
+            Content-Length:
+                - "2533"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 13 Jan 2026 13:42:14 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 90870ae5-75a3-438d-b037-0bb51b53b904
+        status: 200 OK
+        code: 200
+        duration: 98.580987ms
+    - id: 34
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/a42e3a68-6562-42d1-98e7-c5b50180d8c2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 2533
+        body: '{"server": {"id": "a42e3a68-6562-42d1-98e7-c5b50180d8c2", "name": "test-acc-server-scratch", "arch": "x86_64", "commercial_type": "L40S-1-48G", "boot_type": "local", "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf", "hostname": "test-acc-server-scratch", "image": {"id": "f3431c05-e917-4bf0-b9db-9d4c14716a5e", "name": "Ubuntu Jammy GPU OS 12 passthrough", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "43d3942a-890e-4bae-b657-a776667db001", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-10-20T14:33:32.134908+00:00", "modification_date": "2025-10-20T14:33:32.134908+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-2"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "f091a98e-364d-4132-9f80-8adee7c8ae70", "state": "available", "zone": "fr-par-2"}, "1": {"boot": false, "id": "2f460ab5-ddc6-4992-b98e-01451bd69af6", "name": "tf-vol-serene-moore", "volume_type": "scratch", "export_uri": null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf", "server": {"id": "a42e3a68-6562-42d1-98e7-c5b50180d8c2", "name": "test-acc-server-scratch"}, "size": 1600000000000, "state": "available", "creation_date": "2026-01-13T13:41:49.344351+00:00", "modification_date": "2026-01-13T13:41:50.438626+00:00", "tags": [], "zone": "fr-par-2"}}, "tags": ["terraform-test", "scaleway_instance_server", "scratch"], "state": "stopping", "protected": false, "state_detail": "terminating", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:9d:6f:f7", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": false, "enable_ipv6": false, "private_ip": null, "creation_date": "2026-01-13T13:41:50.438626+00:00", "modification_date": "2026-01-13T13:42:14.313349+00:00", "bootscript": null, "security_group": {"id": "eaabb9f4-fbdf-4310-9cb6-4d42934b673a", "name": "Default security group"}, "location": {"zone_id": "fr-par-2", "platform_id": "30", "cluster_id": "16", "hypervisor_id": "1901", "node_id": "8"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-2", "filesystems": [], "end_of_service": false, "dns": "a42e3a68-6562-42d1-98e7-c5b50180d8c2.pub.instances.scw.cloud"}}'
+        headers:
+            Content-Length:
+                - "2533"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 13 Jan 2026 13:42:19 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - dda41ef5-efd5-4d80-a55e-988577012f9f
+        status: 200 OK
+        code: 200
+        duration: 228.353006ms
+    - id: 35
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/a42e3a68-6562-42d1-98e7-c5b50180d8c2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 2533
+        body: '{"server": {"id": "a42e3a68-6562-42d1-98e7-c5b50180d8c2", "name": "test-acc-server-scratch", "arch": "x86_64", "commercial_type": "L40S-1-48G", "boot_type": "local", "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf", "hostname": "test-acc-server-scratch", "image": {"id": "f3431c05-e917-4bf0-b9db-9d4c14716a5e", "name": "Ubuntu Jammy GPU OS 12 passthrough", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "43d3942a-890e-4bae-b657-a776667db001", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-10-20T14:33:32.134908+00:00", "modification_date": "2025-10-20T14:33:32.134908+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-2"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "f091a98e-364d-4132-9f80-8adee7c8ae70", "state": "available", "zone": "fr-par-2"}, "1": {"boot": false, "id": "2f460ab5-ddc6-4992-b98e-01451bd69af6", "name": "tf-vol-serene-moore", "volume_type": "scratch", "export_uri": null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf", "server": {"id": "a42e3a68-6562-42d1-98e7-c5b50180d8c2", "name": "test-acc-server-scratch"}, "size": 1600000000000, "state": "available", "creation_date": "2026-01-13T13:41:49.344351+00:00", "modification_date": "2026-01-13T13:41:50.438626+00:00", "tags": [], "zone": "fr-par-2"}}, "tags": ["terraform-test", "scaleway_instance_server", "scratch"], "state": "stopping", "protected": false, "state_detail": "terminating", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:9d:6f:f7", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": false, "enable_ipv6": false, "private_ip": null, "creation_date": "2026-01-13T13:41:50.438626+00:00", "modification_date": "2026-01-13T13:42:14.313349+00:00", "bootscript": null, "security_group": {"id": "eaabb9f4-fbdf-4310-9cb6-4d42934b673a", "name": "Default security group"}, "location": {"zone_id": "fr-par-2", "platform_id": "30", "cluster_id": "16", "hypervisor_id": "1901", "node_id": "8"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-2", "filesystems": [], "end_of_service": false, "dns": "a42e3a68-6562-42d1-98e7-c5b50180d8c2.pub.instances.scw.cloud"}}'
+        headers:
+            Content-Length:
+                - "2533"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 13 Jan 2026 13:42:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 7cde2386-3057-4ea3-9daf-a26161a97070
+        status: 200 OK
+        code: 200
+        duration: 160.793172ms
+    - id: 36
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/a42e3a68-6562-42d1-98e7-c5b50180d8c2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 143
+        body: '{"type": "not_found", "message": "resource is not found", "resource": "instance_server", "resource_id": "a42e3a68-6562-42d1-98e7-c5b50180d8c2"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 13 Jan 2026 13:42:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 9180c59a-e812-4cb3-9718-21a094193914
+        status: 404 Not Found
+        code: 404
+        duration: 178.020548ms
+    - id: 37
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/volumes/f091a98e-364d-4132-9f80-8adee7c8ae70
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 143
+        body: '{"type": "not_found", "message": "resource is not found", "resource": "instance_volume", "resource_id": "f091a98e-364d-4132-9f80-8adee7c8ae70"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 13 Jan 2026 13:42:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 649f0404-e620-4dfd-a75e-00e06929b9d9
+        status: 404 Not Found
+        code: 404
+        duration: 33.177777ms
+    - id: 38
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-2/volumes/f091a98e-364d-4132-9f80-8adee7c8ae70
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 504
+        body: '{"id":"f091a98e-364d-4132-9f80-8adee7c8ae70", "name":"Ubuntu Jammy GPU OS 12 passthrough_sbs_volume_0", "type":"sbs_5k", "size":20000000000, "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "created_at":"2026-01-13T13:41:50.617692Z", "updated_at":"2026-01-13T13:42:26.360106Z", "references":[], "parent_snapshot_id":"43d3942a-890e-4bae-b657-a776667db001", "status":"available", "tags":[], "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":"2026-01-13T13:42:26.360106Z", "zone":"fr-par-2"}'
+        headers:
+            Content-Length:
+                - "504"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 13 Jan 2026 13:42:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 728c3cf1-4449-48b5-bac0-225d5a93d770
+        status: 200 OK
+        code: 200
+        duration: 161.441798ms
+    - id: 39
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-2/volumes/f091a98e-364d-4132-9f80-8adee7c8ae70
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 13 Jan 2026 13:42:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 6fb341b2-66f1-46c7-a255-000d788f8cdf
+        status: 204 No Content
+        code: 204
+        duration: 182.656712ms
+    - id: 40
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/volumes/2f460ab5-ddc6-4992-b98e-01451bd69af6
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 143
+        body: '{"type": "not_found", "message": "resource is not found", "resource": "instance_volume", "resource_id": "2f460ab5-ddc6-4992-b98e-01451bd69af6"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 13 Jan 2026 13:42:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 79d48d11-4fd3-4d1d-b25f-ef061077c1f1
+        status: 404 Not Found
+        code: 404
+        duration: 36.318778ms
+    - id: 41
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/a42e3a68-6562-42d1-98e7-c5b50180d8c2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 143
+        body: '{"type": "not_found", "message": "resource is not found", "resource": "instance_server", "resource_id": "a42e3a68-6562-42d1-98e7-c5b50180d8c2"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 13 Jan 2026 13:42:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 61b54d0c-92d1-41fb-b953-35a2573a7993
+        status: 404 Not Found
+        code: 404
+        duration: 64.353791ms
+    - id: 42
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-2/volumes/2f460ab5-ddc6-4992-b98e-01451bd69af6
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 143
+        body: '{"type": "not_found", "message": "resource is not found", "resource": "instance_volume", "resource_id": "2f460ab5-ddc6-4992-b98e-01451bd69af6"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 13 Jan 2026 13:42:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge02)
+            X-Request-Id:
+                - 5ce37164-e69a-4e64-b1d2-24793f95dc60
+        status: 404 Not Found
+        code: 404
+        duration: 32.544389ms


### PR DESCRIPTION
The instance API now automatically resizes the scratch volume to the instance's maximum capacity on attach. This PR updates the expected values in the scratch storage test to prevent non-empty plan after apply, and changes the instance type for the one that has the smallest capacity.

This should fix the nightly tests for the instance package.