### PR TITLE
fix(vpcgw): remove outdated locality check

### DIFF
--- a/internal/services/vpcgw/network.go
+++ b/internal/services/vpcgw/network.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/scaleway/scaleway-sdk-go/api/vpcgw/v2"
 	"github.com/scaleway/scaleway-sdk-go/scw"
-	"github.com/scaleway/terraform-provider-scaleway/v2/internal/cdf"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/dsf"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/httperrors"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/identity"
@@ -39,7 +38,6 @@ func ResourceNetwork() *schema.Resource {
 		},
 		SchemaVersion: 0,
 		SchemaFunc:    networkSchema,
-		CustomizeDiff: cdf.LocalityCheck("gateway_id", "private_network_id"),
 	}
 }
 


### PR DESCRIPTION
Remove unnecessary locality check between gateway_id & private_network_id, private networks are not zonal anymore

It causes terraform to reject valid configurations where a gateway in one zone is connected to a private network in the same region 