### PR TITLE
chore(iam): fix saml nightly

### DIFF
--- a/internal/services/iam/saml_configuration_action_test.go
+++ b/internal/services/iam/saml_configuration_action_test.go
@@ -21,7 +21,7 @@ func TestAccActionUpdateSamlConfiguration_Basic(t *testing.T) {
 		t.Skip("No default organization ID found, skipping test")
 	}
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: tt.ProviderFactories,
 		CheckDestroy:             checkSamlDestroyed(tt),
 		Steps: []resource.TestStep{
@@ -93,7 +93,7 @@ func TestAccActionUpdateSamlConfiguration_WithDefaultOrganizationID(t *testing.T
 		t.Skip("No default organization ID found, skipping test")
 	}
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: tt.ProviderFactories,
 		CheckDestroy:             checkSamlDestroyed(tt),
 		Steps: []resource.TestStep{

--- a/internal/services/iam/saml_data_source_test.go
+++ b/internal/services/iam/saml_data_source_test.go
@@ -18,7 +18,7 @@ func TestAccDataSourceSaml_Basic(t *testing.T) {
 		t.Skip("No default organization ID found, skipping test")
 	}
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: tt.ProviderFactories,
 		CheckDestroy:             checkSamlDestroyed(tt),
 		Steps: []resource.TestStep{
@@ -56,7 +56,7 @@ func TestAccDataSourceSaml_WithDefaultOrganizationID(t *testing.T) {
 		t.Skip("No default organization ID found, skipping test")
 	}
 	{
-		resource.ParallelTest(t, resource.TestCase{
+		resource.Test(t, resource.TestCase{
 			ProtoV6ProviderFactories: tt.ProviderFactories,
 			CheckDestroy:             checkSamlDestroyed(tt),
 			Steps: []resource.TestStep{
@@ -93,7 +93,7 @@ func TestAccDataSourceSaml_InvalidDeactivated(t *testing.T) {
 		t.Skip("No default organization ID found, skipping test")
 	}
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: tt.ProviderFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/services/iam/saml_resource_test.go
+++ b/internal/services/iam/saml_resource_test.go
@@ -21,7 +21,7 @@ func TestAccSamlResource_Basic(t *testing.T) {
 		t.Skip("No default organization ID found, skipping test")
 	}
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: tt.ProviderFactories,
 		CheckDestroy:             checkSamlDestroyed(tt),
 		Steps: []resource.TestStep{
@@ -60,7 +60,7 @@ func TestAccSamlResource_WithDefaultOrganizationID(t *testing.T) {
 		t.Skip("No default organization ID found, skipping test")
 	}
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: tt.ProviderFactories,
 		CheckDestroy:             checkSamlDestroyed(tt),
 		Steps: []resource.TestStep{


### PR DESCRIPTION
The SAML tests rely on SAML not having been previously enabled on an organization. Each SAML enable creates a different saml_id on IAM side. Therefore SAML enabling is not idempotent, and the tests fail because of conflicts when running simultaneously. 