### PR TITLE
chore(secret/keymanager): better tests

### DIFF
--- a/internal/services/keymanager/sign_ephemeral_resource_test.go
+++ b/internal/services/keymanager/sign_ephemeral_resource_test.go
@@ -34,7 +34,7 @@ func TestAccSignEphemeralResource_Basic(t *testing.T) {
 			{
 				Config: fmt.Sprintf(`
 				resource "scaleway_key_manager_key" "test_key" {
-					name        = "tf-test-encrypt-key"
+					name        = "tf-test-sign-key"
 					region      = "fr-par"
 					usage       = "asymmetric_signing"
 					algorithm   = "rsa_pss_2048_sha256"

--- a/internal/services/keymanager/testdata/sign-ephemeral-resource-basic.cassette.yaml
+++ b/internal/services/keymanager/testdata/sign-ephemeral-resource-basic.cassette.yaml
@@ -20,22 +20,22 @@ interactions:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 447
-        body: '{"id":"d556b504-dec6-4c40-a4b6-a541a41f4996", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"test-sign-secret", "status":"ready", "created_at":"2026-01-08T14:24:42.644862Z", "updated_at":"2026-01-08T14:24:42.644862Z", "tags":[], "version_count":0, "description":"", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}'
+        content_length: 430
+        body: '{"id":"d56237fa-e1c3-40e1-ba83-41dddfacae31","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-sign-secret","status":"ready","created_at":"2026-01-30T16:15:05.262533Z","updated_at":"2026-01-30T16:15:05.262533Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "447"
+                - "430"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 08 Jan 2026 14:24:42 GMT
+                - Fri, 30 Jan 2026 16:15:05 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - aa2ef3ca-1234-4005-9a23-07cf7f9f264e
+                - dad9ad40-6a6e-46e1-87a7-2c6baa1e479c
         status: 200 OK
         code: 200
-        duration: 249.292626ms
+        duration: 268.027259ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -46,28 +46,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/d556b504-dec6-4c40-a4b6-a541a41f4996
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/d56237fa-e1c3-40e1-ba83-41dddfacae31
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 447
-        body: '{"id":"d556b504-dec6-4c40-a4b6-a541a41f4996", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"test-sign-secret", "status":"ready", "created_at":"2026-01-08T14:24:42.644862Z", "updated_at":"2026-01-08T14:24:42.644862Z", "tags":[], "version_count":0, "description":"", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}'
+        content_length: 430
+        body: '{"id":"d56237fa-e1c3-40e1-ba83-41dddfacae31","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-sign-secret","status":"ready","created_at":"2026-01-30T16:15:05.262533Z","updated_at":"2026-01-30T16:15:05.262533Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "447"
+                - "430"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 08 Jan 2026 14:24:42 GMT
+                - Fri, 30 Jan 2026 16:15:05 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 8a16bd80-c431-4989-908e-06ddff51db2a
+                - bf220b42-3580-426b-bf7f-5ac817ac933b
         status: 200 OK
         code: 200
-        duration: 71.694309ms
+        duration: 83.141879ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -81,36 +81,36 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/d556b504-dec6-4c40-a4b6-a541a41f4996/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/d56237fa-e1c3-40e1-ba83-41dddfacae31/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 32
-        body: '{"versions":[], "total_count":0}'
+        content_length: 31
+        body: '{"versions":[],"total_count":0}'
         headers:
             Content-Length:
-                - "32"
+                - "31"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 08 Jan 2026 14:24:42 GMT
+                - Fri, 30 Jan 2026 16:15:05 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 195f977c-daab-4d4f-a394-272d0a7a023f
+                - f52e2698-5d4c-48f2-ac9b-c6ed8489a285
         status: 200 OK
         code: 200
-        duration: 94.186478ms
+        duration: 46.010113ms
     - id: 3
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 192
+        content_length: 189
         host: api.scaleway.com
-        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-encrypt-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"tags":null,"unprotected":true,"origin":"unknown_origin"}'
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-sign-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"tags":null,"unprotected":true,"origin":"unknown_origin"}'
         headers:
             Content-Type:
                 - application/json
@@ -122,22 +122,22 @@ interactions:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 517
-        body: '{"id":"82633728-cda1-4645-9f23-e1f20ae953e0", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-encrypt-key", "usage":{"asymmetric_signing":"rsa_pss_2048_sha256"}, "state":"enabled", "rotation_count":1, "created_at":"2026-01-08T14:24:42.714632Z", "updated_at":"2026-01-08T14:24:42.823086Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-01-08T14:24:42.823086Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 498
+        body: '{"id":"9398c1ca-68c4-4519-8d88-e3eb876aaf5a","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-sign-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-01-30T16:15:05.381560Z","updated_at":"2026-01-30T16:15:05.424645Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-01-30T16:15:05.424645Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "517"
+                - "498"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 08 Jan 2026 14:24:42 GMT
+                - Fri, 30 Jan 2026 16:15:05 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - bcc8944b-3e25-4959-9075-3cb4ae77983b
+                - 9b885f1e-679a-400b-8faf-fb21e2f4d85f
         status: 200 OK
         code: 200
-        duration: 457.678594ms
+        duration: 445.937937ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -148,28 +148,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/82633728-cda1-4645-9f23-e1f20ae953e0
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/9398c1ca-68c4-4519-8d88-e3eb876aaf5a
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 517
-        body: '{"id":"82633728-cda1-4645-9f23-e1f20ae953e0", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-encrypt-key", "usage":{"asymmetric_signing":"rsa_pss_2048_sha256"}, "state":"enabled", "rotation_count":1, "created_at":"2026-01-08T14:24:42.714632Z", "updated_at":"2026-01-08T14:24:42.823086Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-01-08T14:24:42.823086Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 498
+        body: '{"id":"9398c1ca-68c4-4519-8d88-e3eb876aaf5a","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-sign-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-01-30T16:15:05.381560Z","updated_at":"2026-01-30T16:15:05.424645Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-01-30T16:15:05.424645Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "517"
+                - "498"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 08 Jan 2026 14:24:42 GMT
+                - Fri, 30 Jan 2026 16:15:05 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - b59f9c63-5afc-4c25-a2c9-008214fd0137
+                - ba57134c-bf75-4cf5-af83-6a9b2860c73c
         status: 200 OK
         code: 200
-        duration: 76.085195ms
+        duration: 77.102512ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -183,28 +183,28 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/82633728-cda1-4645-9f23-e1f20ae953e0/sign
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/9398c1ca-68c4-4519-8d88-e3eb876aaf5a/sign
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 409
-        body: '{"key_id":"82633728-cda1-4645-9f23-e1f20ae953e0", "signature":"E6+lj9lvhqWZvx8tTK7NAGz4ygdKbY/o9Uotw3aya/9wop5li2PFYMQKvjl8i1UrMEirmUeqdwx4ms+b6RZ5T+h8wBCkT/LicCkOmHxhwkWnJjFGennm7WSyafT+7mj45EqEqWPzzyPazgYKzIHA5VLH4CFFWAnitJnmxl4axw21zTv80n2OZYFAXMBsH9xoE34XJPeQpQPoyq8WO1YHhoKH4MgXc/Ca6ihpRMGbi5OKEh9xXn/8fuUXyfLzWA1dWiEJ/H18O0a0K1CcGS59Q4tCCb/jfjJ5umGH6WQmONMcJ+QqCeDa/iSrmBk6O1OGs9MHQ/Z7JPon/prv/BESyA=="}'
+        content_length: 408
+        body: '{"key_id":"9398c1ca-68c4-4519-8d88-e3eb876aaf5a","signature":"HW3+vxV5JfypLlh2uOv+eD2brR+p92N+RHxl1OjalDreNzAmguvteDlbpYBvLcXaXvIHY3b29W6BhS/bN67SzwNDbLoYBvSvgbNn5MsKkvQTbcUu3odzog95S9JwTx87pxRQ6W8C77jkZA7nvdSOoFuaizvOBBV06h7qbJwsoVpu33/i7lX67pfyJFuU8Ai0Uj4/b68YDPVjmjleQTC7mRufdKkjVmDBPbblB4jVP4ywI75U9cZNvq8Q7HkcXyC9oXB1op5Fql//PeVBs40YPe5KhMqBajfRr+sj6RcuNXaX2RbdGZxT96M7vowW6rYbSD2LfnPiStbSzstX/CO9iA=="}'
         headers:
             Content-Length:
-                - "409"
+                - "408"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 08 Jan 2026 14:24:43 GMT
+                - Fri, 30 Jan 2026 16:15:05 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - d58f4567-c7d9-48c3-8ff6-33d38f147f92
+                - 024d3913-039b-4922-ab0d-a787f7f2af5b
         status: 200 OK
         code: 200
-        duration: 105.058692ms
+        duration: 128.936928ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -212,34 +212,34 @@ interactions:
         proto_minor: 1
         content_length: 496
         host: api.scaleway.com
-        body: '{"data":"RTYrbGo5bHZocVdadng4dFRLN05BR3o0eWdkS2JZL285VW90dzNheWEvOXdvcDVsaTJQRllNUUt2amw4aTFVck1FaXJtVWVxZHd4NG1zK2I2Ulo1VCtoOHdCQ2tUL0xpY0NrT21IeGh3a1duSmpGR2Vubm03V1N5YWZUKzdtajQ1RXFFcVdQenp5UGF6Z1lLeklIQTVWTEg0Q0ZGV0FuaXRKbm14bDRheHcyMXpUdjgwbjJPWllGQVhNQnNIOXhvRTM0WEpQZVFwUVBveXE4V08xWUhob0tINE1nWGMvQ2E2aWhwUk1HYmk1T0tFaDl4WG4vOGZ1VVh5Zkx6V0ExZFdpRUovSDE4TzBhMEsxQ2NHUzU5UTR0Q0NiL2pmako1dW1HSDZXUW1PTk1jSitRcUNlRGEvaVNybUJrNk8xT0dzOU1IUS9aN0pQb24vcHJ2L0JFU3lBPT0=","description":"version1"}'
+        body: '{"data":"SFczK3Z4VjVKZnlwTGxoMnVPditlRDJiclIrcDkyTitSSHhsMU9qYWxEcmVOekFtZ3V2dGVEbGJwWUJ2TGNYYVh2SUhZM2IyOVc2QmhTL2JONjdTendORGJMb1lCdlN2Z2JObjVNc0trdlFUYmNVdTNvZHpvZzk1UzlKd1R4ODdweFJRNlc4Qzc3amtaQTdudmRTT29GdWFpenZPQkJWMDZoN3FiSndzb1ZwdTMzL2k3bFg2N3BmeUpGdVU4QWkwVWo0L2I2OFlEUFZqbWpsZVFUQzdtUnVmZEtralZtREJQYmJsQjRqVlA0eXdJNzVVOWNaTnZxOFE3SGtjWHlDOW9YQjFvcDVGcWwvL1BlVkJzNDBZUGU1S2hNcUJhamZScitzajZSY3VOWGFYMlJiZEdaeFQ5Nk03dm93VzZyWWJTRDJMZm5QaVN0YlN6c3RYL0NPOWlBPT0=","description":"version1"}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/d556b504-dec6-4c40-a4b6-a541a41f4996/versions
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/d56237fa-e1c3-40e1-ba83-41dddfacae31/versions
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 312
-        body: '{"revision":1, "secret_id":"d556b504-dec6-4c40-a4b6-a541a41f4996", "status":"enabled", "created_at":"2026-01-08T14:24:43.379734Z", "updated_at":"2026-01-08T14:24:43.379734Z", "deleted_at":null, "description":"version1", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 302
+        body: '{"revision":1,"secret_id":"d56237fa-e1c3-40e1-ba83-41dddfacae31","status":"enabled","created_at":"2026-01-30T16:15:05.982171Z","updated_at":"2026-01-30T16:15:05.982171Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "312"
+                - "302"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 08 Jan 2026 14:24:43 GMT
+                - Fri, 30 Jan 2026 16:15:06 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 71c02a11-411e-46dd-95d4-a09edbf115a5
+                - abd67403-bb9b-41e6-bc0e-f94732f23242
         status: 200 OK
         code: 200
-        duration: 467.701443ms
+        duration: 393.785443ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -250,28 +250,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/d556b504-dec6-4c40-a4b6-a541a41f4996/versions/1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/d56237fa-e1c3-40e1-ba83-41dddfacae31/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 312
-        body: '{"revision":1, "secret_id":"d556b504-dec6-4c40-a4b6-a541a41f4996", "status":"enabled", "created_at":"2026-01-08T14:24:43.379734Z", "updated_at":"2026-01-08T14:24:43.379734Z", "deleted_at":null, "description":"version1", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 302
+        body: '{"revision":1,"secret_id":"d56237fa-e1c3-40e1-ba83-41dddfacae31","status":"enabled","created_at":"2026-01-30T16:15:05.982171Z","updated_at":"2026-01-30T16:15:05.982171Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "312"
+                - "302"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 08 Jan 2026 14:24:43 GMT
+                - Fri, 30 Jan 2026 16:15:06 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - ced56ce5-6455-4465-8e34-08215409bd68
+                - 9222d763-6836-45cd-bccc-4408b6a7f75f
         status: 200 OK
         code: 200
-        duration: 73.931656ms
+        duration: 95.148072ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -282,28 +282,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/d556b504-dec6-4c40-a4b6-a541a41f4996/versions/1/access
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/d56237fa-e1c3-40e1-ba83-41dddfacae31/versions/1/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 573
-        body: '{"secret_id":"d556b504-dec6-4c40-a4b6-a541a41f4996", "revision":1, "data":"RTYrbGo5bHZocVdadng4dFRLN05BR3o0eWdkS2JZL285VW90dzNheWEvOXdvcDVsaTJQRllNUUt2amw4aTFVck1FaXJtVWVxZHd4NG1zK2I2Ulo1VCtoOHdCQ2tUL0xpY0NrT21IeGh3a1duSmpGR2Vubm03V1N5YWZUKzdtajQ1RXFFcVdQenp5UGF6Z1lLeklIQTVWTEg0Q0ZGV0FuaXRKbm14bDRheHcyMXpUdjgwbjJPWllGQVhNQnNIOXhvRTM0WEpQZVFwUVBveXE4V08xWUhob0tINE1nWGMvQ2E2aWhwUk1HYmk1T0tFaDl4WG4vOGZ1VVh5Zkx6V0ExZFdpRUovSDE4TzBhMEsxQ2NHUzU5UTR0Q0NiL2pmako1dW1HSDZXUW1PTk1jSitRcUNlRGEvaVNybUJrNk8xT0dzOU1IUS9aN0pQb24vcHJ2L0JFU3lBPT0=", "data_crc32":null, "type":"opaque"}'
+        content_length: 569
+        body: '{"secret_id":"d56237fa-e1c3-40e1-ba83-41dddfacae31","revision":1,"data":"SFczK3Z4VjVKZnlwTGxoMnVPditlRDJiclIrcDkyTitSSHhsMU9qYWxEcmVOekFtZ3V2dGVEbGJwWUJ2TGNYYVh2SUhZM2IyOVc2QmhTL2JONjdTendORGJMb1lCdlN2Z2JObjVNc0trdlFUYmNVdTNvZHpvZzk1UzlKd1R4ODdweFJRNlc4Qzc3amtaQTdudmRTT29GdWFpenZPQkJWMDZoN3FiSndzb1ZwdTMzL2k3bFg2N3BmeUpGdVU4QWkwVWo0L2I2OFlEUFZqbWpsZVFUQzdtUnVmZEtralZtREJQYmJsQjRqVlA0eXdJNzVVOWNaTnZxOFE3SGtjWHlDOW9YQjFvcDVGcWwvL1BlVkJzNDBZUGU1S2hNcUJhamZScitzajZSY3VOWGFYMlJiZEdaeFQ5Nk03dm93VzZyWWJTRDJMZm5QaVN0YlN6c3RYL0NPOWlBPT0=","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "573"
+                - "569"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 08 Jan 2026 14:24:43 GMT
+                - Fri, 30 Jan 2026 16:15:06 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - a9ff160f-e117-43ee-ad37-e1a2bc829bd7
+                - 56f6f4c0-f779-47dc-af69-a53c94849ff3
         status: 200 OK
         code: 200
-        duration: 127.70544ms
+        duration: 116.930602ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -314,28 +314,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/d556b504-dec6-4c40-a4b6-a541a41f4996/versions/1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/d56237fa-e1c3-40e1-ba83-41dddfacae31/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 312
-        body: '{"revision":1, "secret_id":"d556b504-dec6-4c40-a4b6-a541a41f4996", "status":"enabled", "created_at":"2026-01-08T14:24:43.379734Z", "updated_at":"2026-01-08T14:24:43.379734Z", "deleted_at":null, "description":"version1", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 302
+        body: '{"revision":1,"secret_id":"d56237fa-e1c3-40e1-ba83-41dddfacae31","status":"enabled","created_at":"2026-01-30T16:15:05.982171Z","updated_at":"2026-01-30T16:15:05.982171Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "312"
+                - "302"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 08 Jan 2026 14:24:43 GMT
+                - Fri, 30 Jan 2026 16:15:06 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - dca16bde-8a9d-4b41-815f-0f9b9a4aed14
+                - 9dbb0274-a12b-49af-aec3-f85acbaab283
         status: 200 OK
         code: 200
-        duration: 37.40407ms
+        duration: 52.872156ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -349,28 +349,28 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/82633728-cda1-4645-9f23-e1f20ae953e0/sign
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/9398c1ca-68c4-4519-8d88-e3eb876aaf5a/sign
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 409
-        body: '{"key_id":"82633728-cda1-4645-9f23-e1f20ae953e0", "signature":"suhZqaFoxLZfTxMEmCP+Q+qXSYIfE/6tefOqTXGzsC1JymyLI5MrvSvlKDww5TrKb8/PKF+j0I4zV+uHYvRXlT38lu0ERTT2qChYnvLGSFFxKtXOgcGUnz8r4GFnN3agxNWlPMEMIUHES7+lX7Vs+tzczAQ2unZC2PK05eSurYRvkvZtS/lyqbbKUtEXaK9nV+YQkfDIo8b7YDQb5unPbbLN9Zoic7vb0pz2oq8PfaZxbGjI8ab6zHuhgEisOS03iB86H9Sc8Ew/NMc25je8QW2o3Slc4kz8eMjNikNYsomdO+IhzG6uF1dCz2TAMIrUAq/yH+Pm6oswvseaaGq/Aw=="}'
+        content_length: 408
+        body: '{"key_id":"9398c1ca-68c4-4519-8d88-e3eb876aaf5a","signature":"tqfe/y2Imohfx6PMtSzgZ57515UDJQ2olWaHIVNISTziMHi2Yt3+UstvKuanepMFhS47jWdtc/37TYlX7wQgudGsk3BofooUJN+15dBBV/OIXtJT3h1xG32p1duCg4cU7V3PLKyV/URmd6k7LU7FeeBjyvyymkitkg7GaKY+5rpRVRsrOaJQzNahGz5zOAmlimbuj8qNXI3KlXYjIwVHunskIk5X0WtD24mQGRUXqzKlMJ76t9bbEsB9vKAPMi7yTu9pYXoqiLWBNq/vknmRhAOWnQ1mWskDvrKaTUp2Bb+EGzl5pa3I/kfrliCH0vYYI8hhfz9hl6FP7uoPFZCrvA=="}'
         headers:
             Content-Length:
-                - "409"
+                - "408"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 08 Jan 2026 14:24:43 GMT
+                - Fri, 30 Jan 2026 16:15:06 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - fb014976-8442-4c1d-a28d-6e596f035634
+                - 936c6f09-02ce-47ff-9c4d-56acd3b044e9
         status: 200 OK
         code: 200
-        duration: 101.231274ms
+        duration: 113.489607ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -381,28 +381,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/d556b504-dec6-4c40-a4b6-a541a41f4996/versions/1/access
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/d56237fa-e1c3-40e1-ba83-41dddfacae31/versions/1/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 573
-        body: '{"secret_id":"d556b504-dec6-4c40-a4b6-a541a41f4996", "revision":1, "data":"RTYrbGo5bHZocVdadng4dFRLN05BR3o0eWdkS2JZL285VW90dzNheWEvOXdvcDVsaTJQRllNUUt2amw4aTFVck1FaXJtVWVxZHd4NG1zK2I2Ulo1VCtoOHdCQ2tUL0xpY0NrT21IeGh3a1duSmpGR2Vubm03V1N5YWZUKzdtajQ1RXFFcVdQenp5UGF6Z1lLeklIQTVWTEg0Q0ZGV0FuaXRKbm14bDRheHcyMXpUdjgwbjJPWllGQVhNQnNIOXhvRTM0WEpQZVFwUVBveXE4V08xWUhob0tINE1nWGMvQ2E2aWhwUk1HYmk1T0tFaDl4WG4vOGZ1VVh5Zkx6V0ExZFdpRUovSDE4TzBhMEsxQ2NHUzU5UTR0Q0NiL2pmako1dW1HSDZXUW1PTk1jSitRcUNlRGEvaVNybUJrNk8xT0dzOU1IUS9aN0pQb24vcHJ2L0JFU3lBPT0=", "data_crc32":null, "type":"opaque"}'
+        content_length: 569
+        body: '{"secret_id":"d56237fa-e1c3-40e1-ba83-41dddfacae31","revision":1,"data":"SFczK3Z4VjVKZnlwTGxoMnVPditlRDJiclIrcDkyTitSSHhsMU9qYWxEcmVOekFtZ3V2dGVEbGJwWUJ2TGNYYVh2SUhZM2IyOVc2QmhTL2JONjdTendORGJMb1lCdlN2Z2JObjVNc0trdlFUYmNVdTNvZHpvZzk1UzlKd1R4ODdweFJRNlc4Qzc3amtaQTdudmRTT29GdWFpenZPQkJWMDZoN3FiSndzb1ZwdTMzL2k3bFg2N3BmeUpGdVU4QWkwVWo0L2I2OFlEUFZqbWpsZVFUQzdtUnVmZEtralZtREJQYmJsQjRqVlA0eXdJNzVVOWNaTnZxOFE3SGtjWHlDOW9YQjFvcDVGcWwvL1BlVkJzNDBZUGU1S2hNcUJhamZScitzajZSY3VOWGFYMlJiZEdaeFQ5Nk03dm93VzZyWWJTRDJMZm5QaVN0YlN6c3RYL0NPOWlBPT0=","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "573"
+                - "569"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 08 Jan 2026 14:24:44 GMT
+                - Fri, 30 Jan 2026 16:15:06 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 54f04a71-0097-4fd1-ab69-4ec6c369981d
+                - dfa3839f-6d0b-4643-bb1c-7424f77e856f
         status: 200 OK
         code: 200
-        duration: 65.967349ms
+        duration: 133.266622ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -413,28 +413,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/d556b504-dec6-4c40-a4b6-a541a41f4996/versions/1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/d56237fa-e1c3-40e1-ba83-41dddfacae31/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 312
-        body: '{"revision":1, "secret_id":"d556b504-dec6-4c40-a4b6-a541a41f4996", "status":"enabled", "created_at":"2026-01-08T14:24:43.379734Z", "updated_at":"2026-01-08T14:24:43.379734Z", "deleted_at":null, "description":"version1", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 302
+        body: '{"revision":1,"secret_id":"d56237fa-e1c3-40e1-ba83-41dddfacae31","status":"enabled","created_at":"2026-01-30T16:15:05.982171Z","updated_at":"2026-01-30T16:15:05.982171Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "312"
+                - "302"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 08 Jan 2026 14:24:44 GMT
+                - Fri, 30 Jan 2026 16:15:06 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 4d68077f-13d9-42d9-b51e-7f4e0725c10f
+                - f43792e1-7ab8-4f30-9ba8-e6f71725823b
         status: 200 OK
         code: 200
-        duration: 53.275707ms
+        duration: 37.162203ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -445,28 +445,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/d556b504-dec6-4c40-a4b6-a541a41f4996
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/d56237fa-e1c3-40e1-ba83-41dddfacae31
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 447
-        body: '{"id":"d556b504-dec6-4c40-a4b6-a541a41f4996", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"test-sign-secret", "status":"ready", "created_at":"2026-01-08T14:24:42.644862Z", "updated_at":"2026-01-08T14:24:42.644862Z", "tags":[], "version_count":1, "description":"", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}'
+        content_length: 430
+        body: '{"id":"d56237fa-e1c3-40e1-ba83-41dddfacae31","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-sign-secret","status":"ready","created_at":"2026-01-30T16:15:05.262533Z","updated_at":"2026-01-30T16:15:05.262533Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "447"
+                - "430"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 08 Jan 2026 14:24:44 GMT
+                - Fri, 30 Jan 2026 16:15:06 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 5dbc6bef-b799-42ad-a1cd-0dbcf03aaa1d
+                - 0548038d-069d-4564-ab1f-9b467000e5af
         status: 200 OK
         code: 200
-        duration: 62.897293ms
+        duration: 49.347294ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -477,28 +477,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/82633728-cda1-4645-9f23-e1f20ae953e0
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/9398c1ca-68c4-4519-8d88-e3eb876aaf5a
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 517
-        body: '{"id":"82633728-cda1-4645-9f23-e1f20ae953e0", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-encrypt-key", "usage":{"asymmetric_signing":"rsa_pss_2048_sha256"}, "state":"enabled", "rotation_count":1, "created_at":"2026-01-08T14:24:42.714632Z", "updated_at":"2026-01-08T14:24:42.823086Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-01-08T14:24:42.823086Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 498
+        body: '{"id":"9398c1ca-68c4-4519-8d88-e3eb876aaf5a","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-sign-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"enabled","rotation_count":1,"created_at":"2026-01-30T16:15:05.381560Z","updated_at":"2026-01-30T16:15:05.424645Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-01-30T16:15:05.424645Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "517"
+                - "498"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 08 Jan 2026 14:24:44 GMT
+                - Fri, 30 Jan 2026 16:15:06 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - e74a13a6-35e8-45c3-b748-b571f9a1233b
+                - 63c592d2-3298-477b-a39a-06305dfcf9ef
         status: 200 OK
         code: 200
-        duration: 79.950359ms
+        duration: 79.224414ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -512,28 +512,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/d556b504-dec6-4c40-a4b6-a541a41f4996/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/d56237fa-e1c3-40e1-ba83-41dddfacae31/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 344
-        body: '{"versions":[{"revision":1, "secret_id":"d556b504-dec6-4c40-a4b6-a541a41f4996", "status":"enabled", "created_at":"2026-01-08T14:24:43.379734Z", "updated_at":"2026-01-08T14:24:43.379734Z", "deleted_at":null, "description":"version1", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}], "total_count":1}'
+        content_length: 333
+        body: '{"versions":[{"revision":1,"secret_id":"d56237fa-e1c3-40e1-ba83-41dddfacae31","status":"enabled","created_at":"2026-01-30T16:15:05.982171Z","updated_at":"2026-01-30T16:15:05.982171Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
-                - "344"
+                - "333"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 08 Jan 2026 14:24:44 GMT
+                - Fri, 30 Jan 2026 16:15:07 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - a9717fe0-8c54-4761-833a-cd118f525fa5
+                - c0a0630c-5c8e-4b7d-9323-f42c50429345
         status: 200 OK
         code: 200
-        duration: 52.26685ms
+        duration: 39.84502ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -547,28 +547,28 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/82633728-cda1-4645-9f23-e1f20ae953e0/sign
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/9398c1ca-68c4-4519-8d88-e3eb876aaf5a/sign
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 409
-        body: '{"key_id":"82633728-cda1-4645-9f23-e1f20ae953e0", "signature":"wxrfzCutC/gUrsMUGVT+8BjxwBTruX+nfkXqy3JmbD3w+pgIXxX4yMurcjfQeoZyOUJNKIffGKCXScwACaicyD16Iy+gSKGaeJkOIx1NdSFuaYhkJWBjh40krf4OO4TrNoBUOKAQmYbxXJd/CjJALhzOMgggQz4UIYHKFfgOK2cdg6nPHaMpRCV2x0ZQrfGEpqrej0My7N5hSOiD4yGHw3WDEdfkRffp3hUgDOyfKKKJL5swAmd59Smz+Vs1zccwbLg34Wq28saJ/PNiqBPHnjtX/QnX1tg7ccyFqGXFBGwbhvzOMDCtjSKOOPdlzL+rTniSxHt5ECo6jdLrK5fLPA=="}'
+        content_length: 408
+        body: '{"key_id":"9398c1ca-68c4-4519-8d88-e3eb876aaf5a","signature":"l75bUMXY6kYSgqtJsd4DzdWRpXhhHV2hXPO+/JYsP41KeJiPl/SFeCYdQhEfbjD0o+b92s0+vyzOKdo+2DSPvBdCbWq3IZxIdqxB44tASxai70Y8xi+HkO/r/sPti9CoNzujMaOY5nvcEVugMIk6hRDO/NTqRGSIt2fb27iiPeya46yMx81QSNYTJmz2AZMJZON3hU47HeYAF3Rpb1lAphAVJe/Viknq8eqS6/mJleEjequHqP34WiJslBbVd2Sau1exqcg2byWAI7OBd86oKjIbk3KETZn5meRPqfo3+T+59xNJHyF5sVPsAV/Ox/pR5LItTaV6yCaLUn92sRornQ=="}'
         headers:
             Content-Length:
-                - "409"
+                - "408"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 08 Jan 2026 14:24:44 GMT
+                - Fri, 30 Jan 2026 16:15:07 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 6870da5a-ecf1-448f-b776-62757e06414b
+                - ff43e6cd-25c0-430a-b5ef-580244154807
         status: 200 OK
         code: 200
-        duration: 126.825137ms
+        duration: 146.571775ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -579,28 +579,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/d556b504-dec6-4c40-a4b6-a541a41f4996/versions/1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/d56237fa-e1c3-40e1-ba83-41dddfacae31/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 312
-        body: '{"revision":1, "secret_id":"d556b504-dec6-4c40-a4b6-a541a41f4996", "status":"enabled", "created_at":"2026-01-08T14:24:43.379734Z", "updated_at":"2026-01-08T14:24:43.379734Z", "deleted_at":null, "description":"version1", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 302
+        body: '{"revision":1,"secret_id":"d56237fa-e1c3-40e1-ba83-41dddfacae31","status":"enabled","created_at":"2026-01-30T16:15:05.982171Z","updated_at":"2026-01-30T16:15:05.982171Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "312"
+                - "302"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 08 Jan 2026 14:24:44 GMT
+                - Fri, 30 Jan 2026 16:15:07 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 68243630-fe9b-4f9a-9cd4-5b8379343260
+                - eea88ef4-0fc1-408d-bdd4-bc6808f6513e
         status: 200 OK
         code: 200
-        duration: 37.804339ms
+        duration: 80.916898ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -611,28 +611,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/d556b504-dec6-4c40-a4b6-a541a41f4996/versions/1/access
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/d56237fa-e1c3-40e1-ba83-41dddfacae31/versions/1/access
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 573
-        body: '{"secret_id":"d556b504-dec6-4c40-a4b6-a541a41f4996", "revision":1, "data":"RTYrbGo5bHZocVdadng4dFRLN05BR3o0eWdkS2JZL285VW90dzNheWEvOXdvcDVsaTJQRllNUUt2amw4aTFVck1FaXJtVWVxZHd4NG1zK2I2Ulo1VCtoOHdCQ2tUL0xpY0NrT21IeGh3a1duSmpGR2Vubm03V1N5YWZUKzdtajQ1RXFFcVdQenp5UGF6Z1lLeklIQTVWTEg0Q0ZGV0FuaXRKbm14bDRheHcyMXpUdjgwbjJPWllGQVhNQnNIOXhvRTM0WEpQZVFwUVBveXE4V08xWUhob0tINE1nWGMvQ2E2aWhwUk1HYmk1T0tFaDl4WG4vOGZ1VVh5Zkx6V0ExZFdpRUovSDE4TzBhMEsxQ2NHUzU5UTR0Q0NiL2pmako1dW1HSDZXUW1PTk1jSitRcUNlRGEvaVNybUJrNk8xT0dzOU1IUS9aN0pQb24vcHJ2L0JFU3lBPT0=", "data_crc32":null, "type":"opaque"}'
+        content_length: 569
+        body: '{"secret_id":"d56237fa-e1c3-40e1-ba83-41dddfacae31","revision":1,"data":"SFczK3Z4VjVKZnlwTGxoMnVPditlRDJiclIrcDkyTitSSHhsMU9qYWxEcmVOekFtZ3V2dGVEbGJwWUJ2TGNYYVh2SUhZM2IyOVc2QmhTL2JONjdTendORGJMb1lCdlN2Z2JObjVNc0trdlFUYmNVdTNvZHpvZzk1UzlKd1R4ODdweFJRNlc4Qzc3amtaQTdudmRTT29GdWFpenZPQkJWMDZoN3FiSndzb1ZwdTMzL2k3bFg2N3BmeUpGdVU4QWkwVWo0L2I2OFlEUFZqbWpsZVFUQzdtUnVmZEtralZtREJQYmJsQjRqVlA0eXdJNzVVOWNaTnZxOFE3SGtjWHlDOW9YQjFvcDVGcWwvL1BlVkJzNDBZUGU1S2hNcUJhamZScitzajZSY3VOWGFYMlJiZEdaeFQ5Nk03dm93VzZyWWJTRDJMZm5QaVN0YlN6c3RYL0NPOWlBPT0=","data_crc32":null,"type":"opaque"}'
         headers:
             Content-Length:
-                - "573"
+                - "569"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 08 Jan 2026 14:24:44 GMT
+                - Fri, 30 Jan 2026 16:15:07 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - a5a4dacd-0516-48e7-8e18-21708efae032
+                - 4f56c519-1174-437b-b6f9-cea7dc413c9b
         status: 200 OK
         code: 200
-        duration: 127.465865ms
+        duration: 95.753675ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -643,28 +643,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/d556b504-dec6-4c40-a4b6-a541a41f4996/versions/1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/d56237fa-e1c3-40e1-ba83-41dddfacae31/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 312
-        body: '{"revision":1, "secret_id":"d556b504-dec6-4c40-a4b6-a541a41f4996", "status":"enabled", "created_at":"2026-01-08T14:24:43.379734Z", "updated_at":"2026-01-08T14:24:43.379734Z", "deleted_at":null, "description":"version1", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
+        content_length: 302
+        body: '{"revision":1,"secret_id":"d56237fa-e1c3-40e1-ba83-41dddfacae31","status":"enabled","created_at":"2026-01-30T16:15:05.982171Z","updated_at":"2026-01-30T16:15:05.982171Z","deleted_at":null,"description":"version1","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "312"
+                - "302"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 08 Jan 2026 14:24:44 GMT
+                - Fri, 30 Jan 2026 16:15:07 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 0354d4e3-12ad-4f27-84ca-170d4b42a969
+                - a2ab57e3-bae8-45c0-b3af-c08d87cb2a77
         status: 200 OK
         code: 200
-        duration: 34.074404ms
+        duration: 32.154674ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -675,7 +675,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/d556b504-dec6-4c40-a4b6-a541a41f4996/versions/1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/d56237fa-e1c3-40e1-ba83-41dddfacae31/versions/1
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -687,14 +687,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 08 Jan 2026 14:24:45 GMT
+                - Fri, 30 Jan 2026 16:15:07 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - a6ae9d38-3e8e-4dec-bbf1-c5a2aa8d55fb
+                - f74a5b21-45f2-4f0f-bb27-592aca2db1fe
         status: 204 No Content
         code: 204
-        duration: 126.39325ms
+        duration: 92.577733ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -705,7 +705,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/82633728-cda1-4645-9f23-e1f20ae953e0
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/9398c1ca-68c4-4519-8d88-e3eb876aaf5a
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -717,14 +717,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 08 Jan 2026 14:24:45 GMT
+                - Fri, 30 Jan 2026 16:15:07 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - c5cf960b-edd6-4120-ad57-530221f079dd
+                - 855b8a31-1bfb-48bc-8797-4d04fd847258
         status: 204 No Content
         code: 204
-        duration: 122.50331ms
+        duration: 113.808956ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -735,7 +735,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/d556b504-dec6-4c40-a4b6-a541a41f4996
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/d56237fa-e1c3-40e1-ba83-41dddfacae31
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -747,14 +747,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 08 Jan 2026 14:24:45 GMT
+                - Fri, 30 Jan 2026 16:15:07 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 812bf7c2-5024-4a35-b5de-5b2d48334610
+                - 1abbfeed-a047-4d2f-a062-51ba293c27f5
         status: 204 No Content
         code: 204
-        duration: 163.507752ms
+        duration: 154.668677ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -765,28 +765,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/82633728-cda1-4645-9f23-e1f20ae953e0
+        url: https://api.scaleway.com/key-manager/v1alpha1/regions/fr-par/keys/9398c1ca-68c4-4519-8d88-e3eb876aaf5a
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 557
-        body: '{"id":"82633728-cda1-4645-9f23-e1f20ae953e0", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"tf-test-encrypt-key", "usage":{"asymmetric_signing":"rsa_pss_2048_sha256"}, "state":"scheduled_for_deletion", "rotation_count":1, "created_at":"2026-01-08T14:24:42.714632Z", "updated_at":"2026-01-08T14:24:42.823086Z", "protected":false, "locked":false, "description":null, "tags":[], "rotated_at":"2026-01-08T14:24:42.823086Z", "rotation_policy":null, "origin":"scaleway_kms", "deletion_requested_at":"2026-01-08T14:24:45.124187Z", "region":"fr-par"}'
+        content_length: 538
+        body: '{"id":"9398c1ca-68c4-4519-8d88-e3eb876aaf5a","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-sign-key","usage":{"asymmetric_signing":"rsa_pss_2048_sha256"},"state":"scheduled_for_deletion","rotation_count":1,"created_at":"2026-01-30T16:15:05.381560Z","updated_at":"2026-01-30T16:15:05.424645Z","protected":false,"locked":false,"description":null,"tags":[],"rotated_at":"2026-01-30T16:15:05.424645Z","rotation_policy":null,"origin":"scaleway_kms","deletion_requested_at":"2026-01-30T16:15:07.765950Z","region":"fr-par"}'
         headers:
             Content-Length:
-                - "557"
+                - "538"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 08 Jan 2026 14:24:45 GMT
+                - Fri, 30 Jan 2026 16:15:07 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 23df223d-fe93-41fb-8f19-b116611126cb
+                - 039452a4-3acb-456c-9e10-5d3c4ec70a66
         status: 200 OK
         code: 200
-        duration: 103.970854ms
+        duration: 86.796432ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -797,25 +797,25 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/d556b504-dec6-4c40-a4b6-a541a41f4996
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/d56237fa-e1c3-40e1-ba83-41dddfacae31
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 472
-        body: '{"id":"d556b504-dec6-4c40-a4b6-a541a41f4996", "project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "name":"test-sign-secret", "status":"ready", "created_at":"2026-01-08T14:24:42.644862Z", "updated_at":"2026-01-08T14:24:42.644862Z", "tags":[], "version_count":1, "description":"", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":"2026-01-08T14:24:45.147470Z", "key_id":null, "region":"fr-par"}'
+        content_length: 455
+        body: '{"id":"d56237fa-e1c3-40e1-ba83-41dddfacae31","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-sign-secret","status":"ready","created_at":"2026-01-30T16:15:05.262533Z","updated_at":"2026-01-30T16:15:05.262533Z","tags":[],"version_count":1,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-01-30T16:15:07.785039Z","key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "472"
+                - "455"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 08 Jan 2026 14:24:45 GMT
+                - Fri, 30 Jan 2026 16:15:07 GMT
             Server:
                 - Scaleway API Gateway (fr-par-1;edge01)
             X-Request-Id:
-                - 6475963a-16a0-4160-a4f5-6a6e0f0b0d6a
+                - a93da044-89eb-4ae8-ab18-eed84effbb0f
         status: 200 OK
         code: 200
-        duration: 92.707695ms
+        duration: 50.354328ms

--- a/internal/services/secret/testdata/data-source-secret-basic.cassette.yaml
+++ b/internal/services/secret/testdata/data-source-secret-basic.cassette.yaml
@@ -6,149 +6,9 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 130
+        content_length: 199
         host: api.scaleway.com
-        body: '{"name":"test-acc-scaleway-project-1417389955111742815","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","description":""}'
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/account/v3/projects
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 287
-        body: '{"id":"572984ce-3a11-430c-a0d8-a345cfed2df9", "name":"test-acc-scaleway-project-1417389955111742815", "organization_id":"105bdce1-64c0-48ab-899d-868455867ecf", "created_at":"2025-12-16T11:13:34.684746Z", "updated_at":"2025-12-16T11:13:34.684746Z", "description":"", "qualification":null}'
-        headers:
-            Content-Length:
-                - "287"
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 16 Dec 2025 11:13:34 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
-            X-Request-Id:
-                - e1f75987-e5ee-4116-a07c-9e8d707175da
-        status: 200 OK
-        code: 200
-        duration: 8.14369936s
-    - id: 1
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 141
-        host: api.scaleway.com
-        body: '{"name":"test-acc-scaleway-iam-app-635616833082840529","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","description":"","tags":null}'
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/iam/v1alpha1/applications
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 344
-        body: '{"id":"4697bd91-1bd6-4ff0-94eb-5d0b8afc5ecf", "name":"test-acc-scaleway-iam-app-635616833082840529", "description":"", "created_at":"2025-12-16T11:13:35.264826Z", "updated_at":"2025-12-16T11:13:35.264826Z", "organization_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "nb_api_keys":0, "tags":[]}'
-        headers:
-            Content-Length:
-                - "344"
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 16 Dec 2025 11:13:35 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
-            X-Request-Id:
-                - 5149cbf1-7a00-486e-a02d-44be2f1e3a25
-        status: 200 OK
-        code: 200
-        duration: 304.616977ms
-    - id: 2
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 323
-        host: api.scaleway.com
-        body: '{"name":"test-acc-scaleway-iam-policy-2078185620077057919","description":"","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","rules":[{"permission_set_names":["IAMManager"],"condition":"","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf"}],"tags":null,"application_id":"4697bd91-1bd6-4ff0-94eb-5d0b8afc5ecf"}'
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/iam/v1alpha1/policies
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 441
-        body: '{"id":"e9f70716-a0cb-4a0a-91e6-95da6a76d253", "name":"test-acc-scaleway-iam-policy-2078185620077057919", "description":"", "organization_id":"105bdce1-64c0-48ab-899d-868455867ecf", "created_at":"2025-12-16T11:13:35.577820Z", "updated_at":"2025-12-16T11:13:35.577820Z", "editable":true, "deletable":true, "managed":false, "nb_rules":0, "nb_scopes":0, "nb_permission_sets":0, "tags":[], "application_id":"4697bd91-1bd6-4ff0-94eb-5d0b8afc5ecf"}'
-        headers:
-            Content-Length:
-                - "441"
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 16 Dec 2025 11:13:35 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
-            X-Request-Id:
-                - 2b6e86fc-c643-43e8-a288-e4335525f3d5
-        status: 200 OK
-        code: 200
-        duration: 273.899427ms
-    - id: 3
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 134
-        host: api.scaleway.com
-        body: '{"application_id":"4697bd91-1bd6-4ff0-94eb-5d0b8afc5ecf","default_project_id":"572984ce-3a11-430c-a0d8-a345cfed2df9","description":""}'
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/iam/v1alpha1/api-keys
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 417
-        body: '{"access_key":"SCW7Y72B0YTS5KPM3MEE", "secret_key":"11111111-1111-1111-1111-111111111111", "description":"", "created_at":"2025-12-16T11:13:35.889267Z", "updated_at":"2025-12-16T11:13:35.889267Z", "expires_at":null, "default_project_id":"572984ce-3a11-430c-a0d8-a345cfed2df9", "editable":true, "deletable":true, "managed":false, "creation_ip":"212.133.41.101", "application_id":"4697bd91-1bd6-4ff0-94eb-5d0b8afc5ecf"}'
-        headers:
-            Content-Length:
-                - "417"
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 16 Dec 2025 11:13:35 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
-            X-Request-Id:
-                - dd5889df-83e1-44b1-a762-62929d2d04bb
-        status: 200 OK
-        code: 200
-        duration: 339.188446ms
-    - id: 4
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 194
-        host: api.scaleway.com
-        body: '{"project_id":"572984ce-3a11-430c-a0d8-a345cfed2df9","name":"scalewayDataSourceSecret","tags":null,"description":"DataSourceSecret test description","type":"opaque","path":"/","protected":false}'
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","tags":null,"description":"DataSourceSecret test description","type":"opaque","path":"/","protected":false}'
         headers:
             Content-Type:
                 - application/json
@@ -160,23 +20,23 @@ interactions:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 488
-        body: '{"id":"c3d68e15-905e-42b6-9ff5-99ac961b95ff", "project_id":"572984ce-3a11-430c-a0d8-a345cfed2df9", "name":"scalewayDataSourceSecret", "status":"ready", "created_at":"2025-12-16T11:13:37.086931Z", "updated_at":"2025-12-16T11:13:37.086931Z", "tags":[], "version_count":0, "description":"DataSourceSecret test description", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}'
+        content_length: 476
+        body: '{"id":"50addb35-3a12-42cd-b522-b2bdd75f5cc1","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-01-30T16:28:02.051406Z","updated_at":"2026-01-30T16:28:02.051406Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "488"
+                - "476"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 16 Dec 2025 11:13:37 GMT
+                - Fri, 30 Jan 2026 16:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             X-Request-Id:
-                - 7e83eeab-7aba-4375-836b-7f661ba579bb
+                - 9decbbbf-d09c-4d0e-98a0-4c5039073dcf
         status: 200 OK
         code: 200
-        duration: 334.766538ms
-    - id: 5
+        duration: 370.620735ms
+    - id: 1
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -186,29 +46,29 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c3d68e15-905e-42b6-9ff5-99ac961b95ff
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/50addb35-3a12-42cd-b522-b2bdd75f5cc1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 488
-        body: '{"id":"c3d68e15-905e-42b6-9ff5-99ac961b95ff", "project_id":"572984ce-3a11-430c-a0d8-a345cfed2df9", "name":"scalewayDataSourceSecret", "status":"ready", "created_at":"2025-12-16T11:13:37.086931Z", "updated_at":"2025-12-16T11:13:37.086931Z", "tags":[], "version_count":0, "description":"DataSourceSecret test description", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}'
+        content_length: 476
+        body: '{"id":"50addb35-3a12-42cd-b522-b2bdd75f5cc1","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-01-30T16:28:02.051406Z","updated_at":"2026-01-30T16:28:02.051406Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "488"
+                - "476"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 16 Dec 2025 11:13:37 GMT
+                - Fri, 30 Jan 2026 16:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             X-Request-Id:
-                - dcf4ff7e-b1ad-40c1-bda6-c275a5ebb04d
+                - ebcc9130-04b0-41a9-b4d8-4879f3a48d8d
         status: 200 OK
         code: 200
-        duration: 103.939251ms
-    - id: 6
+        duration: 49.429867ms
+    - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -221,29 +81,29 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c3d68e15-905e-42b6-9ff5-99ac961b95ff/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/50addb35-3a12-42cd-b522-b2bdd75f5cc1/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 32
-        body: '{"versions":[], "total_count":0}'
+        content_length: 31
+        body: '{"versions":[],"total_count":0}'
         headers:
             Content-Length:
-                - "32"
+                - "31"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 16 Dec 2025 11:13:37 GMT
+                - Fri, 30 Jan 2026 16:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             X-Request-Id:
-                - bdd853ce-1fab-42d2-83e3-a5bd476db219
+                - 915ccf73-f612-4cd3-befe-b36ba4e2b611
         status: 200 OK
         code: 200
-        duration: 215.000735ms
-    - id: 7
+        duration: 73.36435ms
+    - id: 3
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -253,29 +113,29 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c3d68e15-905e-42b6-9ff5-99ac961b95ff
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/50addb35-3a12-42cd-b522-b2bdd75f5cc1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 488
-        body: '{"id":"c3d68e15-905e-42b6-9ff5-99ac961b95ff", "project_id":"572984ce-3a11-430c-a0d8-a345cfed2df9", "name":"scalewayDataSourceSecret", "status":"ready", "created_at":"2025-12-16T11:13:37.086931Z", "updated_at":"2025-12-16T11:13:37.086931Z", "tags":[], "version_count":0, "description":"DataSourceSecret test description", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}'
+        content_length: 476
+        body: '{"id":"50addb35-3a12-42cd-b522-b2bdd75f5cc1","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-01-30T16:28:02.051406Z","updated_at":"2026-01-30T16:28:02.051406Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "488"
+                - "476"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 16 Dec 2025 11:13:37 GMT
+                - Fri, 30 Jan 2026 16:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             X-Request-Id:
-                - fc306355-27f3-4604-bcea-2fbee4c3245e
+                - 8a4c1901-eaa5-471b-b6d9-72325865177d
         status: 200 OK
         code: 200
-        duration: 123.551647ms
-    - id: 8
+        duration: 74.032831ms
+    - id: 4
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -284,13 +144,11 @@ interactions:
         host: api.scaleway.com
         form:
             name:
-                - scalewayDataSourceSecret
+                - scalewayDataSourceSecretBasic
             order_by:
                 - name_asc
-            organization_id:
-                - 105bdce1-64c0-48ab-899d-868455867ecf
             project_id:
-                - 572984ce-3a11-430c-a0d8-a345cfed2df9
+                - 105bdce1-64c0-48ab-899d-868455867ecf
             scheduled_for_deletion:
                 - "false"
             type:
@@ -298,28 +156,162 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets?name=scalewayDataSourceSecret&order_by=name_asc&organization_id=11111111-1111-1111-1111-111111111111&project_id=572984ce-3a11-430c-a0d8-a345cfed2df9&scheduled_for_deletion=false&type=unknown_type
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets?name=scalewayDataSourceSecretBasic&order_by=name_asc&project_id=105bdce1-64c0-48ab-899d-868455867ecf&scheduled_for_deletion=false&type=unknown_type
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 519
-        body: '{"secrets":[{"id":"c3d68e15-905e-42b6-9ff5-99ac961b95ff", "project_id":"572984ce-3a11-430c-a0d8-a345cfed2df9", "name":"scalewayDataSourceSecret", "status":"ready", "created_at":"2025-12-16T11:13:37.086931Z", "updated_at":"2025-12-16T11:13:37.086931Z", "tags":[], "version_count":0, "description":"DataSourceSecret test description", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}], "total_count":1}'
+        content_length: 506
+        body: '{"secrets":[{"id":"50addb35-3a12-42cd-b522-b2bdd75f5cc1","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-01-30T16:28:02.051406Z","updated_at":"2026-01-30T16:28:02.051406Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
-                - "519"
+                - "506"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 16 Dec 2025 11:13:37 GMT
+                - Fri, 30 Jan 2026 16:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             X-Request-Id:
-                - 0f65f0b7-e481-4ecd-9133-3de1abeb7833
+                - 93360b89-f1f7-4225-adc3-2593fe5b598f
         status: 200 OK
         code: 200
-        duration: 171.608214ms
+        duration: 78.833125ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/50addb35-3a12-42cd-b522-b2bdd75f5cc1/versions?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 31
+        body: '{"versions":[],"total_count":0}'
+        headers:
+            Content-Length:
+                - "31"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 30 Jan 2026 16:28:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - 17722cb5-5ddb-4adf-ab61-0ced888b7bfe
+        status: 200 OK
+        code: 200
+        duration: 37.496507ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/50addb35-3a12-42cd-b522-b2bdd75f5cc1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 476
+        body: '{"id":"50addb35-3a12-42cd-b522-b2bdd75f5cc1","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-01-30T16:28:02.051406Z","updated_at":"2026-01-30T16:28:02.051406Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "476"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 30 Jan 2026 16:28:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - 44cc6256-48a0-480a-9bf7-d13b0b33f322
+        status: 200 OK
+        code: 200
+        duration: 74.210999ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/50addb35-3a12-42cd-b522-b2bdd75f5cc1/versions?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 31
+        body: '{"versions":[],"total_count":0}'
+        headers:
+            Content-Length:
+                - "31"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 30 Jan 2026 16:28:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - 21687112-9c81-476d-9ca5-830982f63daf
+        status: 200 OK
+        code: 200
+        duration: 36.124823ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/50addb35-3a12-42cd-b522-b2bdd75f5cc1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 476
+        body: '{"id":"50addb35-3a12-42cd-b522-b2bdd75f5cc1","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-01-30T16:28:02.051406Z","updated_at":"2026-01-30T16:28:02.051406Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "476"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 30 Jan 2026 16:28:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - 10db99ce-c3c4-4338-9edb-36e83684e5c8
+        status: 200 OK
+        code: 200
+        duration: 71.178456ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -330,28 +322,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c3d68e15-905e-42b6-9ff5-99ac961b95ff
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/50addb35-3a12-42cd-b522-b2bdd75f5cc1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 488
-        body: '{"id":"c3d68e15-905e-42b6-9ff5-99ac961b95ff", "project_id":"572984ce-3a11-430c-a0d8-a345cfed2df9", "name":"scalewayDataSourceSecret", "status":"ready", "created_at":"2025-12-16T11:13:37.086931Z", "updated_at":"2025-12-16T11:13:37.086931Z", "tags":[], "version_count":0, "description":"DataSourceSecret test description", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}'
+        content_length: 476
+        body: '{"id":"50addb35-3a12-42cd-b522-b2bdd75f5cc1","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-01-30T16:28:02.051406Z","updated_at":"2026-01-30T16:28:02.051406Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "488"
+                - "476"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 16 Dec 2025 11:13:37 GMT
+                - Fri, 30 Jan 2026 16:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             X-Request-Id:
-                - 0bfc1d9b-9559-4430-892f-0221db0d9aac
+                - 85678ffe-01e7-4443-8a7d-ec6d2c4094cf
         status: 200 OK
         code: 200
-        duration: 128.465847ms
+        duration: 80.484212ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -359,34 +351,31 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: api.scaleway.com
-        form:
-            page:
-                - "1"
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c3d68e15-905e-42b6-9ff5-99ac961b95ff/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/50addb35-3a12-42cd-b522-b2bdd75f5cc1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 32
-        body: '{"versions":[], "total_count":0}'
+        content_length: 476
+        body: '{"id":"50addb35-3a12-42cd-b522-b2bdd75f5cc1","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-01-30T16:28:02.051406Z","updated_at":"2026-01-30T16:28:02.051406Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "32"
+                - "476"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 16 Dec 2025 11:13:37 GMT
+                - Fri, 30 Jan 2026 16:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             X-Request-Id:
-                - 57733f49-3cdf-4b9c-8f8a-9594e350761d
+                - 322300fe-2dbc-4dfa-a49e-b71d92ac2df1
         status: 200 OK
         code: 200
-        duration: 174.360403ms
+        duration: 39.39874ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -395,33 +384,41 @@ interactions:
         content_length: 0
         host: api.scaleway.com
         form:
-            page:
-                - "1"
+            name:
+                - scalewayDataSourceSecretBasic
+            order_by:
+                - name_asc
+            project_id:
+                - 105bdce1-64c0-48ab-899d-868455867ecf
+            scheduled_for_deletion:
+                - "false"
+            type:
+                - unknown_type
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c3d68e15-905e-42b6-9ff5-99ac961b95ff/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets?name=scalewayDataSourceSecretBasic&order_by=name_asc&project_id=105bdce1-64c0-48ab-899d-868455867ecf&scheduled_for_deletion=false&type=unknown_type
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 32
-        body: '{"versions":[], "total_count":0}'
+        content_length: 506
+        body: '{"secrets":[{"id":"50addb35-3a12-42cd-b522-b2bdd75f5cc1","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-01-30T16:28:02.051406Z","updated_at":"2026-01-30T16:28:02.051406Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
-                - "32"
+                - "506"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 16 Dec 2025 11:13:37 GMT
+                - Fri, 30 Jan 2026 16:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             X-Request-Id:
-                - de89b9f7-98e9-4b36-8fb5-fe96f160529e
+                - 440a78fd-f64c-46bc-b03f-a02b404b9649
         status: 200 OK
         code: 200
-        duration: 163.799119ms
+        duration: 75.745394ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -429,31 +426,34 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: api.scaleway.com
+        form:
+            page:
+                - "1"
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c3d68e15-905e-42b6-9ff5-99ac961b95ff
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/50addb35-3a12-42cd-b522-b2bdd75f5cc1/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 488
-        body: '{"id":"c3d68e15-905e-42b6-9ff5-99ac961b95ff", "project_id":"572984ce-3a11-430c-a0d8-a345cfed2df9", "name":"scalewayDataSourceSecret", "status":"ready", "created_at":"2025-12-16T11:13:37.086931Z", "updated_at":"2025-12-16T11:13:37.086931Z", "tags":[], "version_count":0, "description":"DataSourceSecret test description", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}'
+        content_length: 31
+        body: '{"versions":[],"total_count":0}'
         headers:
             Content-Length:
-                - "488"
+                - "31"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 16 Dec 2025 11:13:38 GMT
+                - Fri, 30 Jan 2026 16:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             X-Request-Id:
-                - 61a6b316-0aaa-4bff-8f16-d524552c819d
+                - 62ffef2e-1d02-4579-aef3-e2a4b67b7772
         status: 200 OK
         code: 200
-        duration: 170.865812ms
+        duration: 38.287985ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -464,28 +464,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c3d68e15-905e-42b6-9ff5-99ac961b95ff
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/50addb35-3a12-42cd-b522-b2bdd75f5cc1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 488
-        body: '{"id":"c3d68e15-905e-42b6-9ff5-99ac961b95ff", "project_id":"572984ce-3a11-430c-a0d8-a345cfed2df9", "name":"scalewayDataSourceSecret", "status":"ready", "created_at":"2025-12-16T11:13:37.086931Z", "updated_at":"2025-12-16T11:13:37.086931Z", "tags":[], "version_count":0, "description":"DataSourceSecret test description", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}'
+        content_length: 476
+        body: '{"id":"50addb35-3a12-42cd-b522-b2bdd75f5cc1","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-01-30T16:28:02.051406Z","updated_at":"2026-01-30T16:28:02.051406Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "488"
+                - "476"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 16 Dec 2025 11:13:38 GMT
+                - Fri, 30 Jan 2026 16:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             X-Request-Id:
-                - bed1fb0f-e8b6-4004-a0a3-1ae6eeeba6f0
+                - bf72b459-251d-405a-aadf-6101b7705bb2
         status: 200 OK
         code: 200
-        duration: 112.939808ms
+        duration: 101.452785ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -493,31 +493,34 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: api.scaleway.com
+        form:
+            page:
+                - "1"
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c3d68e15-905e-42b6-9ff5-99ac961b95ff
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/50addb35-3a12-42cd-b522-b2bdd75f5cc1/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 488
-        body: '{"id":"c3d68e15-905e-42b6-9ff5-99ac961b95ff", "project_id":"572984ce-3a11-430c-a0d8-a345cfed2df9", "name":"scalewayDataSourceSecret", "status":"ready", "created_at":"2025-12-16T11:13:37.086931Z", "updated_at":"2025-12-16T11:13:37.086931Z", "tags":[], "version_count":0, "description":"DataSourceSecret test description", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}'
+        content_length: 31
+        body: '{"versions":[],"total_count":0}'
         headers:
             Content-Length:
-                - "488"
+                - "31"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 16 Dec 2025 11:13:38 GMT
+                - Fri, 30 Jan 2026 16:28:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             X-Request-Id:
-                - 622717ae-cd9d-4bd6-9190-19ac5ab84113
+                - 6c0c7873-7d5b-4b8c-9f8b-ac2263e96128
         status: 200 OK
         code: 200
-        duration: 100.466134ms
+        duration: 50.918352ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -525,44 +528,31 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: api.scaleway.com
-        form:
-            name:
-                - scalewayDataSourceSecret
-            order_by:
-                - name_asc
-            organization_id:
-                - 105bdce1-64c0-48ab-899d-868455867ecf
-            project_id:
-                - 572984ce-3a11-430c-a0d8-a345cfed2df9
-            scheduled_for_deletion:
-                - "false"
-            type:
-                - unknown_type
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets?name=scalewayDataSourceSecret&order_by=name_asc&organization_id=11111111-1111-1111-1111-111111111111&project_id=572984ce-3a11-430c-a0d8-a345cfed2df9&scheduled_for_deletion=false&type=unknown_type
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/50addb35-3a12-42cd-b522-b2bdd75f5cc1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 519
-        body: '{"secrets":[{"id":"c3d68e15-905e-42b6-9ff5-99ac961b95ff", "project_id":"572984ce-3a11-430c-a0d8-a345cfed2df9", "name":"scalewayDataSourceSecret", "status":"ready", "created_at":"2025-12-16T11:13:37.086931Z", "updated_at":"2025-12-16T11:13:37.086931Z", "tags":[], "version_count":0, "description":"DataSourceSecret test description", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}], "total_count":1}'
+        content_length: 476
+        body: '{"id":"50addb35-3a12-42cd-b522-b2bdd75f5cc1","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-01-30T16:28:02.051406Z","updated_at":"2026-01-30T16:28:02.051406Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "519"
+                - "476"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 16 Dec 2025 11:13:38 GMT
+                - Fri, 30 Jan 2026 16:28:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             X-Request-Id:
-                - 418b7fa1-5415-4684-ad23-1a4ea8cf1e0a
+                - 0956089d-463b-415f-b834-321671431dc9
         status: 200 OK
         code: 200
-        duration: 129.356675ms
+        duration: 43.967798ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -576,28 +566,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c3d68e15-905e-42b6-9ff5-99ac961b95ff/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/50addb35-3a12-42cd-b522-b2bdd75f5cc1/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 32
-        body: '{"versions":[], "total_count":0}'
+        content_length: 31
+        body: '{"versions":[],"total_count":0}'
         headers:
             Content-Length:
-                - "32"
+                - "31"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 16 Dec 2025 11:13:38 GMT
+                - Fri, 30 Jan 2026 16:28:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             X-Request-Id:
-                - 64ea0bde-35e1-4d6c-856a-143d2231a99d
+                - e96e7448-9a41-465e-9684-906fafe221a7
         status: 200 OK
         code: 200
-        duration: 195.443387ms
+        duration: 49.241639ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -608,28 +598,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c3d68e15-905e-42b6-9ff5-99ac961b95ff
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/50addb35-3a12-42cd-b522-b2bdd75f5cc1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 488
-        body: '{"id":"c3d68e15-905e-42b6-9ff5-99ac961b95ff", "project_id":"572984ce-3a11-430c-a0d8-a345cfed2df9", "name":"scalewayDataSourceSecret", "status":"ready", "created_at":"2025-12-16T11:13:37.086931Z", "updated_at":"2025-12-16T11:13:37.086931Z", "tags":[], "version_count":0, "description":"DataSourceSecret test description", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}'
+        content_length: 476
+        body: '{"id":"50addb35-3a12-42cd-b522-b2bdd75f5cc1","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-01-30T16:28:02.051406Z","updated_at":"2026-01-30T16:28:02.051406Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "488"
+                - "476"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 16 Dec 2025 11:13:38 GMT
+                - Fri, 30 Jan 2026 16:28:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             X-Request-Id:
-                - cefd83a7-682f-447e-b795-6a146fd3fb7c
+                - 11e2a85c-09b0-486b-920b-8b1f94d9f10d
         status: 200 OK
         code: 200
-        duration: 171.545635ms
+        duration: 96.515494ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -638,148 +628,12 @@ interactions:
         content_length: 0
         host: api.scaleway.com
         form:
-            page:
-                - "1"
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c3d68e15-905e-42b6-9ff5-99ac961b95ff/versions?page=1
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 32
-        body: '{"versions":[], "total_count":0}'
-        headers:
-            Content-Length:
-                - "32"
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 16 Dec 2025 11:13:38 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
-            X-Request-Id:
-                - d990ceac-2f0b-4396-b3e8-30219ca01f4f
-        status: 200 OK
-        code: 200
-        duration: 168.704659ms
-    - id: 19
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c3d68e15-905e-42b6-9ff5-99ac961b95ff
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 488
-        body: '{"id":"c3d68e15-905e-42b6-9ff5-99ac961b95ff", "project_id":"572984ce-3a11-430c-a0d8-a345cfed2df9", "name":"scalewayDataSourceSecret", "status":"ready", "created_at":"2025-12-16T11:13:37.086931Z", "updated_at":"2025-12-16T11:13:37.086931Z", "tags":[], "version_count":0, "description":"DataSourceSecret test description", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}'
-        headers:
-            Content-Length:
-                - "488"
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 16 Dec 2025 11:13:39 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
-            X-Request-Id:
-                - 01e3486f-a7d0-4c7b-ba61-46a2b9e6eb7a
-        status: 200 OK
-        code: 200
-        duration: 135.103676ms
-    - id: 20
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        form:
-            page:
-                - "1"
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c3d68e15-905e-42b6-9ff5-99ac961b95ff/versions?page=1
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 32
-        body: '{"versions":[], "total_count":0}'
-        headers:
-            Content-Length:
-                - "32"
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 16 Dec 2025 11:13:39 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
-            X-Request-Id:
-                - 37be2396-c512-4a78-8850-93740ae397ba
-        status: 200 OK
-        code: 200
-        duration: 179.205047ms
-    - id: 21
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c3d68e15-905e-42b6-9ff5-99ac961b95ff
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 488
-        body: '{"id":"c3d68e15-905e-42b6-9ff5-99ac961b95ff", "project_id":"572984ce-3a11-430c-a0d8-a345cfed2df9", "name":"scalewayDataSourceSecret", "status":"ready", "created_at":"2025-12-16T11:13:37.086931Z", "updated_at":"2025-12-16T11:13:37.086931Z", "tags":[], "version_count":0, "description":"DataSourceSecret test description", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}'
-        headers:
-            Content-Length:
-                - "488"
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 16 Dec 2025 11:13:39 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
-            X-Request-Id:
-                - 70094782-1b66-4e86-9eaf-eb2c4175b7ac
-        status: 200 OK
-        code: 200
-        duration: 157.010499ms
-    - id: 22
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        form:
             name:
-                - scalewayDataSourceSecret
+                - scalewayDataSourceSecretBasic
             order_by:
                 - name_asc
-            organization_id:
-                - 105bdce1-64c0-48ab-899d-868455867ecf
             project_id:
-                - 572984ce-3a11-430c-a0d8-a345cfed2df9
+                - 105bdce1-64c0-48ab-899d-868455867ecf
             scheduled_for_deletion:
                 - "false"
             type:
@@ -787,29 +641,29 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets?name=scalewayDataSourceSecret&order_by=name_asc&organization_id=11111111-1111-1111-1111-111111111111&project_id=572984ce-3a11-430c-a0d8-a345cfed2df9&scheduled_for_deletion=false&type=unknown_type
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets?name=scalewayDataSourceSecretBasic&order_by=name_asc&project_id=105bdce1-64c0-48ab-899d-868455867ecf&scheduled_for_deletion=false&type=unknown_type
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 519
-        body: '{"secrets":[{"id":"c3d68e15-905e-42b6-9ff5-99ac961b95ff", "project_id":"572984ce-3a11-430c-a0d8-a345cfed2df9", "name":"scalewayDataSourceSecret", "status":"ready", "created_at":"2025-12-16T11:13:37.086931Z", "updated_at":"2025-12-16T11:13:37.086931Z", "tags":[], "version_count":0, "description":"DataSourceSecret test description", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}], "total_count":1}'
+        content_length: 506
+        body: '{"secrets":[{"id":"50addb35-3a12-42cd-b522-b2bdd75f5cc1","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-01-30T16:28:02.051406Z","updated_at":"2026-01-30T16:28:02.051406Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
-                - "519"
+                - "506"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 16 Dec 2025 11:13:39 GMT
+                - Fri, 30 Jan 2026 16:28:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             X-Request-Id:
-                - 0488e50f-cb90-4740-8c46-837eef7994f0
+                - 0b72e604-3390-408f-9609-78e588b9b52d
         status: 200 OK
         code: 200
-        duration: 162.649101ms
-    - id: 23
+        duration: 110.092131ms
+    - id: 19
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -822,28 +676,157 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c3d68e15-905e-42b6-9ff5-99ac961b95ff/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/50addb35-3a12-42cd-b522-b2bdd75f5cc1/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 32
-        body: '{"versions":[], "total_count":0}'
+        content_length: 31
+        body: '{"versions":[],"total_count":0}'
         headers:
             Content-Length:
-                - "32"
+                - "31"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 16 Dec 2025 11:13:39 GMT
+                - Fri, 30 Jan 2026 16:28:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             X-Request-Id:
-                - c2a0a4eb-d73f-43db-8871-4e799ef64b7f
+                - 5dfb9797-ef7b-4937-86c6-71b998a63fcc
         status: 200 OK
         code: 200
-        duration: 219.965689ms
+        duration: 83.621793ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/50addb35-3a12-42cd-b522-b2bdd75f5cc1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 476
+        body: '{"id":"50addb35-3a12-42cd-b522-b2bdd75f5cc1","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-01-30T16:28:02.051406Z","updated_at":"2026-01-30T16:28:02.051406Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "476"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 30 Jan 2026 16:28:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - ebb715f4-8960-49ab-8275-68797fb7276b
+        status: 200 OK
+        code: 200
+        duration: 110.286431ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/50addb35-3a12-42cd-b522-b2bdd75f5cc1/versions?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 31
+        body: '{"versions":[],"total_count":0}'
+        headers:
+            Content-Length:
+                - "31"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 30 Jan 2026 16:28:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - 032edd63-ce2e-465f-a15c-f1f269e5e1c4
+        status: 200 OK
+        code: 200
+        duration: 41.33363ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/50addb35-3a12-42cd-b522-b2bdd75f5cc1
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 30 Jan 2026 16:28:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - eb176db9-0b2c-49d9-b132-196b58a12126
+        status: 204 No Content
+        code: 204
+        duration: 92.433423ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/50addb35-3a12-42cd-b522-b2bdd75f5cc1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 501
+        body: '{"id":"50addb35-3a12-42cd-b522-b2bdd75f5cc1","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-01-30T16:28:02.051406Z","updated_at":"2026-01-30T16:28:02.051406Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-01-30T16:28:03.845467Z","key_id":null,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "501"
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 30 Jan 2026 16:28:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - 655ffd23-4bb7-4ace-a588-6fe5ebbe0ea7
+        status: 200 OK
+        code: 200
+        duration: 82.09055ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -854,28 +837,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c3d68e15-905e-42b6-9ff5-99ac961b95ff
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/50addb35-3a12-42cd-b522-b2bdd75f5cc1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 488
-        body: '{"id":"c3d68e15-905e-42b6-9ff5-99ac961b95ff", "project_id":"572984ce-3a11-430c-a0d8-a345cfed2df9", "name":"scalewayDataSourceSecret", "status":"ready", "created_at":"2025-12-16T11:13:37.086931Z", "updated_at":"2025-12-16T11:13:37.086931Z", "tags":[], "version_count":0, "description":"DataSourceSecret test description", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}'
+        content_length: 501
+        body: '{"id":"50addb35-3a12-42cd-b522-b2bdd75f5cc1","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-01-30T16:28:02.051406Z","updated_at":"2026-01-30T16:28:02.051406Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-01-30T16:28:03.845467Z","key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "488"
+                - "501"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 16 Dec 2025 11:13:39 GMT
+                - Fri, 30 Jan 2026 16:28:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             X-Request-Id:
-                - 246301fa-6cf6-44d6-b396-e41567f3eda5
+                - d34b9cc6-6b8d-4034-8326-2e159fe9e873
         status: 200 OK
         code: 200
-        duration: 248.319949ms
+        duration: 34.058603ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -883,277 +866,28 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: api.scaleway.com
-        form:
-            page:
-                - "1"
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c3d68e15-905e-42b6-9ff5-99ac961b95ff/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/50addb35-3a12-42cd-b522-b2bdd75f5cc1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 32
-        body: '{"versions":[], "total_count":0}'
+        content_length: 501
+        body: '{"id":"50addb35-3a12-42cd-b522-b2bdd75f5cc1","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-01-30T16:28:02.051406Z","updated_at":"2026-01-30T16:28:02.051406Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-01-30T16:28:03.845467Z","key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "32"
+                - "501"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 16 Dec 2025 11:13:41 GMT
+                - Fri, 30 Jan 2026 16:28:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-1;edge02)
             X-Request-Id:
-                - 4cabc40c-494b-419c-a713-5cbeda5b05e0
+                - 7d39e5d7-1468-49de-9bea-28d51a95f296
         status: 200 OK
         code: 200
-        duration: 1.843590239s
-    - id: 26
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c3d68e15-905e-42b6-9ff5-99ac961b95ff
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 0
-        body: ""
-        headers:
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 16 Dec 2025 11:13:42 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
-            X-Request-Id:
-                - 12053d4c-6b42-411c-9542-0103ce465824
-        status: 204 No Content
-        code: 204
-        duration: 412.982045ms
-    - id: 27
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/iam/v1alpha1/api-keys/SCWXXXXXXXXXXXXXXXXX
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 0
-        body: ""
-        headers:
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 16 Dec 2025 11:13:42 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
-            X-Request-Id:
-                - ad0fdd13-d610-40b9-b288-fdc9c61c9a9d
-        status: 204 No Content
-        code: 204
-        duration: 447.284478ms
-    - id: 28
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/iam/v1alpha1/policies/e9f70716-a0cb-4a0a-91e6-95da6a76d253
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 0
-        body: ""
-        headers:
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 16 Dec 2025 11:13:43 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
-            X-Request-Id:
-                - b7c3a249-514e-444c-b65e-0cc313a37271
-        status: 204 No Content
-        code: 204
-        duration: 270.796033ms
-    - id: 29
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/iam/v1alpha1/applications/4697bd91-1bd6-4ff0-94eb-5d0b8afc5ecf
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 0
-        body: ""
-        headers:
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 16 Dec 2025 11:13:43 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
-            X-Request-Id:
-                - 2e926716-33a5-4473-89e4-f3b6f0aeb3a9
-        status: 204 No Content
-        code: 204
-        duration: 234.535953ms
-    - id: 30
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/account/v3/projects/572984ce-3a11-430c-a0d8-a345cfed2df9
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 0
-        body: ""
-        headers:
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 16 Dec 2025 11:13:45 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
-            X-Request-Id:
-                - 71d00606-f035-42d3-92c8-c6ce4c9b5dec
-        status: 204 No Content
-        code: 204
-        duration: 1.59628795s
-    - id: 31
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c3d68e15-905e-42b6-9ff5-99ac961b95ff
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 513
-        body: '{"id":"c3d68e15-905e-42b6-9ff5-99ac961b95ff", "project_id":"572984ce-3a11-430c-a0d8-a345cfed2df9", "name":"scalewayDataSourceSecret", "status":"ready", "created_at":"2025-12-16T11:13:37.086931Z", "updated_at":"2025-12-16T11:13:37.086931Z", "tags":[], "version_count":0, "description":"DataSourceSecret test description", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":"2025-12-16T11:13:42.329838Z", "key_id":null, "region":"fr-par"}'
-        headers:
-            Content-Length:
-                - "513"
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 16 Dec 2025 11:13:45 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
-            X-Request-Id:
-                - 02c63698-023d-4374-9f3d-d0a435c3de9e
-        status: 200 OK
-        code: 200
-        duration: 99.403802ms
-    - id: 32
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c3d68e15-905e-42b6-9ff5-99ac961b95ff
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 513
-        body: '{"id":"c3d68e15-905e-42b6-9ff5-99ac961b95ff", "project_id":"572984ce-3a11-430c-a0d8-a345cfed2df9", "name":"scalewayDataSourceSecret", "status":"ready", "created_at":"2025-12-16T11:13:37.086931Z", "updated_at":"2025-12-16T11:13:37.086931Z", "tags":[], "version_count":0, "description":"DataSourceSecret test description", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":"2025-12-16T11:13:42.329838Z", "key_id":null, "region":"fr-par"}'
-        headers:
-            Content-Length:
-                - "513"
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 16 Dec 2025 11:13:45 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
-            X-Request-Id:
-                - 31cb3a95-8b9b-4709-a82b-1ac6a1b45cb0
-        status: 200 OK
-        code: 200
-        duration: 66.249409ms
-    - id: 33
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/c3d68e15-905e-42b6-9ff5-99ac961b95ff
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 127
-        body: '{"message":"resource is not found","resource":"secret","resource_id":"c3d68e15-905e-42b6-9ff5-99ac961b95ff","type":"not_found"}'
-        headers:
-            Content-Length:
-                - "127"
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 16 Dec 2025 11:13:45 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
-            X-Request-Id:
-                - 18b295e9-b585-40b0-ac15-f59c90096334
-        status: 404 Not Found
-        code: 404
-        duration: 417.030567ms
+        duration: 98.830225ms


### PR DESCRIPTION
- keymanager: rename a keymanager key that had the same name in two separate tests
- secret: remove IAM overhead that lead to random provider inconsistency on subsequent runs