### PR TITLE
docs(secret): fix erraneous secret_version data format description

### DIFF
--- a/docs/data-sources/secret_version.md
+++ b/docs/data-sources/secret_version.md
@@ -88,7 +88,7 @@ see [Sensitive Data in State](https://developer.hashicorp.com/terraform/language
 This section lists the attributes that are exported by the `scaleway_secret_version` data source. These attributes can be referenced in other parts of your Terraform configuration:
 
 - `description` - (Optional) The description of the secret version (e.g. `my-new-description`).
-- `data` - The data payload of the secret version. This is a sensitive attribute containing the secret value. Learn more in the [data section](#data).
+- `data` - The data payload of the secret version. This is a sensitive attribute containing the secret value, encoded in base64. Learn more in the [data section](#data).
 - `status` - The status of the secret version.
 - `created_at` - The date and time of the secret version's creation in RFC 3339 format.
 - `updated_at` - The date and time of the secret version's last update in RFC 3339 format.

--- a/docs/resources/secret_version.md
+++ b/docs/resources/secret_version.md
@@ -37,8 +37,8 @@ resource "scaleway_secret_version" "v1" {
 The following arguments are supported:
 
 - `secret_id` - (Required) The ID of the secret associated with the version.
-- `data` - (Optional) The data payload of the secret version. Must not exceed 64KiB in size (e.g. `my-secret-version-payload`). Find out more on the [data section](#data).
-- `data_wo` - (Optional) The data payload of your secret version in [write-only](https://developer.hashicorp.com/terraform/language/manage-sensitive-data/write-only) mode. Must not exceed 64KiB in size (e.g. `my-secret-version-payload`). Find out more on the [data section](#data).
+- `data` - (Optional) The raw data payload of the secret version. Must not exceed 64KiB in size (e.g. `my-secret-version-payload`). Find out more on the [data section](#data).
+- `data_wo` - (Optional) The raw data payload of your secret version in [write-only](https://developer.hashicorp.com/terraform/language/manage-sensitive-data/write-only) mode. Must not exceed 64KiB in size (e.g. `my-secret-version-payload`). Find out more on the [data section](#data).
 - `data_wo_version` - (Optional) The version of the [write-only](https://developer.hashicorp.com/terraform/language/manage-sensitive-data/write-only) data. To update the `data_wo`, you must also update the `data_wo_version`.
 - `description` - (Optional) Description of the secret version (e.g. `my-new-description`).
 - `region` - (Defaults to the region specified in the [provider configuration](../index.md#region)). The [region](../guides/regions_and_zones.md#regions) where the resource exists.
@@ -47,7 +47,7 @@ The following arguments are supported:
 
 Only one of `data` or `data_wo` should be specified. If both are provided, Terraform will return an error.
 
-Note: The `data` (or `data_wo`) can be provided as either plain text or base64. When plain text is provided, the provider automatically handles base64 encoding before sending it to the API. The maximum size for either field is 64KiB.
+Note: The `data` (or `data_wo`) should be a raw string. **The provider handles encoding this string to base64 before sending it to the API so you do not need to encode the data yourself.** The maximum size for either field is 64KiB.
 
 #### `data`
 Updating `data` will force the creation of a new secret version.

--- a/internal/services/secret/version.go
+++ b/internal/services/secret/version.go
@@ -44,7 +44,7 @@ func versionSchema() map[string]*schema.Schema {
 		"data": {
 			Type:        schema.TypeString,
 			Optional:    true,
-			Description: "The data payload of the secret version. Must not exceed 64KiB in size (e.g. `my-secret-version-payload`). Only one of `data` or `data_wo` should be specified.",
+			Description: "The raw data payload of the secret version. Must not exceed 64KiB in size (e.g. `my-secret-version-payload`). Only one of `data` or `data_wo` should be specified.",
 			Sensitive:   true,
 			ForceNew:    true,
 			StateFunc: func(i any) string {
@@ -55,7 +55,7 @@ func versionSchema() map[string]*schema.Schema {
 		"data_wo": {
 			Type:        schema.TypeString,
 			Optional:    true,
-			Description: "The data payload of your secret version in [write-only](https://developer.hashicorp.com/terraform/language/manage-sensitive-data/write-only) mode. Must not exceed 64KiB in size (e.g. `my-secret-version-payload`). Only one of `data` or `data_wo` should be specified. `data_wo` will not be set in the Terraform state. To update the `data_wo`, you must also update the `data_wo_version`.",
+			Description: "The raw data payload of your secret version in [write-only](https://developer.hashicorp.com/terraform/language/manage-sensitive-data/write-only) mode. Must not exceed 64KiB in size (e.g. `my-secret-version-payload`). Only one of `data` or `data_wo` should be specified. `data_wo` will not be set in the Terraform state. To update the `data_wo`, you must also update the `data_wo_version`.",
 			Sensitive:   true,
 			WriteOnly:   true,
 			StateFunc: func(i any) string {

--- a/templates/data-sources/secret_version.md.tmpl
+++ b/templates/data-sources/secret_version.md.tmpl
@@ -88,7 +88,7 @@ see [Sensitive Data in State](https://developer.hashicorp.com/terraform/language
 This section lists the attributes that are exported by the `scaleway_secret_version` data source. These attributes can be referenced in other parts of your Terraform configuration:
 
 - `description` - (Optional) The description of the secret version (e.g. `my-new-description`).
-- `data` - The data payload of the secret version. This is a sensitive attribute containing the secret value. Learn more in the [data section](#data).
+- `data` - The data payload of the secret version. This is a sensitive attribute containing the secret value, encoded in base64. Learn more in the [data section](#data).
 - `status` - The status of the secret version.
 - `created_at` - The date and time of the secret version's creation in RFC 3339 format.
 - `updated_at` - The date and time of the secret version's last update in RFC 3339 format.

--- a/templates/resources/secret_version.md.tmpl
+++ b/templates/resources/secret_version.md.tmpl
@@ -38,8 +38,8 @@ resource "scaleway_secret_version" "v1" {
 The following arguments are supported:
 
 - `secret_id` - (Required) The ID of the secret associated with the version.
-- `data` - (Optional) The data payload of the secret version. Must not exceed 64KiB in size (e.g. `my-secret-version-payload`). Find out more on the [data section](#data).
-- `data_wo` - (Optional) The data payload of your secret version in [write-only](https://developer.hashicorp.com/terraform/language/manage-sensitive-data/write-only) mode. Must not exceed 64KiB in size (e.g. `my-secret-version-payload`). Find out more on the [data section](#data).
+- `data` - (Optional) The raw data payload of the secret version. Must not exceed 64KiB in size (e.g. `my-secret-version-payload`). Find out more on the [data section](#data).
+- `data_wo` - (Optional) The raw data payload of your secret version in [write-only](https://developer.hashicorp.com/terraform/language/manage-sensitive-data/write-only) mode. Must not exceed 64KiB in size (e.g. `my-secret-version-payload`). Find out more on the [data section](#data).
 - `data_wo_version` - (Optional) The version of the [write-only](https://developer.hashicorp.com/terraform/language/manage-sensitive-data/write-only) data. To update the `data_wo`, you must also update the `data_wo_version`.
 - `description` - (Optional) Description of the secret version (e.g. `my-new-description`).
 - `region` - (Defaults to the region specified in the [provider configuration](../index.md#region)). The [region](../guides/regions_and_zones.md#regions) where the resource exists.
@@ -48,7 +48,7 @@ The following arguments are supported:
 
 Only one of `data` or `data_wo` should be specified. If both are provided, Terraform will return an error.
 
-Note: The `data` (or `data_wo`) can be provided as either plain text or base64. When plain text is provided, the provider automatically handles base64 encoding before sending it to the API. The maximum size for either field is 64KiB.
+Note: The `data` (or `data_wo`) should be a raw string. **The provider handles encoding this string to base64 before sending it to the API so you do not need to encode the data yourself.** The maximum size for either field is 64KiB.
 
 #### `data`
 Updating `data` will force the creation of a new secret version.


### PR DESCRIPTION
My conclusion is the following:

I bamboozled myself.

Earlier this month I made [a commit](https://github.com/scaleway/terraform-provider-scaleway/commit/597e2ac8e32cdf8ac4fc25947a4931fe4c326679) that edited a specific line of doc from:
`Note: The `data` should be a base64-encoded string when sent from the API. **The provider handles this encoding so you do not need to encode the data yourself.**` 
to
`Note: The `data` (or `data_wo`) can be provided as either plain text or base64. When plain text is provided, the provider automatically handles base64 encoding before sending it to the API. The maximum size for either field is 64KiB.`

This was a sincere misunderstanding, which stemmed from several misunderstandings about our handling of base64. I now understand that:
- StateFuncs (like [this one](https://github.com/scaleway/terraform-provider-scaleway/blob/02532be961ca0e411981f4140679524a602eea5b/internal/services/secret/version.go#L61)) only impacts the state, not the resource attribute that we manipulate in the create function. The data we pass to the SDK [here](https://github.com/scaleway/terraform-provider-scaleway/blob/02532be961ca0e411981f4140679524a602eea5b/internal/services/secret/version.go#L123) is raw.
- The base64 encoding of all []byte fields is systematically performed in the SDK by the json marshaller, regardless of content
- All data passed to secret_version data and data_wo should be considered raw. If we want to handle already encoded data (for example for safely passing binary data) we should have a dedicated field (like a `data_binary` field). This could be useful for the keymanager Verify datasource, for which we need to pass the binary signature as base64 (the decoded version contains non-UTF8 character). In the current context, when we pass it (encoded) to the secret_version, we then encode it again in the SDK. That's fine, it's just a bit confusing handling the several levels of encoding (my whole debacle is a good testimony of it).
- 
