### PR TITLE
tests(serverless_jobs): bump go-vcr.v4 for jobs package

### DIFF
--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -38,6 +38,7 @@ var foldersUsingVCRv4 = []string{
 	"container",
 	"iam",
 	"instance",
+	"jobs",
 	"k8s",
 	"keymanager",
 	"marketplace",

--- a/internal/services/jobs/testdata/action-job-definition-start-basic.cassette.yaml
+++ b/internal/services/jobs/testdata/action-job-definition-start-basic.cassette.yaml
@@ -7,13 +7,8 @@ interactions:
         proto_major: 1
         proto_minor: 1
         content_length: 300
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
         body: '{"name":"test-jobs-action-start","cpu_limit":120,"memory_limit":256,"local_storage_capacity":5120,"image_uri":"docker.io/alpine:latest","command":"","startup_command":["echo","-e"],"args":["Hello World"],"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","environment_variables":{},"description":""}'
-        form: {}
         headers:
             Content-Type:
                 - application/json
@@ -25,816 +20,569 @@ interactions:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 492
-        uncompressed: false
-        body: '{"args":["Hello World"],"command":"","cpu_limit":120,"created_at":"2026-02-09T16:05:29.318129Z","cron_schedule":null,"description":"","environment_variables":{},"id":"eaf1f559-fbb0-4c0f-b66c-0096c70929d4","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-action-start","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":["echo","-e"],"updated_at":"2026-02-09T16:05:29.318129Z"}'
+        content_length: 509
+        body: '{"id":"3b508982-3117-40fb-b9ba-6e46b6b6d0bf", "name":"test-jobs-action-start", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.467867Z", "updated_at":"2026-02-16T17:24:00.467867Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":null, "startup_command":["echo", "-e"], "args":["Hello World"], "region":"fr-par"}'
         headers:
             Content-Length:
-                - "492"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "509"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 09 Feb 2026 16:05:29 GMT
+                - Mon, 16 Feb 2026 17:24:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 18d521a2-4efb-46cb-a970-3a80c17759f7
+                - b4089963-e16a-4ae7-969b-66620a9d2853
         status: 200 OK
         code: 200
-        duration: 166.007818ms
+        duration: 169.042776ms
     - id: 1
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/eaf1f559-fbb0-4c0f-b66c-0096c70929d4
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/3b508982-3117-40fb-b9ba-6e46b6b6d0bf
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 492
-        uncompressed: false
-        body: '{"args":["Hello World"],"command":"","cpu_limit":120,"created_at":"2026-02-09T16:05:29.318129Z","cron_schedule":null,"description":"","environment_variables":{},"id":"eaf1f559-fbb0-4c0f-b66c-0096c70929d4","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-action-start","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":["echo","-e"],"updated_at":"2026-02-09T16:05:29.318129Z"}'
+        content_length: 509
+        body: '{"id":"3b508982-3117-40fb-b9ba-6e46b6b6d0bf", "name":"test-jobs-action-start", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.467867Z", "updated_at":"2026-02-16T17:24:00.467867Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":null, "startup_command":["echo", "-e"], "args":["Hello World"], "region":"fr-par"}'
         headers:
             Content-Length:
-                - "492"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "509"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 09 Feb 2026 16:05:29 GMT
+                - Mon, 16 Feb 2026 17:24:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - cfdddbd6-d53e-48b2-b14b-2549bff6d2c3
+                - 90076f1b-9741-42a2-a42f-a0a45755ab52
         status: 200 OK
         code: 200
-        duration: 49.171542ms
+        duration: 46.171518ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        form:
+            job_definition_id:
+                - 3b508982-3117-40fb-b9ba-6e46b6b6d0bf
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=eaf1f559-fbb0-4c0f-b66c-0096c70929d4
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=3b508982-3117-40fb-b9ba-6e46b6b6d0bf
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 30
-        uncompressed: false
-        body: '{"secrets":[],"total_count":0}'
+        content_length: 31
+        body: '{"secrets":[], "total_count":0}'
         headers:
             Content-Length:
-                - "30"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "31"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 09 Feb 2026 16:05:29 GMT
+                - Mon, 16 Feb 2026 17:24:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - f2913964-97af-4fdb-b5aa-41e53698aa72
+                - 4159bc91-4cc3-42ba-8247-0f4ba8df0c1a
         status: 200 OK
         code: 200
-        duration: 45.536554ms
+        duration: 46.965969ms
     - id: 3
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 2
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
         body: '{}'
-        form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/eaf1f559-fbb0-4c0f-b66c-0096c70929d4/start
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/3b508982-3117-40fb-b9ba-6e46b6b6d0bf/start
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 462
-        uncompressed: false
-        body: '{"job_runs":[{"args":["Hello World"],"command":"","cpu_limit":120,"created_at":"2026-02-09T16:05:29.547710Z","environment_variables":{},"id":"2763d7c8-4faa-41b6-aa2b-6e15e5d90188","job_definition_id":"eaf1f559-fbb0-4c0f-b66c-0096c70929d4","local_storage_capacity":5120,"memory_limit":256,"region":"fr-par","run_duration":null,"started_at":null,"startup_command":["echo","-e"],"state":"validated","terminated_at":null,"updated_at":"2026-02-09T16:05:29.883810Z"}]}'
+        content_length: 478
+        body: '{"job_runs":[{"id":"bdd8d5e1-4466-4c8e-a18e-c360edbeec59", "job_definition_id":"3b508982-3117-40fb-b9ba-6e46b6b6d0bf", "created_at":"2026-02-16T17:24:00.679932Z", "updated_at":"2026-02-16T17:24:01.008186Z", "started_at":null, "terminated_at":null, "run_duration":null, "state":"validated", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "command":"", "environment_variables":{}, "startup_command":["echo", "-e"], "args":["Hello World"], "region":"fr-par"}]}'
         headers:
             Content-Length:
-                - "462"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "478"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 09 Feb 2026 16:05:29 GMT
+                - Mon, 16 Feb 2026 17:24:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 31af0661-6940-4b68-b4ba-db10cb1fb423
+                - c5adfa7d-0191-42c3-a509-298eb6bd82b5
         status: 200 OK
         code: 200
-        duration: 474.789322ms
+        duration: 466.135784ms
     - id: 4
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        form:
+            job_definition_id:
+                - 3b508982-3117-40fb-b9ba-6e46b6b6d0bf
+            order_by:
+                - created_at_asc
+            state:
+                - unknown_state
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-runs?job_definition_id=eaf1f559-fbb0-4c0f-b66c-0096c70929d4&order_by=created_at_asc&state=unknown_state
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-runs?job_definition_id=3b508982-3117-40fb-b9ba-6e46b6b6d0bf&order_by=created_at_asc&state=unknown_state
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 478
-        uncompressed: false
-        body: '{"job_runs":[{"args":["Hello World"],"command":"","cpu_limit":120,"created_at":"2026-02-09T16:05:29.547710Z","environment_variables":{},"id":"2763d7c8-4faa-41b6-aa2b-6e15e5d90188","job_definition_id":"eaf1f559-fbb0-4c0f-b66c-0096c70929d4","local_storage_capacity":5120,"memory_limit":256,"region":"fr-par","run_duration":null,"started_at":null,"startup_command":["echo","-e"],"state":"validated","terminated_at":null,"updated_at":"2026-02-09T16:05:29.883810Z"}],"total_count":1}'
+        content_length: 495
+        body: '{"job_runs":[{"id":"bdd8d5e1-4466-4c8e-a18e-c360edbeec59", "job_definition_id":"3b508982-3117-40fb-b9ba-6e46b6b6d0bf", "created_at":"2026-02-16T17:24:00.679932Z", "updated_at":"2026-02-16T17:24:01.008186Z", "started_at":null, "terminated_at":null, "run_duration":null, "state":"validated", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "command":"", "environment_variables":{}, "startup_command":["echo", "-e"], "args":["Hello World"], "region":"fr-par"}], "total_count":1}'
         headers:
             Content-Length:
-                - "478"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "495"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 09 Feb 2026 16:05:30 GMT
+                - Mon, 16 Feb 2026 17:24:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 92eaa0a1-b3cc-4242-a5bc-88be1d87cc08
+                - b444c040-d4d7-4f40-95f9-63f45d27e65e
         status: 200 OK
         code: 200
-        duration: 69.898897ms
+        duration: 54.797909ms
     - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/eaf1f559-fbb0-4c0f-b66c-0096c70929d4
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/3b508982-3117-40fb-b9ba-6e46b6b6d0bf
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 492
-        uncompressed: false
-        body: '{"args":["Hello World"],"command":"","cpu_limit":120,"created_at":"2026-02-09T16:05:29.318129Z","cron_schedule":null,"description":"","environment_variables":{},"id":"eaf1f559-fbb0-4c0f-b66c-0096c70929d4","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-action-start","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":["echo","-e"],"updated_at":"2026-02-09T16:05:29.318129Z"}'
+        content_length: 509
+        body: '{"id":"3b508982-3117-40fb-b9ba-6e46b6b6d0bf", "name":"test-jobs-action-start", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.467867Z", "updated_at":"2026-02-16T17:24:00.467867Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":null, "startup_command":["echo", "-e"], "args":["Hello World"], "region":"fr-par"}'
         headers:
             Content-Length:
-                - "492"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "509"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 09 Feb 2026 16:05:30 GMT
+                - Mon, 16 Feb 2026 17:24:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 7dd9a151-7e87-4f36-9d17-166785389366
+                - 44279e75-6817-4721-b9c8-c8bcc905d01e
         status: 200 OK
         code: 200
-        duration: 48.337481ms
+        duration: 30.381784ms
     - id: 6
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        form:
+            job_definition_id:
+                - 3b508982-3117-40fb-b9ba-6e46b6b6d0bf
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=eaf1f559-fbb0-4c0f-b66c-0096c70929d4
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=3b508982-3117-40fb-b9ba-6e46b6b6d0bf
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 30
-        uncompressed: false
-        body: '{"secrets":[],"total_count":0}'
+        content_length: 31
+        body: '{"secrets":[], "total_count":0}'
         headers:
             Content-Length:
-                - "30"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "31"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 09 Feb 2026 16:05:30 GMT
+                - Mon, 16 Feb 2026 17:24:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - a75460f4-13e0-4bc1-8c84-e9df7f37ff0f
+                - a2555166-583d-4440-bed2-01f1b36e0925
         status: 200 OK
         code: 200
-        duration: 44.803621ms
+        duration: 245.937179ms
     - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/eaf1f559-fbb0-4c0f-b66c-0096c70929d4
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/3b508982-3117-40fb-b9ba-6e46b6b6d0bf
         method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 52
-        uncompressed: false
         body: '{"message":"one or more job runs are still running"}'
         headers:
             Content-Length:
                 - "52"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 09 Feb 2026 16:05:30 GMT
+                - Mon, 16 Feb 2026 17:24:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 60f396a5-2a66-4753-9f19-3dd70b9665f8
+                - 60ec0327-f3f3-4f70-9a7e-b7bbd8bbefca
         status: 403 Forbidden
         code: 403
-        duration: 52.715442ms
+        duration: 28.88742ms
     - id: 8
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        form:
+            job_definition_id:
+                - 3b508982-3117-40fb-b9ba-6e46b6b6d0bf
+            order_by:
+                - created_at_asc
+            state:
+                - unknown_state
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-runs?job_definition_id=eaf1f559-fbb0-4c0f-b66c-0096c70929d4&order_by=created_at_asc&state=unknown_state
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-runs?job_definition_id=3b508982-3117-40fb-b9ba-6e46b6b6d0bf&order_by=created_at_asc&state=unknown_state
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 475
-        uncompressed: false
-        body: '{"job_runs":[{"args":["Hello World"],"command":"","cpu_limit":120,"created_at":"2026-02-09T16:05:29.547710Z","environment_variables":{},"id":"2763d7c8-4faa-41b6-aa2b-6e15e5d90188","job_definition_id":"eaf1f559-fbb0-4c0f-b66c-0096c70929d4","local_storage_capacity":5120,"memory_limit":256,"region":"fr-par","run_duration":null,"started_at":null,"startup_command":["echo","-e"],"state":"queued","terminated_at":null,"updated_at":"2026-02-09T16:05:30.602800Z"}],"total_count":1}'
+        content_length: 492
+        body: '{"job_runs":[{"id":"bdd8d5e1-4466-4c8e-a18e-c360edbeec59", "job_definition_id":"3b508982-3117-40fb-b9ba-6e46b6b6d0bf", "created_at":"2026-02-16T17:24:00.679932Z", "updated_at":"2026-02-16T17:24:01.920572Z", "started_at":null, "terminated_at":null, "run_duration":null, "state":"queued", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "command":"", "environment_variables":{}, "startup_command":["echo", "-e"], "args":["Hello World"], "region":"fr-par"}], "total_count":1}'
         headers:
             Content-Length:
-                - "475"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "492"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 09 Feb 2026 16:05:30 GMT
+                - Mon, 16 Feb 2026 17:24:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - d60781c2-34c4-4846-afd1-a2a7056bb86a
+                - cc69c730-049f-425d-9168-5863fc55f678
         status: 200 OK
         code: 200
-        duration: 57.403793ms
+        duration: 86.101843ms
     - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 2
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
         body: '{}'
-        form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-runs/2763d7c8-4faa-41b6-aa2b-6e15e5d90188/stop
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-runs/bdd8d5e1-4466-4c8e-a18e-c360edbeec59/stop
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 474
-        uncompressed: false
-        body: '{"args":["Hello World"],"command":"","cpu_limit":120,"created_at":"2026-02-09T16:05:29.547710Z","environment_variables":{},"id":"2763d7c8-4faa-41b6-aa2b-6e15e5d90188","job_definition_id":"eaf1f559-fbb0-4c0f-b66c-0096c70929d4","local_storage_capacity":5120,"memory_limit":256,"reason":"cancellation","region":"fr-par","run_duration":null,"started_at":null,"startup_command":["echo","-e"],"state":"interrupting","terminated_at":null,"updated_at":"2026-02-09T16:05:30.721798Z"}'
+        content_length: 491
+        body: '{"id":"bdd8d5e1-4466-4c8e-a18e-c360edbeec59", "job_definition_id":"3b508982-3117-40fb-b9ba-6e46b6b6d0bf", "created_at":"2026-02-16T17:24:00.679932Z", "updated_at":"2026-02-16T17:24:02.497175Z", "started_at":null, "terminated_at":null, "run_duration":null, "state":"interrupting", "reason":"cancellation", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "command":"", "environment_variables":{}, "startup_command":["echo", "-e"], "args":["Hello World"], "region":"fr-par"}'
         headers:
             Content-Length:
-                - "474"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "491"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 09 Feb 2026 16:05:30 GMT
+                - Mon, 16 Feb 2026 17:24:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 06a14931-a847-480b-a793-2143a26e2e87
+                - 9e8d02ad-b989-4ad5-a0af-a907a3228dcf
         status: 200 OK
         code: 200
-        duration: 127.384363ms
+        duration: 260.403662ms
     - id: 10
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-runs/2763d7c8-4faa-41b6-aa2b-6e15e5d90188
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-runs/bdd8d5e1-4466-4c8e-a18e-c360edbeec59
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 474
-        uncompressed: false
-        body: '{"args":["Hello World"],"command":"","cpu_limit":120,"created_at":"2026-02-09T16:05:29.547710Z","environment_variables":{},"id":"2763d7c8-4faa-41b6-aa2b-6e15e5d90188","job_definition_id":"eaf1f559-fbb0-4c0f-b66c-0096c70929d4","local_storage_capacity":5120,"memory_limit":256,"reason":"cancellation","region":"fr-par","run_duration":null,"started_at":null,"startup_command":["echo","-e"],"state":"interrupting","terminated_at":null,"updated_at":"2026-02-09T16:05:30.721798Z"}'
+        content_length: 491
+        body: '{"id":"bdd8d5e1-4466-4c8e-a18e-c360edbeec59", "job_definition_id":"3b508982-3117-40fb-b9ba-6e46b6b6d0bf", "created_at":"2026-02-16T17:24:00.679932Z", "updated_at":"2026-02-16T17:24:02.497175Z", "started_at":null, "terminated_at":null, "run_duration":null, "state":"interrupting", "reason":"cancellation", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "command":"", "environment_variables":{}, "startup_command":["echo", "-e"], "args":["Hello World"], "region":"fr-par"}'
         headers:
             Content-Length:
-                - "474"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "491"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 09 Feb 2026 16:05:30 GMT
+                - Mon, 16 Feb 2026 17:24:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 209d1684-1feb-4200-b7d0-8e97250be8ef
+                - 3684ba60-604e-44d0-9cb2-61e3782429b1
         status: 200 OK
         code: 200
-        duration: 39.309139ms
+        duration: 37.925455ms
     - id: 11
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-runs/2763d7c8-4faa-41b6-aa2b-6e15e5d90188
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-runs/bdd8d5e1-4466-4c8e-a18e-c360edbeec59
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 473
-        uncompressed: false
-        body: '{"args":["Hello World"],"command":"","cpu_limit":120,"created_at":"2026-02-09T16:05:29.547710Z","environment_variables":{},"id":"2763d7c8-4faa-41b6-aa2b-6e15e5d90188","job_definition_id":"eaf1f559-fbb0-4c0f-b66c-0096c70929d4","local_storage_capacity":5120,"memory_limit":256,"reason":"cancellation","region":"fr-par","run_duration":null,"started_at":null,"startup_command":["echo","-e"],"state":"interrupted","terminated_at":null,"updated_at":"2026-02-09T16:05:31.662010Z"}'
+        content_length: 490
+        body: '{"id":"bdd8d5e1-4466-4c8e-a18e-c360edbeec59", "job_definition_id":"3b508982-3117-40fb-b9ba-6e46b6b6d0bf", "created_at":"2026-02-16T17:24:00.679932Z", "updated_at":"2026-02-16T17:24:03.268696Z", "started_at":null, "terminated_at":null, "run_duration":null, "state":"interrupted", "reason":"cancellation", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "command":"", "environment_variables":{}, "startup_command":["echo", "-e"], "args":["Hello World"], "region":"fr-par"}'
         headers:
             Content-Length:
-                - "473"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "490"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 09 Feb 2026 16:05:45 GMT
+                - Mon, 16 Feb 2026 17:24:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 7f7815df-97e9-496a-83af-6787b9cc6893
+                - 13e9db69-85c0-4309-80e1-35a0517be8c1
         status: 200 OK
         code: 200
-        duration: 138.25723ms
+        duration: 41.931412ms
     - id: 12
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/eaf1f559-fbb0-4c0f-b66c-0096c70929d4
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/3b508982-3117-40fb-b9ba-6e46b6b6d0bf
         method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 0
-        uncompressed: false
         body: ""
         headers:
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 09 Feb 2026 16:05:46 GMT
+                - Mon, 16 Feb 2026 17:24:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 35403137-f528-4f61-93c1-5abb42663b32
+                - 766c9607-02f2-4c02-8412-5afc5f48ac25
         status: 204 No Content
         code: 204
-        duration: 82.346149ms
+        duration: 35.943854ms
     - id: 13
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        form:
+            job_definition_id:
+                - 3b508982-3117-40fb-b9ba-6e46b6b6d0bf
+            order_by:
+                - created_at_asc
+            state:
+                - unknown_state
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-runs?job_definition_id=eaf1f559-fbb0-4c0f-b66c-0096c70929d4&order_by=created_at_asc&state=unknown_state
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-runs?job_definition_id=3b508982-3117-40fb-b9ba-6e46b6b6d0bf&order_by=created_at_asc&state=unknown_state
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 31
-        uncompressed: false
-        body: '{"job_runs":[],"total_count":0}'
+        content_length: 32
+        body: '{"job_runs":[], "total_count":0}'
         headers:
             Content-Length:
-                - "31"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "32"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 09 Feb 2026 16:05:46 GMT
+                - Mon, 16 Feb 2026 17:24:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - c6f26f86-01cb-4255-a2d0-f3d9dc5371e8
+                - 99eba1dc-7149-4a19-a1d4-4fd423af597f
         status: 200 OK
         code: 200
-        duration: 49.471238ms
+        duration: 44.327789ms
     - id: 14
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/eaf1f559-fbb0-4c0f-b66c-0096c70929d4
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/3b508982-3117-40fb-b9ba-6e46b6b6d0bf
         method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 41
-        uncompressed: false
         body: '{"message":"job definition is not found"}'
         headers:
             Content-Length:
                 - "41"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 09 Feb 2026 16:05:46 GMT
+                - Mon, 16 Feb 2026 17:24:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 895700a4-ed22-491f-a292-06d10c803e9d
+                - ee742cba-eefa-4030-8c7e-fc6c67c3ae06
         status: 404 Not Found
         code: 404
-        duration: 24.668809ms
+        duration: 27.157683ms
     - id: 15
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        form:
+            job_definition_id:
+                - 3b508982-3117-40fb-b9ba-6e46b6b6d0bf
+            order_by:
+                - created_at_asc
+            state:
+                - unknown_state
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-runs?job_definition_id=eaf1f559-fbb0-4c0f-b66c-0096c70929d4&order_by=created_at_asc&state=unknown_state
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-runs?job_definition_id=3b508982-3117-40fb-b9ba-6e46b6b6d0bf&order_by=created_at_asc&state=unknown_state
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 31
-        uncompressed: false
-        body: '{"job_runs":[],"total_count":0}'
+        content_length: 32
+        body: '{"job_runs":[], "total_count":0}'
         headers:
             Content-Length:
-                - "31"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "32"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 09 Feb 2026 16:05:46 GMT
+                - Mon, 16 Feb 2026 17:24:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 76b932b3-018a-4d7d-8ca4-348fbe505b08
+                - 898db9b1-7c05-4dba-b9cf-847029f4e983
         status: 200 OK
         code: 200
-        duration: 59.184353ms
+        duration: 63.399514ms
     - id: 16
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/eaf1f559-fbb0-4c0f-b66c-0096c70929d4
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/3b508982-3117-40fb-b9ba-6e46b6b6d0bf
         method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 41
-        uncompressed: false
         body: '{"message":"job definition is not found"}'
         headers:
             Content-Length:
                 - "41"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 09 Feb 2026 16:05:46 GMT
+                - Mon, 16 Feb 2026 17:24:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 89f051b8-bb06-42c4-9402-c9b744e10b40
+                - c66c7da2-a8d1-4f8f-9a1d-2f99a56f6034
         status: 404 Not Found
         code: 404
-        duration: 27.708653ms
+        duration: 22.597019ms

--- a/internal/services/jobs/testdata/action-job-definition-start-legacy-command.cassette.yaml
+++ b/internal/services/jobs/testdata/action-job-definition-start-legacy-command.cassette.yaml
@@ -7,13 +7,8 @@ interactions:
         proto_major: 1
         proto_minor: 1
         content_length: 294
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
         body: '{"name":"test-jobs-action-start","cpu_limit":120,"memory_limit":256,"local_storage_capacity":5120,"image_uri":"docker.io/alpine:latest","command":"echo ''Hello World''","startup_command":[],"args":[],"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","environment_variables":{},"description":""}'
-        form: {}
         headers:
             Content-Type:
                 - application/json
@@ -25,816 +20,569 @@ interactions:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 486
-        uncompressed: false
-        body: '{"args":[],"command":"echo ''Hello World''","cpu_limit":120,"created_at":"2026-02-09T14:52:44.191363Z","cron_schedule":null,"description":"","environment_variables":{},"id":"d1623346-739b-46d6-806f-395f323929ab","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-action-start","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-09T14:52:44.191363Z"}'
+        content_length: 502
+        body: '{"id":"382066bb-c496-40ec-8574-80fe9e4f54cc", "name":"test-jobs-action-start", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.464810Z", "updated_at":"2026-02-16T17:24:00.464810Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"echo ''Hello World''", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":null, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
-                - "486"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "502"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 09 Feb 2026 14:52:44 GMT
+                - Mon, 16 Feb 2026 17:24:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 3175aef2-5728-4ad8-ae4f-88a2c013a198
+                - 5ff49fff-32c5-43bd-b7a0-f4319a311f08
         status: 200 OK
         code: 200
-        duration: 125.125375ms
+        duration: 191.522939ms
     - id: 1
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/d1623346-739b-46d6-806f-395f323929ab
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/382066bb-c496-40ec-8574-80fe9e4f54cc
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 486
-        uncompressed: false
-        body: '{"args":[],"command":"echo ''Hello World''","cpu_limit":120,"created_at":"2026-02-09T14:52:44.191363Z","cron_schedule":null,"description":"","environment_variables":{},"id":"d1623346-739b-46d6-806f-395f323929ab","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-action-start","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-09T14:52:44.191363Z"}'
+        content_length: 502
+        body: '{"id":"382066bb-c496-40ec-8574-80fe9e4f54cc", "name":"test-jobs-action-start", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.464810Z", "updated_at":"2026-02-16T17:24:00.464810Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"echo ''Hello World''", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":null, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
-                - "486"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "502"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 09 Feb 2026 14:52:44 GMT
+                - Mon, 16 Feb 2026 17:24:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - cb7a3e8c-7dce-43ea-aa32-2ce40d6401a4
+                - a56ae15f-bf2e-410c-bb07-17559942882f
         status: 200 OK
         code: 200
-        duration: 61.210946ms
+        duration: 56.109676ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        form:
+            job_definition_id:
+                - 382066bb-c496-40ec-8574-80fe9e4f54cc
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=d1623346-739b-46d6-806f-395f323929ab
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=382066bb-c496-40ec-8574-80fe9e4f54cc
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 30
-        uncompressed: false
-        body: '{"secrets":[],"total_count":0}'
+        content_length: 31
+        body: '{"secrets":[], "total_count":0}'
         headers:
             Content-Length:
-                - "30"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "31"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 09 Feb 2026 14:52:44 GMT
+                - Mon, 16 Feb 2026 17:24:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - ec35a9be-85d1-4164-8f62-4b93324d5a20
+                - 45911787-5872-4bb9-be37-b286f6639555
         status: 200 OK
         code: 200
-        duration: 59.379673ms
+        duration: 63.471624ms
     - id: 3
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 2
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
         body: '{}'
-        form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/d1623346-739b-46d6-806f-395f323929ab/start
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/382066bb-c496-40ec-8574-80fe9e4f54cc/start
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 456
-        uncompressed: false
-        body: '{"job_runs":[{"args":[],"command":"echo ''Hello World''","cpu_limit":120,"created_at":"2026-02-09T14:52:44.409527Z","environment_variables":{},"id":"32b05057-b2b5-4610-b2ca-3321f0fb67be","job_definition_id":"d1623346-739b-46d6-806f-395f323929ab","local_storage_capacity":5120,"memory_limit":256,"region":"fr-par","run_duration":null,"started_at":null,"startup_command":[],"state":"validated","terminated_at":null,"updated_at":"2026-02-09T14:52:44.724513Z"}]}'
+        content_length: 471
+        body: '{"job_runs":[{"id":"730e67e8-18c9-4bcf-a2fa-65070cce8e0b", "job_definition_id":"382066bb-c496-40ec-8574-80fe9e4f54cc", "created_at":"2026-02-16T17:24:00.686466Z", "updated_at":"2026-02-16T17:24:01.012689Z", "started_at":null, "terminated_at":null, "run_duration":null, "state":"validated", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "command":"echo ''Hello World''", "environment_variables":{}, "startup_command":[], "args":[], "region":"fr-par"}]}'
         headers:
             Content-Length:
-                - "456"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "471"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 09 Feb 2026 14:52:44 GMT
+                - Mon, 16 Feb 2026 17:24:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - cc66c884-f66c-4223-aae0-594b33bf3185
+                - ef3bae28-d40e-46dc-8fb6-779ba7b667b5
         status: 200 OK
         code: 200
-        duration: 444.786407ms
+        duration: 445.58336ms
     - id: 4
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        form:
+            job_definition_id:
+                - 382066bb-c496-40ec-8574-80fe9e4f54cc
+            order_by:
+                - created_at_asc
+            state:
+                - unknown_state
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-runs?job_definition_id=d1623346-739b-46d6-806f-395f323929ab&order_by=created_at_asc&state=unknown_state
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-runs?job_definition_id=382066bb-c496-40ec-8574-80fe9e4f54cc&order_by=created_at_asc&state=unknown_state
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 472
-        uncompressed: false
-        body: '{"job_runs":[{"args":[],"command":"echo ''Hello World''","cpu_limit":120,"created_at":"2026-02-09T14:52:44.409527Z","environment_variables":{},"id":"32b05057-b2b5-4610-b2ca-3321f0fb67be","job_definition_id":"d1623346-739b-46d6-806f-395f323929ab","local_storage_capacity":5120,"memory_limit":256,"region":"fr-par","run_duration":null,"started_at":null,"startup_command":[],"state":"validated","terminated_at":null,"updated_at":"2026-02-09T14:52:44.724513Z"}],"total_count":1}'
+        content_length: 488
+        body: '{"job_runs":[{"id":"730e67e8-18c9-4bcf-a2fa-65070cce8e0b", "job_definition_id":"382066bb-c496-40ec-8574-80fe9e4f54cc", "created_at":"2026-02-16T17:24:00.686466Z", "updated_at":"2026-02-16T17:24:01.012689Z", "started_at":null, "terminated_at":null, "run_duration":null, "state":"validated", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "command":"echo ''Hello World''", "environment_variables":{}, "startup_command":[], "args":[], "region":"fr-par"}], "total_count":1}'
         headers:
             Content-Length:
-                - "472"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "488"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 09 Feb 2026 14:52:44 GMT
+                - Mon, 16 Feb 2026 17:24:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 0be64999-7813-4510-ab83-452c49c3023c
+                - 35675ccb-f48d-4e08-8650-6fab5a6669f3
         status: 200 OK
         code: 200
-        duration: 45.363062ms
+        duration: 33.817902ms
     - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/d1623346-739b-46d6-806f-395f323929ab
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/382066bb-c496-40ec-8574-80fe9e4f54cc
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 486
-        uncompressed: false
-        body: '{"args":[],"command":"echo ''Hello World''","cpu_limit":120,"created_at":"2026-02-09T14:52:44.191363Z","cron_schedule":null,"description":"","environment_variables":{},"id":"d1623346-739b-46d6-806f-395f323929ab","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-action-start","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-09T14:52:44.191363Z"}'
+        content_length: 502
+        body: '{"id":"382066bb-c496-40ec-8574-80fe9e4f54cc", "name":"test-jobs-action-start", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.464810Z", "updated_at":"2026-02-16T17:24:00.464810Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"echo ''Hello World''", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":null, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
-                - "486"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "502"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 09 Feb 2026 14:52:45 GMT
+                - Mon, 16 Feb 2026 17:24:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 31a8f67f-d0bb-4f9f-9395-976af9bc3178
+                - de9cfae7-bfc1-482b-81fc-a54df2e5cd4f
         status: 200 OK
         code: 200
-        duration: 49.240091ms
+        duration: 32.3715ms
     - id: 6
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        form:
+            job_definition_id:
+                - 382066bb-c496-40ec-8574-80fe9e4f54cc
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=d1623346-739b-46d6-806f-395f323929ab
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=382066bb-c496-40ec-8574-80fe9e4f54cc
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 30
-        uncompressed: false
-        body: '{"secrets":[],"total_count":0}'
+        content_length: 31
+        body: '{"secrets":[], "total_count":0}'
         headers:
             Content-Length:
-                - "30"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "31"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 09 Feb 2026 14:52:45 GMT
+                - Mon, 16 Feb 2026 17:24:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - a7b12cce-7571-4c75-b210-d5252a2c53f3
+                - ecc37b96-5312-434a-8019-fb3d1f976ba3
         status: 200 OK
         code: 200
-        duration: 39.302528ms
+        duration: 51.480727ms
     - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/d1623346-739b-46d6-806f-395f323929ab
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/382066bb-c496-40ec-8574-80fe9e4f54cc
         method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 52
-        uncompressed: false
         body: '{"message":"one or more job runs are still running"}'
         headers:
             Content-Length:
                 - "52"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 09 Feb 2026 14:52:45 GMT
+                - Mon, 16 Feb 2026 17:24:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - ac2a9b9c-6cde-4c72-b2b7-de22c1ee7c5d
+                - 2204c45d-fc49-44ac-933c-74c43a1715dc
         status: 403 Forbidden
         code: 403
-        duration: 49.422365ms
+        duration: 99.121834ms
     - id: 8
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        form:
+            job_definition_id:
+                - 382066bb-c496-40ec-8574-80fe9e4f54cc
+            order_by:
+                - created_at_asc
+            state:
+                - unknown_state
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-runs?job_definition_id=d1623346-739b-46d6-806f-395f323929ab&order_by=created_at_asc&state=unknown_state
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-runs?job_definition_id=382066bb-c496-40ec-8574-80fe9e4f54cc&order_by=created_at_asc&state=unknown_state
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 469
-        uncompressed: false
-        body: '{"job_runs":[{"args":[],"command":"echo ''Hello World''","cpu_limit":120,"created_at":"2026-02-09T14:52:44.409527Z","environment_variables":{},"id":"32b05057-b2b5-4610-b2ca-3321f0fb67be","job_definition_id":"d1623346-739b-46d6-806f-395f323929ab","local_storage_capacity":5120,"memory_limit":256,"region":"fr-par","run_duration":null,"started_at":null,"startup_command":[],"state":"queued","terminated_at":null,"updated_at":"2026-02-09T14:52:45.490384Z"}],"total_count":1}'
+        content_length: 485
+        body: '{"job_runs":[{"id":"730e67e8-18c9-4bcf-a2fa-65070cce8e0b", "job_definition_id":"382066bb-c496-40ec-8574-80fe9e4f54cc", "created_at":"2026-02-16T17:24:00.686466Z", "updated_at":"2026-02-16T17:24:01.982686Z", "started_at":null, "terminated_at":null, "run_duration":null, "state":"queued", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "command":"echo ''Hello World''", "environment_variables":{}, "startup_command":[], "args":[], "region":"fr-par"}], "total_count":1}'
         headers:
             Content-Length:
-                - "469"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "485"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 09 Feb 2026 14:52:45 GMT
+                - Mon, 16 Feb 2026 17:24:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 2e81d2ec-df7e-49b5-bfcd-e764d309ec89
+                - 1c27053f-3645-48ef-bb3b-2616d52bd294
         status: 200 OK
         code: 200
-        duration: 44.073426ms
+        duration: 48.225341ms
     - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 2
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
         body: '{}'
-        form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-runs/32b05057-b2b5-4610-b2ca-3321f0fb67be/stop
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-runs/730e67e8-18c9-4bcf-a2fa-65070cce8e0b/stop
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 468
-        uncompressed: false
-        body: '{"args":[],"command":"echo ''Hello World''","cpu_limit":120,"created_at":"2026-02-09T14:52:44.409527Z","environment_variables":{},"id":"32b05057-b2b5-4610-b2ca-3321f0fb67be","job_definition_id":"d1623346-739b-46d6-806f-395f323929ab","local_storage_capacity":5120,"memory_limit":256,"reason":"cancellation","region":"fr-par","run_duration":null,"started_at":null,"startup_command":[],"state":"interrupting","terminated_at":null,"updated_at":"2026-02-09T14:52:45.773241Z"}'
+        content_length: 484
+        body: '{"id":"730e67e8-18c9-4bcf-a2fa-65070cce8e0b", "job_definition_id":"382066bb-c496-40ec-8574-80fe9e4f54cc", "created_at":"2026-02-16T17:24:00.686466Z", "updated_at":"2026-02-16T17:24:02.328021Z", "started_at":null, "terminated_at":null, "run_duration":null, "state":"interrupting", "reason":"cancellation", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "command":"echo ''Hello World''", "environment_variables":{}, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
-                - "468"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "484"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 09 Feb 2026 14:52:45 GMT
+                - Mon, 16 Feb 2026 17:24:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 8e8d9d5c-af73-4bfd-833a-0371b45717b4
+                - 9f59b073-bdd4-4ea6-a3ad-81be652cc841
         status: 200 OK
         code: 200
-        duration: 115.842703ms
+        duration: 246.187745ms
     - id: 10
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-runs/32b05057-b2b5-4610-b2ca-3321f0fb67be
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-runs/730e67e8-18c9-4bcf-a2fa-65070cce8e0b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 468
-        uncompressed: false
-        body: '{"args":[],"command":"echo ''Hello World''","cpu_limit":120,"created_at":"2026-02-09T14:52:44.409527Z","environment_variables":{},"id":"32b05057-b2b5-4610-b2ca-3321f0fb67be","job_definition_id":"d1623346-739b-46d6-806f-395f323929ab","local_storage_capacity":5120,"memory_limit":256,"reason":"cancellation","region":"fr-par","run_duration":null,"started_at":null,"startup_command":[],"state":"interrupting","terminated_at":null,"updated_at":"2026-02-09T14:52:45.773241Z"}'
+        content_length: 484
+        body: '{"id":"730e67e8-18c9-4bcf-a2fa-65070cce8e0b", "job_definition_id":"382066bb-c496-40ec-8574-80fe9e4f54cc", "created_at":"2026-02-16T17:24:00.686466Z", "updated_at":"2026-02-16T17:24:02.328021Z", "started_at":null, "terminated_at":null, "run_duration":null, "state":"interrupting", "reason":"cancellation", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "command":"echo ''Hello World''", "environment_variables":{}, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
-                - "468"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "484"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 09 Feb 2026 14:52:45 GMT
+                - Mon, 16 Feb 2026 17:24:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - e8eeae66-262b-478e-9083-fee3bf5bfc08
+                - 5249152b-f0fc-42b7-aefa-4ea77acd105a
         status: 200 OK
         code: 200
-        duration: 61.496022ms
+        duration: 43.896195ms
     - id: 11
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-runs/32b05057-b2b5-4610-b2ca-3321f0fb67be
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-runs/730e67e8-18c9-4bcf-a2fa-65070cce8e0b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 467
-        uncompressed: false
-        body: '{"args":[],"command":"echo ''Hello World''","cpu_limit":120,"created_at":"2026-02-09T14:52:44.409527Z","environment_variables":{},"id":"32b05057-b2b5-4610-b2ca-3321f0fb67be","job_definition_id":"d1623346-739b-46d6-806f-395f323929ab","local_storage_capacity":5120,"memory_limit":256,"reason":"cancellation","region":"fr-par","run_duration":null,"started_at":null,"startup_command":[],"state":"interrupted","terminated_at":null,"updated_at":"2026-02-09T14:52:46.756399Z"}'
+        content_length: 483
+        body: '{"id":"730e67e8-18c9-4bcf-a2fa-65070cce8e0b", "job_definition_id":"382066bb-c496-40ec-8574-80fe9e4f54cc", "created_at":"2026-02-16T17:24:00.686466Z", "updated_at":"2026-02-16T17:24:03.505696Z", "started_at":null, "terminated_at":null, "run_duration":null, "state":"interrupted", "reason":"cancellation", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "command":"echo ''Hello World''", "environment_variables":{}, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
-                - "467"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "483"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 09 Feb 2026 14:53:00 GMT
+                - Mon, 16 Feb 2026 17:24:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - a7a20696-8c81-4f1e-ac6f-8bd26e5baf21
+                - 3839794d-f282-4c85-b6ce-0615920a96f3
         status: 200 OK
         code: 200
-        duration: 44.001061ms
+        duration: 61.810541ms
     - id: 12
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/d1623346-739b-46d6-806f-395f323929ab
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/382066bb-c496-40ec-8574-80fe9e4f54cc
         method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 0
-        uncompressed: false
         body: ""
         headers:
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 09 Feb 2026 14:53:01 GMT
+                - Mon, 16 Feb 2026 17:24:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 0944e9f9-5a95-4bcd-b159-3c1c8c3659b9
+                - 8695900c-36f5-4e79-b5f9-2b26a8d466e3
         status: 204 No Content
         code: 204
-        duration: 131.41535ms
+        duration: 34.321037ms
     - id: 13
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        form:
+            job_definition_id:
+                - 382066bb-c496-40ec-8574-80fe9e4f54cc
+            order_by:
+                - created_at_asc
+            state:
+                - unknown_state
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-runs?job_definition_id=d1623346-739b-46d6-806f-395f323929ab&order_by=created_at_asc&state=unknown_state
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-runs?job_definition_id=382066bb-c496-40ec-8574-80fe9e4f54cc&order_by=created_at_asc&state=unknown_state
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 31
-        uncompressed: false
-        body: '{"job_runs":[],"total_count":0}'
+        content_length: 32
+        body: '{"job_runs":[], "total_count":0}'
         headers:
             Content-Length:
-                - "31"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "32"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 09 Feb 2026 14:53:01 GMT
+                - Mon, 16 Feb 2026 17:24:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - d656cefe-82f4-4442-af6c-010801044f46
+                - f6fffe8a-144b-4bed-bf7e-32b1420229c0
         status: 200 OK
         code: 200
-        duration: 49.445516ms
+        duration: 42.9818ms
     - id: 14
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/d1623346-739b-46d6-806f-395f323929ab
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/382066bb-c496-40ec-8574-80fe9e4f54cc
         method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 41
-        uncompressed: false
         body: '{"message":"job definition is not found"}'
         headers:
             Content-Length:
                 - "41"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 09 Feb 2026 14:53:01 GMT
+                - Mon, 16 Feb 2026 17:24:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - abdd26eb-62b7-4885-a05d-eec6d02c7e34
+                - 9c378f3d-643e-4294-a060-bf2062335277
         status: 404 Not Found
         code: 404
-        duration: 22.509598ms
+        duration: 24.578808ms
     - id: 15
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        form:
+            job_definition_id:
+                - 382066bb-c496-40ec-8574-80fe9e4f54cc
+            order_by:
+                - created_at_asc
+            state:
+                - unknown_state
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-runs?job_definition_id=d1623346-739b-46d6-806f-395f323929ab&order_by=created_at_asc&state=unknown_state
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-runs?job_definition_id=382066bb-c496-40ec-8574-80fe9e4f54cc&order_by=created_at_asc&state=unknown_state
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 31
-        uncompressed: false
-        body: '{"job_runs":[],"total_count":0}'
+        content_length: 32
+        body: '{"job_runs":[], "total_count":0}'
         headers:
             Content-Length:
-                - "31"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "32"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 09 Feb 2026 14:53:01 GMT
+                - Mon, 16 Feb 2026 17:24:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 19f7c6e0-dcb6-44aa-adef-736aa91b51f5
+                - 8feb0110-323e-41a8-90d8-13d486c29092
         status: 200 OK
         code: 200
-        duration: 48.156985ms
+        duration: 31.247822ms
     - id: 16
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/d1623346-739b-46d6-806f-395f323929ab
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/382066bb-c496-40ec-8574-80fe9e4f54cc
         method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 41
-        uncompressed: false
         body: '{"message":"job definition is not found"}'
         headers:
             Content-Length:
                 - "41"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Mon, 09 Feb 2026 14:53:01 GMT
+                - Mon, 16 Feb 2026 17:24:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 7d79333f-a555-4550-9ec8-b8cbeceefb04
+                - e822c835-9990-41f6-aef2-316e83f22b9c
         status: 404 Not Found
         code: 404
-        duration: 23.039574ms
+        duration: 19.502033ms

--- a/internal/services/jobs/testdata/job-definition-basic.cassette.yaml
+++ b/internal/services/jobs/testdata/job-definition-basic.cassette.yaml
@@ -7,13 +7,8 @@ interactions:
         proto_major: 1
         proto_minor: 1
         content_length: 284
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
         body: '{"name":"test-jobs-job-definition-basic","cpu_limit":120,"memory_limit":256,"local_storage_capacity":5120,"image_uri":"docker.io/alpine:latest","command":"","startup_command":[],"args":[],"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","environment_variables":{},"description":""}'
-        form: {}
         headers:
             Content-Type:
                 - application/json
@@ -25,765 +20,515 @@ interactions:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 492
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":120,"created_at":"2026-02-03T20:18:43.695165Z","cron_schedule":null,"description":"","environment_variables":{},"id":"01fa2009-322b-4a53-b578-e7fd57c117b4","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-job-definition-basic","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T20:18:43.695165Z"}'
+        body: '{"id":"053f21c0-d2ca-46e7-9d07-f22d19a6bf55", "name":"test-jobs-job-definition-basic", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.470628Z", "updated_at":"2026-02-16T17:24:00.470628Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":null, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
                 - "492"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 20:18:43 GMT
+                - Mon, 16 Feb 2026 17:24:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - dee9a896-003e-43f1-910e-9b88a3f64bbd
+                - f59eacc3-b4f3-44d5-8912-137b6aa3c09a
         status: 200 OK
         code: 200
-        duration: 173.543195ms
+        duration: 175.25163ms
     - id: 1
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/01fa2009-322b-4a53-b578-e7fd57c117b4
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/053f21c0-d2ca-46e7-9d07-f22d19a6bf55
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 492
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":120,"created_at":"2026-02-03T20:18:43.695165Z","cron_schedule":null,"description":"","environment_variables":{},"id":"01fa2009-322b-4a53-b578-e7fd57c117b4","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-job-definition-basic","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T20:18:43.695165Z"}'
+        body: '{"id":"053f21c0-d2ca-46e7-9d07-f22d19a6bf55", "name":"test-jobs-job-definition-basic", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.470628Z", "updated_at":"2026-02-16T17:24:00.470628Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":null, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
                 - "492"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 20:18:43 GMT
+                - Mon, 16 Feb 2026 17:24:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - b15a47c3-413e-4786-ae41-f72c8da876cd
+                - ddea8c6e-3dc5-49a0-bfb0-bb0e89178c1a
         status: 200 OK
         code: 200
-        duration: 65.564479ms
+        duration: 43.527427ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        form:
+            job_definition_id:
+                - 053f21c0-d2ca-46e7-9d07-f22d19a6bf55
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=01fa2009-322b-4a53-b578-e7fd57c117b4
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=053f21c0-d2ca-46e7-9d07-f22d19a6bf55
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 31
-        uncompressed: false
-        body: '{"secrets":[],"total_count":0}'
+        body: '{"secrets":[], "total_count":0}'
         headers:
             Content-Length:
                 - "31"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 20:18:43 GMT
+                - Mon, 16 Feb 2026 17:24:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - cd05eec3-2047-4428-9ec6-f709b41cf5dd
+                - a2e99104-eda5-4106-a59e-2dce7357bce0
         status: 200 OK
         code: 200
-        duration: 70.564952ms
+        duration: 36.814375ms
     - id: 3
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/01fa2009-322b-4a53-b578-e7fd57c117b4
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/053f21c0-d2ca-46e7-9d07-f22d19a6bf55
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 492
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":120,"created_at":"2026-02-03T20:18:43.695165Z","cron_schedule":null,"description":"","environment_variables":{},"id":"01fa2009-322b-4a53-b578-e7fd57c117b4","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-job-definition-basic","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T20:18:43.695165Z"}'
+        body: '{"id":"053f21c0-d2ca-46e7-9d07-f22d19a6bf55", "name":"test-jobs-job-definition-basic", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.470628Z", "updated_at":"2026-02-16T17:24:00.470628Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":null, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
                 - "492"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 20:18:44 GMT
+                - Mon, 16 Feb 2026 17:24:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 6457b569-9635-4e2d-aa00-10cc6e24e101
+                - 369c760e-c62d-4a3f-abf2-b299cb0c83fb
         status: 200 OK
         code: 200
-        duration: 57.99759ms
+        duration: 42.839288ms
     - id: 4
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/01fa2009-322b-4a53-b578-e7fd57c117b4
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/053f21c0-d2ca-46e7-9d07-f22d19a6bf55
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 492
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":120,"created_at":"2026-02-03T20:18:43.695165Z","cron_schedule":null,"description":"","environment_variables":{},"id":"01fa2009-322b-4a53-b578-e7fd57c117b4","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-job-definition-basic","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T20:18:43.695165Z"}'
+        body: '{"id":"053f21c0-d2ca-46e7-9d07-f22d19a6bf55", "name":"test-jobs-job-definition-basic", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.470628Z", "updated_at":"2026-02-16T17:24:00.470628Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":null, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
                 - "492"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 20:18:44 GMT
+                - Mon, 16 Feb 2026 17:24:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 58753f06-8e61-4dc3-8232-3e23d6b33dc9
+                - 21a59f7f-87e3-427d-96ac-0d952bc6d0de
         status: 200 OK
         code: 200
-        duration: 51.101512ms
+        duration: 59.947967ms
     - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        form:
+            job_definition_id:
+                - 053f21c0-d2ca-46e7-9d07-f22d19a6bf55
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=01fa2009-322b-4a53-b578-e7fd57c117b4
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=053f21c0-d2ca-46e7-9d07-f22d19a6bf55
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 31
-        uncompressed: false
-        body: '{"secrets":[],"total_count":0}'
+        body: '{"secrets":[], "total_count":0}'
         headers:
             Content-Length:
                 - "31"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 20:18:44 GMT
+                - Mon, 16 Feb 2026 17:24:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - a5b51f01-037c-4f0d-bae6-b7df341eef8b
+                - 5f2eeade-c165-4c04-b3eb-9775b8954ca9
         status: 200 OK
         code: 200
-        duration: 41.424736ms
+        duration: 47.467472ms
     - id: 6
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/01fa2009-322b-4a53-b578-e7fd57c117b4
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/053f21c0-d2ca-46e7-9d07-f22d19a6bf55
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 492
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":120,"created_at":"2026-02-03T20:18:43.695165Z","cron_schedule":null,"description":"","environment_variables":{},"id":"01fa2009-322b-4a53-b578-e7fd57c117b4","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-job-definition-basic","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T20:18:43.695165Z"}'
+        body: '{"id":"053f21c0-d2ca-46e7-9d07-f22d19a6bf55", "name":"test-jobs-job-definition-basic", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.470628Z", "updated_at":"2026-02-16T17:24:00.470628Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":null, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
                 - "492"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 20:18:44 GMT
+                - Mon, 16 Feb 2026 17:24:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 29e82aa7-b196-4ff1-a88a-399099eb0ba6
+                - 9cd3d6f3-9ce2-4b58-8dfe-f25a957a7adb
         status: 200 OK
         code: 200
-        duration: 44.454944ms
+        duration: 45.162506ms
     - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        form:
+            job_definition_id:
+                - 053f21c0-d2ca-46e7-9d07-f22d19a6bf55
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=01fa2009-322b-4a53-b578-e7fd57c117b4
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=053f21c0-d2ca-46e7-9d07-f22d19a6bf55
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 31
-        uncompressed: false
-        body: '{"secrets":[],"total_count":0}'
+        body: '{"secrets":[], "total_count":0}'
         headers:
             Content-Length:
                 - "31"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 20:18:44 GMT
+                - Mon, 16 Feb 2026 17:24:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 131589b6-5cb2-4a07-a1c0-61822a52a97c
+                - 417cf0bb-1db3-4a19-b757-7fa899866ddc
         status: 200 OK
         code: 200
-        duration: 41.352229ms
+        duration: 24.912449ms
     - id: 8
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 151
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
         body: '{"name":"test-jobs-job-definition-basic-renamed","cpu_limit":240,"memory_limit":128,"local_storage_capacity":1024,"image_uri":"docker.io/nginx:latest"}'
-        form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/01fa2009-322b-4a53-b578-e7fd57c117b4
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/053f21c0-d2ca-46e7-9d07-f22d19a6bf55
         method: PATCH
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 499
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":240,"created_at":"2026-02-03T20:18:43.695165Z","cron_schedule":null,"description":"","environment_variables":{},"id":"01fa2009-322b-4a53-b578-e7fd57c117b4","image_uri":"docker.io/nginx:latest","job_timeout":"86400s","local_storage_capacity":1024,"memory_limit":128,"name":"test-jobs-job-definition-basic-renamed","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T20:18:44.653405Z"}'
+        body: '{"id":"053f21c0-d2ca-46e7-9d07-f22d19a6bf55", "name":"test-jobs-job-definition-basic-renamed", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.470628Z", "updated_at":"2026-02-16T17:24:01.796646Z", "cpu_limit":240, "memory_limit":128, "local_storage_capacity":1024, "image_uri":"docker.io/nginx:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":null, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
                 - "499"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 20:18:44 GMT
+                - Mon, 16 Feb 2026 17:24:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 14c63e8e-b74e-407e-9b67-02d53e123c93
+                - b49484bb-d52a-48f0-aa90-92b0020312e4
         status: 200 OK
         code: 200
-        duration: 95.570563ms
+        duration: 204.679362ms
     - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/01fa2009-322b-4a53-b578-e7fd57c117b4
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/053f21c0-d2ca-46e7-9d07-f22d19a6bf55
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 499
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":240,"created_at":"2026-02-03T20:18:43.695165Z","cron_schedule":null,"description":"","environment_variables":{},"id":"01fa2009-322b-4a53-b578-e7fd57c117b4","image_uri":"docker.io/nginx:latest","job_timeout":"86400s","local_storage_capacity":1024,"memory_limit":128,"name":"test-jobs-job-definition-basic-renamed","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T20:18:44.653405Z"}'
+        body: '{"id":"053f21c0-d2ca-46e7-9d07-f22d19a6bf55", "name":"test-jobs-job-definition-basic-renamed", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.470628Z", "updated_at":"2026-02-16T17:24:01.796646Z", "cpu_limit":240, "memory_limit":128, "local_storage_capacity":1024, "image_uri":"docker.io/nginx:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":null, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
                 - "499"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 20:18:44 GMT
+                - Mon, 16 Feb 2026 17:24:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 4de39f74-f49e-4aab-9741-ab7d6dd7e2c2
+                - 4fad190c-810d-4545-b776-069904a15056
         status: 200 OK
         code: 200
-        duration: 55.789718ms
+        duration: 100.921301ms
     - id: 10
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        form:
+            job_definition_id:
+                - 053f21c0-d2ca-46e7-9d07-f22d19a6bf55
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=01fa2009-322b-4a53-b578-e7fd57c117b4
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=053f21c0-d2ca-46e7-9d07-f22d19a6bf55
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 31
-        uncompressed: false
-        body: '{"secrets":[],"total_count":0}'
+        body: '{"secrets":[], "total_count":0}'
         headers:
             Content-Length:
                 - "31"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 20:18:44 GMT
+                - Mon, 16 Feb 2026 17:24:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - e349b633-35db-4959-a5e7-87921b630f6a
+                - 2ffa47da-9a7c-4d04-b759-e38943690f4b
         status: 200 OK
         code: 200
-        duration: 51.936272ms
+        duration: 23.068299ms
     - id: 11
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/01fa2009-322b-4a53-b578-e7fd57c117b4
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/053f21c0-d2ca-46e7-9d07-f22d19a6bf55
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 499
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":240,"created_at":"2026-02-03T20:18:43.695165Z","cron_schedule":null,"description":"","environment_variables":{},"id":"01fa2009-322b-4a53-b578-e7fd57c117b4","image_uri":"docker.io/nginx:latest","job_timeout":"86400s","local_storage_capacity":1024,"memory_limit":128,"name":"test-jobs-job-definition-basic-renamed","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T20:18:44.653405Z"}'
+        body: '{"id":"053f21c0-d2ca-46e7-9d07-f22d19a6bf55", "name":"test-jobs-job-definition-basic-renamed", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.470628Z", "updated_at":"2026-02-16T17:24:01.796646Z", "cpu_limit":240, "memory_limit":128, "local_storage_capacity":1024, "image_uri":"docker.io/nginx:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":null, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
                 - "499"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 20:18:44 GMT
+                - Mon, 16 Feb 2026 17:24:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - a5dcb683-cc65-4667-ad62-a7d42cba0b51
+                - 66bc91c0-0298-4441-8c28-aace5b4666ec
         status: 200 OK
         code: 200
-        duration: 53.47705ms
+        duration: 27.737613ms
     - id: 12
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/01fa2009-322b-4a53-b578-e7fd57c117b4
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/053f21c0-d2ca-46e7-9d07-f22d19a6bf55
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 499
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":240,"created_at":"2026-02-03T20:18:43.695165Z","cron_schedule":null,"description":"","environment_variables":{},"id":"01fa2009-322b-4a53-b578-e7fd57c117b4","image_uri":"docker.io/nginx:latest","job_timeout":"86400s","local_storage_capacity":1024,"memory_limit":128,"name":"test-jobs-job-definition-basic-renamed","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T20:18:44.653405Z"}'
+        body: '{"id":"053f21c0-d2ca-46e7-9d07-f22d19a6bf55", "name":"test-jobs-job-definition-basic-renamed", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.470628Z", "updated_at":"2026-02-16T17:24:01.796646Z", "cpu_limit":240, "memory_limit":128, "local_storage_capacity":1024, "image_uri":"docker.io/nginx:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":null, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
                 - "499"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 20:18:45 GMT
+                - Mon, 16 Feb 2026 17:24:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - abc808a0-94c4-4ff8-a5b6-d558bed4d91a
+                - 40f0f1d4-268e-4ebf-a98e-99f2ae49d987
         status: 200 OK
         code: 200
-        duration: 37.585807ms
+        duration: 36.206354ms
     - id: 13
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        form:
+            job_definition_id:
+                - 053f21c0-d2ca-46e7-9d07-f22d19a6bf55
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=01fa2009-322b-4a53-b578-e7fd57c117b4
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=053f21c0-d2ca-46e7-9d07-f22d19a6bf55
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 31
-        uncompressed: false
-        body: '{"secrets":[],"total_count":0}'
+        body: '{"secrets":[], "total_count":0}'
         headers:
             Content-Length:
                 - "31"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 20:18:45 GMT
+                - Mon, 16 Feb 2026 17:24:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - ca548049-2050-4495-bc97-e3df06be9b8f
+                - d58cabdf-dda8-49bf-816c-316b1b80f735
         status: 200 OK
         code: 200
-        duration: 42.646003ms
+        duration: 23.381866ms
     - id: 14
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/01fa2009-322b-4a53-b578-e7fd57c117b4
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/053f21c0-d2ca-46e7-9d07-f22d19a6bf55
         method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 0
-        uncompressed: false
         body: ""
         headers:
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 20:18:45 GMT
+                - Mon, 16 Feb 2026 17:24:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 1f7157ca-2850-4dde-baed-c31ca1060e3a
+                - 6ffd4840-7e7e-44b0-b382-62416672810a
         status: 204 No Content
         code: 204
-        duration: 57.01435ms
+        duration: 42.25895ms
     - id: 15
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/01fa2009-322b-4a53-b578-e7fd57c117b4
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/053f21c0-d2ca-46e7-9d07-f22d19a6bf55
         method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 41
-        uncompressed: false
         body: '{"message":"job definition is not found"}'
         headers:
             Content-Length:
                 - "41"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 20:18:45 GMT
+                - Mon, 16 Feb 2026 17:24:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 67c4f8a9-b589-4651-af2d-128d2748a257
+                - 6a914a3a-02e6-4062-9603-15bb262ae033
         status: 404 Not Found
         code: 404
-        duration: 29.729574ms
+        duration: 21.761583ms

--- a/internal/services/jobs/testdata/job-definition-command-and-args.cassette.yaml
+++ b/internal/services/jobs/testdata/job-definition-command-and-args.cassette.yaml
@@ -7,13 +7,8 @@ interactions:
         proto_major: 1
         proto_minor: 1
         content_length: 294
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
         body: '{"name":"test-jobs-job-definition-cmd-args","cpu_limit":120,"memory_limit":256,"local_storage_capacity":5120,"image_uri":"docker.io/alpine:latest","command":"","startup_command":["mysql"],"args":[],"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","environment_variables":{},"description":""}'
-        form: {}
         headers:
             Content-Type:
                 - application/json
@@ -25,1159 +20,783 @@ interactions:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 502
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":120,"created_at":"2026-02-03T21:30:32.891490Z","cron_schedule":null,"description":"","environment_variables":{},"id":"ad7bce8c-512a-4e85-ac93-f1adb7acb79c","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-job-definition-cmd-args","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":["mysql"],"updated_at":"2026-02-03T21:30:32.891490Z"}'
+        body: '{"id":"b6c35647-4c37-42ea-8cc1-8f3cfc7984bd", "name":"test-jobs-job-definition-cmd-args", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.474478Z", "updated_at":"2026-02-16T17:24:00.474478Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":null, "startup_command":["mysql"], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
                 - "502"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 21:30:32 GMT
+                - Mon, 16 Feb 2026 17:24:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - eac39982-832b-4e56-a77e-ce6d4b4dbbaf
+                - 251f0e28-4727-4be8-b250-1bf388462afc
         status: 200 OK
         code: 200
-        duration: 141.697918ms
+        duration: 152.311783ms
     - id: 1
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/ad7bce8c-512a-4e85-ac93-f1adb7acb79c
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/b6c35647-4c37-42ea-8cc1-8f3cfc7984bd
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 502
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":120,"created_at":"2026-02-03T21:30:32.891490Z","cron_schedule":null,"description":"","environment_variables":{},"id":"ad7bce8c-512a-4e85-ac93-f1adb7acb79c","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-job-definition-cmd-args","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":["mysql"],"updated_at":"2026-02-03T21:30:32.891490Z"}'
+        body: '{"id":"b6c35647-4c37-42ea-8cc1-8f3cfc7984bd", "name":"test-jobs-job-definition-cmd-args", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.474478Z", "updated_at":"2026-02-16T17:24:00.474478Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":null, "startup_command":["mysql"], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
                 - "502"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 21:30:32 GMT
+                - Mon, 16 Feb 2026 17:24:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 2f6df960-bf35-4213-a173-3b0561f5f8a8
+                - 15ce2dc8-f73c-4b50-9c7e-3705f46711f3
         status: 200 OK
         code: 200
-        duration: 58.135646ms
+        duration: 47.146774ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        form:
+            job_definition_id:
+                - b6c35647-4c37-42ea-8cc1-8f3cfc7984bd
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=ad7bce8c-512a-4e85-ac93-f1adb7acb79c
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=b6c35647-4c37-42ea-8cc1-8f3cfc7984bd
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 31
-        uncompressed: false
-        body: '{"secrets":[],"total_count":0}'
+        body: '{"secrets":[], "total_count":0}'
         headers:
             Content-Length:
                 - "31"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 21:30:32 GMT
+                - Mon, 16 Feb 2026 17:24:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 10963b71-ec18-42c8-8430-1dc0b90166b2
+                - f524f49d-ede9-46d1-8199-3f35d481403a
         status: 200 OK
         code: 200
-        duration: 32.583113ms
+        duration: 46.123446ms
     - id: 3
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/ad7bce8c-512a-4e85-ac93-f1adb7acb79c
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/b6c35647-4c37-42ea-8cc1-8f3cfc7984bd
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 502
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":120,"created_at":"2026-02-03T21:30:32.891490Z","cron_schedule":null,"description":"","environment_variables":{},"id":"ad7bce8c-512a-4e85-ac93-f1adb7acb79c","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-job-definition-cmd-args","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":["mysql"],"updated_at":"2026-02-03T21:30:32.891490Z"}'
+        body: '{"id":"b6c35647-4c37-42ea-8cc1-8f3cfc7984bd", "name":"test-jobs-job-definition-cmd-args", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.474478Z", "updated_at":"2026-02-16T17:24:00.474478Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":null, "startup_command":["mysql"], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
                 - "502"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 21:30:33 GMT
+                - Mon, 16 Feb 2026 17:24:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - c94d8be8-f85c-437b-a62b-bb9a5ad6c258
+                - fbb982f5-445e-486c-a8e7-52ab917d02b7
         status: 200 OK
         code: 200
-        duration: 42.300983ms
+        duration: 40.455141ms
     - id: 4
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/ad7bce8c-512a-4e85-ac93-f1adb7acb79c
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/b6c35647-4c37-42ea-8cc1-8f3cfc7984bd
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 502
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":120,"created_at":"2026-02-03T21:30:32.891490Z","cron_schedule":null,"description":"","environment_variables":{},"id":"ad7bce8c-512a-4e85-ac93-f1adb7acb79c","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-job-definition-cmd-args","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":["mysql"],"updated_at":"2026-02-03T21:30:32.891490Z"}'
+        body: '{"id":"b6c35647-4c37-42ea-8cc1-8f3cfc7984bd", "name":"test-jobs-job-definition-cmd-args", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.474478Z", "updated_at":"2026-02-16T17:24:00.474478Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":null, "startup_command":["mysql"], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
                 - "502"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 21:30:33 GMT
+                - Mon, 16 Feb 2026 17:24:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 977063f5-9723-49c3-97d5-3cc3e00e5072
+                - 505d2304-46d3-42e4-90fc-037c1278b9f9
         status: 200 OK
         code: 200
-        duration: 46.251386ms
+        duration: 29.576392ms
     - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        form:
+            job_definition_id:
+                - b6c35647-4c37-42ea-8cc1-8f3cfc7984bd
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=ad7bce8c-512a-4e85-ac93-f1adb7acb79c
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=b6c35647-4c37-42ea-8cc1-8f3cfc7984bd
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 31
-        uncompressed: false
-        body: '{"secrets":[],"total_count":0}'
+        body: '{"secrets":[], "total_count":0}'
         headers:
             Content-Length:
                 - "31"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 21:30:33 GMT
+                - Mon, 16 Feb 2026 17:24:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 260c1bbe-98cf-4754-9572-ac0d244bce48
+                - 6e83ac49-7048-409b-8251-1b80d8389eb9
         status: 200 OK
         code: 200
-        duration: 30.863051ms
+        duration: 41.76946ms
     - id: 6
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/ad7bce8c-512a-4e85-ac93-f1adb7acb79c
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/b6c35647-4c37-42ea-8cc1-8f3cfc7984bd
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 502
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":120,"created_at":"2026-02-03T21:30:32.891490Z","cron_schedule":null,"description":"","environment_variables":{},"id":"ad7bce8c-512a-4e85-ac93-f1adb7acb79c","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-job-definition-cmd-args","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":["mysql"],"updated_at":"2026-02-03T21:30:32.891490Z"}'
+        body: '{"id":"b6c35647-4c37-42ea-8cc1-8f3cfc7984bd", "name":"test-jobs-job-definition-cmd-args", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.474478Z", "updated_at":"2026-02-16T17:24:00.474478Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":null, "startup_command":["mysql"], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
                 - "502"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 21:30:33 GMT
+                - Mon, 16 Feb 2026 17:24:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 22d894e2-bca3-461c-b9b9-e2df8159366f
+                - 5cf4200d-c0f5-4b0c-bab9-b1797e4e36eb
         status: 200 OK
         code: 200
-        duration: 44.751187ms
+        duration: 41.815518ms
     - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        form:
+            job_definition_id:
+                - b6c35647-4c37-42ea-8cc1-8f3cfc7984bd
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=ad7bce8c-512a-4e85-ac93-f1adb7acb79c
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=b6c35647-4c37-42ea-8cc1-8f3cfc7984bd
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 31
-        uncompressed: false
-        body: '{"secrets":[],"total_count":0}'
+        body: '{"secrets":[], "total_count":0}'
         headers:
             Content-Length:
                 - "31"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 21:30:33 GMT
+                - Mon, 16 Feb 2026 17:24:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 947f301f-cadd-4ee4-9184-a6523c5e9095
+                - 377a2887-48ab-49e9-b295-3c5a54ff3fa1
         status: 200 OK
         code: 200
-        duration: 57.017666ms
+        duration: 28.525613ms
     - id: 8
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 86
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
         body: '{"startup_command":["mysql","other-cmd"],"args":["override","default","image","args"]}'
-        form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/ad7bce8c-512a-4e85-ac93-f1adb7acb79c
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/b6c35647-4c37-42ea-8cc1-8f3cfc7984bd
         method: PATCH
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 553
-        uncompressed: false
-        body: '{"args":["override","default","image","args"],"command":"","cpu_limit":120,"created_at":"2026-02-03T21:30:32.891490Z","cron_schedule":null,"description":"","environment_variables":{},"id":"ad7bce8c-512a-4e85-ac93-f1adb7acb79c","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-job-definition-cmd-args","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":["mysql","other-cmd"],"updated_at":"2026-02-03T21:30:33.739440Z"}'
+        body: '{"id":"b6c35647-4c37-42ea-8cc1-8f3cfc7984bd", "name":"test-jobs-job-definition-cmd-args", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.474478Z", "updated_at":"2026-02-16T17:24:01.796469Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":null, "startup_command":["mysql", "other-cmd"], "args":["override", "default", "image", "args"], "region":"fr-par"}'
         headers:
             Content-Length:
                 - "553"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 21:30:33 GMT
+                - Mon, 16 Feb 2026 17:24:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - fdf47aee-faf6-4152-84e0-ffbe7570b2e6
+                - d9ed4587-c1e6-4e57-ac0b-cd1190ed62f8
         status: 200 OK
         code: 200
-        duration: 78.919879ms
+        duration: 209.384514ms
     - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/ad7bce8c-512a-4e85-ac93-f1adb7acb79c
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/b6c35647-4c37-42ea-8cc1-8f3cfc7984bd
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 553
-        uncompressed: false
-        body: '{"args":["override","default","image","args"],"command":"","cpu_limit":120,"created_at":"2026-02-03T21:30:32.891490Z","cron_schedule":null,"description":"","environment_variables":{},"id":"ad7bce8c-512a-4e85-ac93-f1adb7acb79c","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-job-definition-cmd-args","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":["mysql","other-cmd"],"updated_at":"2026-02-03T21:30:33.739440Z"}'
+        body: '{"id":"b6c35647-4c37-42ea-8cc1-8f3cfc7984bd", "name":"test-jobs-job-definition-cmd-args", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.474478Z", "updated_at":"2026-02-16T17:24:01.796469Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":null, "startup_command":["mysql", "other-cmd"], "args":["override", "default", "image", "args"], "region":"fr-par"}'
         headers:
             Content-Length:
                 - "553"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 21:30:33 GMT
+                - Mon, 16 Feb 2026 17:24:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 42bdde76-cb6c-4bf2-8d54-3becef281aff
+                - b809e1ea-19d6-4a8d-a435-5f9c46323e2d
         status: 200 OK
         code: 200
-        duration: 33.029021ms
+        duration: 29.159909ms
     - id: 10
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        form:
+            job_definition_id:
+                - b6c35647-4c37-42ea-8cc1-8f3cfc7984bd
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=ad7bce8c-512a-4e85-ac93-f1adb7acb79c
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=b6c35647-4c37-42ea-8cc1-8f3cfc7984bd
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 31
-        uncompressed: false
-        body: '{"secrets":[],"total_count":0}'
+        body: '{"secrets":[], "total_count":0}'
         headers:
             Content-Length:
                 - "31"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 21:30:33 GMT
+                - Mon, 16 Feb 2026 17:24:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 04cd1718-504d-4bc6-bffa-56e8e60c3e0f
+                - 67e11c92-a791-49ce-9049-1a3054ab5e27
         status: 200 OK
         code: 200
-        duration: 44.383015ms
+        duration: 27.695964ms
     - id: 11
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/ad7bce8c-512a-4e85-ac93-f1adb7acb79c
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/b6c35647-4c37-42ea-8cc1-8f3cfc7984bd
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 553
-        uncompressed: false
-        body: '{"args":["override","default","image","args"],"command":"","cpu_limit":120,"created_at":"2026-02-03T21:30:32.891490Z","cron_schedule":null,"description":"","environment_variables":{},"id":"ad7bce8c-512a-4e85-ac93-f1adb7acb79c","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-job-definition-cmd-args","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":["mysql","other-cmd"],"updated_at":"2026-02-03T21:30:33.739440Z"}'
+        body: '{"id":"b6c35647-4c37-42ea-8cc1-8f3cfc7984bd", "name":"test-jobs-job-definition-cmd-args", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.474478Z", "updated_at":"2026-02-16T17:24:01.796469Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":null, "startup_command":["mysql", "other-cmd"], "args":["override", "default", "image", "args"], "region":"fr-par"}'
         headers:
             Content-Length:
                 - "553"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 21:30:33 GMT
+                - Mon, 16 Feb 2026 17:24:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - d3e315c4-7e04-4562-94db-2f937d502150
+                - 4669613d-983c-4dc5-9bf2-5e3a2ee8107e
         status: 200 OK
         code: 200
-        duration: 35.713275ms
+        duration: 35.314799ms
     - id: 12
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/ad7bce8c-512a-4e85-ac93-f1adb7acb79c
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/b6c35647-4c37-42ea-8cc1-8f3cfc7984bd
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 553
-        uncompressed: false
-        body: '{"args":["override","default","image","args"],"command":"","cpu_limit":120,"created_at":"2026-02-03T21:30:32.891490Z","cron_schedule":null,"description":"","environment_variables":{},"id":"ad7bce8c-512a-4e85-ac93-f1adb7acb79c","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-job-definition-cmd-args","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":["mysql","other-cmd"],"updated_at":"2026-02-03T21:30:33.739440Z"}'
+        body: '{"id":"b6c35647-4c37-42ea-8cc1-8f3cfc7984bd", "name":"test-jobs-job-definition-cmd-args", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.474478Z", "updated_at":"2026-02-16T17:24:01.796469Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":null, "startup_command":["mysql", "other-cmd"], "args":["override", "default", "image", "args"], "region":"fr-par"}'
         headers:
             Content-Length:
                 - "553"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 21:30:34 GMT
+                - Mon, 16 Feb 2026 17:24:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - f9f3f13f-16e4-418d-9be2-e7d798ab9e84
+                - 11360ccd-bac8-41c7-b8c8-f0bba5e148c9
         status: 200 OK
         code: 200
-        duration: 31.335338ms
+        duration: 118.786368ms
     - id: 13
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        form:
+            job_definition_id:
+                - b6c35647-4c37-42ea-8cc1-8f3cfc7984bd
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=ad7bce8c-512a-4e85-ac93-f1adb7acb79c
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=b6c35647-4c37-42ea-8cc1-8f3cfc7984bd
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 31
-        uncompressed: false
-        body: '{"secrets":[],"total_count":0}'
+        body: '{"secrets":[], "total_count":0}'
         headers:
             Content-Length:
                 - "31"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 21:30:34 GMT
+                - Mon, 16 Feb 2026 17:24:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - b30d01e2-8603-4513-9312-c8d323dec4e9
+                - f2f2b4a6-9d88-4b8e-96ef-76ee072cb48c
         status: 200 OK
         code: 200
-        duration: 34.732542ms
+        duration: 94.35212ms
     - id: 14
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/ad7bce8c-512a-4e85-ac93-f1adb7acb79c
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/b6c35647-4c37-42ea-8cc1-8f3cfc7984bd
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 553
-        uncompressed: false
-        body: '{"args":["override","default","image","args"],"command":"","cpu_limit":120,"created_at":"2026-02-03T21:30:32.891490Z","cron_schedule":null,"description":"","environment_variables":{},"id":"ad7bce8c-512a-4e85-ac93-f1adb7acb79c","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-job-definition-cmd-args","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":["mysql","other-cmd"],"updated_at":"2026-02-03T21:30:33.739440Z"}'
+        body: '{"id":"b6c35647-4c37-42ea-8cc1-8f3cfc7984bd", "name":"test-jobs-job-definition-cmd-args", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.474478Z", "updated_at":"2026-02-16T17:24:01.796469Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":null, "startup_command":["mysql", "other-cmd"], "args":["override", "default", "image", "args"], "region":"fr-par"}'
         headers:
             Content-Length:
                 - "553"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 21:30:34 GMT
+                - Mon, 16 Feb 2026 17:24:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 634a8233-1b47-4d9a-a23a-b24e19d59c4c
+                - c2c9ce70-3f10-4348-824d-1e1ea72855d7
         status: 200 OK
         code: 200
-        duration: 48.900453ms
+        duration: 33.075097ms
     - id: 15
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        form:
+            job_definition_id:
+                - b6c35647-4c37-42ea-8cc1-8f3cfc7984bd
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=ad7bce8c-512a-4e85-ac93-f1adb7acb79c
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=b6c35647-4c37-42ea-8cc1-8f3cfc7984bd
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 31
-        uncompressed: false
-        body: '{"secrets":[],"total_count":0}'
+        body: '{"secrets":[], "total_count":0}'
         headers:
             Content-Length:
                 - "31"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 21:30:34 GMT
+                - Mon, 16 Feb 2026 17:24:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 612c55cc-9422-4869-aead-28870fb48eb6
+                - f517ca02-67ef-4a88-9c89-4bfc033c0270
         status: 200 OK
         code: 200
-        duration: 45.606724ms
+        duration: 28.376778ms
     - id: 16
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 44
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
         body: '{"startup_command":[],"args":["new","args"]}'
-        form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/ad7bce8c-512a-4e85-ac93-f1adb7acb79c
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/b6c35647-4c37-42ea-8cc1-8f3cfc7984bd
         method: PATCH
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 508
-        uncompressed: false
-        body: '{"args":["new","args"],"command":"","cpu_limit":120,"created_at":"2026-02-03T21:30:32.891490Z","cron_schedule":null,"description":"","environment_variables":{},"id":"ad7bce8c-512a-4e85-ac93-f1adb7acb79c","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-job-definition-cmd-args","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T21:30:34.602443Z"}'
+        body: '{"id":"b6c35647-4c37-42ea-8cc1-8f3cfc7984bd", "name":"test-jobs-job-definition-cmd-args", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.474478Z", "updated_at":"2026-02-16T17:24:03.020146Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":null, "startup_command":[], "args":["new", "args"], "region":"fr-par"}'
         headers:
             Content-Length:
                 - "508"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 21:30:34 GMT
+                - Mon, 16 Feb 2026 17:24:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - dc6e682e-2c75-4d2c-9a13-b048ade2b331
+                - 97677007-7c94-4cdd-8145-53e61d0e5a9c
         status: 200 OK
         code: 200
-        duration: 65.686123ms
+        duration: 53.531094ms
     - id: 17
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/ad7bce8c-512a-4e85-ac93-f1adb7acb79c
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/b6c35647-4c37-42ea-8cc1-8f3cfc7984bd
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 508
-        uncompressed: false
-        body: '{"args":["new","args"],"command":"","cpu_limit":120,"created_at":"2026-02-03T21:30:32.891490Z","cron_schedule":null,"description":"","environment_variables":{},"id":"ad7bce8c-512a-4e85-ac93-f1adb7acb79c","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-job-definition-cmd-args","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T21:30:34.602443Z"}'
+        body: '{"id":"b6c35647-4c37-42ea-8cc1-8f3cfc7984bd", "name":"test-jobs-job-definition-cmd-args", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.474478Z", "updated_at":"2026-02-16T17:24:03.020146Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":null, "startup_command":[], "args":["new", "args"], "region":"fr-par"}'
         headers:
             Content-Length:
                 - "508"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 21:30:34 GMT
+                - Mon, 16 Feb 2026 17:24:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 52082970-212c-400c-ae15-c825204b79fa
+                - 054b9189-b4a9-4292-980d-60c147a93a77
         status: 200 OK
         code: 200
-        duration: 34.119199ms
+        duration: 29.887642ms
     - id: 18
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        form:
+            job_definition_id:
+                - b6c35647-4c37-42ea-8cc1-8f3cfc7984bd
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=ad7bce8c-512a-4e85-ac93-f1adb7acb79c
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=b6c35647-4c37-42ea-8cc1-8f3cfc7984bd
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 31
-        uncompressed: false
-        body: '{"secrets":[],"total_count":0}'
+        body: '{"secrets":[], "total_count":0}'
         headers:
             Content-Length:
                 - "31"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 21:30:34 GMT
+                - Mon, 16 Feb 2026 17:24:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 8af9309c-0a49-4918-b19d-0977a61b2ecb
+                - 5067e1f1-2c01-481b-a86f-6990156d731a
         status: 200 OK
         code: 200
-        duration: 48.998187ms
+        duration: 30.05489ms
     - id: 19
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/ad7bce8c-512a-4e85-ac93-f1adb7acb79c
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/b6c35647-4c37-42ea-8cc1-8f3cfc7984bd
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 508
-        uncompressed: false
-        body: '{"args":["new","args"],"command":"","cpu_limit":120,"created_at":"2026-02-03T21:30:32.891490Z","cron_schedule":null,"description":"","environment_variables":{},"id":"ad7bce8c-512a-4e85-ac93-f1adb7acb79c","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-job-definition-cmd-args","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T21:30:34.602443Z"}'
+        body: '{"id":"b6c35647-4c37-42ea-8cc1-8f3cfc7984bd", "name":"test-jobs-job-definition-cmd-args", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.474478Z", "updated_at":"2026-02-16T17:24:03.020146Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":null, "startup_command":[], "args":["new", "args"], "region":"fr-par"}'
         headers:
             Content-Length:
                 - "508"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 21:30:34 GMT
+                - Mon, 16 Feb 2026 17:24:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 3083fc94-585b-49aa-b735-ba83af1ffc7c
+                - 58517fb0-c913-45dc-8cef-e226c94aee14
         status: 200 OK
         code: 200
-        duration: 37.197964ms
+        duration: 25.349077ms
     - id: 20
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/ad7bce8c-512a-4e85-ac93-f1adb7acb79c
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/b6c35647-4c37-42ea-8cc1-8f3cfc7984bd
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 508
-        uncompressed: false
-        body: '{"args":["new","args"],"command":"","cpu_limit":120,"created_at":"2026-02-03T21:30:32.891490Z","cron_schedule":null,"description":"","environment_variables":{},"id":"ad7bce8c-512a-4e85-ac93-f1adb7acb79c","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-job-definition-cmd-args","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T21:30:34.602443Z"}'
+        body: '{"id":"b6c35647-4c37-42ea-8cc1-8f3cfc7984bd", "name":"test-jobs-job-definition-cmd-args", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.474478Z", "updated_at":"2026-02-16T17:24:03.020146Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":null, "startup_command":[], "args":["new", "args"], "region":"fr-par"}'
         headers:
             Content-Length:
                 - "508"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 21:30:35 GMT
+                - Mon, 16 Feb 2026 17:24:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 78a0a0d3-9a8e-4315-b545-015848cab613
+                - 26fb160d-fb93-4ea0-9b21-915d2e5a0b35
         status: 200 OK
         code: 200
-        duration: 34.73159ms
+        duration: 28.020429ms
     - id: 21
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        form:
+            job_definition_id:
+                - b6c35647-4c37-42ea-8cc1-8f3cfc7984bd
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=ad7bce8c-512a-4e85-ac93-f1adb7acb79c
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=b6c35647-4c37-42ea-8cc1-8f3cfc7984bd
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 31
-        uncompressed: false
-        body: '{"secrets":[],"total_count":0}'
+        body: '{"secrets":[], "total_count":0}'
         headers:
             Content-Length:
                 - "31"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 21:30:35 GMT
+                - Mon, 16 Feb 2026 17:24:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 48ea1148-7f60-4643-8dce-7ba503f8b3a8
+                - 4bfe188d-ec7f-405d-b3b6-6f0f21659175
         status: 200 OK
         code: 200
-        duration: 30.909669ms
+        duration: 24.743114ms
     - id: 22
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/ad7bce8c-512a-4e85-ac93-f1adb7acb79c
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/b6c35647-4c37-42ea-8cc1-8f3cfc7984bd
         method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 0
-        uncompressed: false
         body: ""
         headers:
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 21:30:35 GMT
+                - Mon, 16 Feb 2026 17:24:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 5bc04513-9bd0-4c81-9a96-303442b94945
+                - d9b35caa-6be4-42b4-83c0-4c28493af1e5
         status: 204 No Content
         code: 204
-        duration: 61.535174ms
+        duration: 51.989601ms
     - id: 23
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/ad7bce8c-512a-4e85-ac93-f1adb7acb79c
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/b6c35647-4c37-42ea-8cc1-8f3cfc7984bd
         method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 41
-        uncompressed: false
         body: '{"message":"job definition is not found"}'
         headers:
             Content-Length:
                 - "41"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 21:30:35 GMT
+                - Mon, 16 Feb 2026 17:24:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - f58d358e-493f-4174-9d03-9897334e0fee
+                - d6ae01a5-5544-463e-a5ea-0ff1a6427387
         status: 404 Not Found
         code: 404
-        duration: 19.76622ms
+        duration: 19.427682ms

--- a/internal/services/jobs/testdata/job-definition-cron.cassette.yaml
+++ b/internal/services/jobs/testdata/job-definition-cron.cassette.yaml
@@ -7,13 +7,8 @@ interactions:
         proto_major: 1
         proto_minor: 1
         content_length: 350
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
         body: '{"name":"test-jobs-job-definition-cron","cpu_limit":120,"memory_limit":256,"local_storage_capacity":5120,"image_uri":"docker.io/alpine:latest","command":"","startup_command":[],"args":[],"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","environment_variables":{},"description":"","cron_schedule":{"schedule":"5 4 1 * *","timezone":"Europe/Paris"}}'
-        form: {}
         headers:
             Content-Type:
                 - application/json
@@ -25,1159 +20,783 @@ interactions:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 521
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":120,"created_at":"2026-02-03T10:39:58.007793Z","cron_schedule":{"schedule":"5 4 1 * *","timezone":"Europe/Paris"},"description":"","environment_variables":{},"id":"93ced617-aa3f-4369-bfac-a3e546509ae6","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-job-definition-cron","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T10:39:58.007793Z"}'
+        content_length: 538
+        body: '{"id":"07f0d6fa-5d33-46dc-a4a9-7c930ce346ee", "name":"test-jobs-job-definition-cron", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.476537Z", "updated_at":"2026-02-16T17:24:00.476537Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":{"schedule":"5 4 1 * *", "timezone":"Europe/Paris"}, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
-                - "521"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "538"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:39:58 GMT
+                - Mon, 16 Feb 2026 17:24:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 2f90df4c-b223-4df2-b40f-7fd3939a4218
+                - 0c820452-5ff7-4218-9474-3f23225dd30f
         status: 200 OK
         code: 200
-        duration: 265.511636ms
+        duration: 169.790449ms
     - id: 1
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/93ced617-aa3f-4369-bfac-a3e546509ae6
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/07f0d6fa-5d33-46dc-a4a9-7c930ce346ee
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 538
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":120,"created_at":"2026-02-03T10:39:58.007793Z","cron_schedule":{"schedule":"5 4 1 * *","timezone":"Europe/Paris"},"description":"","environment_variables":{},"id":"93ced617-aa3f-4369-bfac-a3e546509ae6","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-job-definition-cron","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T10:39:58.007793Z"}'
+        body: '{"id":"07f0d6fa-5d33-46dc-a4a9-7c930ce346ee", "name":"test-jobs-job-definition-cron", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.476537Z", "updated_at":"2026-02-16T17:24:00.476537Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":{"schedule":"5 4 1 * *", "timezone":"Europe/Paris"}, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
                 - "538"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:39:58 GMT
+                - Mon, 16 Feb 2026 17:24:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 1861c0d9-0e48-478c-953f-6a9c6586d7c1
+                - c4b50a75-2166-4b87-9fb2-f84b2e21fff1
         status: 200 OK
         code: 200
-        duration: 57.625848ms
+        duration: 36.125053ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        form:
+            job_definition_id:
+                - 07f0d6fa-5d33-46dc-a4a9-7c930ce346ee
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=93ced617-aa3f-4369-bfac-a3e546509ae6
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=07f0d6fa-5d33-46dc-a4a9-7c930ce346ee
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 31
-        uncompressed: false
-        body: '{"secrets":[],"total_count":0}'
+        body: '{"secrets":[], "total_count":0}'
         headers:
             Content-Length:
                 - "31"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:39:58 GMT
+                - Mon, 16 Feb 2026 17:24:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 45e3c690-e7e3-4cdf-bbf2-36cee1085566
+                - aa47ac9d-81b4-40e4-bf3f-3852ec898a39
         status: 200 OK
         code: 200
-        duration: 209.562952ms
+        duration: 39.031533ms
     - id: 3
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/93ced617-aa3f-4369-bfac-a3e546509ae6
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/07f0d6fa-5d33-46dc-a4a9-7c930ce346ee
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 538
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":120,"created_at":"2026-02-03T10:39:58.007793Z","cron_schedule":{"schedule":"5 4 1 * *","timezone":"Europe/Paris"},"description":"","environment_variables":{},"id":"93ced617-aa3f-4369-bfac-a3e546509ae6","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-job-definition-cron","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T10:39:58.007793Z"}'
+        body: '{"id":"07f0d6fa-5d33-46dc-a4a9-7c930ce346ee", "name":"test-jobs-job-definition-cron", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.476537Z", "updated_at":"2026-02-16T17:24:00.476537Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":{"schedule":"5 4 1 * *", "timezone":"Europe/Paris"}, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
                 - "538"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:39:58 GMT
+                - Mon, 16 Feb 2026 17:24:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - cc0c2596-afc2-41aa-ab12-1ad685050c9f
+                - 5109adb0-9c96-48ae-b147-6b7dd8e07210
         status: 200 OK
         code: 200
-        duration: 189.729204ms
+        duration: 37.000859ms
     - id: 4
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/93ced617-aa3f-4369-bfac-a3e546509ae6
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/07f0d6fa-5d33-46dc-a4a9-7c930ce346ee
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 538
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":120,"created_at":"2026-02-03T10:39:58.007793Z","cron_schedule":{"schedule":"5 4 1 * *","timezone":"Europe/Paris"},"description":"","environment_variables":{},"id":"93ced617-aa3f-4369-bfac-a3e546509ae6","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-job-definition-cron","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T10:39:58.007793Z"}'
+        body: '{"id":"07f0d6fa-5d33-46dc-a4a9-7c930ce346ee", "name":"test-jobs-job-definition-cron", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.476537Z", "updated_at":"2026-02-16T17:24:00.476537Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":{"schedule":"5 4 1 * *", "timezone":"Europe/Paris"}, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
                 - "538"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:39:58 GMT
+                - Mon, 16 Feb 2026 17:24:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - db9c615f-7aaf-412b-84f7-8d4a2e056509
+                - 35978ed7-c623-4f40-bb0f-74ba82cfe898
         status: 200 OK
         code: 200
-        duration: 122.665849ms
+        duration: 41.087823ms
     - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        form:
+            job_definition_id:
+                - 07f0d6fa-5d33-46dc-a4a9-7c930ce346ee
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=93ced617-aa3f-4369-bfac-a3e546509ae6
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=07f0d6fa-5d33-46dc-a4a9-7c930ce346ee
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 31
-        uncompressed: false
-        body: '{"secrets":[],"total_count":0}'
+        body: '{"secrets":[], "total_count":0}'
         headers:
             Content-Length:
                 - "31"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:39:59 GMT
+                - Mon, 16 Feb 2026 17:24:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 462ae03b-0016-487c-9cf9-ce19a21d8c74
+                - 7f293e04-3437-4af9-9d03-9ec8b7001bbe
         status: 200 OK
         code: 200
-        duration: 42.564724ms
+        duration: 27.323886ms
     - id: 6
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/93ced617-aa3f-4369-bfac-a3e546509ae6
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/07f0d6fa-5d33-46dc-a4a9-7c930ce346ee
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 538
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":120,"created_at":"2026-02-03T10:39:58.007793Z","cron_schedule":{"schedule":"5 4 1 * *","timezone":"Europe/Paris"},"description":"","environment_variables":{},"id":"93ced617-aa3f-4369-bfac-a3e546509ae6","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-job-definition-cron","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T10:39:58.007793Z"}'
+        body: '{"id":"07f0d6fa-5d33-46dc-a4a9-7c930ce346ee", "name":"test-jobs-job-definition-cron", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.476537Z", "updated_at":"2026-02-16T17:24:00.476537Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":{"schedule":"5 4 1 * *", "timezone":"Europe/Paris"}, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
                 - "538"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:39:59 GMT
+                - Mon, 16 Feb 2026 17:24:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 27cfc744-9372-4a2a-af36-42d095528049
+                - b40d1889-34fe-4df2-a2f6-defa29856752
         status: 200 OK
         code: 200
-        duration: 110.174548ms
+        duration: 47.709732ms
     - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        form:
+            job_definition_id:
+                - 07f0d6fa-5d33-46dc-a4a9-7c930ce346ee
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=93ced617-aa3f-4369-bfac-a3e546509ae6
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=07f0d6fa-5d33-46dc-a4a9-7c930ce346ee
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 31
-        uncompressed: false
-        body: '{"secrets":[],"total_count":0}'
+        body: '{"secrets":[], "total_count":0}'
         headers:
             Content-Length:
                 - "31"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:39:59 GMT
+                - Mon, 16 Feb 2026 17:24:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - a87adcf2-cca4-4386-84e0-93ad578b661a
+                - 3b38acee-3faf-4f00-8cc6-39d22738b880
         status: 200 OK
         code: 200
-        duration: 34.087503ms
+        duration: 28.177921ms
     - id: 8
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 71
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
         body: '{"cron_schedule":{"schedule":"5 5 * * *","timezone":"America/Jamaica"}}'
-        form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/93ced617-aa3f-4369-bfac-a3e546509ae6
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/07f0d6fa-5d33-46dc-a4a9-7c930ce346ee
         method: PATCH
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 541
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":120,"created_at":"2026-02-03T10:39:58.007793Z","cron_schedule":{"schedule":"5 5 * * *","timezone":"America/Jamaica"},"description":"","environment_variables":{},"id":"93ced617-aa3f-4369-bfac-a3e546509ae6","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-job-definition-cron","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T10:39:59.502274Z"}'
+        body: '{"id":"07f0d6fa-5d33-46dc-a4a9-7c930ce346ee", "name":"test-jobs-job-definition-cron", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.476537Z", "updated_at":"2026-02-16T17:24:01.796584Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":{"schedule":"5 5 * * *", "timezone":"America/Jamaica"}, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
                 - "541"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:39:59 GMT
+                - Mon, 16 Feb 2026 17:24:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 899c351f-678a-49e6-a7cf-f2b468f3c6fb
+                - b3f7d931-6951-4b37-b657-c22a282f1dd3
         status: 200 OK
         code: 200
-        duration: 332.351962ms
+        duration: 310.229619ms
     - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/93ced617-aa3f-4369-bfac-a3e546509ae6
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/07f0d6fa-5d33-46dc-a4a9-7c930ce346ee
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 524
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":120,"created_at":"2026-02-03T10:39:58.007793Z","cron_schedule":{"schedule":"5 5 * * *","timezone":"America/Jamaica"},"description":"","environment_variables":{},"id":"93ced617-aa3f-4369-bfac-a3e546509ae6","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-job-definition-cron","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T10:39:59.502274Z"}'
+        content_length: 541
+        body: '{"id":"07f0d6fa-5d33-46dc-a4a9-7c930ce346ee", "name":"test-jobs-job-definition-cron", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.476537Z", "updated_at":"2026-02-16T17:24:01.796584Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":{"schedule":"5 5 * * *", "timezone":"America/Jamaica"}, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
-                - "524"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "541"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:39:59 GMT
+                - Mon, 16 Feb 2026 17:24:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 2d469d1f-1642-4c3d-a3ad-fd4e8e7ff139
+                - 0fe946fc-dded-4539-8e12-f61adf2e8f99
         status: 200 OK
         code: 200
-        duration: 33.158135ms
+        duration: 31.272116ms
     - id: 10
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        form:
+            job_definition_id:
+                - 07f0d6fa-5d33-46dc-a4a9-7c930ce346ee
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=93ced617-aa3f-4369-bfac-a3e546509ae6
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=07f0d6fa-5d33-46dc-a4a9-7c930ce346ee
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 31
-        uncompressed: false
-        body: '{"secrets":[],"total_count":0}'
+        body: '{"secrets":[], "total_count":0}'
         headers:
             Content-Length:
                 - "31"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:39:59 GMT
+                - Mon, 16 Feb 2026 17:24:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 082aa8ce-ebc5-416c-879c-9481a2c75c1f
+                - 13197fae-4996-4288-99c8-ba23be940ec9
         status: 200 OK
         code: 200
-        duration: 28.61423ms
+        duration: 28.741732ms
     - id: 11
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/93ced617-aa3f-4369-bfac-a3e546509ae6
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/07f0d6fa-5d33-46dc-a4a9-7c930ce346ee
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 541
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":120,"created_at":"2026-02-03T10:39:58.007793Z","cron_schedule":{"schedule":"5 5 * * *","timezone":"America/Jamaica"},"description":"","environment_variables":{},"id":"93ced617-aa3f-4369-bfac-a3e546509ae6","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-job-definition-cron","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T10:39:59.502274Z"}'
+        body: '{"id":"07f0d6fa-5d33-46dc-a4a9-7c930ce346ee", "name":"test-jobs-job-definition-cron", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.476537Z", "updated_at":"2026-02-16T17:24:01.796584Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":{"schedule":"5 5 * * *", "timezone":"America/Jamaica"}, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
                 - "541"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:40:00 GMT
+                - Mon, 16 Feb 2026 17:24:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 1afbdc84-eb6b-49e7-bc5a-4e0bec08920c
+                - 4d935747-34f7-4a21-a8a7-5b376a8736c4
         status: 200 OK
         code: 200
-        duration: 210.823282ms
+        duration: 37.408823ms
     - id: 12
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/93ced617-aa3f-4369-bfac-a3e546509ae6
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/07f0d6fa-5d33-46dc-a4a9-7c930ce346ee
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 524
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":120,"created_at":"2026-02-03T10:39:58.007793Z","cron_schedule":{"schedule":"5 5 * * *","timezone":"America/Jamaica"},"description":"","environment_variables":{},"id":"93ced617-aa3f-4369-bfac-a3e546509ae6","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-job-definition-cron","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T10:39:59.502274Z"}'
+        content_length: 541
+        body: '{"id":"07f0d6fa-5d33-46dc-a4a9-7c930ce346ee", "name":"test-jobs-job-definition-cron", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.476537Z", "updated_at":"2026-02-16T17:24:01.796584Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":{"schedule":"5 5 * * *", "timezone":"America/Jamaica"}, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
-                - "524"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "541"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:40:00 GMT
+                - Mon, 16 Feb 2026 17:24:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - ca52ba39-bf72-4a66-a82f-d612480c8287
+                - b77241db-d0f0-47f7-9af8-25a808072a26
         status: 200 OK
         code: 200
-        duration: 72.822035ms
+        duration: 38.292093ms
     - id: 13
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        form:
+            job_definition_id:
+                - 07f0d6fa-5d33-46dc-a4a9-7c930ce346ee
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=93ced617-aa3f-4369-bfac-a3e546509ae6
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=07f0d6fa-5d33-46dc-a4a9-7c930ce346ee
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 31
-        uncompressed: false
-        body: '{"secrets":[],"total_count":0}'
+        body: '{"secrets":[], "total_count":0}'
         headers:
             Content-Length:
                 - "31"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:40:00 GMT
+                - Mon, 16 Feb 2026 17:24:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 59311ad6-481f-4273-b064-fa8185bff5fe
+                - 9debae89-3e82-441e-83ee-21f6b08a7a90
         status: 200 OK
         code: 200
-        duration: 32.47499ms
+        duration: 100.229572ms
     - id: 14
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/93ced617-aa3f-4369-bfac-a3e546509ae6
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/07f0d6fa-5d33-46dc-a4a9-7c930ce346ee
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 541
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":120,"created_at":"2026-02-03T10:39:58.007793Z","cron_schedule":{"schedule":"5 5 * * *","timezone":"America/Jamaica"},"description":"","environment_variables":{},"id":"93ced617-aa3f-4369-bfac-a3e546509ae6","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-job-definition-cron","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T10:39:59.502274Z"}'
+        body: '{"id":"07f0d6fa-5d33-46dc-a4a9-7c930ce346ee", "name":"test-jobs-job-definition-cron", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.476537Z", "updated_at":"2026-02-16T17:24:01.796584Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":{"schedule":"5 5 * * *", "timezone":"America/Jamaica"}, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
                 - "541"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:40:00 GMT
+                - Mon, 16 Feb 2026 17:24:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - f4b213fc-ce92-486c-a216-184c1bf11b5f
+                - a10f68bb-258a-41f1-9b05-b6edc6696dcb
         status: 200 OK
         code: 200
-        duration: 118.392873ms
+        duration: 38.672747ms
     - id: 15
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        form:
+            job_definition_id:
+                - 07f0d6fa-5d33-46dc-a4a9-7c930ce346ee
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=93ced617-aa3f-4369-bfac-a3e546509ae6
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=07f0d6fa-5d33-46dc-a4a9-7c930ce346ee
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 30
-        uncompressed: false
-        body: '{"secrets":[],"total_count":0}'
+        content_length: 31
+        body: '{"secrets":[], "total_count":0}'
         headers:
             Content-Length:
-                - "30"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "31"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:40:00 GMT
+                - Mon, 16 Feb 2026 17:24:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 46a02475-ca70-42db-bf1b-1c0445fa0a1e
+                - 0bdfe1d6-d3e1-4e5a-9816-7f65540572a9
         status: 200 OK
         code: 200
-        duration: 24.272555ms
+        duration: 32.740842ms
     - id: 16
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 51
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
         body: '{"cron_schedule":{"schedule":null,"timezone":null}}'
-        form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/93ced617-aa3f-4369-bfac-a3e546509ae6
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/07f0d6fa-5d33-46dc-a4a9-7c930ce346ee
         method: PATCH
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 475
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":120,"created_at":"2026-02-03T10:39:58.007793Z","cron_schedule":null,"description":"","environment_variables":{},"id":"93ced617-aa3f-4369-bfac-a3e546509ae6","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-job-definition-cron","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T10:40:00.859399Z"}'
+        content_length: 491
+        body: '{"id":"07f0d6fa-5d33-46dc-a4a9-7c930ce346ee", "name":"test-jobs-job-definition-cron", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.476537Z", "updated_at":"2026-02-16T17:24:03.115211Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":null, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
-                - "475"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "491"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:40:00 GMT
+                - Mon, 16 Feb 2026 17:24:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - b74858f4-2868-4256-9911-398c371b1242
+                - 2b83927a-88b1-4f21-ba52-838c1365c95e
         status: 200 OK
         code: 200
-        duration: 369.566304ms
+        duration: 124.855098ms
     - id: 17
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/93ced617-aa3f-4369-bfac-a3e546509ae6
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/07f0d6fa-5d33-46dc-a4a9-7c930ce346ee
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 491
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":120,"created_at":"2026-02-03T10:39:58.007793Z","cron_schedule":null,"description":"","environment_variables":{},"id":"93ced617-aa3f-4369-bfac-a3e546509ae6","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-job-definition-cron","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T10:40:00.859399Z"}'
+        body: '{"id":"07f0d6fa-5d33-46dc-a4a9-7c930ce346ee", "name":"test-jobs-job-definition-cron", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.476537Z", "updated_at":"2026-02-16T17:24:03.115211Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":null, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
                 - "491"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:40:01 GMT
+                - Mon, 16 Feb 2026 17:24:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 40e9859c-1096-43b3-9607-04f6a233cd9f
+                - 14802cb4-0e57-423c-9421-69a9e9e7ff54
         status: 200 OK
         code: 200
-        duration: 47.199821ms
+        duration: 29.801027ms
     - id: 18
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        form:
+            job_definition_id:
+                - 07f0d6fa-5d33-46dc-a4a9-7c930ce346ee
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=93ced617-aa3f-4369-bfac-a3e546509ae6
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=07f0d6fa-5d33-46dc-a4a9-7c930ce346ee
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 31
-        uncompressed: false
-        body: '{"secrets":[],"total_count":0}'
+        body: '{"secrets":[], "total_count":0}'
         headers:
             Content-Length:
                 - "31"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:40:01 GMT
+                - Mon, 16 Feb 2026 17:24:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - fb312e5d-71f9-4d0c-982c-a25aff647925
+                - affe4196-c95a-4c03-8af9-0eb4a06c0f58
         status: 200 OK
         code: 200
-        duration: 29.663443ms
+        duration: 27.364391ms
     - id: 19
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/93ced617-aa3f-4369-bfac-a3e546509ae6
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/07f0d6fa-5d33-46dc-a4a9-7c930ce346ee
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 475
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":120,"created_at":"2026-02-03T10:39:58.007793Z","cron_schedule":null,"description":"","environment_variables":{},"id":"93ced617-aa3f-4369-bfac-a3e546509ae6","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-job-definition-cron","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T10:40:00.859399Z"}'
+        content_length: 491
+        body: '{"id":"07f0d6fa-5d33-46dc-a4a9-7c930ce346ee", "name":"test-jobs-job-definition-cron", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.476537Z", "updated_at":"2026-02-16T17:24:03.115211Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":null, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
-                - "475"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "491"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:40:01 GMT
+                - Mon, 16 Feb 2026 17:24:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - e8c1551d-74bb-4c9c-8eeb-8474a116ac29
+                - 95610daa-f69a-4244-a5fb-757ec2691479
         status: 200 OK
         code: 200
-        duration: 151.802521ms
+        duration: 29.035781ms
     - id: 20
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/93ced617-aa3f-4369-bfac-a3e546509ae6
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/07f0d6fa-5d33-46dc-a4a9-7c930ce346ee
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 491
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":120,"created_at":"2026-02-03T10:39:58.007793Z","cron_schedule":null,"description":"","environment_variables":{},"id":"93ced617-aa3f-4369-bfac-a3e546509ae6","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-job-definition-cron","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T10:40:00.859399Z"}'
+        body: '{"id":"07f0d6fa-5d33-46dc-a4a9-7c930ce346ee", "name":"test-jobs-job-definition-cron", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.476537Z", "updated_at":"2026-02-16T17:24:03.115211Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":null, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
                 - "491"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:40:01 GMT
+                - Mon, 16 Feb 2026 17:24:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 5a8f3a9d-0343-4c3a-9661-d37b8fa1a1b2
+                - 0d18499f-2f96-4876-9caf-bc6a4b7387a9
         status: 200 OK
         code: 200
-        duration: 74.400834ms
+        duration: 30.326687ms
     - id: 21
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        form:
+            job_definition_id:
+                - 07f0d6fa-5d33-46dc-a4a9-7c930ce346ee
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=93ced617-aa3f-4369-bfac-a3e546509ae6
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=07f0d6fa-5d33-46dc-a4a9-7c930ce346ee
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 30
-        uncompressed: false
-        body: '{"secrets":[],"total_count":0}'
+        content_length: 31
+        body: '{"secrets":[], "total_count":0}'
         headers:
             Content-Length:
-                - "30"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "31"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:40:01 GMT
+                - Mon, 16 Feb 2026 17:24:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - a4c4360b-ead7-41fe-b656-493a003ff8bb
+                - 8cf16c1b-947d-4e77-8372-020f8c6e6695
         status: 200 OK
         code: 200
-        duration: 28.677499ms
+        duration: 30.620536ms
     - id: 22
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/93ced617-aa3f-4369-bfac-a3e546509ae6
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/07f0d6fa-5d33-46dc-a4a9-7c930ce346ee
         method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 0
-        uncompressed: false
         body: ""
         headers:
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:40:01 GMT
+                - Mon, 16 Feb 2026 17:24:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 8fa8c978-0bea-4eeb-9b64-41ae20588528
+                - ff5beb9e-edd7-45ed-8f6b-74c15a11096e
         status: 204 No Content
         code: 204
-        duration: 66.165617ms
+        duration: 35.657108ms
     - id: 23
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/93ced617-aa3f-4369-bfac-a3e546509ae6
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/07f0d6fa-5d33-46dc-a4a9-7c930ce346ee
         method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 41
-        uncompressed: false
         body: '{"message":"job definition is not found"}'
         headers:
             Content-Length:
                 - "41"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:40:02 GMT
+                - Mon, 16 Feb 2026 17:24:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - b509d26b-2ce6-475c-9001-d5503149a8eb
+                - af6353f6-fecc-4b05-bd9f-8dc0897ee8c6
         status: 404 Not Found
         code: 404
-        duration: 23.063542ms
+        duration: 20.387166ms

--- a/internal/services/jobs/testdata/job-definition-local-storage-capacity.cassette.yaml
+++ b/internal/services/jobs/testdata/job-definition-local-storage-capacity.cassette.yaml
@@ -7,13 +7,8 @@ interactions:
         proto_major: 1
         proto_minor: 1
         content_length: 292
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
         body: '{"name":"test-jobs-job-definition-local-storage","cpu_limit":120,"memory_limit":256,"local_storage_capacity":1000,"image_uri":"docker.io/alpine:latest","command":"","startup_command":[],"args":[],"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","environment_variables":{},"description":""}'
-        form: {}
         headers:
             Content-Type:
                 - application/json
@@ -25,765 +20,515 @@ interactions:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 500
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":120,"created_at":"2026-02-03T10:39:57.997809Z","cron_schedule":null,"description":"","environment_variables":{},"id":"fd324f00-997a-498b-9f90-a9c5a0626ce5","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":1000,"memory_limit":256,"name":"test-jobs-job-definition-local-storage","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T10:39:57.997809Z"}'
+        body: '{"id":"dc1a7345-2f18-4279-a2be-869d9badb06f", "name":"test-jobs-job-definition-local-storage", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.468836Z", "updated_at":"2026-02-16T17:24:00.468836Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":1000, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":null, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
                 - "500"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:39:58 GMT
+                - Mon, 16 Feb 2026 17:24:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 2aa2b970-ab29-414d-b4de-96ac180dcb2e
+                - 899b6309-7f2a-4710-b087-2186f83b149d
         status: 200 OK
         code: 200
-        duration: 291.818687ms
+        duration: 169.022418ms
     - id: 1
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/fd324f00-997a-498b-9f90-a9c5a0626ce5
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/dc1a7345-2f18-4279-a2be-869d9badb06f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 484
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":120,"created_at":"2026-02-03T10:39:57.997809Z","cron_schedule":null,"description":"","environment_variables":{},"id":"fd324f00-997a-498b-9f90-a9c5a0626ce5","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":1000,"memory_limit":256,"name":"test-jobs-job-definition-local-storage","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T10:39:57.997809Z"}'
+        content_length: 500
+        body: '{"id":"dc1a7345-2f18-4279-a2be-869d9badb06f", "name":"test-jobs-job-definition-local-storage", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.468836Z", "updated_at":"2026-02-16T17:24:00.468836Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":1000, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":null, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
-                - "484"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "500"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:39:58 GMT
+                - Mon, 16 Feb 2026 17:24:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 8aa8f316-df97-46d3-bb09-1b0f408166af
+                - 27b1333c-2b28-4023-b674-5b4ec0ff8d8a
         status: 200 OK
         code: 200
-        duration: 58.344419ms
+        duration: 55.01276ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        form:
+            job_definition_id:
+                - dc1a7345-2f18-4279-a2be-869d9badb06f
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=fd324f00-997a-498b-9f90-a9c5a0626ce5
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=dc1a7345-2f18-4279-a2be-869d9badb06f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 31
-        uncompressed: false
-        body: '{"secrets":[],"total_count":0}'
+        body: '{"secrets":[], "total_count":0}'
         headers:
             Content-Length:
                 - "31"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:39:58 GMT
+                - Mon, 16 Feb 2026 17:24:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 73c80f66-d2b5-48ee-8652-19f730c8d380
+                - 65994a52-2d49-4a88-96a3-7279cdfc7ce5
         status: 200 OK
         code: 200
-        duration: 208.985106ms
+        duration: 44.518041ms
     - id: 3
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/fd324f00-997a-498b-9f90-a9c5a0626ce5
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/dc1a7345-2f18-4279-a2be-869d9badb06f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 484
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":120,"created_at":"2026-02-03T10:39:57.997809Z","cron_schedule":null,"description":"","environment_variables":{},"id":"fd324f00-997a-498b-9f90-a9c5a0626ce5","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":1000,"memory_limit":256,"name":"test-jobs-job-definition-local-storage","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T10:39:57.997809Z"}'
+        content_length: 500
+        body: '{"id":"dc1a7345-2f18-4279-a2be-869d9badb06f", "name":"test-jobs-job-definition-local-storage", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.468836Z", "updated_at":"2026-02-16T17:24:00.468836Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":1000, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":null, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
-                - "484"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "500"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:39:58 GMT
+                - Mon, 16 Feb 2026 17:24:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - f55d64c4-053a-4334-a1c0-de2ad8bc331d
+                - c1744089-c7a2-4737-bedf-f50344936ced
         status: 200 OK
         code: 200
-        duration: 185.296648ms
+        duration: 61.805683ms
     - id: 4
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/fd324f00-997a-498b-9f90-a9c5a0626ce5
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/dc1a7345-2f18-4279-a2be-869d9badb06f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 484
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":120,"created_at":"2026-02-03T10:39:57.997809Z","cron_schedule":null,"description":"","environment_variables":{},"id":"fd324f00-997a-498b-9f90-a9c5a0626ce5","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":1000,"memory_limit":256,"name":"test-jobs-job-definition-local-storage","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T10:39:57.997809Z"}'
+        content_length: 500
+        body: '{"id":"dc1a7345-2f18-4279-a2be-869d9badb06f", "name":"test-jobs-job-definition-local-storage", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.468836Z", "updated_at":"2026-02-16T17:24:00.468836Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":1000, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":null, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
-                - "484"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "500"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:39:58 GMT
+                - Mon, 16 Feb 2026 17:24:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 51a3aa13-cb2e-4bf0-a5d1-64b1b5815f80
+                - 9b2b4ea4-6c42-4332-a2fb-f236676dbefb
         status: 200 OK
         code: 200
-        duration: 116.730737ms
+        duration: 24.709071ms
     - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        form:
+            job_definition_id:
+                - dc1a7345-2f18-4279-a2be-869d9badb06f
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=fd324f00-997a-498b-9f90-a9c5a0626ce5
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=dc1a7345-2f18-4279-a2be-869d9badb06f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 30
-        uncompressed: false
-        body: '{"secrets":[],"total_count":0}'
+        content_length: 31
+        body: '{"secrets":[], "total_count":0}'
         headers:
             Content-Length:
-                - "30"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "31"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:39:59 GMT
+                - Mon, 16 Feb 2026 17:24:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 7d368c60-0244-43b6-82aa-925aef59cc48
+                - 7084a227-2f31-40ff-a01c-593d518210f5
         status: 200 OK
         code: 200
-        duration: 44.561039ms
+        duration: 35.561289ms
     - id: 6
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/fd324f00-997a-498b-9f90-a9c5a0626ce5
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/dc1a7345-2f18-4279-a2be-869d9badb06f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 484
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":120,"created_at":"2026-02-03T10:39:57.997809Z","cron_schedule":null,"description":"","environment_variables":{},"id":"fd324f00-997a-498b-9f90-a9c5a0626ce5","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":1000,"memory_limit":256,"name":"test-jobs-job-definition-local-storage","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T10:39:57.997809Z"}'
+        content_length: 500
+        body: '{"id":"dc1a7345-2f18-4279-a2be-869d9badb06f", "name":"test-jobs-job-definition-local-storage", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.468836Z", "updated_at":"2026-02-16T17:24:00.468836Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":1000, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":null, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
-                - "484"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "500"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:39:59 GMT
+                - Mon, 16 Feb 2026 17:24:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 8a717248-cd05-485e-bfcd-c443f0502489
+                - 48f26343-5009-4c03-89c3-46ba93d5c05f
         status: 200 OK
         code: 200
-        duration: 114.406356ms
+        duration: 51.815234ms
     - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        form:
+            job_definition_id:
+                - dc1a7345-2f18-4279-a2be-869d9badb06f
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=fd324f00-997a-498b-9f90-a9c5a0626ce5
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=dc1a7345-2f18-4279-a2be-869d9badb06f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 31
-        uncompressed: false
-        body: '{"secrets":[],"total_count":0}'
+        body: '{"secrets":[], "total_count":0}'
         headers:
             Content-Length:
                 - "31"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:39:59 GMT
+                - Mon, 16 Feb 2026 17:24:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 85d5d3ff-5af1-4f56-8a55-cadccb6285fe
+                - 153a06bb-be04-4a48-9597-7e41fafc83e2
         status: 200 OK
         code: 200
-        duration: 29.630632ms
+        duration: 31.00521ms
     - id: 8
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 31
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
         body: '{"local_storage_capacity":2000}'
-        form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/fd324f00-997a-498b-9f90-a9c5a0626ce5
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/dc1a7345-2f18-4279-a2be-869d9badb06f
         method: PATCH
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 484
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":120,"created_at":"2026-02-03T10:39:57.997809Z","cron_schedule":null,"description":"","environment_variables":{},"id":"fd324f00-997a-498b-9f90-a9c5a0626ce5","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":2000,"memory_limit":256,"name":"test-jobs-job-definition-local-storage","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T10:39:59.502894Z"}'
+        content_length: 500
+        body: '{"id":"dc1a7345-2f18-4279-a2be-869d9badb06f", "name":"test-jobs-job-definition-local-storage", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.468836Z", "updated_at":"2026-02-16T17:24:01.768614Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":2000, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":null, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
-                - "484"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "500"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:39:59 GMT
+                - Mon, 16 Feb 2026 17:24:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 05a8125e-fefc-48b0-8dcf-28cba3c5e356
+                - 068c30a8-5e51-4fa2-87aa-bdf36db63e1f
         status: 200 OK
         code: 200
-        duration: 132.082506ms
+        duration: 30.09561ms
     - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/fd324f00-997a-498b-9f90-a9c5a0626ce5
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/dc1a7345-2f18-4279-a2be-869d9badb06f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 484
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":120,"created_at":"2026-02-03T10:39:57.997809Z","cron_schedule":null,"description":"","environment_variables":{},"id":"fd324f00-997a-498b-9f90-a9c5a0626ce5","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":2000,"memory_limit":256,"name":"test-jobs-job-definition-local-storage","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T10:39:59.502894Z"}'
+        content_length: 500
+        body: '{"id":"dc1a7345-2f18-4279-a2be-869d9badb06f", "name":"test-jobs-job-definition-local-storage", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.468836Z", "updated_at":"2026-02-16T17:24:01.768614Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":2000, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":null, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
-                - "484"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "500"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:39:59 GMT
+                - Mon, 16 Feb 2026 17:24:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - eb0770aa-9a68-4ee6-aa36-56c118262c1c
+                - d796cd22-bf4c-45ee-a64c-14038fc2e714
         status: 200 OK
         code: 200
-        duration: 31.940015ms
+        duration: 27.928697ms
     - id: 10
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        form:
+            job_definition_id:
+                - dc1a7345-2f18-4279-a2be-869d9badb06f
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=fd324f00-997a-498b-9f90-a9c5a0626ce5
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=dc1a7345-2f18-4279-a2be-869d9badb06f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 31
-        uncompressed: false
-        body: '{"secrets":[],"total_count":0}'
+        body: '{"secrets":[], "total_count":0}'
         headers:
             Content-Length:
                 - "31"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:39:59 GMT
+                - Mon, 16 Feb 2026 17:24:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 3b17128b-2527-480a-a4ea-8787d6a7ca20
+                - dacb6ad5-03dc-40a4-ba12-c7c06344d333
         status: 200 OK
         code: 200
-        duration: 166.798732ms
+        duration: 97.00932ms
     - id: 11
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/fd324f00-997a-498b-9f90-a9c5a0626ce5
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/dc1a7345-2f18-4279-a2be-869d9badb06f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 500
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":120,"created_at":"2026-02-03T10:39:57.997809Z","cron_schedule":null,"description":"","environment_variables":{},"id":"fd324f00-997a-498b-9f90-a9c5a0626ce5","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":2000,"memory_limit":256,"name":"test-jobs-job-definition-local-storage","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T10:39:59.502894Z"}'
+        body: '{"id":"dc1a7345-2f18-4279-a2be-869d9badb06f", "name":"test-jobs-job-definition-local-storage", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.468836Z", "updated_at":"2026-02-16T17:24:01.768614Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":2000, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":null, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
                 - "500"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:39:59 GMT
+                - Mon, 16 Feb 2026 17:24:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 52aacee0-9530-447d-bfd1-a2c3c0c500ec
+                - 14c3bedd-b61f-48f9-ab2a-1c880d978572
         status: 200 OK
         code: 200
-        duration: 200.94209ms
+        duration: 65.03358ms
     - id: 12
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/fd324f00-997a-498b-9f90-a9c5a0626ce5
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/dc1a7345-2f18-4279-a2be-869d9badb06f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 484
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":120,"created_at":"2026-02-03T10:39:57.997809Z","cron_schedule":null,"description":"","environment_variables":{},"id":"fd324f00-997a-498b-9f90-a9c5a0626ce5","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":2000,"memory_limit":256,"name":"test-jobs-job-definition-local-storage","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T10:39:59.502894Z"}'
+        content_length: 500
+        body: '{"id":"dc1a7345-2f18-4279-a2be-869d9badb06f", "name":"test-jobs-job-definition-local-storage", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.468836Z", "updated_at":"2026-02-16T17:24:01.768614Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":2000, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":null, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
-                - "484"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "500"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:40:00 GMT
+                - Mon, 16 Feb 2026 17:24:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 0ffb9ef4-07a8-4afb-8d78-af21ae665585
+                - 9fb621eb-1710-4fa5-8756-94afd8ac0ddd
         status: 200 OK
         code: 200
-        duration: 139.059968ms
+        duration: 32.41447ms
     - id: 13
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        form:
+            job_definition_id:
+                - dc1a7345-2f18-4279-a2be-869d9badb06f
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=fd324f00-997a-498b-9f90-a9c5a0626ce5
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=dc1a7345-2f18-4279-a2be-869d9badb06f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 31
-        uncompressed: false
-        body: '{"secrets":[],"total_count":0}'
+        body: '{"secrets":[], "total_count":0}'
         headers:
             Content-Length:
                 - "31"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:40:00 GMT
+                - Mon, 16 Feb 2026 17:24:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 1a9a7160-1435-4a06-b47d-a30422b5a306
+                - 16ae9af1-7b47-4a03-9dfc-a4321db9cfd9
         status: 200 OK
         code: 200
-        duration: 44.470669ms
+        duration: 82.038934ms
     - id: 14
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/fd324f00-997a-498b-9f90-a9c5a0626ce5
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/dc1a7345-2f18-4279-a2be-869d9badb06f
         method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 0
-        uncompressed: false
         body: ""
         headers:
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:40:00 GMT
+                - Mon, 16 Feb 2026 17:24:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - e5df8472-5fc4-4fad-9c70-a831162abed8
+                - d67b7973-3abb-4894-afcb-290ea0f38e9f
         status: 204 No Content
         code: 204
-        duration: 87.587692ms
+        duration: 61.309685ms
     - id: 15
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/fd324f00-997a-498b-9f90-a9c5a0626ce5
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/dc1a7345-2f18-4279-a2be-869d9badb06f
         method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 41
-        uncompressed: false
         body: '{"message":"job definition is not found"}'
         headers:
             Content-Length:
                 - "41"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:40:00 GMT
+                - Mon, 16 Feb 2026 17:24:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 35a4c2d7-c022-43a4-a30a-a7e205f5846c
+                - 76685eb8-d1af-4989-b18f-99b63ffb0daf
         status: 404 Not Found
         code: 404
-        duration: 17.687973ms
+        duration: 20.131501ms

--- a/internal/services/jobs/testdata/job-definition-secret-reference.cassette.yaml
+++ b/internal/services/jobs/testdata/job-definition-secret-reference.cassette.yaml
@@ -7,13 +7,8 @@ interactions:
         proto_major: 1
         proto_minor: 1
         content_length: 133
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
         body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"job-secret","tags":null,"type":"opaque","path":"/one","protected":false}'
-        form: {}
         headers:
             Content-Type:
                 - application/json
@@ -25,144 +20,97 @@ interactions:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 444
-        uncompressed: false
-        body: '{"created_at":"2026-02-03T10:57:07.418120Z","deletion_requested_at":null,"description":"","ephemeral_policy":null,"id":"7122f130-69b2-43e7-9980-5e421f7c7727","key_id":null,"managed":false,"name":"job-secret","path":"/one","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","protected":false,"region":"fr-par","status":"ready","tags":[],"type":"opaque","updated_at":"2026-02-03T10:57:07.418120Z","used_by":[],"version_count":0}'
+        body: '{"id":"0331001e-111d-46ea-8277-d107b83b0800", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "name":"job-secret", "status":"ready", "created_at":"2026-02-16T17:24:00.477215Z", "updated_at":"2026-02-16T17:24:00.477215Z", "tags":[], "version_count":0, "description":"", "managed":false, "type":"opaque", "protected":false, "path":"/one", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}'
         headers:
             Content-Length:
                 - "444"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:57:07 GMT
+                - Mon, 16 Feb 2026 17:24:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 2b606756-b4ef-481f-a56f-ba0c78673b18
+                - c5e572ba-6ceb-42e3-ac5d-89f8d19688f4
         status: 200 OK
         code: 200
-        duration: 1.177983832s
+        duration: 101.619544ms
     - id: 1
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/7122f130-69b2-43e7-9980-5e421f7c7727
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/0331001e-111d-46ea-8277-d107b83b0800
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 444
-        uncompressed: false
-        body: '{"created_at":"2026-02-03T10:57:07.418120Z","deletion_requested_at":null,"description":"","ephemeral_policy":null,"id":"7122f130-69b2-43e7-9980-5e421f7c7727","key_id":null,"managed":false,"name":"job-secret","path":"/one","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","protected":false,"region":"fr-par","status":"ready","tags":[],"type":"opaque","updated_at":"2026-02-03T10:57:07.418120Z","used_by":[],"version_count":0}'
+        body: '{"id":"0331001e-111d-46ea-8277-d107b83b0800", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "name":"job-secret", "status":"ready", "created_at":"2026-02-16T17:24:00.477215Z", "updated_at":"2026-02-16T17:24:00.477215Z", "tags":[], "version_count":0, "description":"", "managed":false, "type":"opaque", "protected":false, "path":"/one", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}'
         headers:
             Content-Length:
                 - "444"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:57:07 GMT
+                - Mon, 16 Feb 2026 17:24:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - c4e9e7e7-41c5-46e0-baa6-09a622a25514
+                - bc808928-e8a8-4307-9566-54164e49ef91
         status: 200 OK
         code: 200
-        duration: 55.255739ms
+        duration: 48.390419ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        form:
+            page:
+                - "1"
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/7122f130-69b2-43e7-9980-5e421f7c7727/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/0331001e-111d-46ea-8277-d107b83b0800/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 32
-        uncompressed: false
-        body: '{"total_count":0,"versions":[]}'
+        body: '{"versions":[], "total_count":0}'
         headers:
             Content-Length:
                 - "32"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:57:07 GMT
+                - Mon, 16 Feb 2026 17:24:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 7f940947-b552-430d-8226-4be0e273e0eb
+                - 6924b443-2202-4c5f-9a37-1a3584435000
         status: 200 OK
         code: 200
-        duration: 71.652471ms
+        duration: 48.762618ms
     - id: 3
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 285
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
         body: '{"name":"test-jobs-job-definition-secret","cpu_limit":120,"memory_limit":256,"local_storage_capacity":5120,"image_uri":"docker.io/alpine:latest","command":"","startup_command":[],"args":[],"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","environment_variables":{},"description":""}'
-        form: {}
         headers:
             Content-Type:
                 - application/json
@@ -174,146 +122,97 @@ interactions:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 493
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":120,"created_at":"2026-02-03T10:57:07.653199Z","cron_schedule":null,"description":"","environment_variables":{},"id":"980824ad-ceb5-46a7-a7aa-2b440f297588","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-job-definition-secret","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T10:57:07.653199Z"}'
+        body: '{"id":"f41b902f-9be5-4239-9b92-e06b1489984c", "name":"test-jobs-job-definition-secret", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.661133Z", "updated_at":"2026-02-16T17:24:00.661133Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":null, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
                 - "493"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:57:07 GMT
+                - Mon, 16 Feb 2026 17:24:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - eb19647b-2276-4520-8493-103ca6401b54
+                - 187b3a65-65e2-45aa-87f2-9a739c4b615a
         status: 200 OK
         code: 200
-        duration: 88.611045ms
+        duration: 69.239428ms
     - id: 4
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 27
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
         body: '{"data":"eW91cl9zZWNyZXQ="}'
-        form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/7122f130-69b2-43e7-9980-5e421f7c7727/versions
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/0331001e-111d-46ea-8277-d107b83b0800/versions
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 304
-        uncompressed: false
-        body: '{"created_at":"2026-02-03T10:57:07.900625Z","deleted_at":null,"deletion_requested_at":null,"description":"","ephemeral_properties":null,"latest":true,"region":"fr-par","revision":1,"secret_id":"7122f130-69b2-43e7-9980-5e421f7c7727","status":"enabled","updated_at":"2026-02-03T10:57:07.900625Z"}'
+        body: '{"revision":1, "secret_id":"0331001e-111d-46ea-8277-d107b83b0800", "status":"enabled", "created_at":"2026-02-16T17:24:01.045379Z", "updated_at":"2026-02-16T17:24:01.045379Z", "deleted_at":null, "description":"", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
         headers:
             Content-Length:
                 - "304"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:57:07 GMT
+                - Mon, 16 Feb 2026 17:24:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - a5ab69f9-494d-4501-be6e-dc214afa8ba2
+                - 9e67153d-e4ec-4f61-9395-65ec1502050c
         status: 200 OK
         code: 200
-        duration: 355.51373ms
+        duration: 478.457086ms
     - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/7122f130-69b2-43e7-9980-5e421f7c7727/versions/1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/0331001e-111d-46ea-8277-d107b83b0800/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 304
-        uncompressed: false
-        body: '{"created_at":"2026-02-03T10:57:07.900625Z","deleted_at":null,"deletion_requested_at":null,"description":"","ephemeral_properties":null,"latest":true,"region":"fr-par","revision":1,"secret_id":"7122f130-69b2-43e7-9980-5e421f7c7727","status":"enabled","updated_at":"2026-02-03T10:57:07.900625Z"}'
+        body: '{"revision":1, "secret_id":"0331001e-111d-46ea-8277-d107b83b0800", "status":"enabled", "created_at":"2026-02-16T17:24:01.045379Z", "updated_at":"2026-02-16T17:24:01.045379Z", "deleted_at":null, "description":"", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
         headers:
             Content-Length:
                 - "304"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:57:07 GMT
+                - Mon, 16 Feb 2026 17:24:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 60a8ff53-2edb-453b-a02c-0a1d3c1aaad5
+                - 67c64395-f3ba-4dee-ba1d-ca603589f920
         status: 200 OK
         code: 200
-        duration: 50.830255ms
+        duration: 51.235941ms
     - id: 6
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 311
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"job_definition_id":"980824ad-ceb5-46a7-a7aa-2b440f297588","secrets":[{"secret_manager_id":"7122f130-69b2-43e7-9980-5e421f7c7727","secret_manager_version":"latest","path":"/home/dev/env"},{"secret_manager_id":"7122f130-69b2-43e7-9980-5e421f7c7727","secret_manager_version":"latest","env_var_name":"SOME_ENV"}]}'
-        form: {}
+        body: '{"job_definition_id":"f41b902f-9be5-4239-9b92-e06b1489984c","secrets":[{"secret_manager_id":"0331001e-111d-46ea-8277-d107b83b0800","secret_manager_version":"latest","env_var_name":"SOME_ENV"},{"secret_manager_id":"0331001e-111d-46ea-8277-d107b83b0800","secret_manager_version":"latest","path":"/home/dev/env"}]}'
         headers:
             Content-Type:
                 - application/json
@@ -325,777 +224,521 @@ interactions:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 494
-        uncompressed: false
-        body: '{"secrets":[{"file":{"path":"/home/dev/env"},"job_definition_id":"980824ad-ceb5-46a7-a7aa-2b440f297588","secret_id":"81c30767-8e2a-4cf8-9f6c-a4bd848d464d","secret_manager_id":"7122f130-69b2-43e7-9980-5e421f7c7727","secret_manager_version":"latest"},{"env_var":{"name":"SOME_ENV"},"job_definition_id":"980824ad-ceb5-46a7-a7aa-2b440f297588","secret_id":"ed3f083e-8145-42f8-91a6-5846a9c6be6f","secret_manager_id":"7122f130-69b2-43e7-9980-5e421f7c7727","secret_manager_version":"latest"}]}'
+        body: '{"secrets":[{"secret_id":"9bd5bfa0-918b-4791-ab84-85b945bf287c", "secret_manager_id":"0331001e-111d-46ea-8277-d107b83b0800", "secret_manager_version":"latest", "job_definition_id":"f41b902f-9be5-4239-9b92-e06b1489984c", "env_var":{"name":"SOME_ENV"}}, {"secret_id":"3512bb67-c99c-4e37-b648-e74c2de9dd57", "secret_manager_id":"0331001e-111d-46ea-8277-d107b83b0800", "secret_manager_version":"latest", "job_definition_id":"f41b902f-9be5-4239-9b92-e06b1489984c", "file":{"path":"/home/dev/env"}}]}'
         headers:
             Content-Length:
                 - "494"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:57:08 GMT
+                - Mon, 16 Feb 2026 17:24:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 474e3500-e92a-4366-85a8-bd53f9f1bbbb
+                - 4c81e227-3b87-4caf-8fc4-f42ae02bbe6a
         status: 200 OK
         code: 200
-        duration: 993.167947ms
+        duration: 789.145428ms
     - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/980824ad-ceb5-46a7-a7aa-2b440f297588
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/f41b902f-9be5-4239-9b92-e06b1489984c
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 493
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":120,"created_at":"2026-02-03T10:57:07.653199Z","cron_schedule":null,"description":"","environment_variables":{},"id":"980824ad-ceb5-46a7-a7aa-2b440f297588","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-job-definition-secret","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T10:57:07.653199Z"}'
+        body: '{"id":"f41b902f-9be5-4239-9b92-e06b1489984c", "name":"test-jobs-job-definition-secret", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.661133Z", "updated_at":"2026-02-16T17:24:00.661133Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":null, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
                 - "493"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:57:08 GMT
+                - Mon, 16 Feb 2026 17:24:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 80da59e7-21ae-44a2-ad15-24bfbe8b849a
+                - 8c41e3d2-5e25-4cf7-903f-ec90b145cde3
         status: 200 OK
         code: 200
-        duration: 46.756635ms
+        duration: 28.273774ms
     - id: 8
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        form:
+            job_definition_id:
+                - f41b902f-9be5-4239-9b92-e06b1489984c
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=980824ad-ceb5-46a7-a7aa-2b440f297588
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=f41b902f-9be5-4239-9b92-e06b1489984c
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 511
-        uncompressed: false
-        body: '{"secrets":[{"file":{"path":"/home/dev/env"},"job_definition_id":"980824ad-ceb5-46a7-a7aa-2b440f297588","secret_id":"81c30767-8e2a-4cf8-9f6c-a4bd848d464d","secret_manager_id":"7122f130-69b2-43e7-9980-5e421f7c7727","secret_manager_version":"latest"},{"env_var":{"name":"SOME_ENV"},"job_definition_id":"980824ad-ceb5-46a7-a7aa-2b440f297588","secret_id":"ed3f083e-8145-42f8-91a6-5846a9c6be6f","secret_manager_id":"7122f130-69b2-43e7-9980-5e421f7c7727","secret_manager_version":"latest"}],"total_count":2}'
+        body: '{"secrets":[{"secret_id":"3512bb67-c99c-4e37-b648-e74c2de9dd57", "secret_manager_id":"0331001e-111d-46ea-8277-d107b83b0800", "secret_manager_version":"latest", "job_definition_id":"f41b902f-9be5-4239-9b92-e06b1489984c", "file":{"path":"/home/dev/env"}}, {"secret_id":"9bd5bfa0-918b-4791-ab84-85b945bf287c", "secret_manager_id":"0331001e-111d-46ea-8277-d107b83b0800", "secret_manager_version":"latest", "job_definition_id":"f41b902f-9be5-4239-9b92-e06b1489984c", "env_var":{"name":"SOME_ENV"}}], "total_count":2}'
         headers:
             Content-Length:
                 - "511"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:57:08 GMT
+                - Mon, 16 Feb 2026 17:24:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 81d3388a-4f6a-402e-8962-e4574c7dc5ef
+                - 1d0c5fb8-5b89-41f6-aa1d-d28cbef960a3
         status: 200 OK
         code: 200
-        duration: 63.022784ms
+        duration: 25.54422ms
     - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/980824ad-ceb5-46a7-a7aa-2b440f297588
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/f41b902f-9be5-4239-9b92-e06b1489984c
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 493
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":120,"created_at":"2026-02-03T10:57:07.653199Z","cron_schedule":null,"description":"","environment_variables":{},"id":"980824ad-ceb5-46a7-a7aa-2b440f297588","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-job-definition-secret","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T10:57:07.653199Z"}'
+        body: '{"id":"f41b902f-9be5-4239-9b92-e06b1489984c", "name":"test-jobs-job-definition-secret", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.661133Z", "updated_at":"2026-02-16T17:24:00.661133Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":null, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
                 - "493"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:57:08 GMT
+                - Mon, 16 Feb 2026 17:24:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - b0e23915-5282-47c7-8afb-b19cf07a60fd
+                - fac205cd-7861-4105-8fa2-0066466266f1
         status: 200 OK
         code: 200
-        duration: 70.575621ms
+        duration: 30.248761ms
     - id: 10
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/7122f130-69b2-43e7-9980-5e421f7c7727
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/0331001e-111d-46ea-8277-d107b83b0800
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 444
-        uncompressed: false
-        body: '{"created_at":"2026-02-03T10:57:07.418120Z","deletion_requested_at":null,"description":"","ephemeral_policy":null,"id":"7122f130-69b2-43e7-9980-5e421f7c7727","key_id":null,"managed":false,"name":"job-secret","path":"/one","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","protected":false,"region":"fr-par","status":"ready","tags":[],"type":"opaque","updated_at":"2026-02-03T10:57:07.418120Z","used_by":[],"version_count":1}'
+        body: '{"id":"0331001e-111d-46ea-8277-d107b83b0800", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "name":"job-secret", "status":"ready", "created_at":"2026-02-16T17:24:00.477215Z", "updated_at":"2026-02-16T17:24:00.477215Z", "tags":[], "version_count":1, "description":"", "managed":false, "type":"opaque", "protected":false, "path":"/one", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}'
         headers:
             Content-Length:
                 - "444"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:57:09 GMT
+                - Mon, 16 Feb 2026 17:24:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 8488201c-f9a6-48c8-9792-48174a8a1a58
+                - d698f5af-6164-4a2b-9237-f74214b5ec29
         status: 200 OK
         code: 200
-        duration: 52.170922ms
+        duration: 99.164296ms
     - id: 11
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        form:
+            page:
+                - "1"
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/7122f130-69b2-43e7-9980-5e421f7c7727/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/0331001e-111d-46ea-8277-d107b83b0800/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 336
-        uncompressed: false
-        body: '{"total_count":1,"versions":[{"created_at":"2026-02-03T10:57:07.900625Z","deleted_at":null,"deletion_requested_at":null,"description":"","ephemeral_properties":null,"latest":true,"region":"fr-par","revision":1,"secret_id":"7122f130-69b2-43e7-9980-5e421f7c7727","status":"enabled","updated_at":"2026-02-03T10:57:07.900625Z"}]}'
+        body: '{"versions":[{"revision":1, "secret_id":"0331001e-111d-46ea-8277-d107b83b0800", "status":"enabled", "created_at":"2026-02-16T17:24:01.045379Z", "updated_at":"2026-02-16T17:24:01.045379Z", "deleted_at":null, "description":"", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}], "total_count":1}'
         headers:
             Content-Length:
                 - "336"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:57:09 GMT
+                - Mon, 16 Feb 2026 17:24:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 97f77d18-46ed-4a18-9e42-392981c24511
+                - a3b3493b-fba1-48e2-a8f0-98f106dfebd6
         status: 200 OK
         code: 200
-        duration: 55.706258ms
+        duration: 22.971214ms
     - id: 12
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/7122f130-69b2-43e7-9980-5e421f7c7727/versions/1
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/f41b902f-9be5-4239-9b92-e06b1489984c
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 304
-        uncompressed: false
-        body: '{"created_at":"2026-02-03T10:57:07.900625Z","deleted_at":null,"deletion_requested_at":null,"description":"","ephemeral_properties":null,"latest":true,"region":"fr-par","revision":1,"secret_id":"7122f130-69b2-43e7-9980-5e421f7c7727","status":"enabled","updated_at":"2026-02-03T10:57:07.900625Z"}'
+        content_length: 493
+        body: '{"id":"f41b902f-9be5-4239-9b92-e06b1489984c", "name":"test-jobs-job-definition-secret", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.661133Z", "updated_at":"2026-02-16T17:24:00.661133Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":null, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
-                - "304"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "493"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:57:09 GMT
+                - Mon, 16 Feb 2026 17:24:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 47078e98-3b5e-4a90-8605-c21c55e15d2e
+                - a2d4130d-2f52-45d1-b3a0-4d55705cd0ae
         status: 200 OK
         code: 200
-        duration: 24.230276ms
+        duration: 36.953466ms
     - id: 13
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/980824ad-ceb5-46a7-a7aa-2b440f297588
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/0331001e-111d-46ea-8277-d107b83b0800/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 493
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":120,"created_at":"2026-02-03T10:57:07.653199Z","cron_schedule":null,"description":"","environment_variables":{},"id":"980824ad-ceb5-46a7-a7aa-2b440f297588","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-job-definition-secret","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T10:57:07.653199Z"}'
+        content_length: 304
+        body: '{"revision":1, "secret_id":"0331001e-111d-46ea-8277-d107b83b0800", "status":"enabled", "created_at":"2026-02-16T17:24:01.045379Z", "updated_at":"2026-02-16T17:24:01.045379Z", "deleted_at":null, "description":"", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
         headers:
             Content-Length:
-                - "493"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "304"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:57:09 GMT
+                - Mon, 16 Feb 2026 17:24:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 8547ee74-1266-4e2e-bcfd-79a3c4dda4d6
+                - bd5b251c-3362-4292-8d12-9b25f6fae43f
         status: 200 OK
         code: 200
-        duration: 43.228034ms
+        duration: 38.95826ms
     - id: 14
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        form:
+            job_definition_id:
+                - f41b902f-9be5-4239-9b92-e06b1489984c
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=980824ad-ceb5-46a7-a7aa-2b440f297588
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=f41b902f-9be5-4239-9b92-e06b1489984c
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 511
-        uncompressed: false
-        body: '{"secrets":[{"file":{"path":"/home/dev/env"},"job_definition_id":"980824ad-ceb5-46a7-a7aa-2b440f297588","secret_id":"81c30767-8e2a-4cf8-9f6c-a4bd848d464d","secret_manager_id":"7122f130-69b2-43e7-9980-5e421f7c7727","secret_manager_version":"latest"},{"env_var":{"name":"SOME_ENV"},"job_definition_id":"980824ad-ceb5-46a7-a7aa-2b440f297588","secret_id":"ed3f083e-8145-42f8-91a6-5846a9c6be6f","secret_manager_id":"7122f130-69b2-43e7-9980-5e421f7c7727","secret_manager_version":"latest"}],"total_count":2}'
+        body: '{"secrets":[{"secret_id":"3512bb67-c99c-4e37-b648-e74c2de9dd57", "secret_manager_id":"0331001e-111d-46ea-8277-d107b83b0800", "secret_manager_version":"latest", "job_definition_id":"f41b902f-9be5-4239-9b92-e06b1489984c", "file":{"path":"/home/dev/env"}}, {"secret_id":"9bd5bfa0-918b-4791-ab84-85b945bf287c", "secret_manager_id":"0331001e-111d-46ea-8277-d107b83b0800", "secret_manager_version":"latest", "job_definition_id":"f41b902f-9be5-4239-9b92-e06b1489984c", "env_var":{"name":"SOME_ENV"}}], "total_count":2}'
         headers:
             Content-Length:
                 - "511"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:57:09 GMT
+                - Mon, 16 Feb 2026 17:24:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - e78c6fa3-b487-4ced-aa67-8a52094757e5
+                - be78f40f-3e72-40bb-924a-73ccdc222781
         status: 200 OK
         code: 200
-        duration: 49.170606ms
+        duration: 118.382719ms
     - id: 15
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/7122f130-69b2-43e7-9980-5e421f7c7727
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/0331001e-111d-46ea-8277-d107b83b0800
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 444
-        uncompressed: false
-        body: '{"created_at":"2026-02-03T10:57:07.418120Z","deletion_requested_at":null,"description":"","ephemeral_policy":null,"id":"7122f130-69b2-43e7-9980-5e421f7c7727","key_id":null,"managed":false,"name":"job-secret","path":"/one","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","protected":false,"region":"fr-par","status":"ready","tags":[],"type":"opaque","updated_at":"2026-02-03T10:57:07.418120Z","used_by":[],"version_count":1}'
+        body: '{"id":"0331001e-111d-46ea-8277-d107b83b0800", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "name":"job-secret", "status":"ready", "created_at":"2026-02-16T17:24:00.477215Z", "updated_at":"2026-02-16T17:24:00.477215Z", "tags":[], "version_count":1, "description":"", "managed":false, "type":"opaque", "protected":false, "path":"/one", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}'
         headers:
             Content-Length:
                 - "444"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:57:09 GMT
+                - Mon, 16 Feb 2026 17:24:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - e2313468-7bee-45ba-a056-407992a69abd
+                - f1916960-a01d-40c7-8541-4362a90abe22
         status: 200 OK
         code: 200
-        duration: 28.59868ms
+        duration: 50.539173ms
     - id: 16
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        form:
+            page:
+                - "1"
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/7122f130-69b2-43e7-9980-5e421f7c7727/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/0331001e-111d-46ea-8277-d107b83b0800/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 336
-        uncompressed: false
-        body: '{"total_count":1,"versions":[{"created_at":"2026-02-03T10:57:07.900625Z","deleted_at":null,"deletion_requested_at":null,"description":"","ephemeral_properties":null,"latest":true,"region":"fr-par","revision":1,"secret_id":"7122f130-69b2-43e7-9980-5e421f7c7727","status":"enabled","updated_at":"2026-02-03T10:57:07.900625Z"}]}'
+        body: '{"versions":[{"revision":1, "secret_id":"0331001e-111d-46ea-8277-d107b83b0800", "status":"enabled", "created_at":"2026-02-16T17:24:01.045379Z", "updated_at":"2026-02-16T17:24:01.045379Z", "deleted_at":null, "description":"", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}], "total_count":1}'
         headers:
             Content-Length:
                 - "336"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:57:09 GMT
+                - Mon, 16 Feb 2026 17:24:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - ec28adf2-1afc-45d0-b9b9-4934396840f2
+                - db38b908-6d39-4644-8e3b-7e1dc9573714
         status: 200 OK
         code: 200
-        duration: 36.349826ms
+        duration: 33.41825ms
     - id: 17
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/7122f130-69b2-43e7-9980-5e421f7c7727/versions/1
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/f41b902f-9be5-4239-9b92-e06b1489984c
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 304
-        uncompressed: false
-        body: '{"created_at":"2026-02-03T10:57:07.900625Z","deleted_at":null,"deletion_requested_at":null,"description":"","ephemeral_properties":null,"latest":true,"region":"fr-par","revision":1,"secret_id":"7122f130-69b2-43e7-9980-5e421f7c7727","status":"enabled","updated_at":"2026-02-03T10:57:07.900625Z"}'
+        content_length: 493
+        body: '{"id":"f41b902f-9be5-4239-9b92-e06b1489984c", "name":"test-jobs-job-definition-secret", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.661133Z", "updated_at":"2026-02-16T17:24:00.661133Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":null, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
-                - "304"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "493"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:57:09 GMT
+                - Mon, 16 Feb 2026 17:24:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - df44ebbd-46f2-4d4b-9255-372c44fe942c
+                - 7bfc3bda-495a-441d-93f0-db7ba67f15a7
         status: 200 OK
         code: 200
-        duration: 23.696027ms
+        duration: 34.060973ms
     - id: 18
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/980824ad-ceb5-46a7-a7aa-2b440f297588
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/0331001e-111d-46ea-8277-d107b83b0800/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 493
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":120,"created_at":"2026-02-03T10:57:07.653199Z","cron_schedule":null,"description":"","environment_variables":{},"id":"980824ad-ceb5-46a7-a7aa-2b440f297588","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-job-definition-secret","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T10:57:07.653199Z"}'
+        content_length: 304
+        body: '{"revision":1, "secret_id":"0331001e-111d-46ea-8277-d107b83b0800", "status":"enabled", "created_at":"2026-02-16T17:24:01.045379Z", "updated_at":"2026-02-16T17:24:01.045379Z", "deleted_at":null, "description":"", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
         headers:
             Content-Length:
-                - "493"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "304"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:57:09 GMT
+                - Mon, 16 Feb 2026 17:24:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - fe007617-107d-4ba4-a126-e6287ca61944
+                - f083f8ff-328e-42f3-9f97-18c7010fe696
         status: 200 OK
         code: 200
-        duration: 63.466059ms
+        duration: 50.187294ms
     - id: 19
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        form:
+            job_definition_id:
+                - f41b902f-9be5-4239-9b92-e06b1489984c
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=980824ad-ceb5-46a7-a7aa-2b440f297588
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=f41b902f-9be5-4239-9b92-e06b1489984c
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 511
-        uncompressed: false
-        body: '{"secrets":[{"file":{"path":"/home/dev/env"},"job_definition_id":"980824ad-ceb5-46a7-a7aa-2b440f297588","secret_id":"81c30767-8e2a-4cf8-9f6c-a4bd848d464d","secret_manager_id":"7122f130-69b2-43e7-9980-5e421f7c7727","secret_manager_version":"latest"},{"env_var":{"name":"SOME_ENV"},"job_definition_id":"980824ad-ceb5-46a7-a7aa-2b440f297588","secret_id":"ed3f083e-8145-42f8-91a6-5846a9c6be6f","secret_manager_id":"7122f130-69b2-43e7-9980-5e421f7c7727","secret_manager_version":"latest"}],"total_count":2}'
+        body: '{"secrets":[{"secret_id":"3512bb67-c99c-4e37-b648-e74c2de9dd57", "secret_manager_id":"0331001e-111d-46ea-8277-d107b83b0800", "secret_manager_version":"latest", "job_definition_id":"f41b902f-9be5-4239-9b92-e06b1489984c", "file":{"path":"/home/dev/env"}}, {"secret_id":"9bd5bfa0-918b-4791-ab84-85b945bf287c", "secret_manager_id":"0331001e-111d-46ea-8277-d107b83b0800", "secret_manager_version":"latest", "job_definition_id":"f41b902f-9be5-4239-9b92-e06b1489984c", "env_var":{"name":"SOME_ENV"}}], "total_count":2}'
         headers:
             Content-Length:
                 - "511"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:57:09 GMT
+                - Mon, 16 Feb 2026 17:24:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - f7cbd4ba-6a40-4386-8bbf-0bd69bbd57f3
+                - 902dfa3f-6989-4056-9b4c-3c9dd6360e43
         status: 200 OK
         code: 200
-        duration: 46.704879ms
+        duration: 30.539813ms
     - id: 20
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets/81c30767-8e2a-4cf8-9f6c-a4bd848d464d
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets/9bd5bfa0-918b-4791-ab84-85b945bf287c
         method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 0
-        uncompressed: false
         body: ""
         headers:
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:57:09 GMT
+                - Mon, 16 Feb 2026 17:24:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 129f5093-f535-45b9-8d93-1d0c67836be6
+                - 457f01e2-aa25-4cdc-8b99-6675d73f61a6
         status: 204 No Content
         code: 204
-        duration: 51.27824ms
+        duration: 57.238119ms
     - id: 21
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets/ed3f083e-8145-42f8-91a6-5846a9c6be6f
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets/3512bb67-c99c-4e37-b648-e74c2de9dd57
         method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 0
-        uncompressed: false
         body: ""
         headers:
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:57:09 GMT
+                - Mon, 16 Feb 2026 17:24:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 227db2cb-3628-48a0-93ad-aa7beb6c620e
+                - 658578e5-9c30-45db-bbcc-f0056cf169ad
         status: 204 No Content
         code: 204
-        duration: 47.268047ms
+        duration: 35.978862ms
     - id: 22
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 317
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"job_definition_id":"980824ad-ceb5-46a7-a7aa-2b440f297588","secrets":[{"secret_manager_id":"7122f130-69b2-43e7-9980-5e421f7c7727","secret_manager_version":"latest","path":"/home/dev/secret_file"},{"secret_manager_id":"7122f130-69b2-43e7-9980-5e421f7c7727","secret_manager_version":"1","env_var_name":"ANOTHER_ENV"}]}'
-        form: {}
+        body: '{"job_definition_id":"f41b902f-9be5-4239-9b92-e06b1489984c","secrets":[{"secret_manager_id":"0331001e-111d-46ea-8277-d107b83b0800","secret_manager_version":"latest","path":"/home/dev/secret_file"},{"secret_manager_id":"0331001e-111d-46ea-8277-d107b83b0800","secret_manager_version":"1","env_var_name":"ANOTHER_ENV"}]}'
         headers:
             Content-Type:
                 - application/json
@@ -1107,1398 +750,937 @@ interactions:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 500
-        uncompressed: false
-        body: '{"secrets":[{"file":{"path":"/home/dev/secret_file"},"job_definition_id":"980824ad-ceb5-46a7-a7aa-2b440f297588","secret_id":"752ae75b-c805-4901-8b4f-dbb38113eb40","secret_manager_id":"7122f130-69b2-43e7-9980-5e421f7c7727","secret_manager_version":"latest"},{"env_var":{"name":"ANOTHER_ENV"},"job_definition_id":"980824ad-ceb5-46a7-a7aa-2b440f297588","secret_id":"02f05ee1-cd80-4477-a355-5b50de3f16d0","secret_manager_id":"7122f130-69b2-43e7-9980-5e421f7c7727","secret_manager_version":"1"}]}'
+        body: '{"secrets":[{"secret_id":"0674d35c-41be-487c-b44b-5970553906b6", "secret_manager_id":"0331001e-111d-46ea-8277-d107b83b0800", "secret_manager_version":"latest", "job_definition_id":"f41b902f-9be5-4239-9b92-e06b1489984c", "file":{"path":"/home/dev/secret_file"}}, {"secret_id":"79c73820-585c-426d-b225-fa5ffedbc978", "secret_manager_id":"0331001e-111d-46ea-8277-d107b83b0800", "secret_manager_version":"1", "job_definition_id":"f41b902f-9be5-4239-9b92-e06b1489984c", "env_var":{"name":"ANOTHER_ENV"}}]}'
         headers:
             Content-Length:
                 - "500"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:57:10 GMT
+                - Mon, 16 Feb 2026 17:24:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 9df41e33-39b3-4132-880d-b4c3b0045ac2
+                - f2b0f7f7-02d1-4f35-9a5e-d11222870341
         status: 200 OK
         code: 200
-        duration: 141.547353ms
+        duration: 149.521959ms
     - id: 23
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 2
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
         body: '{}'
-        form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/980824ad-ceb5-46a7-a7aa-2b440f297588
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/f41b902f-9be5-4239-9b92-e06b1489984c
         method: PATCH
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 493
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":120,"created_at":"2026-02-03T10:57:07.653199Z","cron_schedule":null,"description":"","environment_variables":{},"id":"980824ad-ceb5-46a7-a7aa-2b440f297588","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-job-definition-secret","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T10:57:10.070255Z"}'
+        body: '{"id":"f41b902f-9be5-4239-9b92-e06b1489984c", "name":"test-jobs-job-definition-secret", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.661133Z", "updated_at":"2026-02-16T17:24:03.162792Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":null, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
                 - "493"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:57:10 GMT
+                - Mon, 16 Feb 2026 17:24:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 86d5d9a5-42c9-45a3-a309-71f724a03f6c
+                - ac77d7e1-36ee-4824-82e6-d83f08cae42c
         status: 200 OK
         code: 200
-        duration: 66.619588ms
+        duration: 61.333929ms
     - id: 24
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/980824ad-ceb5-46a7-a7aa-2b440f297588
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/f41b902f-9be5-4239-9b92-e06b1489984c
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 493
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":120,"created_at":"2026-02-03T10:57:07.653199Z","cron_schedule":null,"description":"","environment_variables":{},"id":"980824ad-ceb5-46a7-a7aa-2b440f297588","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-job-definition-secret","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T10:57:10.070255Z"}'
+        body: '{"id":"f41b902f-9be5-4239-9b92-e06b1489984c", "name":"test-jobs-job-definition-secret", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.661133Z", "updated_at":"2026-02-16T17:24:03.162792Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":null, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
                 - "493"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:57:10 GMT
+                - Mon, 16 Feb 2026 17:24:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - bfe7a3f2-1d93-4152-8108-765bb5d8af70
+                - 6be21d13-94ad-4c92-a275-a8c3949c7ee4
         status: 200 OK
         code: 200
-        duration: 45.666589ms
+        duration: 30.957797ms
     - id: 25
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        form:
+            job_definition_id:
+                - f41b902f-9be5-4239-9b92-e06b1489984c
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=980824ad-ceb5-46a7-a7aa-2b440f297588
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=f41b902f-9be5-4239-9b92-e06b1489984c
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 517
-        uncompressed: false
-        body: '{"secrets":[{"env_var":{"name":"ANOTHER_ENV"},"job_definition_id":"980824ad-ceb5-46a7-a7aa-2b440f297588","secret_id":"02f05ee1-cd80-4477-a355-5b50de3f16d0","secret_manager_id":"7122f130-69b2-43e7-9980-5e421f7c7727","secret_manager_version":"1"},{"file":{"path":"/home/dev/secret_file"},"job_definition_id":"980824ad-ceb5-46a7-a7aa-2b440f297588","secret_id":"752ae75b-c805-4901-8b4f-dbb38113eb40","secret_manager_id":"7122f130-69b2-43e7-9980-5e421f7c7727","secret_manager_version":"latest"}],"total_count":2}'
+        body: '{"secrets":[{"secret_id":"79c73820-585c-426d-b225-fa5ffedbc978", "secret_manager_id":"0331001e-111d-46ea-8277-d107b83b0800", "secret_manager_version":"1", "job_definition_id":"f41b902f-9be5-4239-9b92-e06b1489984c", "env_var":{"name":"ANOTHER_ENV"}}, {"secret_id":"0674d35c-41be-487c-b44b-5970553906b6", "secret_manager_id":"0331001e-111d-46ea-8277-d107b83b0800", "secret_manager_version":"latest", "job_definition_id":"f41b902f-9be5-4239-9b92-e06b1489984c", "file":{"path":"/home/dev/secret_file"}}], "total_count":2}'
         headers:
             Content-Length:
                 - "517"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:57:10 GMT
+                - Mon, 16 Feb 2026 17:24:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 87d55151-7890-4ce2-9c13-d40c640560d0
+                - 2dada709-8115-446d-845a-246f9f606a9a
         status: 200 OK
         code: 200
-        duration: 44.374427ms
+        duration: 34.852377ms
     - id: 26
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/980824ad-ceb5-46a7-a7aa-2b440f297588
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/f41b902f-9be5-4239-9b92-e06b1489984c
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 493
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":120,"created_at":"2026-02-03T10:57:07.653199Z","cron_schedule":null,"description":"","environment_variables":{},"id":"980824ad-ceb5-46a7-a7aa-2b440f297588","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-job-definition-secret","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T10:57:10.070255Z"}'
+        body: '{"id":"f41b902f-9be5-4239-9b92-e06b1489984c", "name":"test-jobs-job-definition-secret", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.661133Z", "updated_at":"2026-02-16T17:24:03.162792Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":null, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
                 - "493"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:57:10 GMT
+                - Mon, 16 Feb 2026 17:24:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 14becd40-251c-450e-9f10-aa64aee40bb4
+                - e8887c96-8f58-4763-ae05-b04a4ff8e56e
         status: 200 OK
         code: 200
-        duration: 98.360748ms
+        duration: 32.636581ms
     - id: 27
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/7122f130-69b2-43e7-9980-5e421f7c7727
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/0331001e-111d-46ea-8277-d107b83b0800
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 444
-        uncompressed: false
-        body: '{"created_at":"2026-02-03T10:57:07.418120Z","deletion_requested_at":null,"description":"","ephemeral_policy":null,"id":"7122f130-69b2-43e7-9980-5e421f7c7727","key_id":null,"managed":false,"name":"job-secret","path":"/one","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","protected":false,"region":"fr-par","status":"ready","tags":[],"type":"opaque","updated_at":"2026-02-03T10:57:07.418120Z","used_by":[],"version_count":1}'
+        body: '{"id":"0331001e-111d-46ea-8277-d107b83b0800", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "name":"job-secret", "status":"ready", "created_at":"2026-02-16T17:24:00.477215Z", "updated_at":"2026-02-16T17:24:00.477215Z", "tags":[], "version_count":1, "description":"", "managed":false, "type":"opaque", "protected":false, "path":"/one", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}'
         headers:
             Content-Length:
                 - "444"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:57:10 GMT
+                - Mon, 16 Feb 2026 17:24:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - f4a70fa4-75fb-4d67-a408-5750258b5517
+                - 9ebcf91e-b2ea-4b86-8d57-36939c35e66e
         status: 200 OK
         code: 200
-        duration: 76.906326ms
+        duration: 42.620286ms
     - id: 28
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        form:
+            page:
+                - "1"
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/7122f130-69b2-43e7-9980-5e421f7c7727/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/0331001e-111d-46ea-8277-d107b83b0800/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 336
-        uncompressed: false
-        body: '{"total_count":1,"versions":[{"created_at":"2026-02-03T10:57:07.900625Z","deleted_at":null,"deletion_requested_at":null,"description":"","ephemeral_properties":null,"latest":true,"region":"fr-par","revision":1,"secret_id":"7122f130-69b2-43e7-9980-5e421f7c7727","status":"enabled","updated_at":"2026-02-03T10:57:07.900625Z"}]}'
+        body: '{"versions":[{"revision":1, "secret_id":"0331001e-111d-46ea-8277-d107b83b0800", "status":"enabled", "created_at":"2026-02-16T17:24:01.045379Z", "updated_at":"2026-02-16T17:24:01.045379Z", "deleted_at":null, "description":"", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}], "total_count":1}'
         headers:
             Content-Length:
                 - "336"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:57:10 GMT
+                - Mon, 16 Feb 2026 17:24:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - ec90901b-d2a9-47d2-83ef-12ff23b91343
+                - 3bcca005-c848-4686-b70b-eaff72a896d2
         status: 200 OK
         code: 200
-        duration: 78.438026ms
+        duration: 25.453055ms
     - id: 29
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/980824ad-ceb5-46a7-a7aa-2b440f297588
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/f41b902f-9be5-4239-9b92-e06b1489984c
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 493
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":120,"created_at":"2026-02-03T10:57:07.653199Z","cron_schedule":null,"description":"","environment_variables":{},"id":"980824ad-ceb5-46a7-a7aa-2b440f297588","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-job-definition-secret","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T10:57:10.070255Z"}'
+        body: '{"id":"f41b902f-9be5-4239-9b92-e06b1489984c", "name":"test-jobs-job-definition-secret", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.661133Z", "updated_at":"2026-02-16T17:24:03.162792Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":null, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
                 - "493"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:57:10 GMT
+                - Mon, 16 Feb 2026 17:24:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 3ed8c908-b10c-42d9-9f09-92c41305fc8e
+                - 7108d860-c4e9-45fe-879b-4f50c1ca5177
         status: 200 OK
         code: 200
-        duration: 42.09255ms
+        duration: 31.06387ms
     - id: 30
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/7122f130-69b2-43e7-9980-5e421f7c7727/versions/1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/0331001e-111d-46ea-8277-d107b83b0800/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 304
-        uncompressed: false
-        body: '{"created_at":"2026-02-03T10:57:07.900625Z","deleted_at":null,"deletion_requested_at":null,"description":"","ephemeral_properties":null,"latest":true,"region":"fr-par","revision":1,"secret_id":"7122f130-69b2-43e7-9980-5e421f7c7727","status":"enabled","updated_at":"2026-02-03T10:57:07.900625Z"}'
+        body: '{"revision":1, "secret_id":"0331001e-111d-46ea-8277-d107b83b0800", "status":"enabled", "created_at":"2026-02-16T17:24:01.045379Z", "updated_at":"2026-02-16T17:24:01.045379Z", "deleted_at":null, "description":"", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
         headers:
             Content-Length:
                 - "304"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:57:10 GMT
+                - Mon, 16 Feb 2026 17:24:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 837a0c2b-9755-4e16-acfc-8f95ee5ea015
+                - 47b525d2-465a-4dc8-b6c3-506f5613e3cc
         status: 200 OK
         code: 200
-        duration: 44.133047ms
+        duration: 50.990269ms
     - id: 31
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        form:
+            job_definition_id:
+                - f41b902f-9be5-4239-9b92-e06b1489984c
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=980824ad-ceb5-46a7-a7aa-2b440f297588
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=f41b902f-9be5-4239-9b92-e06b1489984c
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 517
-        uncompressed: false
-        body: '{"secrets":[{"env_var":{"name":"ANOTHER_ENV"},"job_definition_id":"980824ad-ceb5-46a7-a7aa-2b440f297588","secret_id":"02f05ee1-cd80-4477-a355-5b50de3f16d0","secret_manager_id":"7122f130-69b2-43e7-9980-5e421f7c7727","secret_manager_version":"1"},{"file":{"path":"/home/dev/secret_file"},"job_definition_id":"980824ad-ceb5-46a7-a7aa-2b440f297588","secret_id":"752ae75b-c805-4901-8b4f-dbb38113eb40","secret_manager_id":"7122f130-69b2-43e7-9980-5e421f7c7727","secret_manager_version":"latest"}],"total_count":2}'
+        body: '{"secrets":[{"secret_id":"79c73820-585c-426d-b225-fa5ffedbc978", "secret_manager_id":"0331001e-111d-46ea-8277-d107b83b0800", "secret_manager_version":"1", "job_definition_id":"f41b902f-9be5-4239-9b92-e06b1489984c", "env_var":{"name":"ANOTHER_ENV"}}, {"secret_id":"0674d35c-41be-487c-b44b-5970553906b6", "secret_manager_id":"0331001e-111d-46ea-8277-d107b83b0800", "secret_manager_version":"latest", "job_definition_id":"f41b902f-9be5-4239-9b92-e06b1489984c", "file":{"path":"/home/dev/secret_file"}}], "total_count":2}'
         headers:
             Content-Length:
                 - "517"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:57:10 GMT
+                - Mon, 16 Feb 2026 17:24:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 73df7260-6a00-4f0c-a9a9-7886581e8906
+                - ed3e331b-b882-4149-b37a-d8a6a35bcc44
         status: 200 OK
         code: 200
-        duration: 48.056966ms
+        duration: 34.058897ms
     - id: 32
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/7122f130-69b2-43e7-9980-5e421f7c7727
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/0331001e-111d-46ea-8277-d107b83b0800
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 444
-        uncompressed: false
-        body: '{"created_at":"2026-02-03T10:57:07.418120Z","deletion_requested_at":null,"description":"","ephemeral_policy":null,"id":"7122f130-69b2-43e7-9980-5e421f7c7727","key_id":null,"managed":false,"name":"job-secret","path":"/one","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","protected":false,"region":"fr-par","status":"ready","tags":[],"type":"opaque","updated_at":"2026-02-03T10:57:07.418120Z","used_by":[],"version_count":1}'
+        body: '{"id":"0331001e-111d-46ea-8277-d107b83b0800", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "name":"job-secret", "status":"ready", "created_at":"2026-02-16T17:24:00.477215Z", "updated_at":"2026-02-16T17:24:00.477215Z", "tags":[], "version_count":1, "description":"", "managed":false, "type":"opaque", "protected":false, "path":"/one", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}'
         headers:
             Content-Length:
                 - "444"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:57:11 GMT
+                - Mon, 16 Feb 2026 17:24:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - df8ef2dd-158b-4949-b7b1-5991dd22828f
+                - f825a59d-ca50-413a-8615-3ad2ffb42ad7
         status: 200 OK
         code: 200
-        duration: 46.508474ms
+        duration: 31.655735ms
     - id: 33
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        form:
+            page:
+                - "1"
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/7122f130-69b2-43e7-9980-5e421f7c7727/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/0331001e-111d-46ea-8277-d107b83b0800/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 336
-        uncompressed: false
-        body: '{"total_count":1,"versions":[{"created_at":"2026-02-03T10:57:07.900625Z","deleted_at":null,"deletion_requested_at":null,"description":"","ephemeral_properties":null,"latest":true,"region":"fr-par","revision":1,"secret_id":"7122f130-69b2-43e7-9980-5e421f7c7727","status":"enabled","updated_at":"2026-02-03T10:57:07.900625Z"}]}'
+        body: '{"versions":[{"revision":1, "secret_id":"0331001e-111d-46ea-8277-d107b83b0800", "status":"enabled", "created_at":"2026-02-16T17:24:01.045379Z", "updated_at":"2026-02-16T17:24:01.045379Z", "deleted_at":null, "description":"", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}], "total_count":1}'
         headers:
             Content-Length:
                 - "336"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:57:11 GMT
+                - Mon, 16 Feb 2026 17:24:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 3030f6fd-3246-41cf-9876-06140f8ef04b
+                - 08ceaeb2-5eb7-4275-89be-cce1e688d16d
         status: 200 OK
         code: 200
-        duration: 43.23752ms
+        duration: 28.991958ms
     - id: 34
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/7122f130-69b2-43e7-9980-5e421f7c7727/versions/1
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/f41b902f-9be5-4239-9b92-e06b1489984c
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 304
-        uncompressed: false
-        body: '{"created_at":"2026-02-03T10:57:07.900625Z","deleted_at":null,"deletion_requested_at":null,"description":"","ephemeral_properties":null,"latest":true,"region":"fr-par","revision":1,"secret_id":"7122f130-69b2-43e7-9980-5e421f7c7727","status":"enabled","updated_at":"2026-02-03T10:57:07.900625Z"}'
+        content_length: 493
+        body: '{"id":"f41b902f-9be5-4239-9b92-e06b1489984c", "name":"test-jobs-job-definition-secret", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.661133Z", "updated_at":"2026-02-16T17:24:03.162792Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":null, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
-                - "304"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "493"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:57:11 GMT
+                - Mon, 16 Feb 2026 17:24:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 716dc519-a359-464f-872e-cd556d614431
+                - 6ce53c20-99c8-474b-a8ad-8bab5a8cc85f
         status: 200 OK
         code: 200
-        duration: 23.741277ms
+        duration: 40.266236ms
     - id: 35
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/980824ad-ceb5-46a7-a7aa-2b440f297588
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/0331001e-111d-46ea-8277-d107b83b0800/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 493
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":120,"created_at":"2026-02-03T10:57:07.653199Z","cron_schedule":null,"description":"","environment_variables":{},"id":"980824ad-ceb5-46a7-a7aa-2b440f297588","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-job-definition-secret","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T10:57:10.070255Z"}'
+        content_length: 304
+        body: '{"revision":1, "secret_id":"0331001e-111d-46ea-8277-d107b83b0800", "status":"enabled", "created_at":"2026-02-16T17:24:01.045379Z", "updated_at":"2026-02-16T17:24:01.045379Z", "deleted_at":null, "description":"", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
         headers:
             Content-Length:
-                - "493"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "304"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:57:11 GMT
+                - Mon, 16 Feb 2026 17:24:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 1a44ae50-db8d-4568-aed2-d643b60d4ca4
+                - 002dc7d8-fa4b-497a-84ef-ee1dad7328d6
         status: 200 OK
         code: 200
-        duration: 40.877346ms
+        duration: 52.569774ms
     - id: 36
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        form:
+            job_definition_id:
+                - f41b902f-9be5-4239-9b92-e06b1489984c
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=980824ad-ceb5-46a7-a7aa-2b440f297588
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=f41b902f-9be5-4239-9b92-e06b1489984c
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 517
-        uncompressed: false
-        body: '{"secrets":[{"env_var":{"name":"ANOTHER_ENV"},"job_definition_id":"980824ad-ceb5-46a7-a7aa-2b440f297588","secret_id":"02f05ee1-cd80-4477-a355-5b50de3f16d0","secret_manager_id":"7122f130-69b2-43e7-9980-5e421f7c7727","secret_manager_version":"1"},{"file":{"path":"/home/dev/secret_file"},"job_definition_id":"980824ad-ceb5-46a7-a7aa-2b440f297588","secret_id":"752ae75b-c805-4901-8b4f-dbb38113eb40","secret_manager_id":"7122f130-69b2-43e7-9980-5e421f7c7727","secret_manager_version":"latest"}],"total_count":2}'
+        body: '{"secrets":[{"secret_id":"79c73820-585c-426d-b225-fa5ffedbc978", "secret_manager_id":"0331001e-111d-46ea-8277-d107b83b0800", "secret_manager_version":"1", "job_definition_id":"f41b902f-9be5-4239-9b92-e06b1489984c", "env_var":{"name":"ANOTHER_ENV"}}, {"secret_id":"0674d35c-41be-487c-b44b-5970553906b6", "secret_manager_id":"0331001e-111d-46ea-8277-d107b83b0800", "secret_manager_version":"latest", "job_definition_id":"f41b902f-9be5-4239-9b92-e06b1489984c", "file":{"path":"/home/dev/secret_file"}}], "total_count":2}'
         headers:
             Content-Length:
                 - "517"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:57:11 GMT
+                - Mon, 16 Feb 2026 17:24:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 043999c7-aee3-4945-8948-8a45ba1236df
+                - c30e13a7-155d-479f-8de7-6eadc4bbb718
         status: 200 OK
         code: 200
-        duration: 42.169864ms
+        duration: 32.650086ms
     - id: 37
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets/02f05ee1-cd80-4477-a355-5b50de3f16d0
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets/79c73820-585c-426d-b225-fa5ffedbc978
         method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 0
-        uncompressed: false
         body: ""
         headers:
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:57:11 GMT
+                - Mon, 16 Feb 2026 17:24:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 5e05617e-2112-4f4c-8650-7dc8e9464909
+                - 6303d588-8587-4b32-934a-aefe9a64cd1d
         status: 204 No Content
         code: 204
-        duration: 52.324736ms
+        duration: 32.044824ms
     - id: 38
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 2
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
         body: '{}'
-        form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/980824ad-ceb5-46a7-a7aa-2b440f297588
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/f41b902f-9be5-4239-9b92-e06b1489984c
         method: PATCH
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 493
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":120,"created_at":"2026-02-03T10:57:07.653199Z","cron_schedule":null,"description":"","environment_variables":{},"id":"980824ad-ceb5-46a7-a7aa-2b440f297588","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-job-definition-secret","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T10:57:11.387509Z"}'
+        body: '{"id":"f41b902f-9be5-4239-9b92-e06b1489984c", "name":"test-jobs-job-definition-secret", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.661133Z", "updated_at":"2026-02-16T17:24:04.251123Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":null, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
                 - "493"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:57:11 GMT
+                - Mon, 16 Feb 2026 17:24:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - fc2f0514-f557-42dd-9e71-ff50fa36ed02
+                - b580a0cb-2b79-4415-920a-e1acfa395a24
         status: 200 OK
         code: 200
-        duration: 43.586519ms
+        duration: 36.780794ms
     - id: 39
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/980824ad-ceb5-46a7-a7aa-2b440f297588
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/f41b902f-9be5-4239-9b92-e06b1489984c
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 493
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":120,"created_at":"2026-02-03T10:57:07.653199Z","cron_schedule":null,"description":"","environment_variables":{},"id":"980824ad-ceb5-46a7-a7aa-2b440f297588","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-job-definition-secret","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T10:57:11.387509Z"}'
+        body: '{"id":"f41b902f-9be5-4239-9b92-e06b1489984c", "name":"test-jobs-job-definition-secret", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.661133Z", "updated_at":"2026-02-16T17:24:04.251123Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":null, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
                 - "493"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:57:11 GMT
+                - Mon, 16 Feb 2026 17:24:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 0ed19643-827b-490a-ab8b-40834ec74edb
+                - 95785979-cd24-48a1-9830-ef78177ec55b
         status: 200 OK
         code: 200
-        duration: 45.944117ms
+        duration: 26.918753ms
     - id: 40
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        form:
+            job_definition_id:
+                - f41b902f-9be5-4239-9b92-e06b1489984c
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=980824ad-ceb5-46a7-a7aa-2b440f297588
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=f41b902f-9be5-4239-9b92-e06b1489984c
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 279
-        uncompressed: false
-        body: '{"secrets":[{"file":{"path":"/home/dev/secret_file"},"job_definition_id":"980824ad-ceb5-46a7-a7aa-2b440f297588","secret_id":"752ae75b-c805-4901-8b4f-dbb38113eb40","secret_manager_id":"7122f130-69b2-43e7-9980-5e421f7c7727","secret_manager_version":"latest"}],"total_count":1}'
+        body: '{"secrets":[{"secret_id":"0674d35c-41be-487c-b44b-5970553906b6", "secret_manager_id":"0331001e-111d-46ea-8277-d107b83b0800", "secret_manager_version":"latest", "job_definition_id":"f41b902f-9be5-4239-9b92-e06b1489984c", "file":{"path":"/home/dev/secret_file"}}], "total_count":1}'
         headers:
             Content-Length:
                 - "279"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:57:11 GMT
+                - Mon, 16 Feb 2026 17:24:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 21d96398-ebe6-44c8-b6ad-0212558ddeb4
+                - f11d27ba-9bc0-4431-8d91-da0724edee3b
         status: 200 OK
         code: 200
-        duration: 30.534175ms
+        duration: 27.024544ms
     - id: 41
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/980824ad-ceb5-46a7-a7aa-2b440f297588
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/f41b902f-9be5-4239-9b92-e06b1489984c
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 493
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":120,"created_at":"2026-02-03T10:57:07.653199Z","cron_schedule":null,"description":"","environment_variables":{},"id":"980824ad-ceb5-46a7-a7aa-2b440f297588","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-job-definition-secret","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T10:57:11.387509Z"}'
+        body: '{"id":"f41b902f-9be5-4239-9b92-e06b1489984c", "name":"test-jobs-job-definition-secret", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.661133Z", "updated_at":"2026-02-16T17:24:04.251123Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":null, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
                 - "493"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:57:11 GMT
+                - Mon, 16 Feb 2026 17:24:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - dca78f10-2cf8-43be-bb93-a161db745c7f
+                - c84ab68b-8612-4a84-86f9-f76a6128607c
         status: 200 OK
         code: 200
-        duration: 41.893802ms
+        duration: 28.769443ms
     - id: 42
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/7122f130-69b2-43e7-9980-5e421f7c7727
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/0331001e-111d-46ea-8277-d107b83b0800
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 444
-        uncompressed: false
-        body: '{"created_at":"2026-02-03T10:57:07.418120Z","deletion_requested_at":null,"description":"","ephemeral_policy":null,"id":"7122f130-69b2-43e7-9980-5e421f7c7727","key_id":null,"managed":false,"name":"job-secret","path":"/one","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","protected":false,"region":"fr-par","status":"ready","tags":[],"type":"opaque","updated_at":"2026-02-03T10:57:07.418120Z","used_by":[],"version_count":1}'
+        body: '{"id":"0331001e-111d-46ea-8277-d107b83b0800", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "name":"job-secret", "status":"ready", "created_at":"2026-02-16T17:24:00.477215Z", "updated_at":"2026-02-16T17:24:00.477215Z", "tags":[], "version_count":1, "description":"", "managed":false, "type":"opaque", "protected":false, "path":"/one", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}'
         headers:
             Content-Length:
                 - "444"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:57:11 GMT
+                - Mon, 16 Feb 2026 17:24:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 12e15bef-91b2-4ebf-a2e5-5d817d472486
+                - 7f53aad8-f42a-4967-bcce-d7682f69d968
         status: 200 OK
         code: 200
-        duration: 36.561345ms
+        duration: 21.580426ms
     - id: 43
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        form:
+            page:
+                - "1"
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/7122f130-69b2-43e7-9980-5e421f7c7727/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/0331001e-111d-46ea-8277-d107b83b0800/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 336
-        uncompressed: false
-        body: '{"total_count":1,"versions":[{"created_at":"2026-02-03T10:57:07.900625Z","deleted_at":null,"deletion_requested_at":null,"description":"","ephemeral_properties":null,"latest":true,"region":"fr-par","revision":1,"secret_id":"7122f130-69b2-43e7-9980-5e421f7c7727","status":"enabled","updated_at":"2026-02-03T10:57:07.900625Z"}]}'
+        body: '{"versions":[{"revision":1, "secret_id":"0331001e-111d-46ea-8277-d107b83b0800", "status":"enabled", "created_at":"2026-02-16T17:24:01.045379Z", "updated_at":"2026-02-16T17:24:01.045379Z", "deleted_at":null, "description":"", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}], "total_count":1}'
         headers:
             Content-Length:
                 - "336"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:57:11 GMT
+                - Mon, 16 Feb 2026 17:24:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - da0acb24-b77b-4980-aa6a-659d5cc4ed7d
+                - d762d873-b888-4201-88df-a08bfc325948
         status: 200 OK
         code: 200
-        duration: 34.814013ms
+        duration: 29.058854ms
     - id: 44
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/980824ad-ceb5-46a7-a7aa-2b440f297588
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/f41b902f-9be5-4239-9b92-e06b1489984c
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 493
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":120,"created_at":"2026-02-03T10:57:07.653199Z","cron_schedule":null,"description":"","environment_variables":{},"id":"980824ad-ceb5-46a7-a7aa-2b440f297588","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-job-definition-secret","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T10:57:11.387509Z"}'
+        body: '{"id":"f41b902f-9be5-4239-9b92-e06b1489984c", "name":"test-jobs-job-definition-secret", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.661133Z", "updated_at":"2026-02-16T17:24:04.251123Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":null, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
                 - "493"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:57:11 GMT
+                - Mon, 16 Feb 2026 17:24:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 0fa6b5cf-6160-4aef-a370-c17bded9dbcc
+                - e240e5b1-7fde-4ca0-98e9-15e8c44be439
         status: 200 OK
         code: 200
-        duration: 31.472094ms
+        duration: 27.299396ms
     - id: 45
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/7122f130-69b2-43e7-9980-5e421f7c7727/versions/1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/0331001e-111d-46ea-8277-d107b83b0800/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 304
-        uncompressed: false
-        body: '{"created_at":"2026-02-03T10:57:07.900625Z","deleted_at":null,"deletion_requested_at":null,"description":"","ephemeral_properties":null,"latest":true,"region":"fr-par","revision":1,"secret_id":"7122f130-69b2-43e7-9980-5e421f7c7727","status":"enabled","updated_at":"2026-02-03T10:57:07.900625Z"}'
+        body: '{"revision":1, "secret_id":"0331001e-111d-46ea-8277-d107b83b0800", "status":"enabled", "created_at":"2026-02-16T17:24:01.045379Z", "updated_at":"2026-02-16T17:24:01.045379Z", "deleted_at":null, "description":"", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
         headers:
             Content-Length:
                 - "304"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:57:11 GMT
+                - Mon, 16 Feb 2026 17:24:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 9a96ba89-5338-42a8-8597-96ff6bdd7aa8
+                - 1af71896-8851-40f5-8d84-acf172293a7b
         status: 200 OK
         code: 200
-        duration: 52.115109ms
+        duration: 51.371262ms
     - id: 46
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        form:
+            job_definition_id:
+                - f41b902f-9be5-4239-9b92-e06b1489984c
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=980824ad-ceb5-46a7-a7aa-2b440f297588
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=f41b902f-9be5-4239-9b92-e06b1489984c
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 279
-        uncompressed: false
-        body: '{"secrets":[{"file":{"path":"/home/dev/secret_file"},"job_definition_id":"980824ad-ceb5-46a7-a7aa-2b440f297588","secret_id":"752ae75b-c805-4901-8b4f-dbb38113eb40","secret_manager_id":"7122f130-69b2-43e7-9980-5e421f7c7727","secret_manager_version":"latest"}],"total_count":1}'
+        body: '{"secrets":[{"secret_id":"0674d35c-41be-487c-b44b-5970553906b6", "secret_manager_id":"0331001e-111d-46ea-8277-d107b83b0800", "secret_manager_version":"latest", "job_definition_id":"f41b902f-9be5-4239-9b92-e06b1489984c", "file":{"path":"/home/dev/secret_file"}}], "total_count":1}'
         headers:
             Content-Length:
                 - "279"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:57:11 GMT
+                - Mon, 16 Feb 2026 17:24:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - b8708479-1fe7-4eff-92c5-abb8514282cb
+                - c7e60701-ff11-4b39-8a7b-6f23e862bca6
         status: 200 OK
         code: 200
-        duration: 36.780188ms
+        duration: 29.662723ms
     - id: 47
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/980824ad-ceb5-46a7-a7aa-2b440f297588
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/f41b902f-9be5-4239-9b92-e06b1489984c
         method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 0
-        uncompressed: false
         body: ""
         headers:
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:57:12 GMT
+                - Mon, 16 Feb 2026 17:24:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 7fdfd030-0f1c-45ba-9b5e-3f48aee466e1
+                - 2e989f1a-44ae-4f48-b655-52cfba35cf84
         status: 204 No Content
         code: 204
-        duration: 89.368575ms
+        duration: 45.410583ms
     - id: 48
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/7122f130-69b2-43e7-9980-5e421f7c7727/versions/1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/0331001e-111d-46ea-8277-d107b83b0800/versions/1
         method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 0
-        uncompressed: false
         body: ""
         headers:
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:57:12 GMT
+                - Mon, 16 Feb 2026 17:24:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 338255dc-e5ec-41b0-9e35-ef54393d7453
+                - 96c5e1fa-be96-4733-8899-84636f157a3a
         status: 204 No Content
         code: 204
-        duration: 92.976113ms
+        duration: 60.717743ms
     - id: 49
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/7122f130-69b2-43e7-9980-5e421f7c7727
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/0331001e-111d-46ea-8277-d107b83b0800
         method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 0
-        uncompressed: false
         body: ""
         headers:
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:57:12 GMT
+                - Mon, 16 Feb 2026 17:24:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - afbe4c20-3830-47fb-ad8c-9dad8cf00696
+                - f551ad04-6aa8-414a-a958-4ba355653d5e
         status: 204 No Content
         code: 204
-        duration: 77.440857ms
+        duration: 54.606295ms
     - id: 50
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/980824ad-ceb5-46a7-a7aa-2b440f297588
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/f41b902f-9be5-4239-9b92-e06b1489984c
         method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 41
-        uncompressed: false
         body: '{"message":"job definition is not found"}'
         headers:
             Content-Length:
                 - "41"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:57:12 GMT
+                - Mon, 16 Feb 2026 17:24:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 19ba40aa-b242-47e0-9a47-e9c3fff1d196
+                - 3da7e175-311e-42f8-9c69-8b20fe43f123
         status: 404 Not Found
         code: 404
-        duration: 24.869743ms
+        duration: 21.791807ms

--- a/internal/services/jobs/testdata/job-definition-timeout.cassette.yaml
+++ b/internal/services/jobs/testdata/job-definition-timeout.cassette.yaml
@@ -7,13 +7,8 @@ interactions:
         proto_major: 1
         proto_minor: 1
         content_length: 318
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
         body: '{"name":"test-jobs-job-definition-timeout","cpu_limit":120,"memory_limit":256,"local_storage_capacity":5120,"image_uri":"docker.io/alpine:latest","command":"","startup_command":[],"args":[],"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","environment_variables":{},"description":"","job_timeout":"1200.000000000s"}'
-        form: {}
         headers:
             Content-Type:
                 - application/json
@@ -25,765 +20,515 @@ interactions:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 477
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":120,"created_at":"2026-02-03T10:39:57.995293Z","cron_schedule":null,"description":"","environment_variables":{},"id":"c1ef776e-308b-4e31-a548-f3df605b13c2","image_uri":"docker.io/alpine:latest","job_timeout":"1200s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-job-definition-timeout","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T10:39:57.995293Z"}'
+        content_length: 493
+        body: '{"id":"21c6f016-a386-4e61-bc7d-d839428b0eaa", "name":"test-jobs-job-definition-timeout", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.470377Z", "updated_at":"2026-02-16T17:24:00.470377Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"1200s", "description":"", "cron_schedule":null, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
-                - "477"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "493"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:39:58 GMT
+                - Mon, 16 Feb 2026 17:24:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 05b3eb6f-3413-434b-85bb-53f83ecd6b38
+                - 66152b48-f49b-4c89-95f1-f24b815750da
         status: 200 OK
         code: 200
-        duration: 274.632227ms
+        duration: 173.150542ms
     - id: 1
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/c1ef776e-308b-4e31-a548-f3df605b13c2
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/21c6f016-a386-4e61-bc7d-d839428b0eaa
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 493
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":120,"created_at":"2026-02-03T10:39:57.995293Z","cron_schedule":null,"description":"","environment_variables":{},"id":"c1ef776e-308b-4e31-a548-f3df605b13c2","image_uri":"docker.io/alpine:latest","job_timeout":"1200s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-job-definition-timeout","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T10:39:57.995293Z"}'
+        body: '{"id":"21c6f016-a386-4e61-bc7d-d839428b0eaa", "name":"test-jobs-job-definition-timeout", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.470377Z", "updated_at":"2026-02-16T17:24:00.470377Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"1200s", "description":"", "cron_schedule":null, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
                 - "493"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:39:58 GMT
+                - Mon, 16 Feb 2026 17:24:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 9f01c188-8a59-4b7b-8ba8-82266e44dc45
+                - 95fdc72c-3e7c-457f-bffd-9fe6944414a1
         status: 200 OK
         code: 200
-        duration: 56.873072ms
+        duration: 43.101426ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        form:
+            job_definition_id:
+                - 21c6f016-a386-4e61-bc7d-d839428b0eaa
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=c1ef776e-308b-4e31-a548-f3df605b13c2
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=21c6f016-a386-4e61-bc7d-d839428b0eaa
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 30
-        uncompressed: false
-        body: '{"secrets":[],"total_count":0}'
+        content_length: 31
+        body: '{"secrets":[], "total_count":0}'
         headers:
             Content-Length:
-                - "30"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "31"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:39:58 GMT
+                - Mon, 16 Feb 2026 17:24:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - e9225018-3244-47b3-855d-62edddd781a0
+                - 774f4e26-a640-4ea0-b69d-0a11537dd091
         status: 200 OK
         code: 200
-        duration: 210.410867ms
+        duration: 49.645056ms
     - id: 3
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/c1ef776e-308b-4e31-a548-f3df605b13c2
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/21c6f016-a386-4e61-bc7d-d839428b0eaa
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 477
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":120,"created_at":"2026-02-03T10:39:57.995293Z","cron_schedule":null,"description":"","environment_variables":{},"id":"c1ef776e-308b-4e31-a548-f3df605b13c2","image_uri":"docker.io/alpine:latest","job_timeout":"1200s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-job-definition-timeout","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T10:39:57.995293Z"}'
+        content_length: 493
+        body: '{"id":"21c6f016-a386-4e61-bc7d-d839428b0eaa", "name":"test-jobs-job-definition-timeout", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.470377Z", "updated_at":"2026-02-16T17:24:00.470377Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"1200s", "description":"", "cron_schedule":null, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
-                - "477"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "493"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:39:58 GMT
+                - Mon, 16 Feb 2026 17:24:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 5dbf1a5e-4e8d-46e9-b6f7-51c305d00fbe
+                - 9b90c9be-323d-4b58-bdb9-cd6c23b98aef
         status: 200 OK
         code: 200
-        duration: 192.398994ms
+        duration: 50.999093ms
     - id: 4
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/c1ef776e-308b-4e31-a548-f3df605b13c2
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/21c6f016-a386-4e61-bc7d-d839428b0eaa
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 493
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":120,"created_at":"2026-02-03T10:39:57.995293Z","cron_schedule":null,"description":"","environment_variables":{},"id":"c1ef776e-308b-4e31-a548-f3df605b13c2","image_uri":"docker.io/alpine:latest","job_timeout":"1200s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-job-definition-timeout","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T10:39:57.995293Z"}'
+        body: '{"id":"21c6f016-a386-4e61-bc7d-d839428b0eaa", "name":"test-jobs-job-definition-timeout", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.470377Z", "updated_at":"2026-02-16T17:24:00.470377Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"1200s", "description":"", "cron_schedule":null, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
                 - "493"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:39:58 GMT
+                - Mon, 16 Feb 2026 17:24:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 84bcda50-d786-4b24-8127-6b38e35297d5
+                - 361f2a3b-5c47-40f2-841c-1d4186faab79
         status: 200 OK
         code: 200
-        duration: 117.882242ms
+        duration: 49.293034ms
     - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        form:
+            job_definition_id:
+                - 21c6f016-a386-4e61-bc7d-d839428b0eaa
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=c1ef776e-308b-4e31-a548-f3df605b13c2
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=21c6f016-a386-4e61-bc7d-d839428b0eaa
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 31
-        uncompressed: false
-        body: '{"secrets":[],"total_count":0}'
+        body: '{"secrets":[], "total_count":0}'
         headers:
             Content-Length:
                 - "31"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:39:59 GMT
+                - Mon, 16 Feb 2026 17:24:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 2c1b4575-bead-4f3e-b912-bd0a0084bd2c
+                - d28e0dcb-1fea-4723-8a27-c93d0b71ba0e
         status: 200 OK
         code: 200
-        duration: 32.036106ms
+        duration: 26.529705ms
     - id: 6
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/c1ef776e-308b-4e31-a548-f3df605b13c2
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/21c6f016-a386-4e61-bc7d-d839428b0eaa
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 493
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":120,"created_at":"2026-02-03T10:39:57.995293Z","cron_schedule":null,"description":"","environment_variables":{},"id":"c1ef776e-308b-4e31-a548-f3df605b13c2","image_uri":"docker.io/alpine:latest","job_timeout":"1200s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-job-definition-timeout","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T10:39:57.995293Z"}'
+        body: '{"id":"21c6f016-a386-4e61-bc7d-d839428b0eaa", "name":"test-jobs-job-definition-timeout", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.470377Z", "updated_at":"2026-02-16T17:24:00.470377Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"1200s", "description":"", "cron_schedule":null, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
                 - "493"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:39:59 GMT
+                - Mon, 16 Feb 2026 17:24:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 8aebfebc-7438-4c93-a562-a8ded84710af
+                - 3ce56a06-3927-4bad-b3c2-fb2147063ab4
         status: 200 OK
         code: 200
-        duration: 117.429301ms
+        duration: 36.414301ms
     - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        form:
+            job_definition_id:
+                - 21c6f016-a386-4e61-bc7d-d839428b0eaa
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=c1ef776e-308b-4e31-a548-f3df605b13c2
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=21c6f016-a386-4e61-bc7d-d839428b0eaa
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 30
-        uncompressed: false
-        body: '{"secrets":[],"total_count":0}'
+        content_length: 31
+        body: '{"secrets":[], "total_count":0}'
         headers:
             Content-Length:
-                - "30"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "31"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:39:59 GMT
+                - Mon, 16 Feb 2026 17:24:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 06b24518-1b6f-4e59-b2ae-8d8461cf3cb7
+                - 2606b2e8-ea7e-4f6a-b44b-41f9e46aedbb
         status: 200 OK
         code: 200
-        duration: 29.301272ms
+        duration: 30.860606ms
     - id: 8
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 33
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
         body: '{"job_timeout":"5400.000000000s"}'
-        form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/c1ef776e-308b-4e31-a548-f3df605b13c2
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/21c6f016-a386-4e61-bc7d-d839428b0eaa
         method: PATCH
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 493
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":120,"created_at":"2026-02-03T10:39:57.995293Z","cron_schedule":null,"description":"","environment_variables":{},"id":"c1ef776e-308b-4e31-a548-f3df605b13c2","image_uri":"docker.io/alpine:latest","job_timeout":"5400s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-job-definition-timeout","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T10:39:59.501213Z"}'
+        body: '{"id":"21c6f016-a386-4e61-bc7d-d839428b0eaa", "name":"test-jobs-job-definition-timeout", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.470377Z", "updated_at":"2026-02-16T17:24:01.756736Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"5400s", "description":"", "cron_schedule":null, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
                 - "493"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:39:59 GMT
+                - Mon, 16 Feb 2026 17:24:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 228675c4-2c98-4087-9844-dcb2d241105e
+                - abf13478-d124-4def-88b5-29ef5eb60c39
         status: 200 OK
         code: 200
-        duration: 112.970315ms
+        duration: 36.121625ms
     - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/c1ef776e-308b-4e31-a548-f3df605b13c2
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/21c6f016-a386-4e61-bc7d-d839428b0eaa
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 477
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":120,"created_at":"2026-02-03T10:39:57.995293Z","cron_schedule":null,"description":"","environment_variables":{},"id":"c1ef776e-308b-4e31-a548-f3df605b13c2","image_uri":"docker.io/alpine:latest","job_timeout":"5400s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-job-definition-timeout","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T10:39:59.501213Z"}'
+        content_length: 493
+        body: '{"id":"21c6f016-a386-4e61-bc7d-d839428b0eaa", "name":"test-jobs-job-definition-timeout", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.470377Z", "updated_at":"2026-02-16T17:24:01.756736Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"5400s", "description":"", "cron_schedule":null, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
-                - "477"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "493"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:39:59 GMT
+                - Mon, 16 Feb 2026 17:24:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 2230e390-0502-4efa-b57c-18c5b2802e74
+                - 54c19b19-87db-410b-8707-b4371b721f3c
         status: 200 OK
         code: 200
-        duration: 36.850128ms
+        duration: 31.616563ms
     - id: 10
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        form:
+            job_definition_id:
+                - 21c6f016-a386-4e61-bc7d-d839428b0eaa
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=c1ef776e-308b-4e31-a548-f3df605b13c2
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=21c6f016-a386-4e61-bc7d-d839428b0eaa
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 30
-        uncompressed: false
-        body: '{"secrets":[],"total_count":0}'
+        content_length: 31
+        body: '{"secrets":[], "total_count":0}'
         headers:
             Content-Length:
-                - "30"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "31"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:39:59 GMT
+                - Mon, 16 Feb 2026 17:24:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 5c78c85a-e548-4a0e-8d5c-8475a0053943
+                - 2a806632-4726-47a9-b3e9-9a2378e276c0
         status: 200 OK
         code: 200
-        duration: 181.669367ms
+        duration: 28.398331ms
     - id: 11
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/c1ef776e-308b-4e31-a548-f3df605b13c2
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/21c6f016-a386-4e61-bc7d-d839428b0eaa
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 477
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":120,"created_at":"2026-02-03T10:39:57.995293Z","cron_schedule":null,"description":"","environment_variables":{},"id":"c1ef776e-308b-4e31-a548-f3df605b13c2","image_uri":"docker.io/alpine:latest","job_timeout":"5400s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-job-definition-timeout","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T10:39:59.501213Z"}'
+        content_length: 493
+        body: '{"id":"21c6f016-a386-4e61-bc7d-d839428b0eaa", "name":"test-jobs-job-definition-timeout", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.470377Z", "updated_at":"2026-02-16T17:24:01.756736Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"5400s", "description":"", "cron_schedule":null, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
-                - "477"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "493"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:39:59 GMT
+                - Mon, 16 Feb 2026 17:24:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - f3a60e55-e2c9-499d-ac93-360ff640de9b
+                - ee829c3a-f97e-426e-b82e-3a13ee6e455c
         status: 200 OK
         code: 200
-        duration: 199.664077ms
+        duration: 27.195001ms
     - id: 12
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/c1ef776e-308b-4e31-a548-f3df605b13c2
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/21c6f016-a386-4e61-bc7d-d839428b0eaa
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 493
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":120,"created_at":"2026-02-03T10:39:57.995293Z","cron_schedule":null,"description":"","environment_variables":{},"id":"c1ef776e-308b-4e31-a548-f3df605b13c2","image_uri":"docker.io/alpine:latest","job_timeout":"5400s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-job-definition-timeout","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T10:39:59.501213Z"}'
+        body: '{"id":"21c6f016-a386-4e61-bc7d-d839428b0eaa", "name":"test-jobs-job-definition-timeout", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.470377Z", "updated_at":"2026-02-16T17:24:01.756736Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"5400s", "description":"", "cron_schedule":null, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
                 - "493"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:40:00 GMT
+                - Mon, 16 Feb 2026 17:24:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 60175598-0510-44ca-a6c9-22f05d66bf7e
+                - d5d90135-d617-44dc-8768-03786f7d38bd
         status: 200 OK
         code: 200
-        duration: 139.026404ms
+        duration: 51.069573ms
     - id: 13
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        form:
+            job_definition_id:
+                - 21c6f016-a386-4e61-bc7d-d839428b0eaa
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=c1ef776e-308b-4e31-a548-f3df605b13c2
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/secrets?job_definition_id=21c6f016-a386-4e61-bc7d-d839428b0eaa
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 30
-        uncompressed: false
-        body: '{"secrets":[],"total_count":0}'
+        content_length: 31
+        body: '{"secrets":[], "total_count":0}'
         headers:
             Content-Length:
-                - "30"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "31"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:40:00 GMT
+                - Mon, 16 Feb 2026 17:24:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - b1956846-a477-4ae7-939b-ed79805ec1e1
+                - d8b7260c-bb8e-4bab-9c7a-6c1f6d257c3e
         status: 200 OK
         code: 200
-        duration: 35.988218ms
+        duration: 29.00308ms
     - id: 14
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/c1ef776e-308b-4e31-a548-f3df605b13c2
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/21c6f016-a386-4e61-bc7d-d839428b0eaa
         method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 0
-        uncompressed: false
         body: ""
         headers:
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:40:00 GMT
+                - Mon, 16 Feb 2026 17:24:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 35073790-f472-453f-8dc7-df8c3251eaad
+                - 11086f5e-3423-4098-bfb0-290e1dd4f575
         status: 204 No Content
         code: 204
-        duration: 54.201849ms
+        duration: 101.995622ms
     - id: 15
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/c1ef776e-308b-4e31-a548-f3df605b13c2
+        url: https://api.scaleway.com/serverless-jobs/v1alpha2/regions/fr-par/job-definitions/21c6f016-a386-4e61-bc7d-d839428b0eaa
         method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 41
-        uncompressed: false
         body: '{"message":"job definition is not found"}'
         headers:
             Content-Length:
                 - "41"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:40:00 GMT
+                - Mon, 16 Feb 2026 17:24:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 5a046801-2b07-4f09-8bf6-d745bab1b306
+                - cb953341-112c-4381-80e9-4ca7c3c75693
         status: 404 Not Found
         code: 404
-        duration: 17.619795ms
+        duration: 22.064208ms

--- a/internal/services/jobs/testdata/job-definition-wrong-secret-reference.cassette.yaml
+++ b/internal/services/jobs/testdata/job-definition-wrong-secret-reference.cassette.yaml
@@ -7,13 +7,8 @@ interactions:
         proto_major: 1
         proto_minor: 1
         content_length: 136
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
         body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"wrong-job-secret","tags":null,"type":"opaque","path":"/","protected":false}'
-        form: {}
         headers:
             Content-Type:
                 - application/json
@@ -25,144 +20,97 @@ interactions:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 430
-        uncompressed: false
-        body: '{"created_at":"2026-02-03T10:39:58.038084Z","deletion_requested_at":null,"description":"","ephemeral_policy":null,"id":"f61f6fb5-7b61-4fb1-ab1a-c6a4eb17b84e","key_id":null,"managed":false,"name":"wrong-job-secret","path":"/","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","protected":false,"region":"fr-par","status":"ready","tags":[],"type":"opaque","updated_at":"2026-02-03T10:39:58.038084Z","used_by":[],"version_count":0}'
+        content_length: 447
+        body: '{"id":"6ec7eacf-38d6-4ea9-a203-2e9365ddf511", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "name":"wrong-job-secret", "status":"ready", "created_at":"2026-02-16T17:24:00.458208Z", "updated_at":"2026-02-16T17:24:00.458208Z", "tags":[], "version_count":0, "description":"", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}'
         headers:
             Content-Length:
-                - "430"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "447"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:39:58 GMT
+                - Mon, 16 Feb 2026 17:24:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 00a31cd8-34fb-4151-854b-0f37a7b80ad0
+                - e5ab7ce1-2165-4dfa-8170-dfd78ec41a14
         status: 200 OK
         code: 200
-        duration: 262.17419ms
+        duration: 76.88283ms
     - id: 1
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f61f6fb5-7b61-4fb1-ab1a-c6a4eb17b84e
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6ec7eacf-38d6-4ea9-a203-2e9365ddf511
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 447
-        uncompressed: false
-        body: '{"created_at":"2026-02-03T10:39:58.038084Z","deletion_requested_at":null,"description":"","ephemeral_policy":null,"id":"f61f6fb5-7b61-4fb1-ab1a-c6a4eb17b84e","key_id":null,"managed":false,"name":"wrong-job-secret","path":"/","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","protected":false,"region":"fr-par","status":"ready","tags":[],"type":"opaque","updated_at":"2026-02-03T10:39:58.038084Z","used_by":[],"version_count":0}'
+        body: '{"id":"6ec7eacf-38d6-4ea9-a203-2e9365ddf511", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "name":"wrong-job-secret", "status":"ready", "created_at":"2026-02-16T17:24:00.458208Z", "updated_at":"2026-02-16T17:24:00.458208Z", "tags":[], "version_count":0, "description":"", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}'
         headers:
             Content-Length:
                 - "447"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:39:58 GMT
+                - Mon, 16 Feb 2026 17:24:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 41be16da-5025-44af-8d00-afefb6053d90
+                - 2ac0135e-c8fe-4190-807a-18609189e072
         status: 200 OK
         code: 200
-        duration: 47.599543ms
+        duration: 54.750189ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        form:
+            page:
+                - "1"
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f61f6fb5-7b61-4fb1-ab1a-c6a4eb17b84e/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6ec7eacf-38d6-4ea9-a203-2e9365ddf511/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 32
-        uncompressed: false
-        body: '{"total_count":0,"versions":[]}'
+        body: '{"versions":[], "total_count":0}'
         headers:
             Content-Length:
                 - "32"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:39:58 GMT
+                - Mon, 16 Feb 2026 17:24:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 2f5d3398-29df-4bd0-8092-e45146024e7e
+                - 3381d0be-23b0-4b05-a60f-29cd4f9dc661
         status: 200 OK
         code: 200
-        duration: 219.579278ms
+        duration: 61.417745ms
     - id: 3
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 285
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
         body: '{"name":"test-jobs-job-definition-secret","cpu_limit":120,"memory_limit":256,"local_storage_capacity":5120,"image_uri":"docker.io/alpine:latest","command":"","startup_command":[],"args":[],"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","environment_variables":{},"description":""}'
-        form: {}
         headers:
             Content-Type:
                 - application/json
@@ -174,293 +122,196 @@ interactions:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 493
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":120,"created_at":"2026-02-03T10:39:58.480634Z","cron_schedule":null,"description":"","environment_variables":{},"id":"36677d13-d4c1-49e9-8107-2178056934e8","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-job-definition-secret","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T10:39:58.480634Z"}'
+        body: '{"id":"2a4c8249-aa6d-482a-992a-7938927a8fe7", "name":"test-jobs-job-definition-secret", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:00.658755Z", "updated_at":"2026-02-16T17:24:00.658755Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":null, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
                 - "493"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:39:58 GMT
+                - Mon, 16 Feb 2026 17:24:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - ce266e44-e038-4e91-8fac-ac721ba8ab06
+                - 83f2a4a5-e99c-4fbd-bc3b-5930b2c64ccb
         status: 200 OK
         code: 200
-        duration: 91.459453ms
+        duration: 71.305909ms
     - id: 4
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 27
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
         body: '{"data":"eW91cl9zZWNyZXQ="}'
-        form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f61f6fb5-7b61-4fb1-ab1a-c6a4eb17b84e/versions
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6ec7eacf-38d6-4ea9-a203-2e9365ddf511/versions
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 304
-        uncompressed: false
-        body: '{"created_at":"2026-02-03T10:39:58.854175Z","deleted_at":null,"deletion_requested_at":null,"description":"","ephemeral_properties":null,"latest":true,"region":"fr-par","revision":1,"secret_id":"f61f6fb5-7b61-4fb1-ab1a-c6a4eb17b84e","status":"enabled","updated_at":"2026-02-03T10:39:58.854175Z"}'
+        body: '{"revision":1, "secret_id":"6ec7eacf-38d6-4ea9-a203-2e9365ddf511", "status":"enabled", "created_at":"2026-02-16T17:24:00.931127Z", "updated_at":"2026-02-16T17:24:00.931127Z", "deleted_at":null, "description":"", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
         headers:
             Content-Length:
                 - "304"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:39:58 GMT
+                - Mon, 16 Feb 2026 17:24:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 1b0f9cbe-7836-40bc-9a28-f95b68d33c63
+                - 211e439d-ee63-4ccb-bbc5-8dfe18cd25af
         status: 200 OK
         code: 200
-        duration: 537.489802ms
+        duration: 357.766499ms
     - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f61f6fb5-7b61-4fb1-ab1a-c6a4eb17b84e/versions/1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6ec7eacf-38d6-4ea9-a203-2e9365ddf511/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 304
-        uncompressed: false
-        body: '{"created_at":"2026-02-03T10:39:58.854175Z","deleted_at":null,"deletion_requested_at":null,"description":"","ephemeral_properties":null,"latest":true,"region":"fr-par","revision":1,"secret_id":"f61f6fb5-7b61-4fb1-ab1a-c6a4eb17b84e","status":"enabled","updated_at":"2026-02-03T10:39:58.854175Z"}'
+        body: '{"revision":1, "secret_id":"6ec7eacf-38d6-4ea9-a203-2e9365ddf511", "status":"enabled", "created_at":"2026-02-16T17:24:00.931127Z", "updated_at":"2026-02-16T17:24:00.931127Z", "deleted_at":null, "description":"", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
         headers:
             Content-Length:
                 - "304"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:39:58 GMT
+                - Mon, 16 Feb 2026 17:24:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 077c7096-c5e9-4eda-a617-69850b3d0410
+                - 964eb48e-0a0f-4a91-b1ee-31d42245d27c
         status: 200 OK
         code: 200
-        duration: 25.852868ms
+        duration: 44.835034ms
     - id: 6
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f61f6fb5-7b61-4fb1-ab1a-c6a4eb17b84e
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6ec7eacf-38d6-4ea9-a203-2e9365ddf511
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 430
-        uncompressed: false
-        body: '{"created_at":"2026-02-03T10:39:58.038084Z","deletion_requested_at":null,"description":"","ephemeral_policy":null,"id":"f61f6fb5-7b61-4fb1-ab1a-c6a4eb17b84e","key_id":null,"managed":false,"name":"wrong-job-secret","path":"/","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","protected":false,"region":"fr-par","status":"ready","tags":[],"type":"opaque","updated_at":"2026-02-03T10:39:58.038084Z","used_by":[],"version_count":1}'
+        content_length: 447
+        body: '{"id":"6ec7eacf-38d6-4ea9-a203-2e9365ddf511", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "name":"wrong-job-secret", "status":"ready", "created_at":"2026-02-16T17:24:00.458208Z", "updated_at":"2026-02-16T17:24:00.458208Z", "tags":[], "version_count":1, "description":"", "managed":false, "type":"opaque", "protected":false, "path":"/", "ephemeral_policy":null, "used_by":[], "deletion_requested_at":null, "key_id":null, "region":"fr-par"}'
         headers:
             Content-Length:
-                - "430"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "447"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:39:59 GMT
+                - Mon, 16 Feb 2026 17:24:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 7038317d-62c6-45bf-a62b-3c28839f59ae
+                - 0fc56371-8709-486e-bfce-b3243dabb665
         status: 200 OK
         code: 200
-        duration: 180.98482ms
+        duration: 21.885339ms
     - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        form:
+            page:
+                - "1"
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f61f6fb5-7b61-4fb1-ab1a-c6a4eb17b84e/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6ec7eacf-38d6-4ea9-a203-2e9365ddf511/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 325
-        uncompressed: false
-        body: '{"total_count":1,"versions":[{"created_at":"2026-02-03T10:39:58.854175Z","deleted_at":null,"deletion_requested_at":null,"description":"","ephemeral_properties":null,"latest":true,"region":"fr-par","revision":1,"secret_id":"f61f6fb5-7b61-4fb1-ab1a-c6a4eb17b84e","status":"enabled","updated_at":"2026-02-03T10:39:58.854175Z"}]}'
+        content_length: 336
+        body: '{"versions":[{"revision":1, "secret_id":"6ec7eacf-38d6-4ea9-a203-2e9365ddf511", "status":"enabled", "created_at":"2026-02-16T17:24:00.931127Z", "updated_at":"2026-02-16T17:24:00.931127Z", "deleted_at":null, "description":"", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}], "total_count":1}'
         headers:
             Content-Length:
-                - "325"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "336"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:39:59 GMT
+                - Mon, 16 Feb 2026 17:24:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - d6880791-8d35-443f-95f3-8f637660fe37
+                - bb94c432-f54a-43d4-a3ac-bc02ddab3db0
         status: 200 OK
         code: 200
-        duration: 43.739293ms
+        duration: 29.978527ms
     - id: 8
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f61f6fb5-7b61-4fb1-ab1a-c6a4eb17b84e/versions/1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6ec7eacf-38d6-4ea9-a203-2e9365ddf511/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 294
-        uncompressed: false
-        body: '{"created_at":"2026-02-03T10:39:58.854175Z","deleted_at":null,"deletion_requested_at":null,"description":"","ephemeral_properties":null,"latest":true,"region":"fr-par","revision":1,"secret_id":"f61f6fb5-7b61-4fb1-ab1a-c6a4eb17b84e","status":"enabled","updated_at":"2026-02-03T10:39:58.854175Z"}'
+        content_length: 304
+        body: '{"revision":1, "secret_id":"6ec7eacf-38d6-4ea9-a203-2e9365ddf511", "status":"enabled", "created_at":"2026-02-16T17:24:00.931127Z", "updated_at":"2026-02-16T17:24:00.931127Z", "deleted_at":null, "description":"", "latest":true, "ephemeral_properties":null, "deletion_requested_at":null, "region":"fr-par"}'
         headers:
             Content-Length:
-                - "294"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
+                - "304"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:39:59 GMT
+                - Mon, 16 Feb 2026 17:24:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - ea9adb46-0122-40e7-bc04-d6446ef3b630
+                - e8ca8e6b-85f8-4618-bd8a-26917fb857c1
         status: 200 OK
         code: 200
-        duration: 25.346886ms
+        duration: 44.193642ms
     - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 285
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
         body: '{"name":"test-jobs-job-definition-secret","cpu_limit":120,"memory_limit":256,"local_storage_capacity":5120,"image_uri":"docker.io/alpine:latest","command":"","startup_command":[],"args":[],"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","environment_variables":{},"description":""}'
-        form: {}
         headers:
             Content-Type:
                 - application/json
@@ -472,124 +323,79 @@ interactions:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 493
-        uncompressed: false
-        body: '{"args":[],"command":"","cpu_limit":120,"created_at":"2026-02-03T10:39:59.546781Z","cron_schedule":null,"description":"","environment_variables":{},"id":"59cc0073-0de8-48d1-a18e-8bdb6e4ba1f7","image_uri":"docker.io/alpine:latest","job_timeout":"86400s","local_storage_capacity":5120,"memory_limit":256,"name":"test-jobs-job-definition-secret","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","startup_command":[],"updated_at":"2026-02-03T10:39:59.546781Z"}'
+        body: '{"id":"071bde44-cca6-4fb7-9968-4defa7f72859", "name":"test-jobs-job-definition-secret", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-02-16T17:24:01.509994Z", "updated_at":"2026-02-16T17:24:01.509994Z", "cpu_limit":120, "memory_limit":256, "local_storage_capacity":5120, "image_uri":"docker.io/alpine:latest", "command":"", "environment_variables":{}, "job_timeout":"86400s", "description":"", "cron_schedule":null, "startup_command":[], "args":[], "region":"fr-par"}'
         headers:
             Content-Length:
                 - "493"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:39:59 GMT
+                - Mon, 16 Feb 2026 17:24:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 35b244d2-8374-4dce-b933-1b5b2b98cd69
+                - b5d9164d-219a-4fb0-88b4-af71ac9914ac
         status: 200 OK
         code: 200
-        duration: 138.527065ms
+        duration: 61.129385ms
     - id: 10
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f61f6fb5-7b61-4fb1-ab1a-c6a4eb17b84e/versions/1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6ec7eacf-38d6-4ea9-a203-2e9365ddf511/versions/1
         method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 0
-        uncompressed: false
         body: ""
         headers:
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:39:59 GMT
+                - Mon, 16 Feb 2026 17:24:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 353ecd2a-3d98-44db-8102-5db02e504fb6
+                - c55c4122-15f9-4193-895b-f225b144ce32
         status: 204 No Content
         code: 204
-        duration: 144.542769ms
+        duration: 68.69594ms
     - id: 11
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: api.scaleway.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.5; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/f61f6fb5-7b61-4fb1-ab1a-c6a4eb17b84e
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6ec7eacf-38d6-4ea9-a203-2e9365ddf511
         method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 0
-        uncompressed: false
         body: ""
         headers:
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Tue, 03 Feb 2026 10:39:59 GMT
+                - Mon, 16 Feb 2026 17:24:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
+                - Scaleway API Gateway (fr-par-1;edge03)
             X-Request-Id:
-                - 750427e7-ca88-4619-a045-cced48b8c9b5
+                - 7372baa4-698a-4b9d-82a4-e31c056662f9
         status: 204 No Content
         code: 204
-        duration: 183.878582ms
+        duration: 75.487443ms


### PR DESCRIPTION
Same as https://github.com/scaleway/terraform-provider-scaleway/pull/3426 for serverless_jobs package