### PR TITLE
feat(domain): Added ressources for external domain management

### DIFF
--- a/docs/resources/domain_external_domain.md
+++ b/docs/resources/domain_external_domain.md
@@ -1,0 +1,54 @@
+---
+subcategory: "Domains and DNS"
+page_title: "Scaleway: scaleway_domain_external_domain"
+---
+
+# Resource: scaleway_domain_external_domain
+
+The `scaleway_domain_external_domain` resource allows you to register an external domain name to be managed by Scaleway.
+This is useful when you want to use Scaleway DNS for a domain registered with another registrar.
+
+Once registered, you will receive a `validation_token` that you must add as a TXT record to your domain's current DNS configuration to prove ownership.
+After ownership is verified, you can point your domain's NS records to the `ns_servers` provided by Scaleway.
+
+Refer to the [Domains and DNS documentation](https://www.scaleway.com/en/docs/network/domains-and-dns/) and the [API documentation](https://developers.scaleway.com/) for more details.
+
+## Example Usage
+
+### Register an External Domain
+
+The following example registers an external domain and retrieves its validation token.
+
+```terraform
+resource "scaleway_domain_external_domain" "example" {
+  domain = "example.com"
+}
+
+output "validation_token" {
+  value = scaleway_domain_external_domain.example.validation_token
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `domain` (Required, String): The domain name to be registered.
+- `project_id` (Optional, String): The Scaleway project ID.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+- `id`: The domain name.
+- `ns_servers`: List of NS servers for the domain once it is validated.
+- `status`: The status of the domain (e.g., `checking`, `active`).
+- `validation_token`: The validation token to be added as a TXT record to the domain's DNS to verify ownership.
+
+## Import
+
+To import an existing external domain, use:
+
+```bash
+terraform import scaleway_domain_external_domain.example example.com
+```

--- a/docs/resources/domain_external_domain_validated.md
+++ b/docs/resources/domain_external_domain_validated.md
@@ -1,0 +1,78 @@
+---
+subcategory: "Domains and DNS"
+page_title: "Scaleway: scaleway_domain_external_domain_validated"
+---
+
+# Resource: scaleway_domain_external_domain_validated
+
+The `scaleway_domain_external_domain_validated` resource allows you to wait until an external domain is validated by Scaleway.
+This resource is used to block the Terraform execution until the validation token has been correctly added to the external domain's DNS records and verified by Scaleway.
+
+
+~> **WARNING:** This resource implements a part of the validation workflow. It does not represent a real-world entity in Scaleway, therefore changing or deleting this resource on its own has no effect. It must be used with a `scaleway_domain_external_domain` resource. 
+
+
+Once the domain is validated, its status becomes `active`, and it can be used within Scaleway services.
+
+Refer to the [Domains and DNS documentation](https://www.scaleway.com/en/docs/network/domains-and-dns/) and the [API documentation](https://developers.scaleway.com/) for more details.
+
+## Example Usage
+
+### Wait for an External Domain to be Validated
+
+The following example registers an external domain and then waits for it to be validated.
+
+```terraform
+
+resource "scaleway_domain_external_domain" "example" {
+  domain = "scw.example.com"
+}
+resource "scaleway_domain_record" "validation" {
+  dns_zone= "example.com"
+  name = "_scaleway-challenge.scw"
+  type = "TXT"
+  data = scaleway_domain_external_domain.example.validation_token
+}
+
+# Wait for domain validation (default timeout is 30 minutes)
+resource "scaleway_domain_external_domain_validated" "example" {
+  domain = scaleway_domain_external_domain.example.domain
+}
+
+# After validation, we can use the domain's NS servers
+resource "scaleway_domain_record" "NS" {
+  for_each = {ns0=scaleway_domain_external_domain_validated.example.ns_servers[0],
+    ns1=scaleway_domain_external_domain_validated.example.ns_servers[1]}
+  dns_zone= "example.com"
+  name = "scw"
+  type = "NS"
+  data = each.value
+}
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `domain` (Required, String): The domain name to be validated.
+- `project_id` (Optional, String): The Scaleway project ID.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+- `id`: The domain name.
+- `ns_servers`: List of NS servers for the domain once it is validated.
+
+## Timeouts
+
+The `timeouts` block allows you to specify a custom duration for waiting until the domain is validated.
+Default timeout is 30 minutes.
+
+- `create`: Custom duration for the validation process.
+
+
+```bash
+terraform import scaleway_domain_external_domain_validated.example example.com
+```

--- a/internal/services/domain/external_domain.go
+++ b/internal/services/domain/external_domain.go
@@ -1,0 +1,116 @@
+package domain
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	domain "github.com/scaleway/scaleway-sdk-go/api/domain/v2beta1"
+	"github.com/scaleway/scaleway-sdk-go/scw"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/httperrors"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/meta"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/services/account"
+)
+
+func ResourceExternalDomain() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceExternalDomainCreate,
+		ReadContext:   resourceExternalDomainRead,
+		DeleteContext: resourceExternalDomainDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"domain": {
+				Type:        schema.TypeString,
+				Description: "The domain name to be managed.",
+				Required:    true,
+				ForceNew:    true,
+			},
+			"project_id": account.ProjectIDSchema(),
+			"ns_servers": {
+				Type:        schema.TypeList,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "List of Ns servers for the domain.",
+				Computed:    true,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Description: "The status of the domain.",
+				Computed:    true,
+			},
+			"validation_token": {
+				Type:        schema.TypeString,
+				Description: "The validation token for the domain.",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func resourceExternalDomainCreate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	registrarAPI := NewRegistrarDomainAPI(m)
+
+	projectID, _, err := meta.ExtractProjectID(d, m)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	domainName := d.Get("domain").(string)
+
+	_, err = registrarAPI.RegisterExternalDomain(&domain.RegistrarAPIRegisterExternalDomainRequest{
+		Domain:    domainName,
+		ProjectID: projectID,
+	}, scw.WithContext(ctx))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(domainName)
+
+	return resourceExternalDomainRead(ctx, d, m)
+}
+
+func resourceExternalDomainRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	registrarAPI := NewRegistrarDomainAPI(m)
+	resp, err := registrarAPI.GetDomain(&domain.RegistrarAPIGetDomainRequest{Domain: d.Id()}, scw.WithContext(ctx))
+	if err != nil {
+		if httperrors.Is404(err) {
+			d.SetId("")
+			return nil
+		}
+		return diag.FromErr(err)
+	}
+	_ = d.Set("domain", resp.Domain)
+	_ = d.Set("project_id", resp.ProjectID)
+	if len(resp.DNSZones) > 0 {
+		_ = d.Set("ns_servers", resp.DNSZones[0].NsDefault)
+	}
+	_ = d.Set("status", resp.Status)
+	if resp.ExternalDomainRegistrationStatus != nil && resp.ExternalDomainRegistrationStatus.ValidationToken != "" {
+		_ = d.Set("validation_token", resp.ExternalDomainRegistrationStatus.ValidationToken)
+	}
+
+	return nil
+}
+
+func resourceExternalDomainDelete(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	if d.Get("status") == "pending" {
+		return diag.Errorf("cannot delete domain with status %s", d.Get("status"))
+	}
+	registrarAPI := NewRegistrarDomainAPI(m)
+	_, err := registrarAPI.DeleteExternalDomain(&domain.RegistrarAPIDeleteExternalDomainRequest{
+		Domain: d.Id(),
+	}, scw.WithContext(ctx))
+	if err != nil {
+		if httperrors.Is404(err) {
+			d.SetId("")
+			return nil
+		}
+		return diag.FromErr(err)
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/internal/services/domain/external_domain_validated.go
+++ b/internal/services/domain/external_domain_validated.go
@@ -1,0 +1,62 @@
+package domain
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/services/account"
+)
+
+func ResourceExternalDomainValidated() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceExternalDomainValidatedCreate,
+		ReadContext:   resourceExternalDomainRead,
+		DeleteContext: resourceExternalDomainValidatedDelete,
+		Timeouts: &schema.ResourceTimeout{
+			Default: schema.DefaultTimeout(defaultDomainRegistrationTimeout),
+		},
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"domain": {
+				Type:        schema.TypeString,
+				Description: "The domain name to be managed.",
+				Required:    true,
+				ForceNew:    true,
+			},
+			"project_id": account.ProjectIDSchema(),
+			"organization_id": {
+				Type:        schema.TypeString,
+				Description: "The organization ID the domain is associated with.",
+				Computed:    true,
+			},
+			"ns_servers": {
+				Type:        schema.TypeList,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "List of Ns servers for the domain.",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func resourceExternalDomainValidatedCreate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	registrarAPI := NewRegistrarDomainAPI(m)
+	domainName := d.Get("domain").(string)
+	_, err := waitForExternalDomainValidation(ctx, registrarAPI, domainName, defaultDomainRegistrationTimeout)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(domainName)
+	return resourceExternalDomainRead(ctx, d, m)
+}
+
+func resourceExternalDomainValidatedDelete(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	d.SetId("")
+
+	return nil
+}

--- a/internal/services/domain/external_domain_validated_test.go
+++ b/internal/services/domain/external_domain_validated_test.go
@@ -1,0 +1,101 @@
+package domain_test
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	domainSDK "github.com/scaleway/scaleway-sdk-go/api/domain/v2beta1"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/acctest"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/httperrors"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/services/domain"
+)
+
+func TestAccDomainExternalDomainValidated_Basic(t *testing.T) {
+	if acctest.TestDomain == "" {
+		t.Skip("Test skipped: SCW_TEST_DOMAIN must be set")
+	}
+	rootZoneProfile := os.Getenv("SCW_TEST_ROOT_ZONE_PROFILE")
+	if rootZoneProfile == "" {
+		t.Skip("Test skipped: SCW_TEST_ROOT_ZONE_PROFILE must be set")
+	}
+
+	tt := acctest.NewTestTools(t)
+	defer tt.Cleanup()
+
+	subdomain := "tf-acc-ext-validated"
+	domainName := fmt.Sprintf("%s.%s", subdomain, acctest.TestDomain)
+	log.Printf("Testing external domain validation for domain: %s", domainName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: tt.ProviderFactories,
+		CheckDestroy:             testAccCheckExternalDomainDestroy(tt),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDomainExternalDomainValidatedConfigBasic(domainName, subdomain, rootZoneProfile),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("scaleway_domain_external_domain.example", "domain", domainName),
+					resource.TestCheckResourceAttrSet("scaleway_domain_external_domain.example", "validation_token"),
+					resource.TestCheckResourceAttr("scaleway_domain_external_domain_validated.example", "domain", domainName),
+					resource.TestCheckResourceAttrSet("scaleway_domain_external_domain_validated.example", "id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckExternalDomainDestroy(tt *acctest.TestTools) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "scaleway_domain_external_domain" {
+				continue
+			}
+
+			registrarAPI := domain.NewRegistrarDomainAPI(tt.Meta)
+
+			_, err := registrarAPI.GetDomain(&domainSDK.RegistrarAPIGetDomainRequest{
+				Domain: rs.Primary.ID,
+			})
+			if err != nil {
+				if httperrors.Is404(err) {
+					continue
+				}
+				return err
+			}
+
+			return fmt.Errorf("external domain %s still exists", rs.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
+func testAccDomainExternalDomainValidatedConfigBasic(domainName, subdomain string,rootZoneProfile string) string {
+	return fmt.Sprintf(`
+resource "scaleway_domain_external_domain" "example" {
+  domain = "%s"
+}
+
+resource "scaleway_domain_record" "validation" {
+  dns_zone   = "%s"
+  name       = "_scaleway-challenge.%s"
+  type       = "TXT"
+  data       = scaleway_domain_external_domain.example.validation_token
+ provider    = scaleway.alt
+}
+
+resource "scaleway_domain_external_domain_validated" "example" {
+  domain = scaleway_domain_external_domain.example.domain
+}
+
+provider "scaleway" {
+  profile="%s"
+  alias="alt"
+}
+
+
+`, domainName, acctest.TestDomain, subdomain, rootZoneProfile)
+}

--- a/internal/services/domain/helpers.go
+++ b/internal/services/domain/helpers.go
@@ -16,6 +16,7 @@ import (
 
 const (
 	defaultWaitDomainsRegistrationRetryInterval = 10 * time.Minute
+	defaultWaitExternalDomainsValidationRetryInterval = 30 * time.Second
 )
 
 // NewDomainAPI returns a new domain API.

--- a/internal/services/domain/testdata/domain-external-domain-validated-basic.cassette.yaml
+++ b/internal/services/domain/testdata/domain-external-domain-validated-basic.cassette.yaml
@@ -1,0 +1,54 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 105
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"domain":"tf-acc-ext-validated.scw.devops.business","project_id":"a790f155-a3c5-41b3-8367-1bdd36a2351c"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1-X:nodwarf5; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/domain/v2beta1/external-domains
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 66
+        uncompressed: false
+        body: '{"message":"the domain scw.devops.business is already registered"}'
+        headers:
+            Content-Length:
+                - "66"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:03:47 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 8ffe528d-6355-4903-94ed-4a0c755ad996
+        status: 403 Forbidden
+        code: 403
+        duration: 198.462851ms

--- a/internal/services/domain/waiters.go
+++ b/internal/services/domain/waiters.go
@@ -82,3 +82,16 @@ func waitForDNSSECStatus(ctx context.Context, api *domain.RegistrarAPI, domainNa
 		RetryInterval: &retryInterval,
 	}, scw.WithContext(ctx))
 }
+
+func waitForExternalDomainValidation(ctx context.Context, api *domain.RegistrarAPI, domainName string, timeout time.Duration) (*domain.Domain, error) {
+	retryInterval := defaultWaitExternalDomainsValidationRetryInterval
+	if transport.DefaultWaitRetryInterval != nil {
+		retryInterval = *transport.DefaultWaitRetryInterval
+	}
+
+	return api.WaitForValidatedExternalDomain(&domain.WaitForValidatedExternalDomainRequest{
+		Domain:        domainName,
+		Timeout:       new(timeout),
+		RetryInterval: &retryInterval,
+	}, scw.WithContext(ctx))
+}

--- a/provider/sdkv2.go
+++ b/provider/sdkv2.go
@@ -154,6 +154,8 @@ func SDKProvider(config *Config) plugin.ProviderFunc {
 				"scaleway_datawarehouse_user":                                 datawarehouse.ResourceUser(),
 				"scaleway_datawarehouse_database":                             datawarehouse.ResourceDatabase(),
 				"scaleway_kafka_cluster":                                      kafka.ResourceCluster(),
+				"scaleway_domain_external":                                    domain.ResourceExternalDomain(),
+				"scaleway_domain_external_validated":                          domain.ResourceExternalDomainValidated(),
 				"scaleway_domain_record":                                      domain.ResourceRecord(),
 				"scaleway_domain_registration":                                domain.ResourceRegistration(),
 				"scaleway_domain_zone":                                        domain.ResourceZone(),


### PR DESCRIPTION
Due to the way actual dns management zones work at Scaleway test is broken. and can't be fixed. even if resource is working well. For testing root zone must be hosted outside Scaleway. 

> [!IMPORTANT]
> This PR depend on this pr : https://github.com/scaleway/scaleway-sdk-go/pull/3005 I made.