### PR TITLE
feat: add datalab integration

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -23,6 +23,11 @@ container:
       - any-glob-to-any-file:
           - internal/services/container/**
 
+datalab:
+  - changed-files:
+      - any-glob-to-any-file:
+          - internal/services/datalab/**
+
 domain:
   - changed-files:
       - any-glob-to-any-file:

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -36,6 +36,7 @@ var foldersUsingVCRv4 = []string{
 	"audittrail",
 	"account",
 	"container",
+	"datalab",
 	"iam",
 	"instance",
 	"jobs",

--- a/internal/services/datalab/data_source_datalab.go
+++ b/internal/services/datalab/data_source_datalab.go
@@ -2,7 +2,6 @@ package datalab
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -56,7 +55,7 @@ func (d *DatalabDataSource) Metadata(_ context.Context, req datasource.MetadataR
 
 func (d *DatalabDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "",
+		MarkdownDescription: "Retrieves information about a Scaleway Datalab instance.",
 		Attributes: map[string]schema.Attribute{
 			"datalab_id": schema.StringAttribute{
 				Optional:            true,
@@ -221,7 +220,7 @@ func (d *DatalabDataSource) Read(ctx context.Context, req datasource.ReadRequest
 		return
 	}
 
-	region, err := d.resolveRegion(config.Region)
+	region, err := resolveRegion(config.Region, d.meta.ScwClient())
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to resolve region", err.Error())
 
@@ -298,19 +297,6 @@ func (d *DatalabDataSource) Read(ctx context.Context, req datasource.ReadRequest
 
 	state := flattenDatalabDataSource(ctx, dl, &resp.Diagnostics)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
-}
-
-func (d *DatalabDataSource) resolveRegion(regionAttr types.String) (scw.Region, error) {
-	if !regionAttr.IsNull() && !regionAttr.IsUnknown() && regionAttr.ValueString() != "" {
-		return scw.ParseRegion(regionAttr.ValueString())
-	}
-
-	region, exists := d.meta.ScwClient().GetDefaultRegion()
-	if exists {
-		return region, nil
-	}
-
-	return "", errors.New("region is required; set it on the data source or configure a default region on the provider")
 }
 
 func flattenDatalabDataSource(ctx context.Context, dl *datalab.Datalab, diags *diag.Diagnostics) datalabDataSourceModel {

--- a/internal/services/datalab/data_source_datalab.go
+++ b/internal/services/datalab/data_source_datalab.go
@@ -1,0 +1,339 @@
+package datalab
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	datalab "github.com/scaleway/scaleway-sdk-go/api/datalab/v1beta1"
+	"github.com/scaleway/scaleway-sdk-go/scw"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/locality/regional"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/meta"
+)
+
+var (
+	_ datasource.DataSource              = (*DatalabDataSource)(nil)
+	_ datasource.DataSourceWithConfigure = (*DatalabDataSource)(nil)
+)
+
+func NewDatalabDataSource() datasource.DataSource {
+	return &DatalabDataSource{}
+}
+
+type DatalabDataSource struct {
+	api  *datalab.API
+	meta *meta.Meta
+}
+
+type datalabDataSourceModel struct {
+	Tags              types.List   `tfsdk:"tags"`
+	PrivateNetworkID  types.String `tfsdk:"private_network_id"`
+	Main              types.Object `tfsdk:"main"`
+	Region            types.String `tfsdk:"region"`
+	ID                types.String `tfsdk:"id"`
+	Description       types.String `tfsdk:"description"`
+	Name              types.String `tfsdk:"name"`
+	SparkVersion      types.String `tfsdk:"spark_version"`
+	DatalabID         types.String `tfsdk:"datalab_id"`
+	ProjectID         types.String `tfsdk:"project_id"`
+	Worker            types.Object `tfsdk:"worker"`
+	NotebookMasterURL types.String `tfsdk:"notebook_master_url"`
+	TotalStorage      types.Object `tfsdk:"total_storage"`
+	Status            types.String `tfsdk:"status"`
+	CreatedAt         types.String `tfsdk:"created_at"`
+	UpdatedAt         types.String `tfsdk:"updated_at"`
+	NotebookURL       types.String `tfsdk:"notebook_url"`
+	HasNotebook       types.Bool   `tfsdk:"has_notebook"`
+}
+
+func (d *DatalabDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_datalab"
+}
+
+func (d *DatalabDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: "",
+		Attributes: map[string]schema.Attribute{
+			"datalab_id": schema.StringAttribute{
+				Optional:            true,
+				MarkdownDescription: "The ID of the Datalab instance to look up.",
+			},
+			"name": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "The name of the Datalab instance to look up.",
+			},
+			"project_id": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "The project ID the Datalab belongs to.",
+			},
+			"region": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "The region the Datalab is in.",
+			},
+			"id": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "The ID of the Datalab instance, in the `{region}/{id}` format.",
+			},
+			"description": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "A description for the Datalab instance.",
+			},
+			"tags": schema.ListAttribute{
+				Computed:            true,
+				ElementType:         types.StringType,
+				MarkdownDescription: "Tags associated with the Datalab instance.",
+			},
+			"spark_version": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "The Spark version used by the Datalab instance.",
+			},
+			"private_network_id": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "The ID of the private network attached to the Datalab.",
+			},
+			"has_notebook": schema.BoolAttribute{
+				Computed:            true,
+				MarkdownDescription: "Whether a JupyterLab notebook is associated with the Datalab.",
+			},
+			"main": schema.SingleNestedAttribute{
+				Computed:            true,
+				MarkdownDescription: "The Spark main node configuration.",
+				Attributes: map[string]schema.Attribute{
+					"node_type": schema.StringAttribute{
+						Computed:            true,
+						MarkdownDescription: "The node type for the main node.",
+					},
+					"spark_ui_url": schema.StringAttribute{
+						Computed:            true,
+						MarkdownDescription: "The Spark UI URL.",
+					},
+					"spark_master_url": schema.StringAttribute{
+						Computed:            true,
+						MarkdownDescription: "The Spark master URL within the VPC.",
+					},
+					"root_volume": schema.SingleNestedAttribute{
+						Computed:            true,
+						MarkdownDescription: "Volume details for the main node.",
+						Attributes: map[string]schema.Attribute{
+							"type": schema.StringAttribute{
+								Computed: true,
+							},
+							"size": schema.Int64Attribute{
+								Computed: true,
+							},
+						},
+					},
+				},
+			},
+			"worker": schema.SingleNestedAttribute{
+				Computed:            true,
+				MarkdownDescription: "The Spark worker nodes configuration.",
+				Attributes: map[string]schema.Attribute{
+					"node_type": schema.StringAttribute{
+						Computed:            true,
+						MarkdownDescription: "The node type for worker nodes.",
+					},
+					"node_count": schema.Int64Attribute{
+						Computed:            true,
+						MarkdownDescription: "The number of worker nodes.",
+					},
+					"root_volume": schema.SingleNestedAttribute{
+						Computed:            true,
+						MarkdownDescription: "Volume details for worker nodes.",
+						Attributes: map[string]schema.Attribute{
+							"type": schema.StringAttribute{
+								Computed: true,
+							},
+							"size": schema.Int64Attribute{
+								Computed: true,
+							},
+						},
+					},
+				},
+			},
+			"total_storage": schema.SingleNestedAttribute{
+				Computed:            true,
+				MarkdownDescription: "Persistent volume storage configuration.",
+				Attributes: map[string]schema.Attribute{
+					"type": schema.StringAttribute{
+						Computed: true,
+					},
+					"size": schema.Int64Attribute{
+						Computed: true,
+					},
+				},
+			},
+			"status": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "The current status of the Datalab instance.",
+			},
+			"created_at": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "The creation timestamp of the Datalab instance.",
+			},
+			"updated_at": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "The last update timestamp of the Datalab instance.",
+			},
+			"notebook_url": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "The URL of the JupyterLab notebook, if available.",
+			},
+			"notebook_master_url": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "The URL used to reach the cluster from the notebook.",
+			},
+		},
+	}
+}
+
+func (d *DatalabDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	m, ok := req.ProviderData.(*meta.Meta)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *meta.Meta, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+
+		return
+	}
+
+	d.meta = m
+	d.api = datalab.NewAPI(d.meta.ScwClient())
+}
+
+func (d *DatalabDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var config datalabDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	region, err := d.resolveRegion(config.Region)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to resolve region", err.Error())
+
+		return
+	}
+
+	var dl *datalab.Datalab
+
+	hasDatalabID := !config.DatalabID.IsNull() && !config.DatalabID.IsUnknown() && config.DatalabID.ValueString() != ""
+	hasName := !config.Name.IsNull() && !config.Name.IsUnknown() && config.Name.ValueString() != ""
+
+	switch {
+	case hasDatalabID:
+		datalabID := config.DatalabID.ValueString()
+
+		parsedRegion, parsedID, parseErr := regional.ParseID(datalabID)
+		if parseErr == nil {
+			region = parsedRegion
+			datalabID = parsedID
+		}
+
+		dl, err = d.api.GetDatalab(&datalab.GetDatalabRequest{
+			Region:    region,
+			DatalabID: datalabID,
+		}, scw.WithContext(ctx))
+		if err != nil {
+			resp.Diagnostics.AddError("Failed to get Datalab", err.Error())
+
+			return
+		}
+	case hasName:
+		name := config.Name.ValueString()
+		listReq := &datalab.ListDatalabsRequest{
+			Region: region,
+			Name:   &name,
+		}
+
+		if !config.ProjectID.IsNull() && !config.ProjectID.IsUnknown() && config.ProjectID.ValueString() != "" {
+			projectID := config.ProjectID.ValueString()
+			listReq.ProjectID = &projectID
+		}
+
+		listResp, listErr := d.api.ListDatalabs(listReq, scw.WithContext(ctx))
+		if listErr != nil {
+			resp.Diagnostics.AddError("Failed to list Datalabs", listErr.Error())
+
+			return
+		}
+
+		if len(listResp.Datalabs) == 0 {
+			resp.Diagnostics.AddError("Datalab not found", fmt.Sprintf("No Datalab found with name %q", name))
+
+			return
+		}
+
+		if len(listResp.Datalabs) > 1 {
+			resp.Diagnostics.AddError(
+				"Multiple Datalabs found",
+				fmt.Sprintf("Found %d Datalabs with name %q. Please use datalab_id to specify exactly which one.", len(listResp.Datalabs), name),
+			)
+
+			return
+		}
+
+		dl = listResp.Datalabs[0]
+	default:
+		resp.Diagnostics.AddError(
+			"Missing lookup attribute",
+			"Either datalab_id or name must be specified.",
+		)
+
+		return
+	}
+
+	state := flattenDatalabDataSource(ctx, dl, &resp.Diagnostics)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (d *DatalabDataSource) resolveRegion(regionAttr types.String) (scw.Region, error) {
+	if !regionAttr.IsNull() && !regionAttr.IsUnknown() && regionAttr.ValueString() != "" {
+		return scw.ParseRegion(regionAttr.ValueString())
+	}
+
+	region, exists := d.meta.ScwClient().GetDefaultRegion()
+	if exists {
+		return region, nil
+	}
+
+	return "", errors.New("region is required; set it on the data source or configure a default region on the provider")
+}
+
+func flattenDatalabDataSource(ctx context.Context, dl *datalab.Datalab, diags *diag.Diagnostics) datalabDataSourceModel {
+	flat := flattenDatalab(ctx, dl, diags)
+
+	return datalabDataSourceModel{
+		DatalabID:         types.StringValue(dl.ID),
+		Name:              flat.Name,
+		ProjectID:         flat.ProjectID,
+		Region:            flat.Region,
+		ID:                flat.ID,
+		Description:       flat.Description,
+		Tags:              flat.Tags,
+		SparkVersion:      flat.SparkVersion,
+		PrivateNetworkID:  flat.PrivateNetworkID,
+		HasNotebook:       flat.HasNotebook,
+		Main:              flat.Main,
+		Worker:            flat.Worker,
+		TotalStorage:      flat.TotalStorage,
+		Status:            flat.Status,
+		CreatedAt:         flat.CreatedAt,
+		UpdatedAt:         flat.UpdatedAt,
+		NotebookURL:       flat.NotebookURL,
+		NotebookMasterURL: flat.NotebookMasterURL,
+	}
+}

--- a/internal/services/datalab/data_source_datalab_test.go
+++ b/internal/services/datalab/data_source_datalab_test.go
@@ -1,0 +1,157 @@
+package datalab_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/acctest"
+)
+
+func TestAccDatalabDataSource_ByID(t *testing.T) {
+	tt := acctest.NewTestTools(t)
+	defer tt.Cleanup()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: tt.ProviderFactories,
+		CheckDestroy:             isDatalabDestroyed(tt),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(datalabTestBaseConfig, "tf_tests_datalab_ds_by_id") + `
+					resource "scaleway_datalab" "main" {
+						name               = "tf_tests_datalab_ds_by_id"
+						spark_version      = "4.0.0"
+						private_network_id = scaleway_vpc_private_network.main.id
+						region             = "fr-par"
+						description        = "test datalab for data source by id"
+						tags               = ["ds-test"]
+
+						main = {
+							node_type = "DATALAB-SHARED-4C-8G"
+						}
+
+						worker = {
+							node_type  = "DATALAB-DEDICATED2-2C-8G"
+							node_count = 1
+						}
+					}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					isDatalabPresent(tt, "scaleway_datalab.main"),
+				),
+			},
+			{
+				Config: fmt.Sprintf(datalabTestBaseConfig, "tf_tests_datalab_ds_by_id") + `
+					resource "scaleway_datalab" "main" {
+						name               = "tf_tests_datalab_ds_by_id"
+						spark_version      = "4.0.0"
+						private_network_id = scaleway_vpc_private_network.main.id
+						region             = "fr-par"
+						description        = "test datalab for data source by id"
+						tags               = ["ds-test"]
+
+						main = {
+							node_type = "DATALAB-SHARED-4C-8G"
+						}
+
+						worker = {
+							node_type  = "DATALAB-DEDICATED2-2C-8G"
+							node_count = 1
+						}
+					}
+
+					data "scaleway_datalab" "by_id" {
+						datalab_id = scaleway_datalab.main.id
+					}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					isDatalabPresent(tt, "scaleway_datalab.main"),
+					resource.TestCheckResourceAttrPair("data.scaleway_datalab.by_id", "name", "scaleway_datalab.main", "name"),
+					resource.TestCheckResourceAttrPair("data.scaleway_datalab.by_id", "spark_version", "scaleway_datalab.main", "spark_version"),
+					resource.TestCheckResourceAttrPair("data.scaleway_datalab.by_id", "region", "scaleway_datalab.main", "region"),
+					resource.TestCheckResourceAttrPair("data.scaleway_datalab.by_id", "project_id", "scaleway_datalab.main", "project_id"),
+					resource.TestCheckResourceAttrPair("data.scaleway_datalab.by_id", "description", "scaleway_datalab.main", "description"),
+					resource.TestCheckResourceAttrPair("data.scaleway_datalab.by_id", "status", "scaleway_datalab.main", "status"),
+					resource.TestCheckResourceAttrPair("data.scaleway_datalab.by_id", "has_notebook", "scaleway_datalab.main", "has_notebook"),
+					resource.TestCheckResourceAttrPair("data.scaleway_datalab.by_id", "created_at", "scaleway_datalab.main", "created_at"),
+					resource.TestCheckResourceAttrPair("data.scaleway_datalab.by_id", "updated_at", "scaleway_datalab.main", "updated_at"),
+					resource.TestCheckResourceAttr("data.scaleway_datalab.by_id", "tags.0", "ds-test"),
+					resource.TestCheckResourceAttr("data.scaleway_datalab.by_id", "tags.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDatalabDataSource_ByName(t *testing.T) {
+	tt := acctest.NewTestTools(t)
+	defer tt.Cleanup()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: tt.ProviderFactories,
+		CheckDestroy:             isDatalabDestroyed(tt),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(datalabTestBaseConfig, "tf_tests_datalab_ds_by_name") + `
+					resource "scaleway_datalab" "main" {
+						name               = "tf_tests_datalab_ds_by_name"
+						spark_version      = "4.0.0"
+						private_network_id = scaleway_vpc_private_network.main.id
+						region             = "fr-par"
+						description        = "test datalab for data source by name"
+
+						main = {
+							node_type = "DATALAB-SHARED-4C-8G"
+						}
+
+						worker = {
+							node_type  = "DATALAB-DEDICATED2-2C-8G"
+							node_count = 1
+						}
+					}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					isDatalabPresent(tt, "scaleway_datalab.main"),
+				),
+			},
+			{
+				Config: fmt.Sprintf(datalabTestBaseConfig, "tf_tests_datalab_ds_by_name") + `
+					resource "scaleway_datalab" "main" {
+						name               = "tf_tests_datalab_ds_by_name"
+						spark_version      = "4.0.0"
+						private_network_id = scaleway_vpc_private_network.main.id
+						region             = "fr-par"
+						description        = "test datalab for data source by name"
+
+						main = {
+							node_type = "DATALAB-SHARED-4C-8G"
+						}
+
+						worker = {
+							node_type  = "DATALAB-DEDICATED2-2C-8G"
+							node_count = 1
+						}
+					}
+
+					data "scaleway_datalab" "by_name" {
+						name   = scaleway_datalab.main.name
+						region = "fr-par"
+					}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					isDatalabPresent(tt, "scaleway_datalab.main"),
+					resource.TestCheckResourceAttrSet("data.scaleway_datalab.by_name", "datalab_id"),
+					resource.TestCheckResourceAttrPair("data.scaleway_datalab.by_name", "name", "scaleway_datalab.main", "name"),
+					resource.TestCheckResourceAttrPair("data.scaleway_datalab.by_name", "spark_version", "scaleway_datalab.main", "spark_version"),
+					resource.TestCheckResourceAttrPair("data.scaleway_datalab.by_name", "region", "scaleway_datalab.main", "region"),
+					resource.TestCheckResourceAttrPair("data.scaleway_datalab.by_name", "project_id", "scaleway_datalab.main", "project_id"),
+					resource.TestCheckResourceAttrPair("data.scaleway_datalab.by_name", "description", "scaleway_datalab.main", "description"),
+					resource.TestCheckResourceAttrPair("data.scaleway_datalab.by_name", "status", "scaleway_datalab.main", "status"),
+					resource.TestCheckResourceAttrPair("data.scaleway_datalab.by_name", "has_notebook", "scaleway_datalab.main", "has_notebook"),
+					resource.TestCheckResourceAttrPair("data.scaleway_datalab.by_name", "created_at", "scaleway_datalab.main", "created_at"),
+					resource.TestCheckResourceAttrPair("data.scaleway_datalab.by_name", "updated_at", "scaleway_datalab.main", "updated_at"),
+				),
+			},
+		},
+	})
+}

--- a/internal/services/datalab/data_source_datalabs.go
+++ b/internal/services/datalab/data_source_datalabs.go
@@ -13,6 +13,7 @@ import (
 	datalab "github.com/scaleway/scaleway-sdk-go/api/datalab/v1beta1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/meta"
+	scwtypes "github.com/scaleway/terraform-provider-scaleway/v2/internal/types"
 )
 
 var (
@@ -258,12 +259,7 @@ func flattenDatalabsList(ctx context.Context, datalabs []*datalab.Datalab, diags
 	items := make([]attr.Value, len(datalabs))
 
 	for i, dl := range datalabs {
-		tagValues := make([]attr.Value, len(dl.Tags))
-		for j, t := range dl.Tags {
-			tagValues[j] = types.StringValue(t)
-		}
-
-		tagList, d := types.ListValue(types.StringType, tagValues)
+		tagList, d := scwtypes.FlattenFrameworkStringList(ctx, dl.Tags)
 		diags.Append(d...)
 
 		createdAt := types.StringNull()
@@ -279,7 +275,7 @@ func flattenDatalabsList(ctx context.Context, datalabs []*datalab.Datalab, diags
 		attrValues := map[string]attr.Value{
 			"id":            types.StringValue(dl.ID),
 			"name":          types.StringValue(dl.Name),
-			"description":   types.StringValue(dl.Description),
+			"description":   scwtypes.FlattenFrameworkStringValue(dl.Description),
 			"status":        types.StringValue(string(dl.Status)),
 			"tags":          tagList,
 			"region":        types.StringValue(dl.Region.String()),

--- a/internal/services/datalab/data_source_datalabs.go
+++ b/internal/services/datalab/data_source_datalabs.go
@@ -2,7 +2,6 @@ package datalab
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -61,7 +60,7 @@ func (d *DatalabsDataSource) Metadata(_ context.Context, req datasource.Metadata
 
 func (d *DatalabsDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "",
+		MarkdownDescription: "Lists Scaleway Datalab instances.",
 		Attributes: map[string]schema.Attribute{
 			"project_id": schema.StringAttribute{
 				Optional:            true,
@@ -168,7 +167,7 @@ func (d *DatalabsDataSource) Read(ctx context.Context, req datasource.ReadReques
 		return
 	}
 
-	region, err := d.resolveRegion(config.Region)
+	region, err := resolveRegion(config.Region, d.meta.ScwClient())
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to resolve region", err.Error())
 
@@ -201,49 +200,18 @@ func (d *DatalabsDataSource) Read(ctx context.Context, req datasource.ReadReques
 		}
 	}
 
-	var allDatalabs []*datalab.Datalab
+	listResp, listErr := d.api.ListDatalabs(listReq, scw.WithContext(ctx), scw.WithAllPages())
+	if listErr != nil {
+		resp.Diagnostics.AddError("Failed to list Datalabs", listErr.Error())
 
-	page := int32(1)
-	pageSize := uint32(100)
-
-	for {
-		listReq.Page = &page
-		listReq.PageSize = &pageSize
-
-		listResp, listErr := d.api.ListDatalabs(listReq, scw.WithContext(ctx))
-		if listErr != nil {
-			resp.Diagnostics.AddError("Failed to list Datalabs", listErr.Error())
-
-			return
-		}
-
-		allDatalabs = append(allDatalabs, listResp.Datalabs...)
-
-		if uint64(len(allDatalabs)) >= listResp.TotalCount {
-			break
-		}
-
-		page++
+		return
 	}
 
 	state := config
-	state.Datalabs = flattenDatalabsList(ctx, allDatalabs, &resp.Diagnostics)
+	state.Datalabs = flattenDatalabsList(ctx, listResp.Datalabs, &resp.Diagnostics)
 	state.Region = types.StringValue(region.String())
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
-}
-
-func (d *DatalabsDataSource) resolveRegion(regionAttr types.String) (scw.Region, error) {
-	if !regionAttr.IsNull() && !regionAttr.IsUnknown() && regionAttr.ValueString() != "" {
-		return scw.ParseRegion(regionAttr.ValueString())
-	}
-
-	region, exists := d.meta.ScwClient().GetDefaultRegion()
-	if exists {
-		return region, nil
-	}
-
-	return "", errors.New("region is required; set it on the data source or configure a default region on the provider")
 }
 
 func flattenDatalabsList(ctx context.Context, datalabs []*datalab.Datalab, diags *diag.Diagnostics) types.List {

--- a/internal/services/datalab/data_source_datalabs.go
+++ b/internal/services/datalab/data_source_datalabs.go
@@ -1,0 +1,303 @@
+package datalab
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	datalab "github.com/scaleway/scaleway-sdk-go/api/datalab/v1beta1"
+	"github.com/scaleway/scaleway-sdk-go/scw"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/meta"
+)
+
+var (
+	_ datasource.DataSource              = (*DatalabsDataSource)(nil)
+	_ datasource.DataSourceWithConfigure = (*DatalabsDataSource)(nil)
+)
+
+func NewDatalabsDataSource() datasource.DataSource {
+	return &DatalabsDataSource{}
+}
+
+type DatalabsDataSource struct {
+	api  *datalab.API
+	meta *meta.Meta
+}
+
+type datalabsDataSourceModel struct {
+	ProjectID      types.String `tfsdk:"project_id"`
+	OrganizationID types.String `tfsdk:"organization_id"`
+	Region         types.String `tfsdk:"region"`
+	Name           types.String `tfsdk:"name"`
+	Tags           types.List   `tfsdk:"tags"`
+	Datalabs       types.List   `tfsdk:"datalabs"`
+}
+
+func datalabsItemAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"id":            types.StringType,
+		"name":          types.StringType,
+		"description":   types.StringType,
+		"status":        types.StringType,
+		"tags":          types.ListType{ElemType: types.StringType},
+		"region":        types.StringType,
+		"project_id":    types.StringType,
+		"spark_version": types.StringType,
+		"has_notebook":  types.BoolType,
+		"created_at":    types.StringType,
+		"updated_at":    types.StringType,
+	}
+}
+
+func (d *DatalabsDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_datalabs"
+}
+
+func (d *DatalabsDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: "",
+		Attributes: map[string]schema.Attribute{
+			"project_id": schema.StringAttribute{
+				Optional:            true,
+				MarkdownDescription: "The project ID to filter Datalabs by.",
+			},
+			"organization_id": schema.StringAttribute{
+				Optional:            true,
+				MarkdownDescription: "The organization ID to filter Datalabs by.",
+			},
+			"region": schema.StringAttribute{
+				Optional:            true,
+				MarkdownDescription: "The region to list Datalabs from.",
+			},
+			"name": schema.StringAttribute{
+				Optional:            true,
+				MarkdownDescription: "The name to filter Datalabs by.",
+			},
+			"tags": schema.ListAttribute{
+				Optional:            true,
+				ElementType:         types.StringType,
+				MarkdownDescription: "The tags to filter Datalabs by.",
+			},
+			"datalabs": schema.ListNestedAttribute{
+				Computed:            true,
+				MarkdownDescription: "The list of Datalab instances.",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"id": schema.StringAttribute{
+							Computed:            true,
+							MarkdownDescription: "The unique identifier of the Datalab instance.",
+						},
+						"name": schema.StringAttribute{
+							Computed:            true,
+							MarkdownDescription: "The name of the Datalab instance.",
+						},
+						"description": schema.StringAttribute{
+							Computed:            true,
+							MarkdownDescription: "The description of the Datalab instance.",
+						},
+						"status": schema.StringAttribute{
+							Computed:            true,
+							MarkdownDescription: "The current status of the Datalab instance.",
+						},
+						"tags": schema.ListAttribute{
+							Computed:            true,
+							ElementType:         types.StringType,
+							MarkdownDescription: "Tags associated with the Datalab instance.",
+						},
+						"region": schema.StringAttribute{
+							Computed:            true,
+							MarkdownDescription: "The region of the Datalab instance.",
+						},
+						"project_id": schema.StringAttribute{
+							Computed:            true,
+							MarkdownDescription: "The project ID of the Datalab instance.",
+						},
+						"spark_version": schema.StringAttribute{
+							Computed:            true,
+							MarkdownDescription: "The Spark version of the Datalab instance.",
+						},
+						"has_notebook": schema.BoolAttribute{
+							Computed:            true,
+							MarkdownDescription: "Whether a JupyterLab notebook is associated with the Datalab.",
+						},
+						"created_at": schema.StringAttribute{
+							Computed:            true,
+							MarkdownDescription: "The creation timestamp of the Datalab instance.",
+						},
+						"updated_at": schema.StringAttribute{
+							Computed:            true,
+							MarkdownDescription: "The last update timestamp of the Datalab instance.",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *DatalabsDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	m, ok := req.ProviderData.(*meta.Meta)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *meta.Meta, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+
+		return
+	}
+
+	d.meta = m
+	d.api = datalab.NewAPI(d.meta.ScwClient())
+}
+
+func (d *DatalabsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var config datalabsDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	region, err := d.resolveRegion(config.Region)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to resolve region", err.Error())
+
+		return
+	}
+
+	listReq := &datalab.ListDatalabsRequest{
+		Region: region,
+	}
+
+	if !config.ProjectID.IsNull() && !config.ProjectID.IsUnknown() && config.ProjectID.ValueString() != "" {
+		projectID := config.ProjectID.ValueString()
+		listReq.ProjectID = &projectID
+	}
+
+	if !config.OrganizationID.IsNull() && !config.OrganizationID.IsUnknown() && config.OrganizationID.ValueString() != "" {
+		orgID := config.OrganizationID.ValueString()
+		listReq.OrganizationID = &orgID
+	}
+
+	if !config.Name.IsNull() && !config.Name.IsUnknown() && config.Name.ValueString() != "" {
+		name := config.Name.ValueString()
+		listReq.Name = &name
+	}
+
+	if !config.Tags.IsNull() && !config.Tags.IsUnknown() {
+		listReq.Tags = expandTags(ctx, config.Tags, &resp.Diagnostics)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
+	var allDatalabs []*datalab.Datalab
+
+	page := int32(1)
+	pageSize := uint32(100)
+
+	for {
+		listReq.Page = &page
+		listReq.PageSize = &pageSize
+
+		listResp, listErr := d.api.ListDatalabs(listReq, scw.WithContext(ctx))
+		if listErr != nil {
+			resp.Diagnostics.AddError("Failed to list Datalabs", listErr.Error())
+
+			return
+		}
+
+		allDatalabs = append(allDatalabs, listResp.Datalabs...)
+
+		if uint64(len(allDatalabs)) >= listResp.TotalCount {
+			break
+		}
+
+		page++
+	}
+
+	state := config
+	state.Datalabs = flattenDatalabsList(ctx, allDatalabs, &resp.Diagnostics)
+	state.Region = types.StringValue(region.String())
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (d *DatalabsDataSource) resolveRegion(regionAttr types.String) (scw.Region, error) {
+	if !regionAttr.IsNull() && !regionAttr.IsUnknown() && regionAttr.ValueString() != "" {
+		return scw.ParseRegion(regionAttr.ValueString())
+	}
+
+	region, exists := d.meta.ScwClient().GetDefaultRegion()
+	if exists {
+		return region, nil
+	}
+
+	return "", errors.New("region is required; set it on the data source or configure a default region on the provider")
+}
+
+func flattenDatalabsList(ctx context.Context, datalabs []*datalab.Datalab, diags *diag.Diagnostics) types.List {
+	itemType := types.ObjectType{AttrTypes: datalabsItemAttrTypes()}
+
+	if len(datalabs) == 0 {
+		emptyList, d := types.ListValue(itemType, []attr.Value{})
+		diags.Append(d...)
+
+		return emptyList
+	}
+
+	items := make([]attr.Value, len(datalabs))
+
+	for i, dl := range datalabs {
+		tagValues := make([]attr.Value, len(dl.Tags))
+		for j, t := range dl.Tags {
+			tagValues[j] = types.StringValue(t)
+		}
+
+		tagList, d := types.ListValue(types.StringType, tagValues)
+		diags.Append(d...)
+
+		createdAt := types.StringNull()
+		if dl.CreatedAt != nil {
+			createdAt = types.StringValue(dl.CreatedAt.Format("2006-01-02T15:04:05Z07:00"))
+		}
+
+		updatedAt := types.StringNull()
+		if dl.UpdatedAt != nil {
+			updatedAt = types.StringValue(dl.UpdatedAt.Format("2006-01-02T15:04:05Z07:00"))
+		}
+
+		attrValues := map[string]attr.Value{
+			"id":            types.StringValue(dl.ID),
+			"name":          types.StringValue(dl.Name),
+			"description":   types.StringValue(dl.Description),
+			"status":        types.StringValue(string(dl.Status)),
+			"tags":          tagList,
+			"region":        types.StringValue(dl.Region.String()),
+			"project_id":    types.StringValue(dl.ProjectID),
+			"spark_version": types.StringValue(dl.SparkVersion),
+			"has_notebook":  types.BoolValue(dl.HasNotebook),
+			"created_at":    createdAt,
+			"updated_at":    updatedAt,
+		}
+
+		obj, d := types.ObjectValue(datalabsItemAttrTypes(), attrValues)
+		diags.Append(d...)
+
+		items[i] = obj
+	}
+
+	list, d := types.ListValue(itemType, items)
+	diags.Append(d...)
+
+	return list
+}

--- a/internal/services/datalab/data_source_datalabs_test.go
+++ b/internal/services/datalab/data_source_datalabs_test.go
@@ -1,0 +1,207 @@
+package datalab_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/acctest"
+)
+
+func TestAccDatalabsDataSource_Basic(t *testing.T) {
+	tt := acctest.NewTestTools(t)
+	defer tt.Cleanup()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: tt.ProviderFactories,
+		CheckDestroy:             isDatalabDestroyed(tt),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(datalabTestBaseConfig, "tf_tests_datalabs_ds_basic") + `
+					resource "scaleway_datalab" "main" {
+						name               = "tf_tests_datalabs_ds_basic"
+						spark_version      = "4.0.0"
+						private_network_id = scaleway_vpc_private_network.main.id
+						region             = "fr-par"
+
+						main = {
+							node_type = "DATALAB-SHARED-4C-8G"
+						}
+
+						worker = {
+							node_type  = "DATALAB-DEDICATED2-2C-8G"
+							node_count = 1
+						}
+					}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					isDatalabPresent(tt, "scaleway_datalab.main"),
+				),
+			},
+			{
+				Config: fmt.Sprintf(datalabTestBaseConfig, "tf_tests_datalabs_ds_basic") + `
+					resource "scaleway_datalab" "main" {
+						name               = "tf_tests_datalabs_ds_basic"
+						spark_version      = "4.0.0"
+						private_network_id = scaleway_vpc_private_network.main.id
+						region             = "fr-par"
+
+						main = {
+							node_type = "DATALAB-SHARED-4C-8G"
+						}
+
+						worker = {
+							node_type  = "DATALAB-DEDICATED2-2C-8G"
+							node_count = 1
+						}
+					}
+
+					data "scaleway_datalabs" "all" {
+						region = "fr-par"
+					}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					isDatalabPresent(tt, "scaleway_datalab.main"),
+					resource.TestCheckResourceAttrSet("data.scaleway_datalabs.all", "datalabs.#"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDatalabsDataSource_FilterByName(t *testing.T) {
+	tt := acctest.NewTestTools(t)
+	defer tt.Cleanup()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: tt.ProviderFactories,
+		CheckDestroy:             isDatalabDestroyed(tt),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(datalabTestBaseConfig, "tf_tests_datalabs_ds_name") + `
+					resource "scaleway_datalab" "main" {
+						name               = "tf_tests_datalabs_ds_name"
+						spark_version      = "4.0.0"
+						private_network_id = scaleway_vpc_private_network.main.id
+						region             = "fr-par"
+
+						main = {
+							node_type = "DATALAB-SHARED-4C-8G"
+						}
+
+						worker = {
+							node_type  = "DATALAB-DEDICATED2-2C-8G"
+							node_count = 1
+						}
+					}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					isDatalabPresent(tt, "scaleway_datalab.main"),
+				),
+			},
+			{
+				Config: fmt.Sprintf(datalabTestBaseConfig, "tf_tests_datalabs_ds_name") + `
+					resource "scaleway_datalab" "main" {
+						name               = "tf_tests_datalabs_ds_name"
+						spark_version      = "4.0.0"
+						private_network_id = scaleway_vpc_private_network.main.id
+						region             = "fr-par"
+
+						main = {
+							node_type = "DATALAB-SHARED-4C-8G"
+						}
+
+						worker = {
+							node_type  = "DATALAB-DEDICATED2-2C-8G"
+							node_count = 1
+						}
+					}
+
+					data "scaleway_datalabs" "by_name" {
+						name   = scaleway_datalab.main.name
+						region = "fr-par"
+					}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					isDatalabPresent(tt, "scaleway_datalab.main"),
+					resource.TestCheckResourceAttrSet("data.scaleway_datalabs.by_name", "datalabs.0.id"),
+					resource.TestCheckResourceAttr("data.scaleway_datalabs.by_name", "datalabs.0.name", "tf_tests_datalabs_ds_name"),
+					resource.TestCheckResourceAttr("data.scaleway_datalabs.by_name", "datalabs.0.spark_version", "4.0.0"),
+					resource.TestCheckResourceAttr("data.scaleway_datalabs.by_name", "datalabs.0.region", "fr-par"),
+					resource.TestCheckResourceAttrSet("data.scaleway_datalabs.by_name", "datalabs.0.project_id"),
+					resource.TestCheckResourceAttrSet("data.scaleway_datalabs.by_name", "datalabs.0.status"),
+					resource.TestCheckResourceAttrSet("data.scaleway_datalabs.by_name", "datalabs.0.created_at"),
+					resource.TestCheckResourceAttrSet("data.scaleway_datalabs.by_name", "datalabs.0.updated_at"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDatalabsDataSource_FilterByTags(t *testing.T) {
+	tt := acctest.NewTestTools(t)
+	defer tt.Cleanup()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: tt.ProviderFactories,
+		CheckDestroy:             isDatalabDestroyed(tt),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(datalabTestBaseConfig, "tf_tests_datalabs_ds_tags") + `
+					resource "scaleway_datalab" "main" {
+						name               = "tf_tests_datalabs_ds_tags"
+						spark_version      = "4.0.0"
+						private_network_id = scaleway_vpc_private_network.main.id
+						region             = "fr-par"
+						tags               = ["ds-filter-test", "env:test"]
+
+						main = {
+							node_type = "DATALAB-SHARED-4C-8G"
+						}
+
+						worker = {
+							node_type  = "DATALAB-DEDICATED2-2C-8G"
+							node_count = 1
+						}
+					}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					isDatalabPresent(tt, "scaleway_datalab.main"),
+				),
+			},
+			{
+				Config: fmt.Sprintf(datalabTestBaseConfig, "tf_tests_datalabs_ds_tags") + `
+					resource "scaleway_datalab" "main" {
+						name               = "tf_tests_datalabs_ds_tags"
+						spark_version      = "4.0.0"
+						private_network_id = scaleway_vpc_private_network.main.id
+						region             = "fr-par"
+						tags               = ["ds-filter-test", "env:test"]
+
+						main = {
+							node_type = "DATALAB-SHARED-4C-8G"
+						}
+
+						worker = {
+							node_type  = "DATALAB-DEDICATED2-2C-8G"
+							node_count = 1
+						}
+					}
+
+					data "scaleway_datalabs" "by_tags" {
+						tags   = ["ds-filter-test"]
+						region = "fr-par"
+					}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					isDatalabPresent(tt, "scaleway_datalab.main"),
+					resource.TestCheckResourceAttrSet("data.scaleway_datalabs.by_tags", "datalabs.0.id"),
+					resource.TestCheckResourceAttr("data.scaleway_datalabs.by_tags", "datalabs.0.name", "tf_tests_datalabs_ds_tags"),
+					resource.TestCheckResourceAttr("data.scaleway_datalabs.by_tags", "datalabs.0.tags.#", "2"),
+					resource.TestCheckResourceAttr("data.scaleway_datalabs.by_tags", "datalabs.0.tags.0", "ds-filter-test"),
+					resource.TestCheckResourceAttr("data.scaleway_datalabs.by_tags", "datalabs.0.tags.1", "env:test"),
+				),
+			},
+		},
+	})
+}

--- a/internal/services/datalab/helpers.go
+++ b/internal/services/datalab/helpers.go
@@ -1,0 +1,34 @@
+package datalab
+
+import (
+	"errors"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/scaleway/scaleway-sdk-go/scw"
+)
+
+func resolveRegion(regionAttr types.String, client *scw.Client) (scw.Region, error) {
+	if !regionAttr.IsNull() && !regionAttr.IsUnknown() && regionAttr.ValueString() != "" {
+		return scw.ParseRegion(regionAttr.ValueString())
+	}
+
+	region, exists := client.GetDefaultRegion()
+	if exists {
+		return region, nil
+	}
+
+	return "", errors.New("region is required; set it on the resource or configure a default region on the provider")
+}
+
+func resolveProjectID(projectIDAttr types.String, client *scw.Client) (string, error) {
+	if !projectIDAttr.IsNull() && !projectIDAttr.IsUnknown() && projectIDAttr.ValueString() != "" {
+		return projectIDAttr.ValueString(), nil
+	}
+
+	projectID, exists := client.GetDefaultProjectID()
+	if exists {
+		return projectID, nil
+	}
+
+	return "", errors.New("project_id is required; set it on the resource or configure a default project on the provider")
+}

--- a/internal/services/datalab/resource_datalab.go
+++ b/internal/services/datalab/resource_datalab.go
@@ -2,7 +2,6 @@ package datalab
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -14,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -110,7 +108,7 @@ func (r *DatalabResource) Metadata(_ context.Context, req resource.MetadataReque
 
 func (r *DatalabResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "",
+		MarkdownDescription: "Manages a Scaleway Datalab instance.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:            true,
@@ -148,7 +146,6 @@ func (r *DatalabResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 			"description": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
-				Default:             stringdefault.StaticString(""),
 				MarkdownDescription: "A description for the Datalab instance.",
 			},
 			"tags": schema.ListAttribute{
@@ -346,14 +343,14 @@ func (r *DatalabResource) Create(ctx context.Context, req resource.CreateRequest
 		return
 	}
 
-	region, err := r.resolveRegion(data.Region)
+	region, err := resolveRegion(data.Region, r.meta.ScwClient())
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to resolve region", err.Error())
 
 		return
 	}
 
-	projectID, err := r.resolveProjectID(data.ProjectID)
+	projectID, err := resolveProjectID(data.ProjectID, r.meta.ScwClient())
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to resolve project ID", err.Error())
 
@@ -634,32 +631,6 @@ func (r *DatalabResource) ImportState(ctx context.Context, req resource.ImportSt
 	}
 
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), regional.NewIDString(region, id))...)
-}
-
-func (r *DatalabResource) resolveRegion(regionAttr types.String) (scw.Region, error) {
-	if !regionAttr.IsNull() && !regionAttr.IsUnknown() && regionAttr.ValueString() != "" {
-		return scw.ParseRegion(regionAttr.ValueString())
-	}
-
-	region, exists := r.meta.ScwClient().GetDefaultRegion()
-	if exists {
-		return region, nil
-	}
-
-	return "", errors.New("region is required; set it on the resource or configure a default region on the provider")
-}
-
-func (r *DatalabResource) resolveProjectID(projectIDAttr types.String) (string, error) {
-	if !projectIDAttr.IsNull() && !projectIDAttr.IsUnknown() && projectIDAttr.ValueString() != "" {
-		return projectIDAttr.ValueString(), nil
-	}
-
-	projectID, exists := r.meta.ScwClient().GetDefaultProjectID()
-	if exists {
-		return projectID, nil
-	}
-
-	return "", errors.New("project_id is required; set it on the resource or configure a default project on the provider")
 }
 
 func flattenDatalab(ctx context.Context, dl *datalab.Datalab, diags *diag.Diagnostics) datalabResourceModel {

--- a/internal/services/datalab/resource_datalab.go
+++ b/internal/services/datalab/resource_datalab.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -23,6 +24,7 @@ import (
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/locality"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/locality/regional"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/meta"
+	scwtypes "github.com/scaleway/terraform-provider-scaleway/v2/internal/types"
 )
 
 var (
@@ -145,6 +147,8 @@ func (r *DatalabResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 			},
 			"description": schema.StringAttribute{
 				Optional:            true,
+				Computed:            true,
+				Default:             stringdefault.StaticString(""),
 				MarkdownDescription: "A description for the Datalab instance.",
 			},
 			"tags": schema.ListAttribute{
@@ -671,19 +675,10 @@ func flattenDatalab(ctx context.Context, dl *datalab.Datalab, diags *diag.Diagno
 		Status:           types.StringValue(string(dl.Status)),
 	}
 
-	if dl.Tags != nil {
-		tagValues := make([]attr.Value, len(dl.Tags))
-		for i, t := range dl.Tags {
-			tagValues[i] = types.StringValue(t)
-		}
+	tagList, d := scwtypes.FlattenFrameworkStringList(ctx, dl.Tags)
+	diags.Append(d...)
 
-		tagList, d := types.ListValue(types.StringType, tagValues)
-		diags.Append(d...)
-
-		model.Tags = tagList
-	} else {
-		model.Tags = types.ListNull(types.StringType)
-	}
+	model.Tags = tagList
 
 	if dl.CreatedAt != nil {
 		model.CreatedAt = types.StringValue(dl.CreatedAt.Format("2006-01-02T15:04:05Z07:00"))

--- a/internal/services/datalab/resource_datalab.go
+++ b/internal/services/datalab/resource_datalab.go
@@ -1,0 +1,783 @@
+package datalab
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	datalab "github.com/scaleway/scaleway-sdk-go/api/datalab/v1beta1"
+	"github.com/scaleway/scaleway-sdk-go/scw"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/httperrors"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/locality"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/locality/regional"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/meta"
+)
+
+var (
+	_ resource.Resource                = (*DatalabResource)(nil)
+	_ resource.ResourceWithConfigure   = (*DatalabResource)(nil)
+	_ resource.ResourceWithImportState = (*DatalabResource)(nil)
+)
+
+func NewDatalabResource() resource.Resource {
+	return &DatalabResource{}
+}
+
+type DatalabResource struct {
+	api  *datalab.API
+	meta *meta.Meta
+}
+
+type datalabResourceModel struct {
+	Tags              types.List   `tfsdk:"tags"`
+	Status            types.String `tfsdk:"status"`
+	Worker            types.Object `tfsdk:"worker"`
+	Region            types.String `tfsdk:"region"`
+	Description       types.String `tfsdk:"description"`
+	Name              types.String `tfsdk:"name"`
+	SparkVersion      types.String `tfsdk:"spark_version"`
+	ProjectID         types.String `tfsdk:"project_id"`
+	PrivateNetworkID  types.String `tfsdk:"private_network_id"`
+	Main              types.Object `tfsdk:"main"`
+	NotebookMasterURL types.String `tfsdk:"notebook_master_url"`
+	TotalStorage      types.Object `tfsdk:"total_storage"`
+	ID                types.String `tfsdk:"id"`
+	CreatedAt         types.String `tfsdk:"created_at"`
+	UpdatedAt         types.String `tfsdk:"updated_at"`
+	NotebookURL       types.String `tfsdk:"notebook_url"`
+	HasNotebook       types.Bool   `tfsdk:"has_notebook"`
+}
+
+type sparkMainModel struct {
+	NodeType       types.String `tfsdk:"node_type"`
+	SparkUIURL     types.String `tfsdk:"spark_ui_url"`
+	SparkMasterURL types.String `tfsdk:"spark_master_url"`
+	RootVolume     types.Object `tfsdk:"root_volume"`
+}
+
+type sparkWorkerModel struct {
+	NodeType   types.String `tfsdk:"node_type"`
+	RootVolume types.Object `tfsdk:"root_volume"`
+	NodeCount  types.Int64  `tfsdk:"node_count"`
+}
+
+type volumeModel struct {
+	Type types.String `tfsdk:"type"`
+	Size types.Int64  `tfsdk:"size"`
+}
+
+func volumeAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"type": types.StringType,
+		"size": types.Int64Type,
+	}
+}
+
+func sparkMainAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"node_type":        types.StringType,
+		"spark_ui_url":     types.StringType,
+		"spark_master_url": types.StringType,
+		"root_volume":      types.ObjectType{AttrTypes: volumeAttrTypes()},
+	}
+}
+
+func sparkWorkerAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"node_type":   types.StringType,
+		"node_count":  types.Int64Type,
+		"root_volume": types.ObjectType{AttrTypes: volumeAttrTypes()},
+	}
+}
+
+func (r *DatalabResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_datalab"
+}
+
+func (r *DatalabResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: "",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "The ID of the Datalab instance, in the `{region}/{id}` format.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"name": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "The name of the Datalab instance. If not provided, a random name is generated.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"project_id": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "The project ID the Datalab belongs to. Defaults to the provider's project ID.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"region": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "The region the Datalab is in. Only `fr-par` is currently supported.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"description": schema.StringAttribute{
+				Optional:            true,
+				MarkdownDescription: "A description for the Datalab instance.",
+			},
+			"tags": schema.ListAttribute{
+				Optional:            true,
+				ElementType:         types.StringType,
+				MarkdownDescription: "Tags associated with the Datalab instance.",
+			},
+			"spark_version": schema.StringAttribute{
+				Required:            true,
+				MarkdownDescription: "The Spark version to use for the Datalab instance. Available versions can be retrieved from `ListClusterVersions`.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"private_network_id": schema.StringAttribute{
+				Required:            true,
+				MarkdownDescription: "The ID of the private network to attach the Datalab to.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"has_notebook": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "Whether a JupyterLab notebook is associated with the Datalab.",
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.RequiresReplace(),
+					boolplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"main": schema.SingleNestedAttribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "The Spark main node configuration.",
+				PlanModifiers: []planmodifier.Object{
+					objectplanmodifier.UseStateForUnknown(),
+				},
+				Attributes: map[string]schema.Attribute{
+					"node_type": schema.StringAttribute{
+						Required:            true,
+						MarkdownDescription: "The node type for the main node.",
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.RequiresReplace(),
+						},
+					},
+					"spark_ui_url": schema.StringAttribute{
+						Computed:            true,
+						MarkdownDescription: "The Spark UI URL.",
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.UseStateForUnknown(),
+						},
+					},
+					"spark_master_url": schema.StringAttribute{
+						Computed:            true,
+						MarkdownDescription: "The Spark master URL within the VPC.",
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.UseStateForUnknown(),
+						},
+					},
+					"root_volume": schema.SingleNestedAttribute{
+						Computed:            true,
+						MarkdownDescription: "Volume details for the main node.",
+						PlanModifiers: []planmodifier.Object{
+							objectplanmodifier.UseStateForUnknown(),
+						},
+						Attributes: map[string]schema.Attribute{
+							"type": schema.StringAttribute{
+								Computed:            true,
+								MarkdownDescription: "The volume type.",
+							},
+							"size": schema.Int64Attribute{
+								Computed:            true,
+								MarkdownDescription: "The volume size in bytes.",
+							},
+						},
+					},
+				},
+			},
+			"worker": schema.SingleNestedAttribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "The Spark worker nodes configuration.",
+				PlanModifiers: []planmodifier.Object{
+					objectplanmodifier.UseStateForUnknown(),
+				},
+				Attributes: map[string]schema.Attribute{
+					"node_type": schema.StringAttribute{
+						Required:            true,
+						MarkdownDescription: "The node type for worker nodes.",
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.RequiresReplace(),
+						},
+					},
+					"node_count": schema.Int64Attribute{
+						Required:            true,
+						MarkdownDescription: "The number of worker nodes.",
+					},
+					"root_volume": schema.SingleNestedAttribute{
+						Computed:            true,
+						MarkdownDescription: "Volume details for worker nodes.",
+						PlanModifiers: []planmodifier.Object{
+							objectplanmodifier.UseStateForUnknown(),
+						},
+						Attributes: map[string]schema.Attribute{
+							"type": schema.StringAttribute{
+								Computed:            true,
+								MarkdownDescription: "The volume type.",
+							},
+							"size": schema.Int64Attribute{
+								Computed:            true,
+								MarkdownDescription: "The volume size in bytes.",
+							},
+						},
+					},
+				},
+			},
+			"total_storage": schema.SingleNestedAttribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "Persistent volume storage configuration.",
+				PlanModifiers: []planmodifier.Object{
+					objectplanmodifier.RequiresReplace(),
+					objectplanmodifier.UseStateForUnknown(),
+				},
+				Attributes: map[string]schema.Attribute{
+					"type": schema.StringAttribute{
+						Optional:            true,
+						Computed:            true,
+						MarkdownDescription: "The volume type. Defaults to `sbs_5k`.",
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.RequiresReplace(),
+						},
+					},
+					"size": schema.Int64Attribute{
+						Optional:            true,
+						Computed:            true,
+						MarkdownDescription: "The volume size in bytes.",
+						PlanModifiers: []planmodifier.Int64{
+							int64planmodifier.RequiresReplace(),
+						},
+					},
+				},
+			},
+			"status": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "The current status of the Datalab instance.",
+			},
+			"created_at": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "The creation timestamp of the Datalab instance.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"updated_at": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "The last update timestamp of the Datalab instance.",
+			},
+			"notebook_url": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "The URL of the JupyterLab notebook, if available.",
+			},
+			"notebook_master_url": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "The URL used to reach the cluster from the notebook.",
+			},
+		},
+	}
+}
+
+func (r *DatalabResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	m, ok := req.ProviderData.(*meta.Meta)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *meta.Meta, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+
+		return
+	}
+
+	r.meta = m
+	r.api = datalab.NewAPI(r.meta.ScwClient())
+}
+
+func (r *DatalabResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data datalabResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	region, err := r.resolveRegion(data.Region)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to resolve region", err.Error())
+
+		return
+	}
+
+	projectID, err := r.resolveProjectID(data.ProjectID)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to resolve project ID", err.Error())
+
+		return
+	}
+
+	createReq := &datalab.CreateDatalabRequest{
+		Region:           region,
+		ProjectID:        projectID,
+		Name:             data.Name.ValueString(),
+		Description:      data.Description.ValueString(),
+		SparkVersion:     data.SparkVersion.ValueString(),
+		PrivateNetworkID: locality.ExpandID(data.PrivateNetworkID.ValueString()),
+		HasNotebook:      data.HasNotebook.ValueBool(),
+	}
+
+	createReq.Tags = expandTags(ctx, data.Tags, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !data.Main.IsNull() && !data.Main.IsUnknown() {
+		var mainData sparkMainModel
+		resp.Diagnostics.Append(data.Main.As(ctx, &mainData, basetypes.ObjectAsOptions{})...)
+
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		createReq.Main = &datalab.CreateDatalabRequestSparkMain{
+			NodeType: mainData.NodeType.ValueString(),
+		}
+	}
+
+	if !data.Worker.IsNull() && !data.Worker.IsUnknown() {
+		var workerData sparkWorkerModel
+		resp.Diagnostics.Append(data.Worker.As(ctx, &workerData, basetypes.ObjectAsOptions{})...)
+
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		createReq.Worker = &datalab.CreateDatalabRequestSparkWorker{
+			NodeType:  workerData.NodeType.ValueString(),
+			NodeCount: uint32(workerData.NodeCount.ValueInt64()),
+		}
+	}
+
+	if !data.TotalStorage.IsNull() && !data.TotalStorage.IsUnknown() {
+		var storageData volumeModel
+		resp.Diagnostics.Append(data.TotalStorage.As(ctx, &storageData, basetypes.ObjectAsOptions{})...)
+
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		createReq.TotalStorage = &datalab.Volume{
+			Type: datalab.VolumeType(storageData.Type.ValueString()),
+			Size: scw.Size(storageData.Size.ValueInt64()),
+		}
+	}
+
+	dl, err := r.api.CreateDatalab(createReq, scw.WithContext(ctx))
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to create Datalab", err.Error())
+
+		return
+	}
+
+	dl, err = r.api.WaitForDatalab(&datalab.WaitForDatalabRequest{
+		Region:    region,
+		DatalabID: dl.ID,
+	}, scw.WithContext(ctx))
+	if err != nil {
+		resp.Diagnostics.AddError("Failed waiting for Datalab", err.Error())
+
+		return
+	}
+
+	if dl.Status != datalab.DatalabStatusReady {
+		resp.Diagnostics.AddError(
+			"Datalab not ready",
+			fmt.Sprintf("Datalab entered terminal status %q instead of ready", dl.Status),
+		)
+
+		return
+	}
+
+	state := flattenDatalab(ctx, dl, &resp.Diagnostics)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *DatalabResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state datalabResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	region, id, err := regional.ParseID(state.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to parse Datalab ID", err.Error())
+
+		return
+	}
+
+	dl, err := r.api.GetDatalab(&datalab.GetDatalabRequest{
+		Region:    region,
+		DatalabID: id,
+	}, scw.WithContext(ctx))
+	if err != nil {
+		if httperrors.Is404(err) {
+			resp.State.RemoveResource(ctx)
+
+			return
+		}
+
+		resp.Diagnostics.AddError("Failed to read Datalab", err.Error())
+
+		return
+	}
+
+	newState := flattenDatalab(ctx, dl, &resp.Diagnostics)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &newState)...)
+}
+
+func (r *DatalabResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var (
+		plan  datalabResourceModel
+		state datalabResourceModel
+	)
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	region, id, err := regional.ParseID(state.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to parse Datalab ID", err.Error())
+
+		return
+	}
+
+	updateReq := &datalab.UpdateDatalabRequest{
+		Region:    region,
+		DatalabID: id,
+	}
+
+	updateReq.Tags = expandTags(ctx, plan.Tags, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !plan.Name.Equal(state.Name) {
+		name := plan.Name.ValueString()
+		updateReq.Name = &name
+	}
+
+	if !plan.Description.Equal(state.Description) {
+		desc := plan.Description.ValueString()
+		updateReq.Description = &desc
+	}
+
+	if !plan.Worker.IsNull() && !plan.Worker.IsUnknown() {
+		var planWorker sparkWorkerModel
+		resp.Diagnostics.Append(plan.Worker.As(ctx, &planWorker, basetypes.ObjectAsOptions{})...)
+
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		if !state.Worker.IsNull() && !state.Worker.IsUnknown() {
+			var stateWorker sparkWorkerModel
+			resp.Diagnostics.Append(state.Worker.As(ctx, &stateWorker, basetypes.ObjectAsOptions{})...)
+
+			if resp.Diagnostics.HasError() {
+				return
+			}
+
+			if !planWorker.NodeCount.Equal(stateWorker.NodeCount) {
+				nodeCount := uint32(planWorker.NodeCount.ValueInt64())
+				updateReq.NodeCount = &nodeCount
+			}
+		}
+	}
+
+	dl, err := r.api.UpdateDatalab(updateReq, scw.WithContext(ctx))
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to update Datalab", err.Error())
+
+		return
+	}
+
+	dl, err = r.api.WaitForDatalab(&datalab.WaitForDatalabRequest{
+		Region:    region,
+		DatalabID: dl.ID,
+	}, scw.WithContext(ctx))
+	if err != nil {
+		resp.Diagnostics.AddError("Failed waiting for Datalab update", err.Error())
+
+		return
+	}
+
+	if dl.Status != datalab.DatalabStatusReady {
+		resp.Diagnostics.AddError(
+			"Datalab not ready after update",
+			fmt.Sprintf("Datalab entered terminal status %q instead of ready", dl.Status),
+		)
+
+		return
+	}
+
+	newState := flattenDatalab(ctx, dl, &resp.Diagnostics)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &newState)...)
+}
+
+func (r *DatalabResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state datalabResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	region, id, err := regional.ParseID(state.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to parse Datalab ID", err.Error())
+
+		return
+	}
+
+	_, err = r.api.DeleteDatalab(&datalab.DeleteDatalabRequest{
+		Region:    region,
+		DatalabID: id,
+	}, scw.WithContext(ctx))
+	if err != nil {
+		if httperrors.Is404(err) {
+			return
+		}
+
+		resp.Diagnostics.AddError("Failed to delete Datalab", err.Error())
+
+		return
+	}
+
+	dl, err := r.api.WaitForDatalab(&datalab.WaitForDatalabRequest{
+		Region:    region,
+		DatalabID: id,
+	}, scw.WithContext(ctx))
+	if err != nil {
+		if httperrors.Is404(err) {
+			return
+		}
+
+		resp.Diagnostics.AddError("Failed waiting for Datalab deletion", err.Error())
+
+		return
+	}
+
+	if dl.Status != datalab.DatalabStatusDeleted {
+		resp.Diagnostics.AddError(
+			"Datalab deletion failed",
+			fmt.Sprintf("Datalab entered terminal status %q instead of deleted", dl.Status),
+		)
+	}
+}
+
+func (r *DatalabResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	region, id, err := regional.ParseID(req.ID)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to parse import ID", "Expected format: {region}/{id}. "+err.Error())
+
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), regional.NewIDString(region, id))...)
+}
+
+func (r *DatalabResource) resolveRegion(regionAttr types.String) (scw.Region, error) {
+	if !regionAttr.IsNull() && !regionAttr.IsUnknown() && regionAttr.ValueString() != "" {
+		return scw.ParseRegion(regionAttr.ValueString())
+	}
+
+	region, exists := r.meta.ScwClient().GetDefaultRegion()
+	if exists {
+		return region, nil
+	}
+
+	return "", errors.New("region is required; set it on the resource or configure a default region on the provider")
+}
+
+func (r *DatalabResource) resolveProjectID(projectIDAttr types.String) (string, error) {
+	if !projectIDAttr.IsNull() && !projectIDAttr.IsUnknown() && projectIDAttr.ValueString() != "" {
+		return projectIDAttr.ValueString(), nil
+	}
+
+	projectID, exists := r.meta.ScwClient().GetDefaultProjectID()
+	if exists {
+		return projectID, nil
+	}
+
+	return "", errors.New("project_id is required; set it on the resource or configure a default project on the provider")
+}
+
+func flattenDatalab(ctx context.Context, dl *datalab.Datalab, diags *diag.Diagnostics) datalabResourceModel {
+	model := datalabResourceModel{
+		ID:               types.StringValue(regional.NewIDString(dl.Region, dl.ID)),
+		Name:             types.StringValue(dl.Name),
+		ProjectID:        types.StringValue(dl.ProjectID),
+		Region:           types.StringValue(dl.Region.String()),
+		Description:      types.StringValue(dl.Description),
+		SparkVersion:     types.StringValue(dl.SparkVersion),
+		PrivateNetworkID: types.StringValue(regional.NewIDString(dl.Region, dl.PrivateNetworkID)),
+		HasNotebook:      types.BoolValue(dl.HasNotebook),
+		Status:           types.StringValue(string(dl.Status)),
+	}
+
+	if dl.Tags != nil {
+		tagValues := make([]attr.Value, len(dl.Tags))
+		for i, t := range dl.Tags {
+			tagValues[i] = types.StringValue(t)
+		}
+
+		tagList, d := types.ListValue(types.StringType, tagValues)
+		diags.Append(d...)
+
+		model.Tags = tagList
+	} else {
+		model.Tags = types.ListNull(types.StringType)
+	}
+
+	if dl.CreatedAt != nil {
+		model.CreatedAt = types.StringValue(dl.CreatedAt.Format("2006-01-02T15:04:05Z07:00"))
+	} else {
+		model.CreatedAt = types.StringNull()
+	}
+
+	if dl.UpdatedAt != nil {
+		model.UpdatedAt = types.StringValue(dl.UpdatedAt.Format("2006-01-02T15:04:05Z07:00"))
+	} else {
+		model.UpdatedAt = types.StringNull()
+	}
+
+	if dl.NotebookURL != nil {
+		model.NotebookURL = types.StringValue(*dl.NotebookURL)
+	} else {
+		model.NotebookURL = types.StringNull()
+	}
+
+	if dl.NotebookMasterURL != nil {
+		model.NotebookMasterURL = types.StringValue(*dl.NotebookMasterURL)
+	} else {
+		model.NotebookMasterURL = types.StringNull()
+	}
+
+	model.Main = flattenSparkMain(dl.Main, diags)
+	model.Worker = flattenSparkWorker(dl.Worker, diags)
+	model.TotalStorage = flattenVolume(dl.TotalStorage, diags)
+
+	return model
+}
+
+func flattenSparkMain(main *datalab.DatalabSparkMain, diags *diag.Diagnostics) types.Object {
+	if main == nil {
+		return types.ObjectNull(sparkMainAttrTypes())
+	}
+
+	rootVolume := flattenVolume(main.RootVolume, diags)
+
+	attrValues := map[string]attr.Value{
+		"node_type":        types.StringValue(main.NodeType),
+		"spark_ui_url":     types.StringValue(main.SparkUIURL),
+		"spark_master_url": types.StringValue(main.SparkMasterURL),
+		"root_volume":      rootVolume,
+	}
+
+	obj, d := types.ObjectValue(sparkMainAttrTypes(), attrValues)
+	diags.Append(d...)
+
+	return obj
+}
+
+func flattenSparkWorker(worker *datalab.DatalabSparkWorker, diags *diag.Diagnostics) types.Object {
+	if worker == nil {
+		return types.ObjectNull(sparkWorkerAttrTypes())
+	}
+
+	rootVolume := flattenVolume(worker.RootVolume, diags)
+
+	attrValues := map[string]attr.Value{
+		"node_type":   types.StringValue(worker.NodeType),
+		"node_count":  types.Int64Value(int64(worker.NodeCount)),
+		"root_volume": rootVolume,
+	}
+
+	obj, d := types.ObjectValue(sparkWorkerAttrTypes(), attrValues)
+	diags.Append(d...)
+
+	return obj
+}
+
+func flattenVolume(vol *datalab.Volume, diags *diag.Diagnostics) types.Object {
+	if vol == nil {
+		return types.ObjectNull(volumeAttrTypes())
+	}
+
+	attrValues := map[string]attr.Value{
+		"type": types.StringValue(string(vol.Type)),
+		"size": types.Int64Value(int64(vol.Size)),
+	}
+
+	obj, d := types.ObjectValue(volumeAttrTypes(), attrValues)
+	diags.Append(d...)
+
+	return obj
+}
+
+func expandTags(ctx context.Context, tags types.List, diags *diag.Diagnostics) []string {
+	if tags.IsNull() || tags.IsUnknown() {
+		return nil
+	}
+
+	var result []string
+	diags.Append(tags.ElementsAs(ctx, &result, false)...)
+
+	return result
+}

--- a/internal/services/datalab/resource_datalab_test.go
+++ b/internal/services/datalab/resource_datalab_test.go
@@ -1,0 +1,304 @@
+package datalab_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	datalabSDK "github.com/scaleway/scaleway-sdk-go/api/datalab/v1beta1"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/acctest"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/httperrors"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/locality/regional"
+)
+
+const datalabTestBaseConfig = `
+resource "scaleway_vpc" "main" {
+	name = "%s"
+}
+
+resource "scaleway_vpc_private_network" "main" {
+	vpc_id = scaleway_vpc.main.id
+	region = "fr-par"
+}
+`
+
+func TestAccDatalabResource_Basic(t *testing.T) {
+	tt := acctest.NewTestTools(t)
+	defer tt.Cleanup()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: tt.ProviderFactories,
+		CheckDestroy:             isDatalabDestroyed(tt),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(datalabTestBaseConfig, "tf_tests_datalab_basic") + `
+					resource "scaleway_datalab" "main" {
+						name               = "tf_tests_datalab_basic"
+						spark_version      = "4.0.0"
+						private_network_id = scaleway_vpc_private_network.main.id
+						region             = "fr-par"
+
+						main = {
+							node_type = "DATALAB-SHARED-4C-8G"
+						}
+
+						worker = {
+							node_type  = "DATALAB-DEDICATED2-2C-8G"
+							node_count = 1
+						}
+					}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					isDatalabPresent(tt, "scaleway_datalab.main"),
+					resource.TestCheckResourceAttr("scaleway_datalab.main", "name", "tf_tests_datalab_basic"),
+					resource.TestCheckResourceAttr("scaleway_datalab.main", "spark_version", "4.0.0"),
+					resource.TestCheckResourceAttr("scaleway_datalab.main", "region", "fr-par"),
+					resource.TestCheckResourceAttr("scaleway_datalab.main", "status", "ready"),
+					resource.TestCheckResourceAttr("scaleway_datalab.main", "main.node_type", "DATALAB-SHARED-4C-8G"),
+					resource.TestCheckResourceAttr("scaleway_datalab.main", "worker.node_type", "DATALAB-DEDICATED2-2C-8G"),
+					resource.TestCheckResourceAttr("scaleway_datalab.main", "worker.node_count", "1"),
+					resource.TestCheckResourceAttrSet("scaleway_datalab.main", "id"),
+					resource.TestCheckResourceAttrSet("scaleway_datalab.main", "project_id"),
+					resource.TestCheckResourceAttrSet("scaleway_datalab.main", "created_at"),
+					resource.TestCheckResourceAttrSet("scaleway_datalab.main", "updated_at"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDatalabResource_Update(t *testing.T) {
+	tt := acctest.NewTestTools(t)
+	defer tt.Cleanup()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: tt.ProviderFactories,
+		CheckDestroy:             isDatalabDestroyed(tt),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(datalabTestBaseConfig, "tf_tests_datalab_update") + `
+					resource "scaleway_datalab" "main" {
+						name               = "tf_tests_datalab_update"
+						description        = "initial description"
+						spark_version      = "4.0.0"
+						private_network_id = scaleway_vpc_private_network.main.id
+						region             = "fr-par"
+						tags               = ["tag1"]
+
+						main = {
+							node_type = "DATALAB-SHARED-4C-8G"
+						}
+
+						worker = {
+							node_type  = "DATALAB-DEDICATED2-2C-8G"
+							node_count = 1
+						}
+					}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					isDatalabPresent(tt, "scaleway_datalab.main"),
+					resource.TestCheckResourceAttr("scaleway_datalab.main", "name", "tf_tests_datalab_update"),
+					resource.TestCheckResourceAttr("scaleway_datalab.main", "description", "initial description"),
+					resource.TestCheckResourceAttr("scaleway_datalab.main", "tags.0", "tag1"),
+					resource.TestCheckResourceAttr("scaleway_datalab.main", "tags.#", "1"),
+				),
+			},
+			{
+				Config: fmt.Sprintf(datalabTestBaseConfig, "tf_tests_datalab_update") + `
+					resource "scaleway_datalab" "main" {
+						name               = "tf_tests_datalab_update_renamed"
+						description        = "updated description"
+						spark_version      = "4.0.0"
+						private_network_id = scaleway_vpc_private_network.main.id
+						region             = "fr-par"
+						tags               = ["tag1", "tag2"]
+
+						main = {
+							node_type = "DATALAB-SHARED-4C-8G"
+						}
+
+						worker = {
+							node_type  = "DATALAB-DEDICATED2-2C-8G"
+							node_count = 1
+						}
+					}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					isDatalabPresent(tt, "scaleway_datalab.main"),
+					resource.TestCheckResourceAttr("scaleway_datalab.main", "name", "tf_tests_datalab_update_renamed"),
+					resource.TestCheckResourceAttr("scaleway_datalab.main", "description", "updated description"),
+					resource.TestCheckResourceAttr("scaleway_datalab.main", "tags.0", "tag1"),
+					resource.TestCheckResourceAttr("scaleway_datalab.main", "tags.1", "tag2"),
+					resource.TestCheckResourceAttr("scaleway_datalab.main", "tags.#", "2"),
+					resource.TestCheckResourceAttr("scaleway_datalab.main", "status", "ready"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDatalabResource_Import(t *testing.T) {
+	tt := acctest.NewTestTools(t)
+	defer tt.Cleanup()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: tt.ProviderFactories,
+		CheckDestroy:             isDatalabDestroyed(tt),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(datalabTestBaseConfig, "tf_tests_datalab_import") + `
+					resource "scaleway_datalab" "main" {
+						name               = "tf_tests_datalab_import"
+						spark_version      = "4.0.0"
+						private_network_id = scaleway_vpc_private_network.main.id
+						region             = "fr-par"
+
+						main = {
+							node_type = "DATALAB-SHARED-4C-8G"
+						}
+
+						worker = {
+							node_type  = "DATALAB-DEDICATED2-2C-8G"
+							node_count = 1
+						}
+					}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					isDatalabPresent(tt, "scaleway_datalab.main"),
+				),
+			},
+			{
+				ResourceName:      "scaleway_datalab.main",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccDatalabResource_WithWorker(t *testing.T) {
+	tt := acctest.NewTestTools(t)
+	defer tt.Cleanup()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: tt.ProviderFactories,
+		CheckDestroy:             isDatalabDestroyed(tt),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(datalabTestBaseConfig, "tf_tests_datalab_worker") + `
+					resource "scaleway_datalab" "main" {
+						name               = "tf_tests_datalab_worker"
+						spark_version      = "4.0.0"
+						private_network_id = scaleway_vpc_private_network.main.id
+						region             = "fr-par"
+
+						main = {
+							node_type = "DATALAB-SHARED-4C-8G"
+						}
+
+						worker = {
+							node_type  = "DATALAB-DEDICATED2-2C-8G"
+							node_count = 1
+						}
+					}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					isDatalabPresent(tt, "scaleway_datalab.main"),
+					resource.TestCheckResourceAttr("scaleway_datalab.main", "name", "tf_tests_datalab_worker"),
+					resource.TestCheckResourceAttr("scaleway_datalab.main", "main.node_type", "DATALAB-SHARED-4C-8G"),
+					resource.TestCheckResourceAttr("scaleway_datalab.main", "worker.node_type", "DATALAB-DEDICATED2-2C-8G"),
+					resource.TestCheckResourceAttr("scaleway_datalab.main", "worker.node_count", "1"),
+					resource.TestCheckResourceAttrSet("scaleway_datalab.main", "status"),
+				),
+			},
+			{
+				Config: fmt.Sprintf(datalabTestBaseConfig, "tf_tests_datalab_worker") + `
+					resource "scaleway_datalab" "main" {
+						name               = "tf_tests_datalab_worker"
+						spark_version      = "4.0.0"
+						private_network_id = scaleway_vpc_private_network.main.id
+						region             = "fr-par"
+
+						main = {
+							node_type = "DATALAB-SHARED-4C-8G"
+						}
+
+						worker = {
+							node_type  = "DATALAB-DEDICATED2-2C-8G"
+							node_count = 2
+						}
+					}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					isDatalabPresent(tt, "scaleway_datalab.main"),
+					resource.TestCheckResourceAttr("scaleway_datalab.main", "worker.node_count", "2"),
+					resource.TestCheckResourceAttr("scaleway_datalab.main", "status", "ready"),
+				),
+			},
+		},
+	})
+}
+
+func isDatalabDestroyed(tt *acctest.TestTools) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		for _, rs := range state.RootModule().Resources {
+			if rs.Type != "scaleway_datalab" {
+				continue
+			}
+
+			api := datalabSDK.NewAPI(tt.Meta.ScwClient())
+
+			region, id, err := regional.ParseID(rs.Primary.ID)
+			if err != nil {
+				return err
+			}
+
+			dl, err := api.GetDatalab(&datalabSDK.GetDatalabRequest{
+				Region:    region,
+				DatalabID: id,
+			})
+			if err != nil {
+				if httperrors.Is404(err) {
+					continue
+				}
+
+				return err
+			}
+
+			if dl.Status == datalabSDK.DatalabStatusDeleted {
+				continue
+			}
+
+			return fmt.Errorf("datalab (%s) still exists with status %s", rs.Primary.ID, dl.Status)
+		}
+
+		return nil
+	}
+}
+
+func isDatalabPresent(tt *acctest.TestTools, n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", n)
+		}
+
+		api := datalabSDK.NewAPI(tt.Meta.ScwClient())
+
+		region, id, err := regional.ParseID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		_, err = api.GetDatalab(&datalabSDK.GetDatalabRequest{
+			Region:    region,
+			DatalabID: id,
+		})
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+}

--- a/internal/services/datalab/sweep_test.go
+++ b/internal/services/datalab/sweep_test.go
@@ -1,0 +1,55 @@
+package datalab_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	datalabSDK "github.com/scaleway/scaleway-sdk-go/api/datalab/v1beta1"
+	"github.com/scaleway/scaleway-sdk-go/scw"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/acctest"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/httperrors"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/logging"
+)
+
+func init() {
+	resource.AddTestSweepers("scaleway_datalab", &resource.Sweeper{
+		Name: "scaleway_datalab",
+		F:    testSweepDatalab,
+	})
+}
+
+func TestMain(m *testing.M) {
+	resource.TestMain(m)
+}
+
+func testSweepDatalab(_ string) error {
+	return acctest.SweepRegions([]scw.Region{scw.RegionFrPar}, func(scwClient *scw.Client, region scw.Region) error {
+		api := datalabSDK.NewAPI(scwClient)
+
+		listResp, err := api.ListDatalabs(&datalabSDK.ListDatalabsRequest{
+			Region: region,
+		}, scw.WithAllPages())
+		if err != nil {
+			return fmt.Errorf("failed to list datalabs: %w", err)
+		}
+
+		for _, dl := range listResp.Datalabs {
+			if !acctest.IsTestResource(dl.Name) {
+				continue
+			}
+
+			_, err := api.DeleteDatalab(&datalabSDK.DeleteDatalabRequest{
+				Region:    region,
+				DatalabID: dl.ID,
+			})
+			if err != nil {
+				if !httperrors.Is404(err) {
+					logging.L.Warningf("sweeper: failed to delete datalab %s: %s", dl.ID, err)
+				}
+			}
+		}
+
+		return nil
+	})
+}

--- a/internal/services/datalab/testdata/datalab-data-source-by-id.cassette.yaml
+++ b/internal/services/datalab/testdata/datalab-data-source-by-id.cassette.yaml
@@ -1,0 +1,1896 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 121
+        host: api.scaleway.com
+        body: '{"name":"tf_tests_datalab_ds_by_id","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","tags":[],"enable_routing":false}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 412
+        body: '{"id":"71a53def-f2cc-43d7-ad53-0cbb035ffcd7","name":"tf_tests_datalab_ds_by_id","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:21:14.936395Z","updated_at":"2026-03-26T11:21:14.936395Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","is_default":false,"private_network_count":0,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "412"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:21:14 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - a3d3980a-f189-419d-9be0-0245d5cadb1e
+        status: 200 OK
+        code: 200
+        duration: 283.247298ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/71a53def-f2cc-43d7-ad53-0cbb035ffcd7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 412
+        body: '{"id":"71a53def-f2cc-43d7-ad53-0cbb035ffcd7","name":"tf_tests_datalab_ds_by_id","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:21:14.936395Z","updated_at":"2026-03-26T11:21:14.936395Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","is_default":false,"private_network_count":0,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "412"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:21:15 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 60743cef-90a4-46db-86d4-a6f0dcb354a4
+        status: 200 OK
+        code: 200
+        duration: 58.868661ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 198
+        host: api.scaleway.com
+        body: '{"name":"tf-pn-sharp-mccarthy","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","tags":[],"subnets":null,"vpc_id":"71a53def-f2cc-43d7-ad53-0cbb035ffcd7","default_route_propagation_enabled":false}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1063
+        body: '{"id":"3589ad86-bbef-457e-bc57-7e355a773820","name":"tf-pn-sharp-mccarthy","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:21:15.091800Z","updated_at":"2026-03-26T11:21:15.091800Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","subnets":[{"id":"b6259fb5-5b1f-4883-a33e-7c548bdb1f1e","created_at":"2026-03-26T11:21:15.091800Z","updated_at":"2026-03-26T11:21:15.091800Z","subnet":"172.16.8.0/22","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"3589ad86-bbef-457e-bc57-7e355a773820","vpc_id":"71a53def-f2cc-43d7-ad53-0cbb035ffcd7"},{"id":"928991f7-a406-4312-b10b-f4cbb268ef97","created_at":"2026-03-26T11:21:15.091800Z","updated_at":"2026-03-26T11:21:15.091800Z","subnet":"fd40:e277:fdde:b5::/64","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"3589ad86-bbef-457e-bc57-7e355a773820","vpc_id":"71a53def-f2cc-43d7-ad53-0cbb035ffcd7"}],"vpc_id":"71a53def-f2cc-43d7-ad53-0cbb035ffcd7","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1063"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:21:15 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - e00d62a3-a5a4-4c2f-819d-f036602c0df6
+        status: 200 OK
+        code: 200
+        duration: 824.845003ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3589ad86-bbef-457e-bc57-7e355a773820
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1063
+        body: '{"id":"3589ad86-bbef-457e-bc57-7e355a773820","name":"tf-pn-sharp-mccarthy","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:21:15.091800Z","updated_at":"2026-03-26T11:21:15.091800Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","subnets":[{"id":"b6259fb5-5b1f-4883-a33e-7c548bdb1f1e","created_at":"2026-03-26T11:21:15.091800Z","updated_at":"2026-03-26T11:21:15.091800Z","subnet":"172.16.8.0/22","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"3589ad86-bbef-457e-bc57-7e355a773820","vpc_id":"71a53def-f2cc-43d7-ad53-0cbb035ffcd7"},{"id":"928991f7-a406-4312-b10b-f4cbb268ef97","created_at":"2026-03-26T11:21:15.091800Z","updated_at":"2026-03-26T11:21:15.091800Z","subnet":"fd40:e277:fdde:b5::/64","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"3589ad86-bbef-457e-bc57-7e355a773820","vpc_id":"71a53def-f2cc-43d7-ad53-0cbb035ffcd7"}],"vpc_id":"71a53def-f2cc-43d7-ad53-0cbb035ffcd7","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1063"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:21:15 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 5ee9fd80-3063-48a4-b7ce-2f4e1687e692
+        status: 200 OK
+        code: 200
+        duration: 63.237381ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 372
+        host: api.scaleway.com
+        body: '{"project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_id","description":"test datalab for data source by id","tags":["ds-test"],"main":{"node_type":"DATALAB-SHARED-4C-8G"},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1},"has_notebook":false,"spark_version":"4.0.0","private_network_id":"3589ad86-bbef-457e-bc57-7e355a773820"}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 954
+        body: '{"id":"0196e41a-0381-455f-9a99-9a6945293567","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_id","description":"test datalab for data source by id","tags":["ds-test"],"created_at":"2026-03-26T11:21:16.085672Z","updated_at":"2026-03-26T11:21:16.085672Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://0196e41a-0381-455f-9a99-9a6945293567.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-0196e41a-0381-455f-9a99-9a6945293567.3589ad86-bbef-457e-bc57-7e355a773820.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"3589ad86-bbef-457e-bc57-7e355a773820","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "954"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:21:17 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 27f17c76-19a2-415c-abe2-574ec0507d2e
+        status: 200 OK
+        code: 200
+        duration: 1.247786869s
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/0196e41a-0381-455f-9a99-9a6945293567
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 954
+        body: '{"id":"0196e41a-0381-455f-9a99-9a6945293567","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_id","description":"test datalab for data source by id","tags":["ds-test"],"created_at":"2026-03-26T11:21:16.085672Z","updated_at":"2026-03-26T11:21:16.085672Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://0196e41a-0381-455f-9a99-9a6945293567.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-0196e41a-0381-455f-9a99-9a6945293567.3589ad86-bbef-457e-bc57-7e355a773820.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"3589ad86-bbef-457e-bc57-7e355a773820","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "954"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:21:17 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - f2931223-7e94-43fc-8b34-93b8dfd615fe
+        status: 200 OK
+        code: 200
+        duration: 74.73108ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/0196e41a-0381-455f-9a99-9a6945293567
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 954
+        body: '{"id":"0196e41a-0381-455f-9a99-9a6945293567","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_id","description":"test datalab for data source by id","tags":["ds-test"],"created_at":"2026-03-26T11:21:16.085672Z","updated_at":"2026-03-26T11:21:16.085672Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://0196e41a-0381-455f-9a99-9a6945293567.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-0196e41a-0381-455f-9a99-9a6945293567.3589ad86-bbef-457e-bc57-7e355a773820.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"3589ad86-bbef-457e-bc57-7e355a773820","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "954"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:21:32 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 37043e78-5265-477a-8af9-5561b6d147a0
+        status: 200 OK
+        code: 200
+        duration: 77.713985ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/0196e41a-0381-455f-9a99-9a6945293567
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 954
+        body: '{"id":"0196e41a-0381-455f-9a99-9a6945293567","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_id","description":"test datalab for data source by id","tags":["ds-test"],"created_at":"2026-03-26T11:21:16.085672Z","updated_at":"2026-03-26T11:21:16.085672Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://0196e41a-0381-455f-9a99-9a6945293567.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-0196e41a-0381-455f-9a99-9a6945293567.3589ad86-bbef-457e-bc57-7e355a773820.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"3589ad86-bbef-457e-bc57-7e355a773820","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "954"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:21:47 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - f4c896a2-6c61-42f7-a984-ab1350479ed4
+        status: 200 OK
+        code: 200
+        duration: 76.252892ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/0196e41a-0381-455f-9a99-9a6945293567
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 954
+        body: '{"id":"0196e41a-0381-455f-9a99-9a6945293567","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_id","description":"test datalab for data source by id","tags":["ds-test"],"created_at":"2026-03-26T11:21:16.085672Z","updated_at":"2026-03-26T11:21:16.085672Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://0196e41a-0381-455f-9a99-9a6945293567.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-0196e41a-0381-455f-9a99-9a6945293567.3589ad86-bbef-457e-bc57-7e355a773820.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"3589ad86-bbef-457e-bc57-7e355a773820","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "954"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:22:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 0f81dc93-851e-4580-9fc5-66aef617abc6
+        status: 200 OK
+        code: 200
+        duration: 66.763442ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/0196e41a-0381-455f-9a99-9a6945293567
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 954
+        body: '{"id":"0196e41a-0381-455f-9a99-9a6945293567","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_id","description":"test datalab for data source by id","tags":["ds-test"],"created_at":"2026-03-26T11:21:16.085672Z","updated_at":"2026-03-26T11:21:16.085672Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://0196e41a-0381-455f-9a99-9a6945293567.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-0196e41a-0381-455f-9a99-9a6945293567.3589ad86-bbef-457e-bc57-7e355a773820.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"3589ad86-bbef-457e-bc57-7e355a773820","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "954"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:22:17 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - e132d1c0-94f3-4a6c-8845-cb2bfcd01407
+        status: 200 OK
+        code: 200
+        duration: 74.863907ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/0196e41a-0381-455f-9a99-9a6945293567
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 954
+        body: '{"id":"0196e41a-0381-455f-9a99-9a6945293567","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_id","description":"test datalab for data source by id","tags":["ds-test"],"created_at":"2026-03-26T11:21:16.085672Z","updated_at":"2026-03-26T11:21:16.085672Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://0196e41a-0381-455f-9a99-9a6945293567.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-0196e41a-0381-455f-9a99-9a6945293567.3589ad86-bbef-457e-bc57-7e355a773820.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"3589ad86-bbef-457e-bc57-7e355a773820","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "954"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:22:32 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - e9e63288-e087-46ae-903d-eb5aff459829
+        status: 200 OK
+        code: 200
+        duration: 80.625632ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/0196e41a-0381-455f-9a99-9a6945293567
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 954
+        body: '{"id":"0196e41a-0381-455f-9a99-9a6945293567","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_id","description":"test datalab for data source by id","tags":["ds-test"],"created_at":"2026-03-26T11:21:16.085672Z","updated_at":"2026-03-26T11:21:16.085672Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://0196e41a-0381-455f-9a99-9a6945293567.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-0196e41a-0381-455f-9a99-9a6945293567.3589ad86-bbef-457e-bc57-7e355a773820.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"3589ad86-bbef-457e-bc57-7e355a773820","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "954"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:22:47 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 1f4999b9-0afe-4c2a-99ec-052a61893fd4
+        status: 200 OK
+        code: 200
+        duration: 72.40208ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/0196e41a-0381-455f-9a99-9a6945293567
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 954
+        body: '{"id":"0196e41a-0381-455f-9a99-9a6945293567","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_id","description":"test datalab for data source by id","tags":["ds-test"],"created_at":"2026-03-26T11:21:16.085672Z","updated_at":"2026-03-26T11:21:16.085672Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://0196e41a-0381-455f-9a99-9a6945293567.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-0196e41a-0381-455f-9a99-9a6945293567.3589ad86-bbef-457e-bc57-7e355a773820.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"3589ad86-bbef-457e-bc57-7e355a773820","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "954"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:23:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 46069c95-a2d3-4a83-96f8-546255b1bc0a
+        status: 200 OK
+        code: 200
+        duration: 70.479659ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/0196e41a-0381-455f-9a99-9a6945293567
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 954
+        body: '{"id":"0196e41a-0381-455f-9a99-9a6945293567","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_id","description":"test datalab for data source by id","tags":["ds-test"],"created_at":"2026-03-26T11:21:16.085672Z","updated_at":"2026-03-26T11:21:16.085672Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://0196e41a-0381-455f-9a99-9a6945293567.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-0196e41a-0381-455f-9a99-9a6945293567.3589ad86-bbef-457e-bc57-7e355a773820.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"3589ad86-bbef-457e-bc57-7e355a773820","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "954"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:23:17 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - a3dca6a2-6920-42e0-9456-663affbb0b8e
+        status: 200 OK
+        code: 200
+        duration: 67.334699ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/0196e41a-0381-455f-9a99-9a6945293567
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 954
+        body: '{"id":"0196e41a-0381-455f-9a99-9a6945293567","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_id","description":"test datalab for data source by id","tags":["ds-test"],"created_at":"2026-03-26T11:21:16.085672Z","updated_at":"2026-03-26T11:21:16.085672Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://0196e41a-0381-455f-9a99-9a6945293567.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-0196e41a-0381-455f-9a99-9a6945293567.3589ad86-bbef-457e-bc57-7e355a773820.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"3589ad86-bbef-457e-bc57-7e355a773820","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "954"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:23:32 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 82a321ac-b443-49c9-b9c2-dab70d1b3ec1
+        status: 200 OK
+        code: 200
+        duration: 79.445382ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/0196e41a-0381-455f-9a99-9a6945293567
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 954
+        body: '{"id":"0196e41a-0381-455f-9a99-9a6945293567","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_id","description":"test datalab for data source by id","tags":["ds-test"],"created_at":"2026-03-26T11:21:16.085672Z","updated_at":"2026-03-26T11:21:16.085672Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://0196e41a-0381-455f-9a99-9a6945293567.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-0196e41a-0381-455f-9a99-9a6945293567.3589ad86-bbef-457e-bc57-7e355a773820.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"3589ad86-bbef-457e-bc57-7e355a773820","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "954"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:23:47 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 72f278d1-235c-4231-bb68-080fbf96c1c0
+        status: 200 OK
+        code: 200
+        duration: 88.366267ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/0196e41a-0381-455f-9a99-9a6945293567
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 954
+        body: '{"id":"0196e41a-0381-455f-9a99-9a6945293567","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_id","description":"test datalab for data source by id","tags":["ds-test"],"created_at":"2026-03-26T11:21:16.085672Z","updated_at":"2026-03-26T11:21:16.085672Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://0196e41a-0381-455f-9a99-9a6945293567.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-0196e41a-0381-455f-9a99-9a6945293567.3589ad86-bbef-457e-bc57-7e355a773820.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"3589ad86-bbef-457e-bc57-7e355a773820","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "954"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:24:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - eeef307f-e13e-4ed8-ad4f-e19f254cc453
+        status: 200 OK
+        code: 200
+        duration: 78.468687ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/0196e41a-0381-455f-9a99-9a6945293567
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 954
+        body: '{"id":"0196e41a-0381-455f-9a99-9a6945293567","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_id","description":"test datalab for data source by id","tags":["ds-test"],"created_at":"2026-03-26T11:21:16.085672Z","updated_at":"2026-03-26T11:21:16.085672Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://0196e41a-0381-455f-9a99-9a6945293567.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-0196e41a-0381-455f-9a99-9a6945293567.3589ad86-bbef-457e-bc57-7e355a773820.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"3589ad86-bbef-457e-bc57-7e355a773820","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "954"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:24:18 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - a7107a0d-ed57-41f9-b8e2-69aec53224a3
+        status: 200 OK
+        code: 200
+        duration: 75.908292ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/0196e41a-0381-455f-9a99-9a6945293567
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 954
+        body: '{"id":"0196e41a-0381-455f-9a99-9a6945293567","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_id","description":"test datalab for data source by id","tags":["ds-test"],"created_at":"2026-03-26T11:21:16.085672Z","updated_at":"2026-03-26T11:21:16.085672Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://0196e41a-0381-455f-9a99-9a6945293567.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-0196e41a-0381-455f-9a99-9a6945293567.3589ad86-bbef-457e-bc57-7e355a773820.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"3589ad86-bbef-457e-bc57-7e355a773820","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "954"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:24:33 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - a1e1d243-4e15-4cee-aecd-e988c38798ab
+        status: 200 OK
+        code: 200
+        duration: 80.927056ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/0196e41a-0381-455f-9a99-9a6945293567
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 954
+        body: '{"id":"0196e41a-0381-455f-9a99-9a6945293567","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_id","description":"test datalab for data source by id","tags":["ds-test"],"created_at":"2026-03-26T11:21:16.085672Z","updated_at":"2026-03-26T11:21:16.085672Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://0196e41a-0381-455f-9a99-9a6945293567.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-0196e41a-0381-455f-9a99-9a6945293567.3589ad86-bbef-457e-bc57-7e355a773820.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"3589ad86-bbef-457e-bc57-7e355a773820","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "954"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:24:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 23cca4e1-0fe5-4150-9798-30c4221a9c51
+        status: 200 OK
+        code: 200
+        duration: 84.406897ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/0196e41a-0381-455f-9a99-9a6945293567
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 954
+        body: '{"id":"0196e41a-0381-455f-9a99-9a6945293567","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_id","description":"test datalab for data source by id","tags":["ds-test"],"created_at":"2026-03-26T11:21:16.085672Z","updated_at":"2026-03-26T11:21:16.085672Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://0196e41a-0381-455f-9a99-9a6945293567.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-0196e41a-0381-455f-9a99-9a6945293567.3589ad86-bbef-457e-bc57-7e355a773820.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"3589ad86-bbef-457e-bc57-7e355a773820","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "954"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:25:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 89ee1eaf-61ee-4cd6-8a17-39413a387573
+        status: 200 OK
+        code: 200
+        duration: 71.209671ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/0196e41a-0381-455f-9a99-9a6945293567
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 954
+        body: '{"id":"0196e41a-0381-455f-9a99-9a6945293567","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_id","description":"test datalab for data source by id","tags":["ds-test"],"created_at":"2026-03-26T11:21:16.085672Z","updated_at":"2026-03-26T11:21:16.085672Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://0196e41a-0381-455f-9a99-9a6945293567.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-0196e41a-0381-455f-9a99-9a6945293567.3589ad86-bbef-457e-bc57-7e355a773820.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"3589ad86-bbef-457e-bc57-7e355a773820","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "954"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:25:18 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - bdf8cb7d-381f-4bb3-9c36-80038a320614
+        status: 200 OK
+        code: 200
+        duration: 71.266859ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/0196e41a-0381-455f-9a99-9a6945293567
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 954
+        body: '{"id":"0196e41a-0381-455f-9a99-9a6945293567","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_id","description":"test datalab for data source by id","tags":["ds-test"],"created_at":"2026-03-26T11:21:16.085672Z","updated_at":"2026-03-26T11:21:16.085672Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://0196e41a-0381-455f-9a99-9a6945293567.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-0196e41a-0381-455f-9a99-9a6945293567.3589ad86-bbef-457e-bc57-7e355a773820.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"3589ad86-bbef-457e-bc57-7e355a773820","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "954"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:25:33 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 6c6c7232-8cf7-4c21-b1df-50c7aa806ad5
+        status: 200 OK
+        code: 200
+        duration: 73.017155ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/0196e41a-0381-455f-9a99-9a6945293567
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 954
+        body: '{"id":"0196e41a-0381-455f-9a99-9a6945293567","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_id","description":"test datalab for data source by id","tags":["ds-test"],"created_at":"2026-03-26T11:21:16.085672Z","updated_at":"2026-03-26T11:21:16.085672Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://0196e41a-0381-455f-9a99-9a6945293567.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-0196e41a-0381-455f-9a99-9a6945293567.3589ad86-bbef-457e-bc57-7e355a773820.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"3589ad86-bbef-457e-bc57-7e355a773820","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "954"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:25:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 2dbf5b46-0472-42db-90d9-a3dae6b445d4
+        status: 200 OK
+        code: 200
+        duration: 82.036037ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/0196e41a-0381-455f-9a99-9a6945293567
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 954
+        body: '{"id":"0196e41a-0381-455f-9a99-9a6945293567","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_id","description":"test datalab for data source by id","tags":["ds-test"],"created_at":"2026-03-26T11:21:16.085672Z","updated_at":"2026-03-26T11:21:16.085672Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://0196e41a-0381-455f-9a99-9a6945293567.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-0196e41a-0381-455f-9a99-9a6945293567.3589ad86-bbef-457e-bc57-7e355a773820.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"3589ad86-bbef-457e-bc57-7e355a773820","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "954"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:26:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - b0175d73-c2b3-439b-a431-fd85f31b3997
+        status: 200 OK
+        code: 200
+        duration: 80.651863ms
+    - id: 25
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/0196e41a-0381-455f-9a99-9a6945293567
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 954
+        body: '{"id":"0196e41a-0381-455f-9a99-9a6945293567","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_id","description":"test datalab for data source by id","tags":["ds-test"],"created_at":"2026-03-26T11:21:16.085672Z","updated_at":"2026-03-26T11:21:16.085672Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://0196e41a-0381-455f-9a99-9a6945293567.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-0196e41a-0381-455f-9a99-9a6945293567.3589ad86-bbef-457e-bc57-7e355a773820.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"3589ad86-bbef-457e-bc57-7e355a773820","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "954"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:26:18 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - f1ad4df7-3188-4bbc-9780-c136b702ffad
+        status: 200 OK
+        code: 200
+        duration: 67.891935ms
+    - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/0196e41a-0381-455f-9a99-9a6945293567
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 954
+        body: '{"id":"0196e41a-0381-455f-9a99-9a6945293567","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_id","description":"test datalab for data source by id","tags":["ds-test"],"created_at":"2026-03-26T11:21:16.085672Z","updated_at":"2026-03-26T11:21:16.085672Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://0196e41a-0381-455f-9a99-9a6945293567.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-0196e41a-0381-455f-9a99-9a6945293567.3589ad86-bbef-457e-bc57-7e355a773820.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"3589ad86-bbef-457e-bc57-7e355a773820","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "954"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:26:33 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - cc7f67ea-6258-475b-940d-d25a85fb617e
+        status: 200 OK
+        code: 200
+        duration: 100.806864ms
+    - id: 27
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/0196e41a-0381-455f-9a99-9a6945293567
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 954
+        body: '{"id":"0196e41a-0381-455f-9a99-9a6945293567","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_id","description":"test datalab for data source by id","tags":["ds-test"],"created_at":"2026-03-26T11:21:16.085672Z","updated_at":"2026-03-26T11:21:16.085672Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://0196e41a-0381-455f-9a99-9a6945293567.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-0196e41a-0381-455f-9a99-9a6945293567.3589ad86-bbef-457e-bc57-7e355a773820.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"3589ad86-bbef-457e-bc57-7e355a773820","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "954"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:26:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 44f4713a-a9c2-4bd3-abc3-45c4689bcc0e
+        status: 200 OK
+        code: 200
+        duration: 84.597113ms
+    - id: 28
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/0196e41a-0381-455f-9a99-9a6945293567
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 951
+        body: '{"id":"0196e41a-0381-455f-9a99-9a6945293567","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_id","description":"test datalab for data source by id","tags":["ds-test"],"created_at":"2026-03-26T11:21:16.085672Z","updated_at":"2026-03-26T11:26:54.056516Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://0196e41a-0381-455f-9a99-9a6945293567.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-0196e41a-0381-455f-9a99-9a6945293567.3589ad86-bbef-457e-bc57-7e355a773820.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"3589ad86-bbef-457e-bc57-7e355a773820","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "951"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:27:04 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - f931347c-dbb4-467c-9d57-345098781162
+        status: 200 OK
+        code: 200
+        duration: 143.452147ms
+    - id: 29
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/0196e41a-0381-455f-9a99-9a6945293567
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 951
+        body: '{"id":"0196e41a-0381-455f-9a99-9a6945293567","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_id","description":"test datalab for data source by id","tags":["ds-test"],"created_at":"2026-03-26T11:21:16.085672Z","updated_at":"2026-03-26T11:26:54.056516Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://0196e41a-0381-455f-9a99-9a6945293567.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-0196e41a-0381-455f-9a99-9a6945293567.3589ad86-bbef-457e-bc57-7e355a773820.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"3589ad86-bbef-457e-bc57-7e355a773820","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "951"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:27:04 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - b57eae4f-ca3b-476b-889a-6c717f7ad57d
+        status: 200 OK
+        code: 200
+        duration: 71.26707ms
+    - id: 30
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/71a53def-f2cc-43d7-ad53-0cbb035ffcd7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 412
+        body: '{"id":"71a53def-f2cc-43d7-ad53-0cbb035ffcd7","name":"tf_tests_datalab_ds_by_id","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:21:14.936395Z","updated_at":"2026-03-26T11:21:14.936395Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","is_default":false,"private_network_count":1,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "412"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:27:04 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 8190df7e-d479-4764-8c06-c3d91e4e69fb
+        status: 200 OK
+        code: 200
+        duration: 61.751581ms
+    - id: 31
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3589ad86-bbef-457e-bc57-7e355a773820
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1063
+        body: '{"id":"3589ad86-bbef-457e-bc57-7e355a773820","name":"tf-pn-sharp-mccarthy","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:21:15.091800Z","updated_at":"2026-03-26T11:21:15.091800Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","subnets":[{"id":"b6259fb5-5b1f-4883-a33e-7c548bdb1f1e","created_at":"2026-03-26T11:21:15.091800Z","updated_at":"2026-03-26T11:21:15.091800Z","subnet":"172.16.8.0/22","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"3589ad86-bbef-457e-bc57-7e355a773820","vpc_id":"71a53def-f2cc-43d7-ad53-0cbb035ffcd7"},{"id":"928991f7-a406-4312-b10b-f4cbb268ef97","created_at":"2026-03-26T11:21:15.091800Z","updated_at":"2026-03-26T11:21:15.091800Z","subnet":"fd40:e277:fdde:b5::/64","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"3589ad86-bbef-457e-bc57-7e355a773820","vpc_id":"71a53def-f2cc-43d7-ad53-0cbb035ffcd7"}],"vpc_id":"71a53def-f2cc-43d7-ad53-0cbb035ffcd7","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1063"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:27:04 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 80acf7d2-1696-4653-9c7b-90c853a24eca
+        status: 200 OK
+        code: 200
+        duration: 55.580897ms
+    - id: 32
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/0196e41a-0381-455f-9a99-9a6945293567
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 951
+        body: '{"id":"0196e41a-0381-455f-9a99-9a6945293567","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_id","description":"test datalab for data source by id","tags":["ds-test"],"created_at":"2026-03-26T11:21:16.085672Z","updated_at":"2026-03-26T11:26:54.056516Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://0196e41a-0381-455f-9a99-9a6945293567.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-0196e41a-0381-455f-9a99-9a6945293567.3589ad86-bbef-457e-bc57-7e355a773820.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"3589ad86-bbef-457e-bc57-7e355a773820","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "951"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:27:04 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - c6520698-7782-4833-8c7b-89ba405179e8
+        status: 200 OK
+        code: 200
+        duration: 78.974365ms
+    - id: 33
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/71a53def-f2cc-43d7-ad53-0cbb035ffcd7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 412
+        body: '{"id":"71a53def-f2cc-43d7-ad53-0cbb035ffcd7","name":"tf_tests_datalab_ds_by_id","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:21:14.936395Z","updated_at":"2026-03-26T11:21:14.936395Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","is_default":false,"private_network_count":1,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "412"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:27:04 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 5de0341d-b864-4fe6-89dc-0b60d4671ebd
+        status: 200 OK
+        code: 200
+        duration: 63.175714ms
+    - id: 34
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3589ad86-bbef-457e-bc57-7e355a773820
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1063
+        body: '{"id":"3589ad86-bbef-457e-bc57-7e355a773820","name":"tf-pn-sharp-mccarthy","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:21:15.091800Z","updated_at":"2026-03-26T11:21:15.091800Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","subnets":[{"id":"b6259fb5-5b1f-4883-a33e-7c548bdb1f1e","created_at":"2026-03-26T11:21:15.091800Z","updated_at":"2026-03-26T11:21:15.091800Z","subnet":"172.16.8.0/22","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"3589ad86-bbef-457e-bc57-7e355a773820","vpc_id":"71a53def-f2cc-43d7-ad53-0cbb035ffcd7"},{"id":"928991f7-a406-4312-b10b-f4cbb268ef97","created_at":"2026-03-26T11:21:15.091800Z","updated_at":"2026-03-26T11:21:15.091800Z","subnet":"fd40:e277:fdde:b5::/64","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"3589ad86-bbef-457e-bc57-7e355a773820","vpc_id":"71a53def-f2cc-43d7-ad53-0cbb035ffcd7"}],"vpc_id":"71a53def-f2cc-43d7-ad53-0cbb035ffcd7","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1063"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:27:04 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - b26169c2-2fdb-4f98-876f-3d9388e16997
+        status: 200 OK
+        code: 200
+        duration: 60.59398ms
+    - id: 35
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/0196e41a-0381-455f-9a99-9a6945293567
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 951
+        body: '{"id":"0196e41a-0381-455f-9a99-9a6945293567","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_id","description":"test datalab for data source by id","tags":["ds-test"],"created_at":"2026-03-26T11:21:16.085672Z","updated_at":"2026-03-26T11:26:54.056516Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://0196e41a-0381-455f-9a99-9a6945293567.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-0196e41a-0381-455f-9a99-9a6945293567.3589ad86-bbef-457e-bc57-7e355a773820.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"3589ad86-bbef-457e-bc57-7e355a773820","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "951"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:27:04 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - f102ff91-1984-42ae-8852-f1e56ff147cd
+        status: 200 OK
+        code: 200
+        duration: 68.738224ms
+    - id: 36
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/0196e41a-0381-455f-9a99-9a6945293567
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 951
+        body: '{"id":"0196e41a-0381-455f-9a99-9a6945293567","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_id","description":"test datalab for data source by id","tags":["ds-test"],"created_at":"2026-03-26T11:21:16.085672Z","updated_at":"2026-03-26T11:26:54.056516Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://0196e41a-0381-455f-9a99-9a6945293567.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-0196e41a-0381-455f-9a99-9a6945293567.3589ad86-bbef-457e-bc57-7e355a773820.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"3589ad86-bbef-457e-bc57-7e355a773820","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "951"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:27:04 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 2a4dea21-67d6-406b-ad60-ac921153bcc6
+        status: 200 OK
+        code: 200
+        duration: 73.182311ms
+    - id: 37
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/0196e41a-0381-455f-9a99-9a6945293567
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 951
+        body: '{"id":"0196e41a-0381-455f-9a99-9a6945293567","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_id","description":"test datalab for data source by id","tags":["ds-test"],"created_at":"2026-03-26T11:21:16.085672Z","updated_at":"2026-03-26T11:26:54.056516Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://0196e41a-0381-455f-9a99-9a6945293567.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-0196e41a-0381-455f-9a99-9a6945293567.3589ad86-bbef-457e-bc57-7e355a773820.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"3589ad86-bbef-457e-bc57-7e355a773820","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "951"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:27:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 15c1ce76-5378-4b94-9aeb-e0b4c1558c93
+        status: 200 OK
+        code: 200
+        duration: 62.221209ms
+    - id: 38
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/0196e41a-0381-455f-9a99-9a6945293567
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 951
+        body: '{"id":"0196e41a-0381-455f-9a99-9a6945293567","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_id","description":"test datalab for data source by id","tags":["ds-test"],"created_at":"2026-03-26T11:21:16.085672Z","updated_at":"2026-03-26T11:26:54.056516Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://0196e41a-0381-455f-9a99-9a6945293567.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-0196e41a-0381-455f-9a99-9a6945293567.3589ad86-bbef-457e-bc57-7e355a773820.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"3589ad86-bbef-457e-bc57-7e355a773820","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "951"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:27:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - e275ee36-c4b6-498c-9613-e6b2874f91c6
+        status: 200 OK
+        code: 200
+        duration: 71.915813ms
+    - id: 39
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/71a53def-f2cc-43d7-ad53-0cbb035ffcd7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 412
+        body: '{"id":"71a53def-f2cc-43d7-ad53-0cbb035ffcd7","name":"tf_tests_datalab_ds_by_id","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:21:14.936395Z","updated_at":"2026-03-26T11:21:14.936395Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","is_default":false,"private_network_count":1,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "412"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:27:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - a1fd09e0-2087-4a9a-ad79-761278a16d52
+        status: 200 OK
+        code: 200
+        duration: 93.080699ms
+    - id: 40
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3589ad86-bbef-457e-bc57-7e355a773820
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1063
+        body: '{"id":"3589ad86-bbef-457e-bc57-7e355a773820","name":"tf-pn-sharp-mccarthy","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:21:15.091800Z","updated_at":"2026-03-26T11:21:15.091800Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","subnets":[{"id":"b6259fb5-5b1f-4883-a33e-7c548bdb1f1e","created_at":"2026-03-26T11:21:15.091800Z","updated_at":"2026-03-26T11:21:15.091800Z","subnet":"172.16.8.0/22","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"3589ad86-bbef-457e-bc57-7e355a773820","vpc_id":"71a53def-f2cc-43d7-ad53-0cbb035ffcd7"},{"id":"928991f7-a406-4312-b10b-f4cbb268ef97","created_at":"2026-03-26T11:21:15.091800Z","updated_at":"2026-03-26T11:21:15.091800Z","subnet":"fd40:e277:fdde:b5::/64","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"3589ad86-bbef-457e-bc57-7e355a773820","vpc_id":"71a53def-f2cc-43d7-ad53-0cbb035ffcd7"}],"vpc_id":"71a53def-f2cc-43d7-ad53-0cbb035ffcd7","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1063"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:27:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - b5692785-b327-4041-b6a6-063d4ddd3f77
+        status: 200 OK
+        code: 200
+        duration: 57.932786ms
+    - id: 41
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/0196e41a-0381-455f-9a99-9a6945293567
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 951
+        body: '{"id":"0196e41a-0381-455f-9a99-9a6945293567","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_id","description":"test datalab for data source by id","tags":["ds-test"],"created_at":"2026-03-26T11:21:16.085672Z","updated_at":"2026-03-26T11:26:54.056516Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://0196e41a-0381-455f-9a99-9a6945293567.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-0196e41a-0381-455f-9a99-9a6945293567.3589ad86-bbef-457e-bc57-7e355a773820.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"3589ad86-bbef-457e-bc57-7e355a773820","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "951"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:27:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - a352c039-8519-452b-ab73-4c8115da6751
+        status: 200 OK
+        code: 200
+        duration: 79.065893ms
+    - id: 42
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/0196e41a-0381-455f-9a99-9a6945293567
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 951
+        body: '{"id":"0196e41a-0381-455f-9a99-9a6945293567","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_id","description":"test datalab for data source by id","tags":["ds-test"],"created_at":"2026-03-26T11:21:16.085672Z","updated_at":"2026-03-26T11:26:54.056516Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://0196e41a-0381-455f-9a99-9a6945293567.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-0196e41a-0381-455f-9a99-9a6945293567.3589ad86-bbef-457e-bc57-7e355a773820.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"3589ad86-bbef-457e-bc57-7e355a773820","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "951"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:27:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 0eba704b-71d4-4cdc-882f-ff5d6f51b91b
+        status: 200 OK
+        code: 200
+        duration: 61.74857ms
+    - id: 43
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/0196e41a-0381-455f-9a99-9a6945293567
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 954
+        body: '{"id":"0196e41a-0381-455f-9a99-9a6945293567","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_id","description":"test datalab for data source by id","tags":["ds-test"],"created_at":"2026-03-26T11:21:16.085672Z","updated_at":"2026-03-26T11:27:05.890967Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://0196e41a-0381-455f-9a99-9a6945293567.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-0196e41a-0381-455f-9a99-9a6945293567.3589ad86-bbef-457e-bc57-7e355a773820.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"3589ad86-bbef-457e-bc57-7e355a773820","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "954"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:27:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 4e96d790-53fd-40f1-bff4-3f6967120b6f
+        status: 200 OK
+        code: 200
+        duration: 149.614152ms
+    - id: 44
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/0196e41a-0381-455f-9a99-9a6945293567
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 954
+        body: '{"id":"0196e41a-0381-455f-9a99-9a6945293567","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_id","description":"test datalab for data source by id","tags":["ds-test"],"created_at":"2026-03-26T11:21:16.085672Z","updated_at":"2026-03-26T11:27:05.890967Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://0196e41a-0381-455f-9a99-9a6945293567.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-0196e41a-0381-455f-9a99-9a6945293567.3589ad86-bbef-457e-bc57-7e355a773820.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"3589ad86-bbef-457e-bc57-7e355a773820","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "954"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:27:06 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 6548afc6-2ddc-4353-82af-c798fe47c7f8
+        status: 200 OK
+        code: 200
+        duration: 63.212234ms
+    - id: 45
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/0196e41a-0381-455f-9a99-9a6945293567
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 954
+        body: '{"id":"0196e41a-0381-455f-9a99-9a6945293567","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_id","description":"test datalab for data source by id","tags":["ds-test"],"created_at":"2026-03-26T11:21:16.085672Z","updated_at":"2026-03-26T11:27:05.890967Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://0196e41a-0381-455f-9a99-9a6945293567.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-0196e41a-0381-455f-9a99-9a6945293567.3589ad86-bbef-457e-bc57-7e355a773820.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"3589ad86-bbef-457e-bc57-7e355a773820","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "954"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:27:21 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - a7ee7d99-e3f1-474e-bd31-175385c643fd
+        status: 200 OK
+        code: 200
+        duration: 79.837614ms
+    - id: 46
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/0196e41a-0381-455f-9a99-9a6945293567
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 954
+        body: '{"id":"0196e41a-0381-455f-9a99-9a6945293567","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_id","description":"test datalab for data source by id","tags":["ds-test"],"created_at":"2026-03-26T11:21:16.085672Z","updated_at":"2026-03-26T11:27:05.890967Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://0196e41a-0381-455f-9a99-9a6945293567.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-0196e41a-0381-455f-9a99-9a6945293567.3589ad86-bbef-457e-bc57-7e355a773820.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"3589ad86-bbef-457e-bc57-7e355a773820","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "954"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:27:36 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - f2ec5699-7edd-4ba5-a6ab-71622f25539a
+        status: 200 OK
+        code: 200
+        duration: 110.47092ms
+    - id: 47
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/0196e41a-0381-455f-9a99-9a6945293567
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 954
+        body: '{"id":"0196e41a-0381-455f-9a99-9a6945293567","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_id","description":"test datalab for data source by id","tags":["ds-test"],"created_at":"2026-03-26T11:21:16.085672Z","updated_at":"2026-03-26T11:27:05.890967Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://0196e41a-0381-455f-9a99-9a6945293567.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-0196e41a-0381-455f-9a99-9a6945293567.3589ad86-bbef-457e-bc57-7e355a773820.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"3589ad86-bbef-457e-bc57-7e355a773820","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "954"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:27:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 1c1e4171-5a17-4962-99a8-7da375959456
+        status: 200 OK
+        code: 200
+        duration: 69.130924ms
+    - id: 48
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/0196e41a-0381-455f-9a99-9a6945293567
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 954
+        body: '{"id":"0196e41a-0381-455f-9a99-9a6945293567","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_id","description":"test datalab for data source by id","tags":["ds-test"],"created_at":"2026-03-26T11:21:16.085672Z","updated_at":"2026-03-26T11:27:05.890967Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://0196e41a-0381-455f-9a99-9a6945293567.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-0196e41a-0381-455f-9a99-9a6945293567.3589ad86-bbef-457e-bc57-7e355a773820.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"3589ad86-bbef-457e-bc57-7e355a773820","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "954"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:28:06 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 8bbca71d-6db5-4c19-bc3b-7ebcc9675957
+        status: 200 OK
+        code: 200
+        duration: 67.210523ms
+    - id: 49
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/0196e41a-0381-455f-9a99-9a6945293567
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 954
+        body: '{"id":"0196e41a-0381-455f-9a99-9a6945293567","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_id","description":"test datalab for data source by id","tags":["ds-test"],"created_at":"2026-03-26T11:21:16.085672Z","updated_at":"2026-03-26T11:27:05.890967Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://0196e41a-0381-455f-9a99-9a6945293567.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-0196e41a-0381-455f-9a99-9a6945293567.3589ad86-bbef-457e-bc57-7e355a773820.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"3589ad86-bbef-457e-bc57-7e355a773820","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "954"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:28:21 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 482e42d4-37bc-44b6-b47f-c074bb7a14bd
+        status: 200 OK
+        code: 200
+        duration: 74.04981ms
+    - id: 50
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/0196e41a-0381-455f-9a99-9a6945293567
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 954
+        body: '{"id":"0196e41a-0381-455f-9a99-9a6945293567","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_id","description":"test datalab for data source by id","tags":["ds-test"],"created_at":"2026-03-26T11:21:16.085672Z","updated_at":"2026-03-26T11:27:05.890967Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://0196e41a-0381-455f-9a99-9a6945293567.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-0196e41a-0381-455f-9a99-9a6945293567.3589ad86-bbef-457e-bc57-7e355a773820.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"3589ad86-bbef-457e-bc57-7e355a773820","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "954"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:28:36 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 2ef29252-e301-4c06-bc4e-c6d4b2d9dc62
+        status: 200 OK
+        code: 200
+        duration: 68.269006ms
+    - id: 51
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/0196e41a-0381-455f-9a99-9a6945293567
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 954
+        body: '{"id":"0196e41a-0381-455f-9a99-9a6945293567","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_id","description":"test datalab for data source by id","tags":["ds-test"],"created_at":"2026-03-26T11:21:16.085672Z","updated_at":"2026-03-26T11:27:05.890967Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://0196e41a-0381-455f-9a99-9a6945293567.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-0196e41a-0381-455f-9a99-9a6945293567.3589ad86-bbef-457e-bc57-7e355a773820.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"3589ad86-bbef-457e-bc57-7e355a773820","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "954"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:28:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - af960c76-dbda-481d-b29f-91b1c0c491fb
+        status: 200 OK
+        code: 200
+        duration: 79.698468ms
+    - id: 52
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/0196e41a-0381-455f-9a99-9a6945293567
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 954
+        body: '{"id":"0196e41a-0381-455f-9a99-9a6945293567","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_id","description":"test datalab for data source by id","tags":["ds-test"],"created_at":"2026-03-26T11:21:16.085672Z","updated_at":"2026-03-26T11:27:05.890967Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://0196e41a-0381-455f-9a99-9a6945293567.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-0196e41a-0381-455f-9a99-9a6945293567.3589ad86-bbef-457e-bc57-7e355a773820.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"3589ad86-bbef-457e-bc57-7e355a773820","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "954"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:29:06 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - dbd38774-e3b3-4374-a1b9-b207fc90cd93
+        status: 200 OK
+        code: 200
+        duration: 83.021913ms
+    - id: 53
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/0196e41a-0381-455f-9a99-9a6945293567
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 954
+        body: '{"id":"0196e41a-0381-455f-9a99-9a6945293567","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_id","description":"test datalab for data source by id","tags":["ds-test"],"created_at":"2026-03-26T11:21:16.085672Z","updated_at":"2026-03-26T11:27:05.890967Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://0196e41a-0381-455f-9a99-9a6945293567.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-0196e41a-0381-455f-9a99-9a6945293567.3589ad86-bbef-457e-bc57-7e355a773820.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"3589ad86-bbef-457e-bc57-7e355a773820","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "954"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:29:21 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - f161875d-ed54-47c1-8a1c-811aee019eb7
+        status: 200 OK
+        code: 200
+        duration: 71.877535ms
+    - id: 54
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/0196e41a-0381-455f-9a99-9a6945293567
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 128
+        body: '{"message":"resource is not found","resource":"datalab","resource_id":"0196e41a-0381-455f-9a99-9a6945293567","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "128"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:29:36 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 8045a73b-16e5-438c-b720-cf223816cb2a
+        status: 404 Not Found
+        code: 404
+        duration: 56.534813ms
+    - id: 55
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3589ad86-bbef-457e-bc57-7e355a773820
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:29:38 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 504c8bb8-0424-44eb-b416-b47fed2da913
+        status: 204 No Content
+        code: 204
+        duration: 1.800288973s
+    - id: 56
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/71a53def-f2cc-43d7-ad53-0cbb035ffcd7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:29:39 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - d5b9b73c-c3fd-45b0-9da9-6d2749fc05f5
+        status: 204 No Content
+        code: 204
+        duration: 502.411454ms
+    - id: 57
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/0196e41a-0381-455f-9a99-9a6945293567
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 128
+        body: '{"message":"resource is not found","resource":"datalab","resource_id":"0196e41a-0381-455f-9a99-9a6945293567","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "128"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:29:39 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - e91b0683-98a8-4ad5-8821-6d83b18154b8
+        status: 404 Not Found
+        code: 404
+        duration: 71.644601ms
+    - id: 58
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/0196e41a-0381-455f-9a99-9a6945293567
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 128
+        body: '{"message":"resource is not found","resource":"datalab","resource_id":"0196e41a-0381-455f-9a99-9a6945293567","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "128"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:29:39 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - bae6e93d-1fbc-416a-bf61-269468b73305
+        status: 404 Not Found
+        code: 404
+        duration: 56.662829ms

--- a/internal/services/datalab/testdata/datalab-data-source-by-name.cassette.yaml
+++ b/internal/services/datalab/testdata/datalab-data-source-by-name.cassette.yaml
@@ -1,0 +1,1943 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 123
+        host: api.scaleway.com
+        body: '{"name":"tf_tests_datalab_ds_by_name","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","tags":[],"enable_routing":false}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 414
+        body: '{"id":"c8436ba4-533a-4715-be7b-461b84e64288","name":"tf_tests_datalab_ds_by_name","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:30:00.483257Z","updated_at":"2026-03-26T11:30:00.483257Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","is_default":false,"private_network_count":0,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "414"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:30:00 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 840f298c-7f1c-49b6-b641-484c5882b572
+        status: 200 OK
+        code: 200
+        duration: 278.990086ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/c8436ba4-533a-4715-be7b-461b84e64288
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 414
+        body: '{"id":"c8436ba4-533a-4715-be7b-461b84e64288","name":"tf_tests_datalab_ds_by_name","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:30:00.483257Z","updated_at":"2026-03-26T11:30:00.483257Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","is_default":false,"private_network_count":0,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "414"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:30:00 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 5554d418-427c-44dc-8c52-a68287c77433
+        status: 200 OK
+        code: 200
+        duration: 61.344661ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 201
+        host: api.scaleway.com
+        body: '{"name":"tf-pn-stupefied-haslett","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","tags":[],"subnets":null,"vpc_id":"c8436ba4-533a-4715-be7b-461b84e64288","default_route_propagation_enabled":false}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1069
+        body: '{"id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","name":"tf-pn-stupefied-haslett","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:30:00.993913Z","updated_at":"2026-03-26T11:30:00.993913Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","subnets":[{"id":"36bb0108-8b3c-468d-a941-029533ec0797","created_at":"2026-03-26T11:30:00.993913Z","updated_at":"2026-03-26T11:30:00.993913Z","subnet":"172.16.20.0/22","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","vpc_id":"c8436ba4-533a-4715-be7b-461b84e64288"},{"id":"eb17edd0-58f7-4e5d-803e-0bb405bacafc","created_at":"2026-03-26T11:30:00.993913Z","updated_at":"2026-03-26T11:30:00.993913Z","subnet":"fd40:e277:fdde:57a5::/64","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","vpc_id":"c8436ba4-533a-4715-be7b-461b84e64288"}],"vpc_id":"c8436ba4-533a-4715-be7b-461b84e64288","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1069"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:30:01 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 0cfab953-e228-48d3-93ab-4c4f8e3af712
+        status: 200 OK
+        code: 200
+        duration: 1.189837998s
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/434418ef-7ec2-41e7-a139-9f30d56acb6f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1069
+        body: '{"id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","name":"tf-pn-stupefied-haslett","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:30:00.993913Z","updated_at":"2026-03-26T11:30:00.993913Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","subnets":[{"id":"36bb0108-8b3c-468d-a941-029533ec0797","created_at":"2026-03-26T11:30:00.993913Z","updated_at":"2026-03-26T11:30:00.993913Z","subnet":"172.16.20.0/22","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","vpc_id":"c8436ba4-533a-4715-be7b-461b84e64288"},{"id":"eb17edd0-58f7-4e5d-803e-0bb405bacafc","created_at":"2026-03-26T11:30:00.993913Z","updated_at":"2026-03-26T11:30:00.993913Z","subnet":"fd40:e277:fdde:57a5::/64","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","vpc_id":"c8436ba4-533a-4715-be7b-461b84e64288"}],"vpc_id":"c8436ba4-533a-4715-be7b-461b84e64288","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1069"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:30:01 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 56840d61-bacf-483b-9899-088ffd151922
+        status: 200 OK
+        code: 200
+        duration: 52.613712ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 369
+        host: api.scaleway.com
+        body: '{"project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_name","description":"test datalab for data source by name","tags":null,"main":{"node_type":"DATALAB-SHARED-4C-8G"},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1},"has_notebook":false,"spark_version":"4.0.0","private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f"}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 949
+        body: '{"id":"4d183142-c753-4c02-baa3-b5af60ecf718","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_name","description":"test datalab for data source by name","tags":[],"created_at":"2026-03-26T11:30:01.995071Z","updated_at":"2026-03-26T11:30:01.995071Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://4d183142-c753-4c02-baa3-b5af60ecf718.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-4d183142-c753-4c02-baa3-b5af60ecf718.434418ef-7ec2-41e7-a139-9f30d56acb6f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "949"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:30:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - e5a0b667-e9f2-486b-91e9-861db2768e27
+        status: 200 OK
+        code: 200
+        duration: 918.793462ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/4d183142-c753-4c02-baa3-b5af60ecf718
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 949
+        body: '{"id":"4d183142-c753-4c02-baa3-b5af60ecf718","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_name","description":"test datalab for data source by name","tags":[],"created_at":"2026-03-26T11:30:01.995071Z","updated_at":"2026-03-26T11:30:01.995071Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://4d183142-c753-4c02-baa3-b5af60ecf718.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-4d183142-c753-4c02-baa3-b5af60ecf718.434418ef-7ec2-41e7-a139-9f30d56acb6f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "949"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:30:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 9dd9f839-62eb-456d-b5c2-b08fe778531c
+        status: 200 OK
+        code: 200
+        duration: 75.082964ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/4d183142-c753-4c02-baa3-b5af60ecf718
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 949
+        body: '{"id":"4d183142-c753-4c02-baa3-b5af60ecf718","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_name","description":"test datalab for data source by name","tags":[],"created_at":"2026-03-26T11:30:01.995071Z","updated_at":"2026-03-26T11:30:01.995071Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://4d183142-c753-4c02-baa3-b5af60ecf718.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-4d183142-c753-4c02-baa3-b5af60ecf718.434418ef-7ec2-41e7-a139-9f30d56acb6f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "949"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:30:17 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 03040321-17e3-40e2-ba9e-b3695fa86d03
+        status: 200 OK
+        code: 200
+        duration: 80.646403ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/4d183142-c753-4c02-baa3-b5af60ecf718
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 949
+        body: '{"id":"4d183142-c753-4c02-baa3-b5af60ecf718","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_name","description":"test datalab for data source by name","tags":[],"created_at":"2026-03-26T11:30:01.995071Z","updated_at":"2026-03-26T11:30:01.995071Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://4d183142-c753-4c02-baa3-b5af60ecf718.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-4d183142-c753-4c02-baa3-b5af60ecf718.434418ef-7ec2-41e7-a139-9f30d56acb6f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "949"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:30:32 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - a748d5be-48a7-404a-a9c3-ca9e8b06bbc9
+        status: 200 OK
+        code: 200
+        duration: 71.933344ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/4d183142-c753-4c02-baa3-b5af60ecf718
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 949
+        body: '{"id":"4d183142-c753-4c02-baa3-b5af60ecf718","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_name","description":"test datalab for data source by name","tags":[],"created_at":"2026-03-26T11:30:01.995071Z","updated_at":"2026-03-26T11:30:01.995071Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://4d183142-c753-4c02-baa3-b5af60ecf718.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-4d183142-c753-4c02-baa3-b5af60ecf718.434418ef-7ec2-41e7-a139-9f30d56acb6f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "949"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:30:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 80a70460-d43a-46ce-b163-246f3f921ed9
+        status: 200 OK
+        code: 200
+        duration: 76.508458ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/4d183142-c753-4c02-baa3-b5af60ecf718
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 949
+        body: '{"id":"4d183142-c753-4c02-baa3-b5af60ecf718","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_name","description":"test datalab for data source by name","tags":[],"created_at":"2026-03-26T11:30:01.995071Z","updated_at":"2026-03-26T11:30:01.995071Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://4d183142-c753-4c02-baa3-b5af60ecf718.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-4d183142-c753-4c02-baa3-b5af60ecf718.434418ef-7ec2-41e7-a139-9f30d56acb6f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "949"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:31:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - ac264362-7893-465e-b5f1-4132b4f41b33
+        status: 200 OK
+        code: 200
+        duration: 72.840051ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/4d183142-c753-4c02-baa3-b5af60ecf718
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 949
+        body: '{"id":"4d183142-c753-4c02-baa3-b5af60ecf718","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_name","description":"test datalab for data source by name","tags":[],"created_at":"2026-03-26T11:30:01.995071Z","updated_at":"2026-03-26T11:30:01.995071Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://4d183142-c753-4c02-baa3-b5af60ecf718.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-4d183142-c753-4c02-baa3-b5af60ecf718.434418ef-7ec2-41e7-a139-9f30d56acb6f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "949"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:31:18 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 14533aef-0ee9-4be3-8ca5-fc70ce6dad4a
+        status: 200 OK
+        code: 200
+        duration: 86.583594ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/4d183142-c753-4c02-baa3-b5af60ecf718
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 949
+        body: '{"id":"4d183142-c753-4c02-baa3-b5af60ecf718","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_name","description":"test datalab for data source by name","tags":[],"created_at":"2026-03-26T11:30:01.995071Z","updated_at":"2026-03-26T11:30:01.995071Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://4d183142-c753-4c02-baa3-b5af60ecf718.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-4d183142-c753-4c02-baa3-b5af60ecf718.434418ef-7ec2-41e7-a139-9f30d56acb6f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "949"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:31:33 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - c5ea8b3e-4d09-486a-9fab-45644f613dc5
+        status: 200 OK
+        code: 200
+        duration: 72.270036ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/4d183142-c753-4c02-baa3-b5af60ecf718
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 949
+        body: '{"id":"4d183142-c753-4c02-baa3-b5af60ecf718","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_name","description":"test datalab for data source by name","tags":[],"created_at":"2026-03-26T11:30:01.995071Z","updated_at":"2026-03-26T11:30:01.995071Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://4d183142-c753-4c02-baa3-b5af60ecf718.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-4d183142-c753-4c02-baa3-b5af60ecf718.434418ef-7ec2-41e7-a139-9f30d56acb6f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "949"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:31:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 86ffac33-54a4-47f2-8d64-b1ca1601bac1
+        status: 200 OK
+        code: 200
+        duration: 97.814621ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/4d183142-c753-4c02-baa3-b5af60ecf718
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 949
+        body: '{"id":"4d183142-c753-4c02-baa3-b5af60ecf718","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_name","description":"test datalab for data source by name","tags":[],"created_at":"2026-03-26T11:30:01.995071Z","updated_at":"2026-03-26T11:30:01.995071Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://4d183142-c753-4c02-baa3-b5af60ecf718.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-4d183142-c753-4c02-baa3-b5af60ecf718.434418ef-7ec2-41e7-a139-9f30d56acb6f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "949"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:32:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - c5e2d1e8-4ea1-4228-a014-00a8a562c9e4
+        status: 200 OK
+        code: 200
+        duration: 68.620207ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/4d183142-c753-4c02-baa3-b5af60ecf718
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 949
+        body: '{"id":"4d183142-c753-4c02-baa3-b5af60ecf718","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_name","description":"test datalab for data source by name","tags":[],"created_at":"2026-03-26T11:30:01.995071Z","updated_at":"2026-03-26T11:30:01.995071Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://4d183142-c753-4c02-baa3-b5af60ecf718.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-4d183142-c753-4c02-baa3-b5af60ecf718.434418ef-7ec2-41e7-a139-9f30d56acb6f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "949"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:32:18 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - d8312ba7-32b1-423e-9ae8-d988165e5c0a
+        status: 200 OK
+        code: 200
+        duration: 82.592045ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/4d183142-c753-4c02-baa3-b5af60ecf718
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 949
+        body: '{"id":"4d183142-c753-4c02-baa3-b5af60ecf718","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_name","description":"test datalab for data source by name","tags":[],"created_at":"2026-03-26T11:30:01.995071Z","updated_at":"2026-03-26T11:30:01.995071Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://4d183142-c753-4c02-baa3-b5af60ecf718.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-4d183142-c753-4c02-baa3-b5af60ecf718.434418ef-7ec2-41e7-a139-9f30d56acb6f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "949"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:32:33 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 598cd9b7-d4db-48dd-8375-8d78a0192508
+        status: 200 OK
+        code: 200
+        duration: 70.981838ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/4d183142-c753-4c02-baa3-b5af60ecf718
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 949
+        body: '{"id":"4d183142-c753-4c02-baa3-b5af60ecf718","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_name","description":"test datalab for data source by name","tags":[],"created_at":"2026-03-26T11:30:01.995071Z","updated_at":"2026-03-26T11:30:01.995071Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://4d183142-c753-4c02-baa3-b5af60ecf718.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-4d183142-c753-4c02-baa3-b5af60ecf718.434418ef-7ec2-41e7-a139-9f30d56acb6f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "949"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:32:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - d027b8d4-2146-441b-b975-8083587851ee
+        status: 200 OK
+        code: 200
+        duration: 98.159482ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/4d183142-c753-4c02-baa3-b5af60ecf718
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 949
+        body: '{"id":"4d183142-c753-4c02-baa3-b5af60ecf718","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_name","description":"test datalab for data source by name","tags":[],"created_at":"2026-03-26T11:30:01.995071Z","updated_at":"2026-03-26T11:30:01.995071Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://4d183142-c753-4c02-baa3-b5af60ecf718.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-4d183142-c753-4c02-baa3-b5af60ecf718.434418ef-7ec2-41e7-a139-9f30d56acb6f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "949"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:33:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 4051b5e5-4702-491b-aca3-9634b641f657
+        status: 200 OK
+        code: 200
+        duration: 83.707977ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/4d183142-c753-4c02-baa3-b5af60ecf718
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 949
+        body: '{"id":"4d183142-c753-4c02-baa3-b5af60ecf718","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_name","description":"test datalab for data source by name","tags":[],"created_at":"2026-03-26T11:30:01.995071Z","updated_at":"2026-03-26T11:30:01.995071Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://4d183142-c753-4c02-baa3-b5af60ecf718.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-4d183142-c753-4c02-baa3-b5af60ecf718.434418ef-7ec2-41e7-a139-9f30d56acb6f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "949"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:33:18 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 532b8198-e87d-4575-ae10-2d70cda89084
+        status: 200 OK
+        code: 200
+        duration: 74.016382ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/4d183142-c753-4c02-baa3-b5af60ecf718
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 949
+        body: '{"id":"4d183142-c753-4c02-baa3-b5af60ecf718","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_name","description":"test datalab for data source by name","tags":[],"created_at":"2026-03-26T11:30:01.995071Z","updated_at":"2026-03-26T11:30:01.995071Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://4d183142-c753-4c02-baa3-b5af60ecf718.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-4d183142-c753-4c02-baa3-b5af60ecf718.434418ef-7ec2-41e7-a139-9f30d56acb6f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "949"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:33:33 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - c1bcc460-a29b-4402-a1d0-9283d4e9b397
+        status: 200 OK
+        code: 200
+        duration: 85.58728ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/4d183142-c753-4c02-baa3-b5af60ecf718
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 949
+        body: '{"id":"4d183142-c753-4c02-baa3-b5af60ecf718","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_name","description":"test datalab for data source by name","tags":[],"created_at":"2026-03-26T11:30:01.995071Z","updated_at":"2026-03-26T11:30:01.995071Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://4d183142-c753-4c02-baa3-b5af60ecf718.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-4d183142-c753-4c02-baa3-b5af60ecf718.434418ef-7ec2-41e7-a139-9f30d56acb6f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "949"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:33:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - f1b283b0-6088-4b64-ab8c-724fc3d5a3f7
+        status: 200 OK
+        code: 200
+        duration: 75.104604ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/4d183142-c753-4c02-baa3-b5af60ecf718
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 949
+        body: '{"id":"4d183142-c753-4c02-baa3-b5af60ecf718","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_name","description":"test datalab for data source by name","tags":[],"created_at":"2026-03-26T11:30:01.995071Z","updated_at":"2026-03-26T11:30:01.995071Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://4d183142-c753-4c02-baa3-b5af60ecf718.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-4d183142-c753-4c02-baa3-b5af60ecf718.434418ef-7ec2-41e7-a139-9f30d56acb6f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "949"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:34:04 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 0e8532bc-6517-4773-ba9e-e01f66b6845c
+        status: 200 OK
+        code: 200
+        duration: 73.389908ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/4d183142-c753-4c02-baa3-b5af60ecf718
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 949
+        body: '{"id":"4d183142-c753-4c02-baa3-b5af60ecf718","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_name","description":"test datalab for data source by name","tags":[],"created_at":"2026-03-26T11:30:01.995071Z","updated_at":"2026-03-26T11:30:01.995071Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://4d183142-c753-4c02-baa3-b5af60ecf718.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-4d183142-c753-4c02-baa3-b5af60ecf718.434418ef-7ec2-41e7-a139-9f30d56acb6f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "949"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:34:19 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - f4dfd1f5-c1aa-413e-b2ff-11b009895624
+        status: 200 OK
+        code: 200
+        duration: 77.001887ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/4d183142-c753-4c02-baa3-b5af60ecf718
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 949
+        body: '{"id":"4d183142-c753-4c02-baa3-b5af60ecf718","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_name","description":"test datalab for data source by name","tags":[],"created_at":"2026-03-26T11:30:01.995071Z","updated_at":"2026-03-26T11:30:01.995071Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://4d183142-c753-4c02-baa3-b5af60ecf718.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-4d183142-c753-4c02-baa3-b5af60ecf718.434418ef-7ec2-41e7-a139-9f30d56acb6f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "949"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:34:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 66dd2b05-823d-4a8a-846d-98424810c2da
+        status: 200 OK
+        code: 200
+        duration: 72.015902ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/4d183142-c753-4c02-baa3-b5af60ecf718
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 949
+        body: '{"id":"4d183142-c753-4c02-baa3-b5af60ecf718","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_name","description":"test datalab for data source by name","tags":[],"created_at":"2026-03-26T11:30:01.995071Z","updated_at":"2026-03-26T11:30:01.995071Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://4d183142-c753-4c02-baa3-b5af60ecf718.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-4d183142-c753-4c02-baa3-b5af60ecf718.434418ef-7ec2-41e7-a139-9f30d56acb6f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "949"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:34:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 7ff6ed57-e40d-4b61-b8f7-b5edd2b5aac7
+        status: 200 OK
+        code: 200
+        duration: 76.330683ms
+    - id: 25
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/4d183142-c753-4c02-baa3-b5af60ecf718
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 949
+        body: '{"id":"4d183142-c753-4c02-baa3-b5af60ecf718","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_name","description":"test datalab for data source by name","tags":[],"created_at":"2026-03-26T11:30:01.995071Z","updated_at":"2026-03-26T11:30:01.995071Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://4d183142-c753-4c02-baa3-b5af60ecf718.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-4d183142-c753-4c02-baa3-b5af60ecf718.434418ef-7ec2-41e7-a139-9f30d56acb6f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "949"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:35:04 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 222acb52-47a6-492f-a362-c6a7c1c59951
+        status: 200 OK
+        code: 200
+        duration: 79.844525ms
+    - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/4d183142-c753-4c02-baa3-b5af60ecf718
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 949
+        body: '{"id":"4d183142-c753-4c02-baa3-b5af60ecf718","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_name","description":"test datalab for data source by name","tags":[],"created_at":"2026-03-26T11:30:01.995071Z","updated_at":"2026-03-26T11:30:01.995071Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://4d183142-c753-4c02-baa3-b5af60ecf718.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-4d183142-c753-4c02-baa3-b5af60ecf718.434418ef-7ec2-41e7-a139-9f30d56acb6f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "949"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:35:19 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - c8329192-67f5-42d9-8a2f-3b32f07ab2ed
+        status: 200 OK
+        code: 200
+        duration: 85.117502ms
+    - id: 27
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/4d183142-c753-4c02-baa3-b5af60ecf718
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 949
+        body: '{"id":"4d183142-c753-4c02-baa3-b5af60ecf718","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_name","description":"test datalab for data source by name","tags":[],"created_at":"2026-03-26T11:30:01.995071Z","updated_at":"2026-03-26T11:30:01.995071Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://4d183142-c753-4c02-baa3-b5af60ecf718.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-4d183142-c753-4c02-baa3-b5af60ecf718.434418ef-7ec2-41e7-a139-9f30d56acb6f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "949"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:35:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 2859c1fc-4029-4b6a-a573-f3265b4e187b
+        status: 200 OK
+        code: 200
+        duration: 70.748984ms
+    - id: 28
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/4d183142-c753-4c02-baa3-b5af60ecf718
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 949
+        body: '{"id":"4d183142-c753-4c02-baa3-b5af60ecf718","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_name","description":"test datalab for data source by name","tags":[],"created_at":"2026-03-26T11:30:01.995071Z","updated_at":"2026-03-26T11:30:01.995071Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://4d183142-c753-4c02-baa3-b5af60ecf718.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-4d183142-c753-4c02-baa3-b5af60ecf718.434418ef-7ec2-41e7-a139-9f30d56acb6f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "949"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:35:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - b5f15f24-6dd9-4025-ae25-2f95ce2a7a85
+        status: 200 OK
+        code: 200
+        duration: 67.942746ms
+    - id: 29
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/4d183142-c753-4c02-baa3-b5af60ecf718
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 946
+        body: '{"id":"4d183142-c753-4c02-baa3-b5af60ecf718","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_name","description":"test datalab for data source by name","tags":[],"created_at":"2026-03-26T11:30:01.995071Z","updated_at":"2026-03-26T11:35:51.150089Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://4d183142-c753-4c02-baa3-b5af60ecf718.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-4d183142-c753-4c02-baa3-b5af60ecf718.434418ef-7ec2-41e7-a139-9f30d56acb6f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "946"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:36:04 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - a43dc0d5-8415-4e55-9c06-e6b89523731d
+        status: 200 OK
+        code: 200
+        duration: 67.599518ms
+    - id: 30
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/4d183142-c753-4c02-baa3-b5af60ecf718
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 946
+        body: '{"id":"4d183142-c753-4c02-baa3-b5af60ecf718","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_name","description":"test datalab for data source by name","tags":[],"created_at":"2026-03-26T11:30:01.995071Z","updated_at":"2026-03-26T11:35:51.150089Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://4d183142-c753-4c02-baa3-b5af60ecf718.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-4d183142-c753-4c02-baa3-b5af60ecf718.434418ef-7ec2-41e7-a139-9f30d56acb6f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "946"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:36:04 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - b4977ec9-017c-4a69-92a7-826d8e39d0bc
+        status: 200 OK
+        code: 200
+        duration: 68.084875ms
+    - id: 31
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/c8436ba4-533a-4715-be7b-461b84e64288
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 414
+        body: '{"id":"c8436ba4-533a-4715-be7b-461b84e64288","name":"tf_tests_datalab_ds_by_name","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:30:00.483257Z","updated_at":"2026-03-26T11:30:00.483257Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","is_default":false,"private_network_count":1,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "414"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:36:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - a9a5b36f-3b73-4768-aae2-b098da0c99e7
+        status: 200 OK
+        code: 200
+        duration: 66.716104ms
+    - id: 32
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/434418ef-7ec2-41e7-a139-9f30d56acb6f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1069
+        body: '{"id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","name":"tf-pn-stupefied-haslett","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:30:00.993913Z","updated_at":"2026-03-26T11:30:00.993913Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","subnets":[{"id":"36bb0108-8b3c-468d-a941-029533ec0797","created_at":"2026-03-26T11:30:00.993913Z","updated_at":"2026-03-26T11:30:00.993913Z","subnet":"172.16.20.0/22","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","vpc_id":"c8436ba4-533a-4715-be7b-461b84e64288"},{"id":"eb17edd0-58f7-4e5d-803e-0bb405bacafc","created_at":"2026-03-26T11:30:00.993913Z","updated_at":"2026-03-26T11:30:00.993913Z","subnet":"fd40:e277:fdde:57a5::/64","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","vpc_id":"c8436ba4-533a-4715-be7b-461b84e64288"}],"vpc_id":"c8436ba4-533a-4715-be7b-461b84e64288","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1069"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:36:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 21617142-77de-44dd-95bc-1d967ce96eb3
+        status: 200 OK
+        code: 200
+        duration: 59.908241ms
+    - id: 33
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/4d183142-c753-4c02-baa3-b5af60ecf718
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 946
+        body: '{"id":"4d183142-c753-4c02-baa3-b5af60ecf718","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_name","description":"test datalab for data source by name","tags":[],"created_at":"2026-03-26T11:30:01.995071Z","updated_at":"2026-03-26T11:35:51.150089Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://4d183142-c753-4c02-baa3-b5af60ecf718.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-4d183142-c753-4c02-baa3-b5af60ecf718.434418ef-7ec2-41e7-a139-9f30d56acb6f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "946"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:36:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 744a255b-413b-4e63-be44-959dc981cf09
+        status: 200 OK
+        code: 200
+        duration: 68.199562ms
+    - id: 34
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/c8436ba4-533a-4715-be7b-461b84e64288
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 414
+        body: '{"id":"c8436ba4-533a-4715-be7b-461b84e64288","name":"tf_tests_datalab_ds_by_name","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:30:00.483257Z","updated_at":"2026-03-26T11:30:00.483257Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","is_default":false,"private_network_count":1,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "414"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:36:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - aa7c3b6d-5f8f-4b74-942b-5e425b9cc22c
+        status: 200 OK
+        code: 200
+        duration: 65.661403ms
+    - id: 35
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/434418ef-7ec2-41e7-a139-9f30d56acb6f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1069
+        body: '{"id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","name":"tf-pn-stupefied-haslett","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:30:00.993913Z","updated_at":"2026-03-26T11:30:00.993913Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","subnets":[{"id":"36bb0108-8b3c-468d-a941-029533ec0797","created_at":"2026-03-26T11:30:00.993913Z","updated_at":"2026-03-26T11:30:00.993913Z","subnet":"172.16.20.0/22","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","vpc_id":"c8436ba4-533a-4715-be7b-461b84e64288"},{"id":"eb17edd0-58f7-4e5d-803e-0bb405bacafc","created_at":"2026-03-26T11:30:00.993913Z","updated_at":"2026-03-26T11:30:00.993913Z","subnet":"fd40:e277:fdde:57a5::/64","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","vpc_id":"c8436ba4-533a-4715-be7b-461b84e64288"}],"vpc_id":"c8436ba4-533a-4715-be7b-461b84e64288","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1069"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:36:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - b188b3a2-f4be-425e-899c-d6e82956292a
+        status: 200 OK
+        code: 200
+        duration: 67.796723ms
+    - id: 36
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/4d183142-c753-4c02-baa3-b5af60ecf718
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 946
+        body: '{"id":"4d183142-c753-4c02-baa3-b5af60ecf718","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_name","description":"test datalab for data source by name","tags":[],"created_at":"2026-03-26T11:30:01.995071Z","updated_at":"2026-03-26T11:35:51.150089Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://4d183142-c753-4c02-baa3-b5af60ecf718.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-4d183142-c753-4c02-baa3-b5af60ecf718.434418ef-7ec2-41e7-a139-9f30d56acb6f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "946"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:36:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 51f15497-7b33-4473-8b68-e76588665577
+        status: 200 OK
+        code: 200
+        duration: 72.098395ms
+    - id: 37
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            name:
+                - tf_tests_datalab_ds_by_name
+            order_by:
+                - name_asc
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs?name=tf_tests_datalab_ds_by_name&order_by=name_asc
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 977
+        body: '{"datalabs":[{"id":"4d183142-c753-4c02-baa3-b5af60ecf718","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_name","description":"test datalab for data source by name","tags":[],"created_at":"2026-03-26T11:30:01.995071Z","updated_at":"2026-03-26T11:35:51.150089Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://4d183142-c753-4c02-baa3-b5af60ecf718.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-4d183142-c753-4c02-baa3-b5af60ecf718.434418ef-7ec2-41e7-a139-9f30d56acb6f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","notebook_master_url":"","region":"fr-par"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "977"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:36:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 8fd91784-2ebc-49d6-b57f-fc33d0596869
+        status: 200 OK
+        code: 200
+        duration: 76.680859ms
+    - id: 38
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/4d183142-c753-4c02-baa3-b5af60ecf718
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 946
+        body: '{"id":"4d183142-c753-4c02-baa3-b5af60ecf718","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_name","description":"test datalab for data source by name","tags":[],"created_at":"2026-03-26T11:30:01.995071Z","updated_at":"2026-03-26T11:35:51.150089Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://4d183142-c753-4c02-baa3-b5af60ecf718.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-4d183142-c753-4c02-baa3-b5af60ecf718.434418ef-7ec2-41e7-a139-9f30d56acb6f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "946"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:36:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - e2d117e0-ab85-4130-b0c7-3dfcadc2c406
+        status: 200 OK
+        code: 200
+        duration: 69.552105ms
+    - id: 39
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            name:
+                - tf_tests_datalab_ds_by_name
+            order_by:
+                - name_asc
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs?name=tf_tests_datalab_ds_by_name&order_by=name_asc
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 977
+        body: '{"datalabs":[{"id":"4d183142-c753-4c02-baa3-b5af60ecf718","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_name","description":"test datalab for data source by name","tags":[],"created_at":"2026-03-26T11:30:01.995071Z","updated_at":"2026-03-26T11:35:51.150089Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://4d183142-c753-4c02-baa3-b5af60ecf718.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-4d183142-c753-4c02-baa3-b5af60ecf718.434418ef-7ec2-41e7-a139-9f30d56acb6f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","notebook_master_url":"","region":"fr-par"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "977"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:36:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 0a9e58ee-71a5-4475-82c2-388e5db40b39
+        status: 200 OK
+        code: 200
+        duration: 70.215107ms
+    - id: 40
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/c8436ba4-533a-4715-be7b-461b84e64288
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 414
+        body: '{"id":"c8436ba4-533a-4715-be7b-461b84e64288","name":"tf_tests_datalab_ds_by_name","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:30:00.483257Z","updated_at":"2026-03-26T11:30:00.483257Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","is_default":false,"private_network_count":1,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "414"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:36:06 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 352b475d-b999-4048-93e4-649e85b700c6
+        status: 200 OK
+        code: 200
+        duration: 54.018213ms
+    - id: 41
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/434418ef-7ec2-41e7-a139-9f30d56acb6f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1069
+        body: '{"id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","name":"tf-pn-stupefied-haslett","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:30:00.993913Z","updated_at":"2026-03-26T11:30:00.993913Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","subnets":[{"id":"36bb0108-8b3c-468d-a941-029533ec0797","created_at":"2026-03-26T11:30:00.993913Z","updated_at":"2026-03-26T11:30:00.993913Z","subnet":"172.16.20.0/22","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","vpc_id":"c8436ba4-533a-4715-be7b-461b84e64288"},{"id":"eb17edd0-58f7-4e5d-803e-0bb405bacafc","created_at":"2026-03-26T11:30:00.993913Z","updated_at":"2026-03-26T11:30:00.993913Z","subnet":"fd40:e277:fdde:57a5::/64","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","vpc_id":"c8436ba4-533a-4715-be7b-461b84e64288"}],"vpc_id":"c8436ba4-533a-4715-be7b-461b84e64288","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1069"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:36:06 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - ea3f71c5-d970-4627-b2cb-ef9f2148b699
+        status: 200 OK
+        code: 200
+        duration: 60.590202ms
+    - id: 42
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/4d183142-c753-4c02-baa3-b5af60ecf718
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 946
+        body: '{"id":"4d183142-c753-4c02-baa3-b5af60ecf718","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_name","description":"test datalab for data source by name","tags":[],"created_at":"2026-03-26T11:30:01.995071Z","updated_at":"2026-03-26T11:35:51.150089Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://4d183142-c753-4c02-baa3-b5af60ecf718.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-4d183142-c753-4c02-baa3-b5af60ecf718.434418ef-7ec2-41e7-a139-9f30d56acb6f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "946"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:36:06 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - ffbea6b4-39b4-460a-8d03-7ef47382924b
+        status: 200 OK
+        code: 200
+        duration: 62.891819ms
+    - id: 43
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            name:
+                - tf_tests_datalab_ds_by_name
+            order_by:
+                - name_asc
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs?name=tf_tests_datalab_ds_by_name&order_by=name_asc
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 977
+        body: '{"datalabs":[{"id":"4d183142-c753-4c02-baa3-b5af60ecf718","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_name","description":"test datalab for data source by name","tags":[],"created_at":"2026-03-26T11:30:01.995071Z","updated_at":"2026-03-26T11:35:51.150089Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://4d183142-c753-4c02-baa3-b5af60ecf718.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-4d183142-c753-4c02-baa3-b5af60ecf718.434418ef-7ec2-41e7-a139-9f30d56acb6f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","notebook_master_url":"","region":"fr-par"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "977"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:36:06 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 06dab5e3-3add-4e9d-8dad-c4b3a95a6e8c
+        status: 200 OK
+        code: 200
+        duration: 80.386867ms
+    - id: 44
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/4d183142-c753-4c02-baa3-b5af60ecf718
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 949
+        body: '{"id":"4d183142-c753-4c02-baa3-b5af60ecf718","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_name","description":"test datalab for data source by name","tags":[],"created_at":"2026-03-26T11:30:01.995071Z","updated_at":"2026-03-26T11:36:06.486700Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://4d183142-c753-4c02-baa3-b5af60ecf718.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-4d183142-c753-4c02-baa3-b5af60ecf718.434418ef-7ec2-41e7-a139-9f30d56acb6f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "949"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:36:06 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 419270fd-ce1e-45a6-abb2-b48a98fbc914
+        status: 200 OK
+        code: 200
+        duration: 158.341012ms
+    - id: 45
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/4d183142-c753-4c02-baa3-b5af60ecf718
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 949
+        body: '{"id":"4d183142-c753-4c02-baa3-b5af60ecf718","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_name","description":"test datalab for data source by name","tags":[],"created_at":"2026-03-26T11:30:01.995071Z","updated_at":"2026-03-26T11:36:06.486700Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://4d183142-c753-4c02-baa3-b5af60ecf718.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-4d183142-c753-4c02-baa3-b5af60ecf718.434418ef-7ec2-41e7-a139-9f30d56acb6f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "949"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:36:06 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - d364779a-cb85-4b61-be1c-2ce9a2ba915b
+        status: 200 OK
+        code: 200
+        duration: 67.23401ms
+    - id: 46
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/4d183142-c753-4c02-baa3-b5af60ecf718
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 949
+        body: '{"id":"4d183142-c753-4c02-baa3-b5af60ecf718","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_name","description":"test datalab for data source by name","tags":[],"created_at":"2026-03-26T11:30:01.995071Z","updated_at":"2026-03-26T11:36:06.486700Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://4d183142-c753-4c02-baa3-b5af60ecf718.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-4d183142-c753-4c02-baa3-b5af60ecf718.434418ef-7ec2-41e7-a139-9f30d56acb6f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "949"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:36:21 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 17af06de-a85a-4e23-b857-e025401c6cc1
+        status: 200 OK
+        code: 200
+        duration: 63.988832ms
+    - id: 47
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/4d183142-c753-4c02-baa3-b5af60ecf718
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 949
+        body: '{"id":"4d183142-c753-4c02-baa3-b5af60ecf718","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_name","description":"test datalab for data source by name","tags":[],"created_at":"2026-03-26T11:30:01.995071Z","updated_at":"2026-03-26T11:36:06.486700Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://4d183142-c753-4c02-baa3-b5af60ecf718.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-4d183142-c753-4c02-baa3-b5af60ecf718.434418ef-7ec2-41e7-a139-9f30d56acb6f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "949"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:36:36 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - e902f171-a9c0-4c1d-a99d-34e14b4896d1
+        status: 200 OK
+        code: 200
+        duration: 68.108652ms
+    - id: 48
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/4d183142-c753-4c02-baa3-b5af60ecf718
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 949
+        body: '{"id":"4d183142-c753-4c02-baa3-b5af60ecf718","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_name","description":"test datalab for data source by name","tags":[],"created_at":"2026-03-26T11:30:01.995071Z","updated_at":"2026-03-26T11:36:06.486700Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://4d183142-c753-4c02-baa3-b5af60ecf718.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-4d183142-c753-4c02-baa3-b5af60ecf718.434418ef-7ec2-41e7-a139-9f30d56acb6f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "949"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:36:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 5cf8c6df-ea4d-4a5a-9e9e-24d5a2ed4f68
+        status: 200 OK
+        code: 200
+        duration: 64.200733ms
+    - id: 49
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/4d183142-c753-4c02-baa3-b5af60ecf718
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 949
+        body: '{"id":"4d183142-c753-4c02-baa3-b5af60ecf718","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_name","description":"test datalab for data source by name","tags":[],"created_at":"2026-03-26T11:30:01.995071Z","updated_at":"2026-03-26T11:36:06.486700Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://4d183142-c753-4c02-baa3-b5af60ecf718.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-4d183142-c753-4c02-baa3-b5af60ecf718.434418ef-7ec2-41e7-a139-9f30d56acb6f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "949"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:37:06 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 6d9844d2-86d0-4e13-a20e-78cf848c37a9
+        status: 200 OK
+        code: 200
+        duration: 71.705721ms
+    - id: 50
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/4d183142-c753-4c02-baa3-b5af60ecf718
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 949
+        body: '{"id":"4d183142-c753-4c02-baa3-b5af60ecf718","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_name","description":"test datalab for data source by name","tags":[],"created_at":"2026-03-26T11:30:01.995071Z","updated_at":"2026-03-26T11:36:06.486700Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://4d183142-c753-4c02-baa3-b5af60ecf718.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-4d183142-c753-4c02-baa3-b5af60ecf718.434418ef-7ec2-41e7-a139-9f30d56acb6f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "949"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:37:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 6d562988-68e1-4837-b29f-2099cd67e7d5
+        status: 200 OK
+        code: 200
+        duration: 72.494174ms
+    - id: 51
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/4d183142-c753-4c02-baa3-b5af60ecf718
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 949
+        body: '{"id":"4d183142-c753-4c02-baa3-b5af60ecf718","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_name","description":"test datalab for data source by name","tags":[],"created_at":"2026-03-26T11:30:01.995071Z","updated_at":"2026-03-26T11:36:06.486700Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://4d183142-c753-4c02-baa3-b5af60ecf718.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-4d183142-c753-4c02-baa3-b5af60ecf718.434418ef-7ec2-41e7-a139-9f30d56acb6f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "949"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:37:37 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 26607465-1e47-401a-8c79-d17db6000fa8
+        status: 200 OK
+        code: 200
+        duration: 72.599124ms
+    - id: 52
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/4d183142-c753-4c02-baa3-b5af60ecf718
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 949
+        body: '{"id":"4d183142-c753-4c02-baa3-b5af60ecf718","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_name","description":"test datalab for data source by name","tags":[],"created_at":"2026-03-26T11:30:01.995071Z","updated_at":"2026-03-26T11:36:06.486700Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://4d183142-c753-4c02-baa3-b5af60ecf718.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-4d183142-c753-4c02-baa3-b5af60ecf718.434418ef-7ec2-41e7-a139-9f30d56acb6f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "949"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:37:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 88a0199b-6a25-46c3-935f-248597779155
+        status: 200 OK
+        code: 200
+        duration: 78.186335ms
+    - id: 53
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/4d183142-c753-4c02-baa3-b5af60ecf718
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 949
+        body: '{"id":"4d183142-c753-4c02-baa3-b5af60ecf718","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_name","description":"test datalab for data source by name","tags":[],"created_at":"2026-03-26T11:30:01.995071Z","updated_at":"2026-03-26T11:36:06.486700Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://4d183142-c753-4c02-baa3-b5af60ecf718.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-4d183142-c753-4c02-baa3-b5af60ecf718.434418ef-7ec2-41e7-a139-9f30d56acb6f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "949"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:38:07 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 0f5f025a-6114-464d-a4dc-ed69747342dd
+        status: 200 OK
+        code: 200
+        duration: 72.920143ms
+    - id: 54
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/4d183142-c753-4c02-baa3-b5af60ecf718
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 949
+        body: '{"id":"4d183142-c753-4c02-baa3-b5af60ecf718","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_name","description":"test datalab for data source by name","tags":[],"created_at":"2026-03-26T11:30:01.995071Z","updated_at":"2026-03-26T11:36:06.486700Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://4d183142-c753-4c02-baa3-b5af60ecf718.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-4d183142-c753-4c02-baa3-b5af60ecf718.434418ef-7ec2-41e7-a139-9f30d56acb6f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "949"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:38:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - f1138f3d-25ae-429c-bcbb-f3afbc0da7c5
+        status: 200 OK
+        code: 200
+        duration: 87.89645ms
+    - id: 55
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/4d183142-c753-4c02-baa3-b5af60ecf718
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 128
+        body: '{"message":"resource is not found","resource":"datalab","resource_id":"4d183142-c753-4c02-baa3-b5af60ecf718","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "128"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:38:37 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 56adc97a-42cf-4903-9ae6-0b334f0aac04
+        status: 404 Not Found
+        code: 404
+        duration: 61.270763ms
+    - id: 56
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/434418ef-7ec2-41e7-a139-9f30d56acb6f
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:38:38 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 03a98fc1-4985-41f9-b826-5576c44ec60a
+        status: 204 No Content
+        code: 204
+        duration: 1.603873932s
+    - id: 57
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/c8436ba4-533a-4715-be7b-461b84e64288
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:38:39 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 0a2fd615-7afc-4482-ba5d-f102c82d940b
+        status: 204 No Content
+        code: 204
+        duration: 712.379345ms
+    - id: 58
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/4d183142-c753-4c02-baa3-b5af60ecf718
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 128
+        body: '{"message":"resource is not found","resource":"datalab","resource_id":"4d183142-c753-4c02-baa3-b5af60ecf718","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "128"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:38:39 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - df3cd9a3-f226-4803-bb8f-ff9c80a27d55
+        status: 404 Not Found
+        code: 404
+        duration: 59.93ms
+    - id: 59
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/4d183142-c753-4c02-baa3-b5af60ecf718
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 128
+        body: '{"message":"resource is not found","resource":"datalab","resource_id":"4d183142-c753-4c02-baa3-b5af60ecf718","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "128"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:38:39 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 67df3462-7a33-45f7-b293-b03d7722dec5
+        status: 404 Not Found
+        code: 404
+        duration: 61.694073ms

--- a/internal/services/datalab/testdata/datalab-resource-basic.cassette.yaml
+++ b/internal/services/datalab/testdata/datalab-resource-basic.cassette.yaml
@@ -1,0 +1,1576 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 118
+        host: api.scaleway.com
+        body: '{"name":"tf_tests_datalab_basic","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","tags":[],"enable_routing":false}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 409
+        body: '{"id":"1ef8336c-285e-4613-beae-907c50e4120f","name":"tf_tests_datalab_basic","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:08:52.506906Z","updated_at":"2026-03-26T11:08:52.506906Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","is_default":false,"private_network_count":0,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "409"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:08:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 0afc3480-e79a-44c4-a390-00fecb5dc070
+        status: 200 OK
+        code: 200
+        duration: 209.226449ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/1ef8336c-285e-4613-beae-907c50e4120f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 409
+        body: '{"id":"1ef8336c-285e-4613-beae-907c50e4120f","name":"tf_tests_datalab_basic","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:08:52.506906Z","updated_at":"2026-03-26T11:08:52.506906Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","is_default":false,"private_network_count":0,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "409"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:08:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 0812508b-4d38-451d-b06a-083321ee4824
+        status: 200 OK
+        code: 200
+        duration: 76.413293ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 200
+        host: api.scaleway.com
+        body: '{"name":"tf-pn-objective-napier","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","tags":[],"subnets":null,"vpc_id":"1ef8336c-285e-4613-beae-907c50e4120f","default_route_propagation_enabled":false}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1067
+        body: '{"id":"8748c884-d99a-4058-a16c-b83a72c2f4e5","name":"tf-pn-objective-napier","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:08:52.701127Z","updated_at":"2026-03-26T11:08:52.701127Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","subnets":[{"id":"b906e043-9336-4ed5-8286-dc3c0da5a4ad","created_at":"2026-03-26T11:08:52.701127Z","updated_at":"2026-03-26T11:08:52.701127Z","subnet":"172.16.0.0/22","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"8748c884-d99a-4058-a16c-b83a72c2f4e5","vpc_id":"1ef8336c-285e-4613-beae-907c50e4120f"},{"id":"55d2a007-b3df-402c-a0eb-94f186a14b36","created_at":"2026-03-26T11:08:52.701127Z","updated_at":"2026-03-26T11:08:52.701127Z","subnet":"fd40:e277:fdde:9a22::/64","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"8748c884-d99a-4058-a16c-b83a72c2f4e5","vpc_id":"1ef8336c-285e-4613-beae-907c50e4120f"}],"vpc_id":"1ef8336c-285e-4613-beae-907c50e4120f","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1067"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:08:54 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 6f782255-bcc9-4073-a67d-b97e374c7a23
+        status: 200 OK
+        code: 200
+        duration: 1.643171428s
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8748c884-d99a-4058-a16c-b83a72c2f4e5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1067
+        body: '{"id":"8748c884-d99a-4058-a16c-b83a72c2f4e5","name":"tf-pn-objective-napier","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:08:52.701127Z","updated_at":"2026-03-26T11:08:52.701127Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","subnets":[{"id":"b906e043-9336-4ed5-8286-dc3c0da5a4ad","created_at":"2026-03-26T11:08:52.701127Z","updated_at":"2026-03-26T11:08:52.701127Z","subnet":"172.16.0.0/22","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"8748c884-d99a-4058-a16c-b83a72c2f4e5","vpc_id":"1ef8336c-285e-4613-beae-907c50e4120f"},{"id":"55d2a007-b3df-402c-a0eb-94f186a14b36","created_at":"2026-03-26T11:08:52.701127Z","updated_at":"2026-03-26T11:08:52.701127Z","subnet":"fd40:e277:fdde:9a22::/64","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"8748c884-d99a-4058-a16c-b83a72c2f4e5","vpc_id":"1ef8336c-285e-4613-beae-907c50e4120f"}],"vpc_id":"1ef8336c-285e-4613-beae-907c50e4120f","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1067"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:08:54 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - b9048db1-b2ac-44fb-ae8f-93780db4be7e
+        status: 200 OK
+        code: 200
+        duration: 72.872213ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 328
+        host: api.scaleway.com
+        body: '{"project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_basic","description":"","tags":null,"main":{"node_type":"DATALAB-SHARED-4C-8G"},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1},"has_notebook":false,"spark_version":"4.0.0","private_network_id":"8748c884-d99a-4058-a16c-b83a72c2f4e5"}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 908
+        body: '{"id":"cd5a1b92-8dca-4280-90c0-2c7528f3dc98","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_basic","description":"","tags":[],"created_at":"2026-03-26T11:08:54.606552Z","updated_at":"2026-03-26T11:08:54.606552Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://cd5a1b92-8dca-4280-90c0-2c7528f3dc98.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-cd5a1b92-8dca-4280-90c0-2c7528f3dc98.8748c884-d99a-4058-a16c-b83a72c2f4e5.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8748c884-d99a-4058-a16c-b83a72c2f4e5","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "908"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:08:55 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 559a454f-f9aa-45a4-9c8b-a032bb8ee31b
+        status: 200 OK
+        code: 200
+        duration: 848.839255ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/cd5a1b92-8dca-4280-90c0-2c7528f3dc98
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 908
+        body: '{"id":"cd5a1b92-8dca-4280-90c0-2c7528f3dc98","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_basic","description":"","tags":[],"created_at":"2026-03-26T11:08:54.606552Z","updated_at":"2026-03-26T11:08:54.606552Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://cd5a1b92-8dca-4280-90c0-2c7528f3dc98.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-cd5a1b92-8dca-4280-90c0-2c7528f3dc98.8748c884-d99a-4058-a16c-b83a72c2f4e5.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8748c884-d99a-4058-a16c-b83a72c2f4e5","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "908"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:08:55 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - b11d540f-5cfd-40d0-92a7-dac38252104c
+        status: 200 OK
+        code: 200
+        duration: 97.825598ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/cd5a1b92-8dca-4280-90c0-2c7528f3dc98
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 908
+        body: '{"id":"cd5a1b92-8dca-4280-90c0-2c7528f3dc98","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_basic","description":"","tags":[],"created_at":"2026-03-26T11:08:54.606552Z","updated_at":"2026-03-26T11:08:54.606552Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://cd5a1b92-8dca-4280-90c0-2c7528f3dc98.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-cd5a1b92-8dca-4280-90c0-2c7528f3dc98.8748c884-d99a-4058-a16c-b83a72c2f4e5.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8748c884-d99a-4058-a16c-b83a72c2f4e5","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "908"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:09:10 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 3d4094dc-6c3d-43be-8f11-f248755585de
+        status: 200 OK
+        code: 200
+        duration: 74.526872ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/cd5a1b92-8dca-4280-90c0-2c7528f3dc98
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 908
+        body: '{"id":"cd5a1b92-8dca-4280-90c0-2c7528f3dc98","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_basic","description":"","tags":[],"created_at":"2026-03-26T11:08:54.606552Z","updated_at":"2026-03-26T11:08:54.606552Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://cd5a1b92-8dca-4280-90c0-2c7528f3dc98.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-cd5a1b92-8dca-4280-90c0-2c7528f3dc98.8748c884-d99a-4058-a16c-b83a72c2f4e5.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8748c884-d99a-4058-a16c-b83a72c2f4e5","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "908"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:09:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - d2a41e7a-e98b-4d01-8098-8ae449e49f31
+        status: 200 OK
+        code: 200
+        duration: 74.469754ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/cd5a1b92-8dca-4280-90c0-2c7528f3dc98
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 908
+        body: '{"id":"cd5a1b92-8dca-4280-90c0-2c7528f3dc98","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_basic","description":"","tags":[],"created_at":"2026-03-26T11:08:54.606552Z","updated_at":"2026-03-26T11:08:54.606552Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://cd5a1b92-8dca-4280-90c0-2c7528f3dc98.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-cd5a1b92-8dca-4280-90c0-2c7528f3dc98.8748c884-d99a-4058-a16c-b83a72c2f4e5.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8748c884-d99a-4058-a16c-b83a72c2f4e5","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "908"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:09:40 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 02825834-1389-4d4a-bf25-5f5d7531cf74
+        status: 200 OK
+        code: 200
+        duration: 72.095705ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/cd5a1b92-8dca-4280-90c0-2c7528f3dc98
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 908
+        body: '{"id":"cd5a1b92-8dca-4280-90c0-2c7528f3dc98","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_basic","description":"","tags":[],"created_at":"2026-03-26T11:08:54.606552Z","updated_at":"2026-03-26T11:08:54.606552Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://cd5a1b92-8dca-4280-90c0-2c7528f3dc98.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-cd5a1b92-8dca-4280-90c0-2c7528f3dc98.8748c884-d99a-4058-a16c-b83a72c2f4e5.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8748c884-d99a-4058-a16c-b83a72c2f4e5","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "908"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:09:55 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - d3db7c84-d8dd-4fc1-a694-98a15710942c
+        status: 200 OK
+        code: 200
+        duration: 92.141735ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/cd5a1b92-8dca-4280-90c0-2c7528f3dc98
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 908
+        body: '{"id":"cd5a1b92-8dca-4280-90c0-2c7528f3dc98","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_basic","description":"","tags":[],"created_at":"2026-03-26T11:08:54.606552Z","updated_at":"2026-03-26T11:08:54.606552Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://cd5a1b92-8dca-4280-90c0-2c7528f3dc98.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-cd5a1b92-8dca-4280-90c0-2c7528f3dc98.8748c884-d99a-4058-a16c-b83a72c2f4e5.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8748c884-d99a-4058-a16c-b83a72c2f4e5","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "908"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:10:10 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - d9a3546d-9232-4b4b-8d3e-aab53ad22d09
+        status: 200 OK
+        code: 200
+        duration: 79.582696ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/cd5a1b92-8dca-4280-90c0-2c7528f3dc98
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 908
+        body: '{"id":"cd5a1b92-8dca-4280-90c0-2c7528f3dc98","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_basic","description":"","tags":[],"created_at":"2026-03-26T11:08:54.606552Z","updated_at":"2026-03-26T11:08:54.606552Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://cd5a1b92-8dca-4280-90c0-2c7528f3dc98.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-cd5a1b92-8dca-4280-90c0-2c7528f3dc98.8748c884-d99a-4058-a16c-b83a72c2f4e5.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8748c884-d99a-4058-a16c-b83a72c2f4e5","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "908"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:10:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 750db088-893c-466a-a7b8-7bc93c26b29d
+        status: 200 OK
+        code: 200
+        duration: 74.240212ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/cd5a1b92-8dca-4280-90c0-2c7528f3dc98
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 908
+        body: '{"id":"cd5a1b92-8dca-4280-90c0-2c7528f3dc98","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_basic","description":"","tags":[],"created_at":"2026-03-26T11:08:54.606552Z","updated_at":"2026-03-26T11:08:54.606552Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://cd5a1b92-8dca-4280-90c0-2c7528f3dc98.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-cd5a1b92-8dca-4280-90c0-2c7528f3dc98.8748c884-d99a-4058-a16c-b83a72c2f4e5.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8748c884-d99a-4058-a16c-b83a72c2f4e5","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "908"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:10:40 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 8ffb03e7-9b20-4613-9d4b-43378ad5e4d7
+        status: 200 OK
+        code: 200
+        duration: 76.930523ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/cd5a1b92-8dca-4280-90c0-2c7528f3dc98
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 908
+        body: '{"id":"cd5a1b92-8dca-4280-90c0-2c7528f3dc98","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_basic","description":"","tags":[],"created_at":"2026-03-26T11:08:54.606552Z","updated_at":"2026-03-26T11:08:54.606552Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://cd5a1b92-8dca-4280-90c0-2c7528f3dc98.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-cd5a1b92-8dca-4280-90c0-2c7528f3dc98.8748c884-d99a-4058-a16c-b83a72c2f4e5.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8748c884-d99a-4058-a16c-b83a72c2f4e5","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "908"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:10:55 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - b1485a3e-a92d-4775-b68f-66425e5f1c1d
+        status: 200 OK
+        code: 200
+        duration: 87.508635ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/cd5a1b92-8dca-4280-90c0-2c7528f3dc98
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 908
+        body: '{"id":"cd5a1b92-8dca-4280-90c0-2c7528f3dc98","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_basic","description":"","tags":[],"created_at":"2026-03-26T11:08:54.606552Z","updated_at":"2026-03-26T11:08:54.606552Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://cd5a1b92-8dca-4280-90c0-2c7528f3dc98.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-cd5a1b92-8dca-4280-90c0-2c7528f3dc98.8748c884-d99a-4058-a16c-b83a72c2f4e5.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8748c884-d99a-4058-a16c-b83a72c2f4e5","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "908"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:11:11 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - b49d3700-350d-4197-851f-636c7a91881e
+        status: 200 OK
+        code: 200
+        duration: 86.347045ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/cd5a1b92-8dca-4280-90c0-2c7528f3dc98
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 908
+        body: '{"id":"cd5a1b92-8dca-4280-90c0-2c7528f3dc98","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_basic","description":"","tags":[],"created_at":"2026-03-26T11:08:54.606552Z","updated_at":"2026-03-26T11:08:54.606552Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://cd5a1b92-8dca-4280-90c0-2c7528f3dc98.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-cd5a1b92-8dca-4280-90c0-2c7528f3dc98.8748c884-d99a-4058-a16c-b83a72c2f4e5.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8748c884-d99a-4058-a16c-b83a72c2f4e5","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "908"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:11:26 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - bdbe1bbb-6160-49f1-9f35-90db61f5e057
+        status: 200 OK
+        code: 200
+        duration: 77.234697ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/cd5a1b92-8dca-4280-90c0-2c7528f3dc98
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 908
+        body: '{"id":"cd5a1b92-8dca-4280-90c0-2c7528f3dc98","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_basic","description":"","tags":[],"created_at":"2026-03-26T11:08:54.606552Z","updated_at":"2026-03-26T11:08:54.606552Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://cd5a1b92-8dca-4280-90c0-2c7528f3dc98.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-cd5a1b92-8dca-4280-90c0-2c7528f3dc98.8748c884-d99a-4058-a16c-b83a72c2f4e5.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8748c884-d99a-4058-a16c-b83a72c2f4e5","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "908"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:11:41 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 3810b38c-ccac-48e0-bc76-d23bcdf56671
+        status: 200 OK
+        code: 200
+        duration: 75.315107ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/cd5a1b92-8dca-4280-90c0-2c7528f3dc98
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 908
+        body: '{"id":"cd5a1b92-8dca-4280-90c0-2c7528f3dc98","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_basic","description":"","tags":[],"created_at":"2026-03-26T11:08:54.606552Z","updated_at":"2026-03-26T11:08:54.606552Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://cd5a1b92-8dca-4280-90c0-2c7528f3dc98.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-cd5a1b92-8dca-4280-90c0-2c7528f3dc98.8748c884-d99a-4058-a16c-b83a72c2f4e5.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8748c884-d99a-4058-a16c-b83a72c2f4e5","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "908"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:11:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - d83973f9-1514-4fe2-9fa0-b29d2d91a424
+        status: 200 OK
+        code: 200
+        duration: 75.648689ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/cd5a1b92-8dca-4280-90c0-2c7528f3dc98
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 908
+        body: '{"id":"cd5a1b92-8dca-4280-90c0-2c7528f3dc98","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_basic","description":"","tags":[],"created_at":"2026-03-26T11:08:54.606552Z","updated_at":"2026-03-26T11:08:54.606552Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://cd5a1b92-8dca-4280-90c0-2c7528f3dc98.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-cd5a1b92-8dca-4280-90c0-2c7528f3dc98.8748c884-d99a-4058-a16c-b83a72c2f4e5.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8748c884-d99a-4058-a16c-b83a72c2f4e5","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "908"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:12:11 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 85a73694-b011-423e-8c4b-1ad42a0a4065
+        status: 200 OK
+        code: 200
+        duration: 78.654332ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/cd5a1b92-8dca-4280-90c0-2c7528f3dc98
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 908
+        body: '{"id":"cd5a1b92-8dca-4280-90c0-2c7528f3dc98","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_basic","description":"","tags":[],"created_at":"2026-03-26T11:08:54.606552Z","updated_at":"2026-03-26T11:08:54.606552Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://cd5a1b92-8dca-4280-90c0-2c7528f3dc98.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-cd5a1b92-8dca-4280-90c0-2c7528f3dc98.8748c884-d99a-4058-a16c-b83a72c2f4e5.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8748c884-d99a-4058-a16c-b83a72c2f4e5","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "908"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:12:26 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 64607e05-0f58-4d2c-beaf-0303c537f395
+        status: 200 OK
+        code: 200
+        duration: 89.00816ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/cd5a1b92-8dca-4280-90c0-2c7528f3dc98
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 908
+        body: '{"id":"cd5a1b92-8dca-4280-90c0-2c7528f3dc98","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_basic","description":"","tags":[],"created_at":"2026-03-26T11:08:54.606552Z","updated_at":"2026-03-26T11:08:54.606552Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://cd5a1b92-8dca-4280-90c0-2c7528f3dc98.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-cd5a1b92-8dca-4280-90c0-2c7528f3dc98.8748c884-d99a-4058-a16c-b83a72c2f4e5.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8748c884-d99a-4058-a16c-b83a72c2f4e5","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "908"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:12:41 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 775361e3-dcd0-472c-bdfe-95c6b3caa9c4
+        status: 200 OK
+        code: 200
+        duration: 80.063507ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/cd5a1b92-8dca-4280-90c0-2c7528f3dc98
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 908
+        body: '{"id":"cd5a1b92-8dca-4280-90c0-2c7528f3dc98","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_basic","description":"","tags":[],"created_at":"2026-03-26T11:08:54.606552Z","updated_at":"2026-03-26T11:08:54.606552Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://cd5a1b92-8dca-4280-90c0-2c7528f3dc98.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-cd5a1b92-8dca-4280-90c0-2c7528f3dc98.8748c884-d99a-4058-a16c-b83a72c2f4e5.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8748c884-d99a-4058-a16c-b83a72c2f4e5","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "908"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:12:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 3ae202a7-1504-43a3-b6a3-3adce78bc30e
+        status: 200 OK
+        code: 200
+        duration: 81.627418ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/cd5a1b92-8dca-4280-90c0-2c7528f3dc98
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 908
+        body: '{"id":"cd5a1b92-8dca-4280-90c0-2c7528f3dc98","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_basic","description":"","tags":[],"created_at":"2026-03-26T11:08:54.606552Z","updated_at":"2026-03-26T11:08:54.606552Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://cd5a1b92-8dca-4280-90c0-2c7528f3dc98.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-cd5a1b92-8dca-4280-90c0-2c7528f3dc98.8748c884-d99a-4058-a16c-b83a72c2f4e5.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8748c884-d99a-4058-a16c-b83a72c2f4e5","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "908"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:13:11 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 987f7630-7f27-4006-b1ef-e396c4ff4016
+        status: 200 OK
+        code: 200
+        duration: 80.618945ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/cd5a1b92-8dca-4280-90c0-2c7528f3dc98
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 908
+        body: '{"id":"cd5a1b92-8dca-4280-90c0-2c7528f3dc98","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_basic","description":"","tags":[],"created_at":"2026-03-26T11:08:54.606552Z","updated_at":"2026-03-26T11:08:54.606552Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://cd5a1b92-8dca-4280-90c0-2c7528f3dc98.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-cd5a1b92-8dca-4280-90c0-2c7528f3dc98.8748c884-d99a-4058-a16c-b83a72c2f4e5.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8748c884-d99a-4058-a16c-b83a72c2f4e5","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "908"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:13:26 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 834fa80e-b3f8-4ae3-b17a-bb72b762b8b2
+        status: 200 OK
+        code: 200
+        duration: 84.475527ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/cd5a1b92-8dca-4280-90c0-2c7528f3dc98
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 908
+        body: '{"id":"cd5a1b92-8dca-4280-90c0-2c7528f3dc98","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_basic","description":"","tags":[],"created_at":"2026-03-26T11:08:54.606552Z","updated_at":"2026-03-26T11:08:54.606552Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://cd5a1b92-8dca-4280-90c0-2c7528f3dc98.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-cd5a1b92-8dca-4280-90c0-2c7528f3dc98.8748c884-d99a-4058-a16c-b83a72c2f4e5.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8748c884-d99a-4058-a16c-b83a72c2f4e5","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "908"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:13:41 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - c6bad4d0-c79d-404e-bb05-a58c287a2329
+        status: 200 OK
+        code: 200
+        duration: 71.139135ms
+    - id: 25
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/cd5a1b92-8dca-4280-90c0-2c7528f3dc98
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 908
+        body: '{"id":"cd5a1b92-8dca-4280-90c0-2c7528f3dc98","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_basic","description":"","tags":[],"created_at":"2026-03-26T11:08:54.606552Z","updated_at":"2026-03-26T11:08:54.606552Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://cd5a1b92-8dca-4280-90c0-2c7528f3dc98.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-cd5a1b92-8dca-4280-90c0-2c7528f3dc98.8748c884-d99a-4058-a16c-b83a72c2f4e5.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8748c884-d99a-4058-a16c-b83a72c2f4e5","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "908"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:13:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 869c41d5-c9ca-4bc3-b832-dd98a0e466b3
+        status: 200 OK
+        code: 200
+        duration: 80.675144ms
+    - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/cd5a1b92-8dca-4280-90c0-2c7528f3dc98
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 908
+        body: '{"id":"cd5a1b92-8dca-4280-90c0-2c7528f3dc98","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_basic","description":"","tags":[],"created_at":"2026-03-26T11:08:54.606552Z","updated_at":"2026-03-26T11:08:54.606552Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://cd5a1b92-8dca-4280-90c0-2c7528f3dc98.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-cd5a1b92-8dca-4280-90c0-2c7528f3dc98.8748c884-d99a-4058-a16c-b83a72c2f4e5.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8748c884-d99a-4058-a16c-b83a72c2f4e5","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "908"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:14:11 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - c313719c-a36b-4c12-aaad-5deed4cf634c
+        status: 200 OK
+        code: 200
+        duration: 70.363075ms
+    - id: 27
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/cd5a1b92-8dca-4280-90c0-2c7528f3dc98
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 908
+        body: '{"id":"cd5a1b92-8dca-4280-90c0-2c7528f3dc98","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_basic","description":"","tags":[],"created_at":"2026-03-26T11:08:54.606552Z","updated_at":"2026-03-26T11:08:54.606552Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://cd5a1b92-8dca-4280-90c0-2c7528f3dc98.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-cd5a1b92-8dca-4280-90c0-2c7528f3dc98.8748c884-d99a-4058-a16c-b83a72c2f4e5.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8748c884-d99a-4058-a16c-b83a72c2f4e5","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "908"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:14:27 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 8d5da54e-5c21-4fef-8c30-83db96c1de78
+        status: 200 OK
+        code: 200
+        duration: 83.283919ms
+    - id: 28
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/cd5a1b92-8dca-4280-90c0-2c7528f3dc98
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 905
+        body: '{"id":"cd5a1b92-8dca-4280-90c0-2c7528f3dc98","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_basic","description":"","tags":[],"created_at":"2026-03-26T11:08:54.606552Z","updated_at":"2026-03-26T11:14:36.740037Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://cd5a1b92-8dca-4280-90c0-2c7528f3dc98.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-cd5a1b92-8dca-4280-90c0-2c7528f3dc98.8748c884-d99a-4058-a16c-b83a72c2f4e5.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8748c884-d99a-4058-a16c-b83a72c2f4e5","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "905"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:14:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 11c6003a-d175-4958-8ddb-1bdcec9b223b
+        status: 200 OK
+        code: 200
+        duration: 78.952698ms
+    - id: 29
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/cd5a1b92-8dca-4280-90c0-2c7528f3dc98
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 905
+        body: '{"id":"cd5a1b92-8dca-4280-90c0-2c7528f3dc98","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_basic","description":"","tags":[],"created_at":"2026-03-26T11:08:54.606552Z","updated_at":"2026-03-26T11:14:36.740037Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://cd5a1b92-8dca-4280-90c0-2c7528f3dc98.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-cd5a1b92-8dca-4280-90c0-2c7528f3dc98.8748c884-d99a-4058-a16c-b83a72c2f4e5.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8748c884-d99a-4058-a16c-b83a72c2f4e5","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "905"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:14:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - b10fb9c7-ad8c-4c17-a3c2-e71255e86492
+        status: 200 OK
+        code: 200
+        duration: 65.813141ms
+    - id: 30
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/1ef8336c-285e-4613-beae-907c50e4120f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 409
+        body: '{"id":"1ef8336c-285e-4613-beae-907c50e4120f","name":"tf_tests_datalab_basic","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:08:52.506906Z","updated_at":"2026-03-26T11:08:52.506906Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","is_default":false,"private_network_count":1,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "409"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:14:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - d4b5825d-6784-47e3-8eeb-2dc4a5da29f8
+        status: 200 OK
+        code: 200
+        duration: 49.057156ms
+    - id: 31
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8748c884-d99a-4058-a16c-b83a72c2f4e5
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1067
+        body: '{"id":"8748c884-d99a-4058-a16c-b83a72c2f4e5","name":"tf-pn-objective-napier","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:08:52.701127Z","updated_at":"2026-03-26T11:08:52.701127Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","subnets":[{"id":"b906e043-9336-4ed5-8286-dc3c0da5a4ad","created_at":"2026-03-26T11:08:52.701127Z","updated_at":"2026-03-26T11:08:52.701127Z","subnet":"172.16.0.0/22","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"8748c884-d99a-4058-a16c-b83a72c2f4e5","vpc_id":"1ef8336c-285e-4613-beae-907c50e4120f"},{"id":"55d2a007-b3df-402c-a0eb-94f186a14b36","created_at":"2026-03-26T11:08:52.701127Z","updated_at":"2026-03-26T11:08:52.701127Z","subnet":"fd40:e277:fdde:9a22::/64","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"8748c884-d99a-4058-a16c-b83a72c2f4e5","vpc_id":"1ef8336c-285e-4613-beae-907c50e4120f"}],"vpc_id":"1ef8336c-285e-4613-beae-907c50e4120f","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1067"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:14:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 0af9805e-0b78-4557-865e-25e9a9780c0c
+        status: 200 OK
+        code: 200
+        duration: 70.819674ms
+    - id: 32
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/cd5a1b92-8dca-4280-90c0-2c7528f3dc98
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 905
+        body: '{"id":"cd5a1b92-8dca-4280-90c0-2c7528f3dc98","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_basic","description":"","tags":[],"created_at":"2026-03-26T11:08:54.606552Z","updated_at":"2026-03-26T11:14:36.740037Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://cd5a1b92-8dca-4280-90c0-2c7528f3dc98.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-cd5a1b92-8dca-4280-90c0-2c7528f3dc98.8748c884-d99a-4058-a16c-b83a72c2f4e5.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8748c884-d99a-4058-a16c-b83a72c2f4e5","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "905"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:14:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 1a8ddeb3-93c6-4993-a242-c0f689c9622d
+        status: 200 OK
+        code: 200
+        duration: 72.326617ms
+    - id: 33
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/cd5a1b92-8dca-4280-90c0-2c7528f3dc98
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 908
+        body: '{"id":"cd5a1b92-8dca-4280-90c0-2c7528f3dc98","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_basic","description":"","tags":[],"created_at":"2026-03-26T11:08:54.606552Z","updated_at":"2026-03-26T11:14:42.858508Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://cd5a1b92-8dca-4280-90c0-2c7528f3dc98.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-cd5a1b92-8dca-4280-90c0-2c7528f3dc98.8748c884-d99a-4058-a16c-b83a72c2f4e5.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8748c884-d99a-4058-a16c-b83a72c2f4e5","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "908"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:14:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - d2be6a53-66e1-42e5-ad41-728f830f119f
+        status: 200 OK
+        code: 200
+        duration: 149.351914ms
+    - id: 34
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/cd5a1b92-8dca-4280-90c0-2c7528f3dc98
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 908
+        body: '{"id":"cd5a1b92-8dca-4280-90c0-2c7528f3dc98","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_basic","description":"","tags":[],"created_at":"2026-03-26T11:08:54.606552Z","updated_at":"2026-03-26T11:14:42.858508Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://cd5a1b92-8dca-4280-90c0-2c7528f3dc98.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-cd5a1b92-8dca-4280-90c0-2c7528f3dc98.8748c884-d99a-4058-a16c-b83a72c2f4e5.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8748c884-d99a-4058-a16c-b83a72c2f4e5","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "908"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:14:43 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 86936790-1a61-4486-b0b1-b9d1ba9ca688
+        status: 200 OK
+        code: 200
+        duration: 70.657699ms
+    - id: 35
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/cd5a1b92-8dca-4280-90c0-2c7528f3dc98
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 908
+        body: '{"id":"cd5a1b92-8dca-4280-90c0-2c7528f3dc98","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_basic","description":"","tags":[],"created_at":"2026-03-26T11:08:54.606552Z","updated_at":"2026-03-26T11:14:42.858508Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://cd5a1b92-8dca-4280-90c0-2c7528f3dc98.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-cd5a1b92-8dca-4280-90c0-2c7528f3dc98.8748c884-d99a-4058-a16c-b83a72c2f4e5.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8748c884-d99a-4058-a16c-b83a72c2f4e5","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "908"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:14:58 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 7def62eb-09ac-43e8-a907-f13a78a7898e
+        status: 200 OK
+        code: 200
+        duration: 65.902969ms
+    - id: 36
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/cd5a1b92-8dca-4280-90c0-2c7528f3dc98
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 908
+        body: '{"id":"cd5a1b92-8dca-4280-90c0-2c7528f3dc98","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_basic","description":"","tags":[],"created_at":"2026-03-26T11:08:54.606552Z","updated_at":"2026-03-26T11:14:42.858508Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://cd5a1b92-8dca-4280-90c0-2c7528f3dc98.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-cd5a1b92-8dca-4280-90c0-2c7528f3dc98.8748c884-d99a-4058-a16c-b83a72c2f4e5.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8748c884-d99a-4058-a16c-b83a72c2f4e5","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "908"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:15:13 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 5320a483-ce0b-4519-814c-8080ec3e0971
+        status: 200 OK
+        code: 200
+        duration: 72.057064ms
+    - id: 37
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/cd5a1b92-8dca-4280-90c0-2c7528f3dc98
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 908
+        body: '{"id":"cd5a1b92-8dca-4280-90c0-2c7528f3dc98","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_basic","description":"","tags":[],"created_at":"2026-03-26T11:08:54.606552Z","updated_at":"2026-03-26T11:14:42.858508Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://cd5a1b92-8dca-4280-90c0-2c7528f3dc98.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-cd5a1b92-8dca-4280-90c0-2c7528f3dc98.8748c884-d99a-4058-a16c-b83a72c2f4e5.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8748c884-d99a-4058-a16c-b83a72c2f4e5","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "908"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:15:28 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - e6efb4c1-fbf1-4dd2-8cac-c2d7d1f48392
+        status: 200 OK
+        code: 200
+        duration: 72.130432ms
+    - id: 38
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/cd5a1b92-8dca-4280-90c0-2c7528f3dc98
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 908
+        body: '{"id":"cd5a1b92-8dca-4280-90c0-2c7528f3dc98","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_basic","description":"","tags":[],"created_at":"2026-03-26T11:08:54.606552Z","updated_at":"2026-03-26T11:14:42.858508Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://cd5a1b92-8dca-4280-90c0-2c7528f3dc98.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-cd5a1b92-8dca-4280-90c0-2c7528f3dc98.8748c884-d99a-4058-a16c-b83a72c2f4e5.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8748c884-d99a-4058-a16c-b83a72c2f4e5","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "908"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:15:43 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 11d9072e-54c5-40a1-83e6-aded297bd1fc
+        status: 200 OK
+        code: 200
+        duration: 84.03695ms
+    - id: 39
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/cd5a1b92-8dca-4280-90c0-2c7528f3dc98
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 908
+        body: '{"id":"cd5a1b92-8dca-4280-90c0-2c7528f3dc98","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_basic","description":"","tags":[],"created_at":"2026-03-26T11:08:54.606552Z","updated_at":"2026-03-26T11:14:42.858508Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://cd5a1b92-8dca-4280-90c0-2c7528f3dc98.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-cd5a1b92-8dca-4280-90c0-2c7528f3dc98.8748c884-d99a-4058-a16c-b83a72c2f4e5.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8748c884-d99a-4058-a16c-b83a72c2f4e5","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "908"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:15:58 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - a91f8d45-89aa-48f2-9217-4402295cc1ed
+        status: 200 OK
+        code: 200
+        duration: 67.09575ms
+    - id: 40
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/cd5a1b92-8dca-4280-90c0-2c7528f3dc98
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 908
+        body: '{"id":"cd5a1b92-8dca-4280-90c0-2c7528f3dc98","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_basic","description":"","tags":[],"created_at":"2026-03-26T11:08:54.606552Z","updated_at":"2026-03-26T11:14:42.858508Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://cd5a1b92-8dca-4280-90c0-2c7528f3dc98.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-cd5a1b92-8dca-4280-90c0-2c7528f3dc98.8748c884-d99a-4058-a16c-b83a72c2f4e5.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8748c884-d99a-4058-a16c-b83a72c2f4e5","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "908"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:16:13 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - e992c475-ed22-4c1f-9ae4-8a63fa1e7ddf
+        status: 200 OK
+        code: 200
+        duration: 77.793689ms
+    - id: 41
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/cd5a1b92-8dca-4280-90c0-2c7528f3dc98
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 908
+        body: '{"id":"cd5a1b92-8dca-4280-90c0-2c7528f3dc98","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_basic","description":"","tags":[],"created_at":"2026-03-26T11:08:54.606552Z","updated_at":"2026-03-26T11:14:42.858508Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://cd5a1b92-8dca-4280-90c0-2c7528f3dc98.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-cd5a1b92-8dca-4280-90c0-2c7528f3dc98.8748c884-d99a-4058-a16c-b83a72c2f4e5.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8748c884-d99a-4058-a16c-b83a72c2f4e5","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "908"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:16:28 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 2f01fe50-6620-47ba-92f7-eec1dfbd9a79
+        status: 200 OK
+        code: 200
+        duration: 75.915297ms
+    - id: 42
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/cd5a1b92-8dca-4280-90c0-2c7528f3dc98
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 908
+        body: '{"id":"cd5a1b92-8dca-4280-90c0-2c7528f3dc98","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_basic","description":"","tags":[],"created_at":"2026-03-26T11:08:54.606552Z","updated_at":"2026-03-26T11:14:42.858508Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://cd5a1b92-8dca-4280-90c0-2c7528f3dc98.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-cd5a1b92-8dca-4280-90c0-2c7528f3dc98.8748c884-d99a-4058-a16c-b83a72c2f4e5.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8748c884-d99a-4058-a16c-b83a72c2f4e5","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "908"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:16:43 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - dcdf8c74-3b7a-45bf-99c3-72dbe2627e31
+        status: 200 OK
+        code: 200
+        duration: 78.587699ms
+    - id: 43
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/cd5a1b92-8dca-4280-90c0-2c7528f3dc98
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 908
+        body: '{"id":"cd5a1b92-8dca-4280-90c0-2c7528f3dc98","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_basic","description":"","tags":[],"created_at":"2026-03-26T11:08:54.606552Z","updated_at":"2026-03-26T11:14:42.858508Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://cd5a1b92-8dca-4280-90c0-2c7528f3dc98.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-cd5a1b92-8dca-4280-90c0-2c7528f3dc98.8748c884-d99a-4058-a16c-b83a72c2f4e5.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8748c884-d99a-4058-a16c-b83a72c2f4e5","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "908"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:16:58 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 92ef423d-ffeb-487f-8c6e-fdce78fd5f94
+        status: 200 OK
+        code: 200
+        duration: 81.940175ms
+    - id: 44
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/cd5a1b92-8dca-4280-90c0-2c7528f3dc98
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 908
+        body: '{"id":"cd5a1b92-8dca-4280-90c0-2c7528f3dc98","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_basic","description":"","tags":[],"created_at":"2026-03-26T11:08:54.606552Z","updated_at":"2026-03-26T11:14:42.858508Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://cd5a1b92-8dca-4280-90c0-2c7528f3dc98.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-cd5a1b92-8dca-4280-90c0-2c7528f3dc98.8748c884-d99a-4058-a16c-b83a72c2f4e5.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8748c884-d99a-4058-a16c-b83a72c2f4e5","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "908"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:17:13 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - fb03620a-30b3-480b-901f-8916398f4f77
+        status: 200 OK
+        code: 200
+        duration: 70.551484ms
+    - id: 45
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/cd5a1b92-8dca-4280-90c0-2c7528f3dc98
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 128
+        body: '{"message":"resource is not found","resource":"datalab","resource_id":"cd5a1b92-8dca-4280-90c0-2c7528f3dc98","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "128"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:17:28 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - b1991cd5-5e40-4602-b623-dbdcb9b4b156
+        status: 404 Not Found
+        code: 404
+        duration: 58.509908ms
+    - id: 46
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8748c884-d99a-4058-a16c-b83a72c2f4e5
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:17:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 8fa8d1a9-fd5e-48b5-8bbe-6606dac84bf2
+        status: 204 No Content
+        code: 204
+        duration: 1.502245966s
+    - id: 47
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/1ef8336c-285e-4613-beae-907c50e4120f
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:17:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 9897b949-f170-44b9-b83a-385ecc09ac2f
+        status: 204 No Content
+        code: 204
+        duration: 513.88486ms
+    - id: 48
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/cd5a1b92-8dca-4280-90c0-2c7528f3dc98
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 128
+        body: '{"message":"resource is not found","resource":"datalab","resource_id":"cd5a1b92-8dca-4280-90c0-2c7528f3dc98","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "128"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:17:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 298cc369-0406-4199-8518-89376e7ceec9
+        status: 404 Not Found
+        code: 404
+        duration: 54.754744ms

--- a/internal/services/datalab/testdata/datalab-resource-import.cassette.yaml
+++ b/internal/services/datalab/testdata/datalab-resource-import.cassette.yaml
@@ -1,0 +1,1608 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 119
+        host: api.scaleway.com
+        body: '{"name":"tf_tests_datalab_import","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","tags":[],"enable_routing":false}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 410
+        body: '{"id":"29f1336a-848c-45b3-a2d8-37fa0492c0e6","name":"tf_tests_datalab_import","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:21:14.915361Z","updated_at":"2026-03-26T11:21:14.915361Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","is_default":false,"private_network_count":0,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "410"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:21:14 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 51dd97df-c279-4187-9bdb-332a92ba6c5b
+        status: 200 OK
+        code: 200
+        duration: 287.140529ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/29f1336a-848c-45b3-a2d8-37fa0492c0e6
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 410
+        body: '{"id":"29f1336a-848c-45b3-a2d8-37fa0492c0e6","name":"tf_tests_datalab_import","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:21:14.915361Z","updated_at":"2026-03-26T11:21:14.915361Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","is_default":false,"private_network_count":0,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "410"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:21:15 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - ca0c9802-061e-4b3f-b331-629e2440cde9
+        status: 200 OK
+        code: 200
+        duration: 63.721309ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 202
+        host: api.scaleway.com
+        body: '{"name":"tf-pn-confident-thompson","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","tags":[],"subnets":null,"vpc_id":"29f1336a-848c-45b3-a2d8-37fa0492c0e6","default_route_propagation_enabled":false}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1069
+        body: '{"id":"10002fd4-8aed-442e-96e6-1615dc721df4","name":"tf-pn-confident-thompson","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:21:15.247998Z","updated_at":"2026-03-26T11:21:15.247998Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","subnets":[{"id":"f5f29390-309a-41cf-a8ea-b388edbf4b9f","created_at":"2026-03-26T11:21:15.247998Z","updated_at":"2026-03-26T11:21:15.247998Z","subnet":"172.16.0.0/22","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"10002fd4-8aed-442e-96e6-1615dc721df4","vpc_id":"29f1336a-848c-45b3-a2d8-37fa0492c0e6"},{"id":"20fd42f8-fe2e-46a7-b70e-53ec6bd9868b","created_at":"2026-03-26T11:21:15.247998Z","updated_at":"2026-03-26T11:21:15.247998Z","subnet":"fd40:e277:fdde:500a::/64","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"10002fd4-8aed-442e-96e6-1615dc721df4","vpc_id":"29f1336a-848c-45b3-a2d8-37fa0492c0e6"}],"vpc_id":"29f1336a-848c-45b3-a2d8-37fa0492c0e6","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1069"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:21:15 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 3bb76cf2-5229-4c14-8447-def1362ba544
+        status: 200 OK
+        code: 200
+        duration: 832.618187ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/10002fd4-8aed-442e-96e6-1615dc721df4
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1069
+        body: '{"id":"10002fd4-8aed-442e-96e6-1615dc721df4","name":"tf-pn-confident-thompson","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:21:15.247998Z","updated_at":"2026-03-26T11:21:15.247998Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","subnets":[{"id":"f5f29390-309a-41cf-a8ea-b388edbf4b9f","created_at":"2026-03-26T11:21:15.247998Z","updated_at":"2026-03-26T11:21:15.247998Z","subnet":"172.16.0.0/22","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"10002fd4-8aed-442e-96e6-1615dc721df4","vpc_id":"29f1336a-848c-45b3-a2d8-37fa0492c0e6"},{"id":"20fd42f8-fe2e-46a7-b70e-53ec6bd9868b","created_at":"2026-03-26T11:21:15.247998Z","updated_at":"2026-03-26T11:21:15.247998Z","subnet":"fd40:e277:fdde:500a::/64","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"10002fd4-8aed-442e-96e6-1615dc721df4","vpc_id":"29f1336a-848c-45b3-a2d8-37fa0492c0e6"}],"vpc_id":"29f1336a-848c-45b3-a2d8-37fa0492c0e6","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1069"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:21:15 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - fce44e8e-d039-401a-8a4c-a813752ae3aa
+        status: 200 OK
+        code: 200
+        duration: 58.93188ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 329
+        host: api.scaleway.com
+        body: '{"project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_import","description":"","tags":null,"main":{"node_type":"DATALAB-SHARED-4C-8G"},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1},"has_notebook":false,"spark_version":"4.0.0","private_network_id":"10002fd4-8aed-442e-96e6-1615dc721df4"}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"416ee08c-b051-4ae7-9116-338de8c851d2","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_import","description":"","tags":[],"created_at":"2026-03-26T11:21:16.037689Z","updated_at":"2026-03-26T11:21:16.037689Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://416ee08c-b051-4ae7-9116-338de8c851d2.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-416ee08c-b051-4ae7-9116-338de8c851d2.10002fd4-8aed-442e-96e6-1615dc721df4.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"10002fd4-8aed-442e-96e6-1615dc721df4","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:21:16 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - b8f75001-c0d7-44f9-bb78-00752edb25c9
+        status: 200 OK
+        code: 200
+        duration: 652.900181ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/416ee08c-b051-4ae7-9116-338de8c851d2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"416ee08c-b051-4ae7-9116-338de8c851d2","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_import","description":"","tags":[],"created_at":"2026-03-26T11:21:16.037689Z","updated_at":"2026-03-26T11:21:16.037689Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://416ee08c-b051-4ae7-9116-338de8c851d2.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-416ee08c-b051-4ae7-9116-338de8c851d2.10002fd4-8aed-442e-96e6-1615dc721df4.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"10002fd4-8aed-442e-96e6-1615dc721df4","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:21:16 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - bac436fb-73ae-4059-be3f-93725965c4f5
+        status: 200 OK
+        code: 200
+        duration: 82.220541ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/416ee08c-b051-4ae7-9116-338de8c851d2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"416ee08c-b051-4ae7-9116-338de8c851d2","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_import","description":"","tags":[],"created_at":"2026-03-26T11:21:16.037689Z","updated_at":"2026-03-26T11:21:16.037689Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://416ee08c-b051-4ae7-9116-338de8c851d2.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-416ee08c-b051-4ae7-9116-338de8c851d2.10002fd4-8aed-442e-96e6-1615dc721df4.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"10002fd4-8aed-442e-96e6-1615dc721df4","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:21:31 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 4c5a3628-6613-4966-872b-3a6fa51ac68c
+        status: 200 OK
+        code: 200
+        duration: 73.228178ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/416ee08c-b051-4ae7-9116-338de8c851d2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"416ee08c-b051-4ae7-9116-338de8c851d2","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_import","description":"","tags":[],"created_at":"2026-03-26T11:21:16.037689Z","updated_at":"2026-03-26T11:21:16.037689Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://416ee08c-b051-4ae7-9116-338de8c851d2.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-416ee08c-b051-4ae7-9116-338de8c851d2.10002fd4-8aed-442e-96e6-1615dc721df4.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"10002fd4-8aed-442e-96e6-1615dc721df4","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:21:46 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 6fb9c8b2-e278-4952-a045-28bc8ee7761f
+        status: 200 OK
+        code: 200
+        duration: 68.01988ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/416ee08c-b051-4ae7-9116-338de8c851d2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"416ee08c-b051-4ae7-9116-338de8c851d2","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_import","description":"","tags":[],"created_at":"2026-03-26T11:21:16.037689Z","updated_at":"2026-03-26T11:21:16.037689Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://416ee08c-b051-4ae7-9116-338de8c851d2.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-416ee08c-b051-4ae7-9116-338de8c851d2.10002fd4-8aed-442e-96e6-1615dc721df4.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"10002fd4-8aed-442e-96e6-1615dc721df4","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:22:01 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - eeb2bbed-eb5e-4408-8921-fa2dbed10ecd
+        status: 200 OK
+        code: 200
+        duration: 67.949312ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/416ee08c-b051-4ae7-9116-338de8c851d2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"416ee08c-b051-4ae7-9116-338de8c851d2","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_import","description":"","tags":[],"created_at":"2026-03-26T11:21:16.037689Z","updated_at":"2026-03-26T11:21:16.037689Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://416ee08c-b051-4ae7-9116-338de8c851d2.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-416ee08c-b051-4ae7-9116-338de8c851d2.10002fd4-8aed-442e-96e6-1615dc721df4.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"10002fd4-8aed-442e-96e6-1615dc721df4","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:22:16 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 06e37b9f-2baf-4f5d-893b-27b8662b22d3
+        status: 200 OK
+        code: 200
+        duration: 69.458414ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/416ee08c-b051-4ae7-9116-338de8c851d2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"416ee08c-b051-4ae7-9116-338de8c851d2","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_import","description":"","tags":[],"created_at":"2026-03-26T11:21:16.037689Z","updated_at":"2026-03-26T11:21:16.037689Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://416ee08c-b051-4ae7-9116-338de8c851d2.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-416ee08c-b051-4ae7-9116-338de8c851d2.10002fd4-8aed-442e-96e6-1615dc721df4.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"10002fd4-8aed-442e-96e6-1615dc721df4","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:22:32 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - b24c2e26-95ae-4a45-b700-95e5a297794a
+        status: 200 OK
+        code: 200
+        duration: 71.815885ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/416ee08c-b051-4ae7-9116-338de8c851d2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"416ee08c-b051-4ae7-9116-338de8c851d2","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_import","description":"","tags":[],"created_at":"2026-03-26T11:21:16.037689Z","updated_at":"2026-03-26T11:21:16.037689Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://416ee08c-b051-4ae7-9116-338de8c851d2.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-416ee08c-b051-4ae7-9116-338de8c851d2.10002fd4-8aed-442e-96e6-1615dc721df4.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"10002fd4-8aed-442e-96e6-1615dc721df4","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:22:47 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - c51eef0b-993b-4d51-a328-d7f53591aa09
+        status: 200 OK
+        code: 200
+        duration: 79.54148ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/416ee08c-b051-4ae7-9116-338de8c851d2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"416ee08c-b051-4ae7-9116-338de8c851d2","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_import","description":"","tags":[],"created_at":"2026-03-26T11:21:16.037689Z","updated_at":"2026-03-26T11:21:16.037689Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://416ee08c-b051-4ae7-9116-338de8c851d2.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-416ee08c-b051-4ae7-9116-338de8c851d2.10002fd4-8aed-442e-96e6-1615dc721df4.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"10002fd4-8aed-442e-96e6-1615dc721df4","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:23:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 5d8ec36d-4c09-455f-8b94-04cc2f3d8652
+        status: 200 OK
+        code: 200
+        duration: 69.764677ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/416ee08c-b051-4ae7-9116-338de8c851d2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"416ee08c-b051-4ae7-9116-338de8c851d2","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_import","description":"","tags":[],"created_at":"2026-03-26T11:21:16.037689Z","updated_at":"2026-03-26T11:21:16.037689Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://416ee08c-b051-4ae7-9116-338de8c851d2.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-416ee08c-b051-4ae7-9116-338de8c851d2.10002fd4-8aed-442e-96e6-1615dc721df4.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"10002fd4-8aed-442e-96e6-1615dc721df4","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:23:17 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 4655f8ac-2fc5-48e0-8993-75873f75eade
+        status: 200 OK
+        code: 200
+        duration: 81.535329ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/416ee08c-b051-4ae7-9116-338de8c851d2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"416ee08c-b051-4ae7-9116-338de8c851d2","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_import","description":"","tags":[],"created_at":"2026-03-26T11:21:16.037689Z","updated_at":"2026-03-26T11:21:16.037689Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://416ee08c-b051-4ae7-9116-338de8c851d2.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-416ee08c-b051-4ae7-9116-338de8c851d2.10002fd4-8aed-442e-96e6-1615dc721df4.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"10002fd4-8aed-442e-96e6-1615dc721df4","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:23:32 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 55ec4632-eb47-48ed-8f58-3ada9738e80e
+        status: 200 OK
+        code: 200
+        duration: 72.755942ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/416ee08c-b051-4ae7-9116-338de8c851d2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"416ee08c-b051-4ae7-9116-338de8c851d2","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_import","description":"","tags":[],"created_at":"2026-03-26T11:21:16.037689Z","updated_at":"2026-03-26T11:21:16.037689Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://416ee08c-b051-4ae7-9116-338de8c851d2.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-416ee08c-b051-4ae7-9116-338de8c851d2.10002fd4-8aed-442e-96e6-1615dc721df4.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"10002fd4-8aed-442e-96e6-1615dc721df4","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:23:47 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - cf165e28-3056-4a90-95cc-a5aa6b913382
+        status: 200 OK
+        code: 200
+        duration: 79.984158ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/416ee08c-b051-4ae7-9116-338de8c851d2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"416ee08c-b051-4ae7-9116-338de8c851d2","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_import","description":"","tags":[],"created_at":"2026-03-26T11:21:16.037689Z","updated_at":"2026-03-26T11:21:16.037689Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://416ee08c-b051-4ae7-9116-338de8c851d2.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-416ee08c-b051-4ae7-9116-338de8c851d2.10002fd4-8aed-442e-96e6-1615dc721df4.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"10002fd4-8aed-442e-96e6-1615dc721df4","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:24:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 6c939c7b-7f13-4e29-9a7e-ff5dcbeae29b
+        status: 200 OK
+        code: 200
+        duration: 82.279031ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/416ee08c-b051-4ae7-9116-338de8c851d2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"416ee08c-b051-4ae7-9116-338de8c851d2","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_import","description":"","tags":[],"created_at":"2026-03-26T11:21:16.037689Z","updated_at":"2026-03-26T11:21:16.037689Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://416ee08c-b051-4ae7-9116-338de8c851d2.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-416ee08c-b051-4ae7-9116-338de8c851d2.10002fd4-8aed-442e-96e6-1615dc721df4.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"10002fd4-8aed-442e-96e6-1615dc721df4","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:24:17 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 02983051-f9e6-464d-a5b8-e4f889c0ca43
+        status: 200 OK
+        code: 200
+        duration: 76.709192ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/416ee08c-b051-4ae7-9116-338de8c851d2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"416ee08c-b051-4ae7-9116-338de8c851d2","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_import","description":"","tags":[],"created_at":"2026-03-26T11:21:16.037689Z","updated_at":"2026-03-26T11:21:16.037689Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://416ee08c-b051-4ae7-9116-338de8c851d2.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-416ee08c-b051-4ae7-9116-338de8c851d2.10002fd4-8aed-442e-96e6-1615dc721df4.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"10002fd4-8aed-442e-96e6-1615dc721df4","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:24:32 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 448e63cd-3c5b-4bf1-961e-006f89e6a5c7
+        status: 200 OK
+        code: 200
+        duration: 71.301039ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/416ee08c-b051-4ae7-9116-338de8c851d2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"416ee08c-b051-4ae7-9116-338de8c851d2","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_import","description":"","tags":[],"created_at":"2026-03-26T11:21:16.037689Z","updated_at":"2026-03-26T11:21:16.037689Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://416ee08c-b051-4ae7-9116-338de8c851d2.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-416ee08c-b051-4ae7-9116-338de8c851d2.10002fd4-8aed-442e-96e6-1615dc721df4.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"10002fd4-8aed-442e-96e6-1615dc721df4","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:24:47 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - fbf74d85-06c9-4e9d-9337-f6637a54ad20
+        status: 200 OK
+        code: 200
+        duration: 86.909384ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/416ee08c-b051-4ae7-9116-338de8c851d2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"416ee08c-b051-4ae7-9116-338de8c851d2","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_import","description":"","tags":[],"created_at":"2026-03-26T11:21:16.037689Z","updated_at":"2026-03-26T11:21:16.037689Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://416ee08c-b051-4ae7-9116-338de8c851d2.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-416ee08c-b051-4ae7-9116-338de8c851d2.10002fd4-8aed-442e-96e6-1615dc721df4.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"10002fd4-8aed-442e-96e6-1615dc721df4","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:25:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 38d3e56a-f9ee-44e9-b41c-a70943270536
+        status: 200 OK
+        code: 200
+        duration: 86.717779ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/416ee08c-b051-4ae7-9116-338de8c851d2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"416ee08c-b051-4ae7-9116-338de8c851d2","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_import","description":"","tags":[],"created_at":"2026-03-26T11:21:16.037689Z","updated_at":"2026-03-26T11:21:16.037689Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://416ee08c-b051-4ae7-9116-338de8c851d2.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-416ee08c-b051-4ae7-9116-338de8c851d2.10002fd4-8aed-442e-96e6-1615dc721df4.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"10002fd4-8aed-442e-96e6-1615dc721df4","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:25:17 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - d3deae4f-7dbb-4fd9-9c9c-f8dc43ec2a12
+        status: 200 OK
+        code: 200
+        duration: 69.133624ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/416ee08c-b051-4ae7-9116-338de8c851d2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"416ee08c-b051-4ae7-9116-338de8c851d2","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_import","description":"","tags":[],"created_at":"2026-03-26T11:21:16.037689Z","updated_at":"2026-03-26T11:21:16.037689Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://416ee08c-b051-4ae7-9116-338de8c851d2.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-416ee08c-b051-4ae7-9116-338de8c851d2.10002fd4-8aed-442e-96e6-1615dc721df4.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"10002fd4-8aed-442e-96e6-1615dc721df4","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:25:32 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - e29dcf78-9bb8-48ef-b82a-9df8f477ea35
+        status: 200 OK
+        code: 200
+        duration: 75.660659ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/416ee08c-b051-4ae7-9116-338de8c851d2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"416ee08c-b051-4ae7-9116-338de8c851d2","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_import","description":"","tags":[],"created_at":"2026-03-26T11:21:16.037689Z","updated_at":"2026-03-26T11:21:16.037689Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://416ee08c-b051-4ae7-9116-338de8c851d2.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-416ee08c-b051-4ae7-9116-338de8c851d2.10002fd4-8aed-442e-96e6-1615dc721df4.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"10002fd4-8aed-442e-96e6-1615dc721df4","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:25:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - f0b3283c-5f14-4c74-9ca1-aa44318ec3f8
+        status: 200 OK
+        code: 200
+        duration: 75.976271ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/416ee08c-b051-4ae7-9116-338de8c851d2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"416ee08c-b051-4ae7-9116-338de8c851d2","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_import","description":"","tags":[],"created_at":"2026-03-26T11:21:16.037689Z","updated_at":"2026-03-26T11:21:16.037689Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://416ee08c-b051-4ae7-9116-338de8c851d2.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-416ee08c-b051-4ae7-9116-338de8c851d2.10002fd4-8aed-442e-96e6-1615dc721df4.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"10002fd4-8aed-442e-96e6-1615dc721df4","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:26:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - f995a88d-3d71-46c9-95ba-d4d5bcee098d
+        status: 200 OK
+        code: 200
+        duration: 88.413186ms
+    - id: 25
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/416ee08c-b051-4ae7-9116-338de8c851d2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"416ee08c-b051-4ae7-9116-338de8c851d2","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_import","description":"","tags":[],"created_at":"2026-03-26T11:21:16.037689Z","updated_at":"2026-03-26T11:21:16.037689Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://416ee08c-b051-4ae7-9116-338de8c851d2.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-416ee08c-b051-4ae7-9116-338de8c851d2.10002fd4-8aed-442e-96e6-1615dc721df4.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"10002fd4-8aed-442e-96e6-1615dc721df4","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:26:18 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 015efd0f-0228-4b0b-80d0-5022a02f3f12
+        status: 200 OK
+        code: 200
+        duration: 76.227415ms
+    - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/416ee08c-b051-4ae7-9116-338de8c851d2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"416ee08c-b051-4ae7-9116-338de8c851d2","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_import","description":"","tags":[],"created_at":"2026-03-26T11:21:16.037689Z","updated_at":"2026-03-26T11:21:16.037689Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://416ee08c-b051-4ae7-9116-338de8c851d2.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-416ee08c-b051-4ae7-9116-338de8c851d2.10002fd4-8aed-442e-96e6-1615dc721df4.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"10002fd4-8aed-442e-96e6-1615dc721df4","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:26:33 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 6bd148e2-dbf5-4bd0-8dae-592e04146aa7
+        status: 200 OK
+        code: 200
+        duration: 79.18069ms
+    - id: 27
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/416ee08c-b051-4ae7-9116-338de8c851d2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 906
+        body: '{"id":"416ee08c-b051-4ae7-9116-338de8c851d2","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_import","description":"","tags":[],"created_at":"2026-03-26T11:21:16.037689Z","updated_at":"2026-03-26T11:26:40.183683Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://416ee08c-b051-4ae7-9116-338de8c851d2.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-416ee08c-b051-4ae7-9116-338de8c851d2.10002fd4-8aed-442e-96e6-1615dc721df4.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"10002fd4-8aed-442e-96e6-1615dc721df4","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "906"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:26:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 29ec1b45-4fea-4d5b-9010-0c7c7edc52f2
+        status: 200 OK
+        code: 200
+        duration: 82.994623ms
+    - id: 28
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/416ee08c-b051-4ae7-9116-338de8c851d2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 906
+        body: '{"id":"416ee08c-b051-4ae7-9116-338de8c851d2","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_import","description":"","tags":[],"created_at":"2026-03-26T11:21:16.037689Z","updated_at":"2026-03-26T11:26:40.183683Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://416ee08c-b051-4ae7-9116-338de8c851d2.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-416ee08c-b051-4ae7-9116-338de8c851d2.10002fd4-8aed-442e-96e6-1615dc721df4.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"10002fd4-8aed-442e-96e6-1615dc721df4","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "906"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:26:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 05705371-3508-4bfb-bb62-0901d85ca741
+        status: 200 OK
+        code: 200
+        duration: 79.469243ms
+    - id: 29
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/29f1336a-848c-45b3-a2d8-37fa0492c0e6
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 410
+        body: '{"id":"29f1336a-848c-45b3-a2d8-37fa0492c0e6","name":"tf_tests_datalab_import","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:21:14.915361Z","updated_at":"2026-03-26T11:21:14.915361Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","is_default":false,"private_network_count":1,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "410"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:26:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 91fb65ea-6b19-47f2-804a-49d42231aeb2
+        status: 200 OK
+        code: 200
+        duration: 52.974942ms
+    - id: 30
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/10002fd4-8aed-442e-96e6-1615dc721df4
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1069
+        body: '{"id":"10002fd4-8aed-442e-96e6-1615dc721df4","name":"tf-pn-confident-thompson","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:21:15.247998Z","updated_at":"2026-03-26T11:21:15.247998Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","subnets":[{"id":"f5f29390-309a-41cf-a8ea-b388edbf4b9f","created_at":"2026-03-26T11:21:15.247998Z","updated_at":"2026-03-26T11:21:15.247998Z","subnet":"172.16.0.0/22","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"10002fd4-8aed-442e-96e6-1615dc721df4","vpc_id":"29f1336a-848c-45b3-a2d8-37fa0492c0e6"},{"id":"20fd42f8-fe2e-46a7-b70e-53ec6bd9868b","created_at":"2026-03-26T11:21:15.247998Z","updated_at":"2026-03-26T11:21:15.247998Z","subnet":"fd40:e277:fdde:500a::/64","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"10002fd4-8aed-442e-96e6-1615dc721df4","vpc_id":"29f1336a-848c-45b3-a2d8-37fa0492c0e6"}],"vpc_id":"29f1336a-848c-45b3-a2d8-37fa0492c0e6","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1069"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:26:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 36a22f07-906e-4b84-83b8-eabdaa525d42
+        status: 200 OK
+        code: 200
+        duration: 62.807744ms
+    - id: 31
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/416ee08c-b051-4ae7-9116-338de8c851d2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 906
+        body: '{"id":"416ee08c-b051-4ae7-9116-338de8c851d2","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_import","description":"","tags":[],"created_at":"2026-03-26T11:21:16.037689Z","updated_at":"2026-03-26T11:26:40.183683Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://416ee08c-b051-4ae7-9116-338de8c851d2.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-416ee08c-b051-4ae7-9116-338de8c851d2.10002fd4-8aed-442e-96e6-1615dc721df4.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"10002fd4-8aed-442e-96e6-1615dc721df4","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "906"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:26:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 661c1eff-2e05-4564-ba9b-a7ff5c438199
+        status: 200 OK
+        code: 200
+        duration: 70.720224ms
+    - id: 32
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/416ee08c-b051-4ae7-9116-338de8c851d2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 906
+        body: '{"id":"416ee08c-b051-4ae7-9116-338de8c851d2","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_import","description":"","tags":[],"created_at":"2026-03-26T11:21:16.037689Z","updated_at":"2026-03-26T11:26:40.183683Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://416ee08c-b051-4ae7-9116-338de8c851d2.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-416ee08c-b051-4ae7-9116-338de8c851d2.10002fd4-8aed-442e-96e6-1615dc721df4.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"10002fd4-8aed-442e-96e6-1615dc721df4","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "906"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:26:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 0bec2e9d-c570-45d4-912c-01be41238c99
+        status: 200 OK
+        code: 200
+        duration: 79.793295ms
+    - id: 33
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/416ee08c-b051-4ae7-9116-338de8c851d2
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"416ee08c-b051-4ae7-9116-338de8c851d2","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_import","description":"","tags":[],"created_at":"2026-03-26T11:21:16.037689Z","updated_at":"2026-03-26T11:26:49.360781Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://416ee08c-b051-4ae7-9116-338de8c851d2.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-416ee08c-b051-4ae7-9116-338de8c851d2.10002fd4-8aed-442e-96e6-1615dc721df4.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"10002fd4-8aed-442e-96e6-1615dc721df4","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:26:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 768b0210-557a-4a38-a962-e3281f96b80d
+        status: 200 OK
+        code: 200
+        duration: 163.263426ms
+    - id: 34
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/416ee08c-b051-4ae7-9116-338de8c851d2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"416ee08c-b051-4ae7-9116-338de8c851d2","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_import","description":"","tags":[],"created_at":"2026-03-26T11:21:16.037689Z","updated_at":"2026-03-26T11:26:49.360781Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://416ee08c-b051-4ae7-9116-338de8c851d2.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-416ee08c-b051-4ae7-9116-338de8c851d2.10002fd4-8aed-442e-96e6-1615dc721df4.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"10002fd4-8aed-442e-96e6-1615dc721df4","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:26:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 4685284e-f411-44f7-9799-d223fb4ba188
+        status: 200 OK
+        code: 200
+        duration: 69.432056ms
+    - id: 35
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/416ee08c-b051-4ae7-9116-338de8c851d2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"416ee08c-b051-4ae7-9116-338de8c851d2","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_import","description":"","tags":[],"created_at":"2026-03-26T11:21:16.037689Z","updated_at":"2026-03-26T11:26:49.360781Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://416ee08c-b051-4ae7-9116-338de8c851d2.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-416ee08c-b051-4ae7-9116-338de8c851d2.10002fd4-8aed-442e-96e6-1615dc721df4.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"10002fd4-8aed-442e-96e6-1615dc721df4","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:27:04 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 6db6cb12-f9c9-4928-92b2-3a847b0cd8d2
+        status: 200 OK
+        code: 200
+        duration: 89.09018ms
+    - id: 36
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/416ee08c-b051-4ae7-9116-338de8c851d2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"416ee08c-b051-4ae7-9116-338de8c851d2","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_import","description":"","tags":[],"created_at":"2026-03-26T11:21:16.037689Z","updated_at":"2026-03-26T11:26:49.360781Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://416ee08c-b051-4ae7-9116-338de8c851d2.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-416ee08c-b051-4ae7-9116-338de8c851d2.10002fd4-8aed-442e-96e6-1615dc721df4.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"10002fd4-8aed-442e-96e6-1615dc721df4","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:27:19 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - efe46453-35fa-414d-9b53-f38129107679
+        status: 200 OK
+        code: 200
+        duration: 65.664341ms
+    - id: 37
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/416ee08c-b051-4ae7-9116-338de8c851d2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"416ee08c-b051-4ae7-9116-338de8c851d2","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_import","description":"","tags":[],"created_at":"2026-03-26T11:21:16.037689Z","updated_at":"2026-03-26T11:26:49.360781Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://416ee08c-b051-4ae7-9116-338de8c851d2.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-416ee08c-b051-4ae7-9116-338de8c851d2.10002fd4-8aed-442e-96e6-1615dc721df4.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"10002fd4-8aed-442e-96e6-1615dc721df4","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:27:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - d9a4654a-671d-46fb-a5e2-259cf6d3f1a5
+        status: 200 OK
+        code: 200
+        duration: 83.713506ms
+    - id: 38
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/416ee08c-b051-4ae7-9116-338de8c851d2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"416ee08c-b051-4ae7-9116-338de8c851d2","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_import","description":"","tags":[],"created_at":"2026-03-26T11:21:16.037689Z","updated_at":"2026-03-26T11:26:49.360781Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://416ee08c-b051-4ae7-9116-338de8c851d2.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-416ee08c-b051-4ae7-9116-338de8c851d2.10002fd4-8aed-442e-96e6-1615dc721df4.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"10002fd4-8aed-442e-96e6-1615dc721df4","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:27:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 66deb42a-ca1a-47f8-8edc-c5833b1481d9
+        status: 200 OK
+        code: 200
+        duration: 71.355038ms
+    - id: 39
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/416ee08c-b051-4ae7-9116-338de8c851d2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"416ee08c-b051-4ae7-9116-338de8c851d2","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_import","description":"","tags":[],"created_at":"2026-03-26T11:21:16.037689Z","updated_at":"2026-03-26T11:26:49.360781Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://416ee08c-b051-4ae7-9116-338de8c851d2.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-416ee08c-b051-4ae7-9116-338de8c851d2.10002fd4-8aed-442e-96e6-1615dc721df4.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"10002fd4-8aed-442e-96e6-1615dc721df4","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:28:04 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - ce0f6c95-26ea-4c16-9e85-2b759846bf60
+        status: 200 OK
+        code: 200
+        duration: 81.625109ms
+    - id: 40
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/416ee08c-b051-4ae7-9116-338de8c851d2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"416ee08c-b051-4ae7-9116-338de8c851d2","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_import","description":"","tags":[],"created_at":"2026-03-26T11:21:16.037689Z","updated_at":"2026-03-26T11:26:49.360781Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://416ee08c-b051-4ae7-9116-338de8c851d2.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-416ee08c-b051-4ae7-9116-338de8c851d2.10002fd4-8aed-442e-96e6-1615dc721df4.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"10002fd4-8aed-442e-96e6-1615dc721df4","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:28:20 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - fc2e9cf9-8e9a-4070-8679-7f92641e41f8
+        status: 200 OK
+        code: 200
+        duration: 85.999318ms
+    - id: 41
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/416ee08c-b051-4ae7-9116-338de8c851d2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"416ee08c-b051-4ae7-9116-338de8c851d2","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_import","description":"","tags":[],"created_at":"2026-03-26T11:21:16.037689Z","updated_at":"2026-03-26T11:26:49.360781Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://416ee08c-b051-4ae7-9116-338de8c851d2.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-416ee08c-b051-4ae7-9116-338de8c851d2.10002fd4-8aed-442e-96e6-1615dc721df4.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"10002fd4-8aed-442e-96e6-1615dc721df4","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:28:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - d0c21bff-453d-4728-b492-ab158775ff2f
+        status: 200 OK
+        code: 200
+        duration: 84.742711ms
+    - id: 42
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/416ee08c-b051-4ae7-9116-338de8c851d2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"416ee08c-b051-4ae7-9116-338de8c851d2","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_import","description":"","tags":[],"created_at":"2026-03-26T11:21:16.037689Z","updated_at":"2026-03-26T11:26:49.360781Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://416ee08c-b051-4ae7-9116-338de8c851d2.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-416ee08c-b051-4ae7-9116-338de8c851d2.10002fd4-8aed-442e-96e6-1615dc721df4.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"10002fd4-8aed-442e-96e6-1615dc721df4","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:28:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 87d7c082-626a-4527-a63a-5c512d0305c8
+        status: 200 OK
+        code: 200
+        duration: 69.664161ms
+    - id: 43
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/416ee08c-b051-4ae7-9116-338de8c851d2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"416ee08c-b051-4ae7-9116-338de8c851d2","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_import","description":"","tags":[],"created_at":"2026-03-26T11:21:16.037689Z","updated_at":"2026-03-26T11:26:49.360781Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://416ee08c-b051-4ae7-9116-338de8c851d2.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-416ee08c-b051-4ae7-9116-338de8c851d2.10002fd4-8aed-442e-96e6-1615dc721df4.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"10002fd4-8aed-442e-96e6-1615dc721df4","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:29:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 040b1686-c833-465b-9d23-29ab4d810112
+        status: 200 OK
+        code: 200
+        duration: 80.864108ms
+    - id: 44
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/416ee08c-b051-4ae7-9116-338de8c851d2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"416ee08c-b051-4ae7-9116-338de8c851d2","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_import","description":"","tags":[],"created_at":"2026-03-26T11:21:16.037689Z","updated_at":"2026-03-26T11:26:49.360781Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://416ee08c-b051-4ae7-9116-338de8c851d2.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-416ee08c-b051-4ae7-9116-338de8c851d2.10002fd4-8aed-442e-96e6-1615dc721df4.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"10002fd4-8aed-442e-96e6-1615dc721df4","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:29:20 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - ef12ab49-3d56-4acb-b270-e804d334331f
+        status: 200 OK
+        code: 200
+        duration: 77.796246ms
+    - id: 45
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/416ee08c-b051-4ae7-9116-338de8c851d2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"416ee08c-b051-4ae7-9116-338de8c851d2","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_import","description":"","tags":[],"created_at":"2026-03-26T11:21:16.037689Z","updated_at":"2026-03-26T11:26:49.360781Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://416ee08c-b051-4ae7-9116-338de8c851d2.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-416ee08c-b051-4ae7-9116-338de8c851d2.10002fd4-8aed-442e-96e6-1615dc721df4.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"10002fd4-8aed-442e-96e6-1615dc721df4","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:29:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - ccf51f11-a187-4f48-ad72-accfa4203846
+        status: 200 OK
+        code: 200
+        duration: 68.753914ms
+    - id: 46
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/416ee08c-b051-4ae7-9116-338de8c851d2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 128
+        body: '{"message":"resource is not found","resource":"datalab","resource_id":"416ee08c-b051-4ae7-9116-338de8c851d2","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "128"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:29:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - e105e567-daab-4094-953a-1443d43d9b14
+        status: 404 Not Found
+        code: 404
+        duration: 66.459012ms
+    - id: 47
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/10002fd4-8aed-442e-96e6-1615dc721df4
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:29:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 89cfc7c7-3e53-41f4-9574-ca2fca4a15fb
+        status: 204 No Content
+        code: 204
+        duration: 1.730441028s
+    - id: 48
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/29f1336a-848c-45b3-a2d8-37fa0492c0e6
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:29:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - e35ed7f7-95e7-45bc-847a-f451a387b27f
+        status: 204 No Content
+        code: 204
+        duration: 416.372117ms
+    - id: 49
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/416ee08c-b051-4ae7-9116-338de8c851d2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 128
+        body: '{"message":"resource is not found","resource":"datalab","resource_id":"416ee08c-b051-4ae7-9116-338de8c851d2","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "128"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:29:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - f96efbe3-138d-4b33-8ed4-136e0d985dd9
+        status: 404 Not Found
+        code: 404
+        duration: 61.110577ms

--- a/internal/services/datalab/testdata/datalab-resource-update.cassette.yaml
+++ b/internal/services/datalab/testdata/datalab-resource-update.cassette.yaml
@@ -1,0 +1,1707 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 119
+        host: api.scaleway.com
+        body: '{"name":"tf_tests_datalab_update","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","tags":[],"enable_routing":false}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 410
+        body: '{"id":"420188e5-1c68-4d96-85fa-ab1564e31edf","name":"tf_tests_datalab_update","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:08:52.536262Z","updated_at":"2026-03-26T11:08:52.536262Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","is_default":false,"private_network_count":0,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "410"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:08:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 507e8168-6332-498b-98b2-329b9a5c92ab
+        status: 200 OK
+        code: 200
+        duration: 231.094403ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/420188e5-1c68-4d96-85fa-ab1564e31edf
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 410
+        body: '{"id":"420188e5-1c68-4d96-85fa-ab1564e31edf","name":"tf_tests_datalab_update","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:08:52.536262Z","updated_at":"2026-03-26T11:08:52.536262Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","is_default":false,"private_network_count":0,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "410"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:08:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 682e8792-9ec2-4788-871f-3623ed719c0a
+        status: 200 OK
+        code: 200
+        duration: 83.679828ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 194
+        host: api.scaleway.com
+        body: '{"name":"tf-pn-lucid-cerf","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","tags":[],"subnets":null,"vpc_id":"420188e5-1c68-4d96-85fa-ab1564e31edf","default_route_propagation_enabled":false}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1061
+        body: '{"id":"b06128e1-b918-4f09-b986-e01e50ebb31f","name":"tf-pn-lucid-cerf","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:08:54.229255Z","updated_at":"2026-03-26T11:08:54.229255Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","subnets":[{"id":"70c806df-b79f-4fd1-a605-49d715cf7d23","created_at":"2026-03-26T11:08:54.229255Z","updated_at":"2026-03-26T11:08:54.229255Z","subnet":"172.16.8.0/22","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"b06128e1-b918-4f09-b986-e01e50ebb31f","vpc_id":"420188e5-1c68-4d96-85fa-ab1564e31edf"},{"id":"0379f4e5-811d-465e-955d-1ccf56ec4caa","created_at":"2026-03-26T11:08:54.229255Z","updated_at":"2026-03-26T11:08:54.229255Z","subnet":"fd40:e277:fdde:2dd5::/64","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"b06128e1-b918-4f09-b986-e01e50ebb31f","vpc_id":"420188e5-1c68-4d96-85fa-ab1564e31edf"}],"vpc_id":"420188e5-1c68-4d96-85fa-ab1564e31edf","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1061"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:08:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 4c846ba7-5a70-473b-be0e-a9e1c60eac3a
+        status: 200 OK
+        code: 200
+        duration: 3.46761033s
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b06128e1-b918-4f09-b986-e01e50ebb31f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1061
+        body: '{"id":"b06128e1-b918-4f09-b986-e01e50ebb31f","name":"tf-pn-lucid-cerf","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:08:54.229255Z","updated_at":"2026-03-26T11:08:54.229255Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","subnets":[{"id":"70c806df-b79f-4fd1-a605-49d715cf7d23","created_at":"2026-03-26T11:08:54.229255Z","updated_at":"2026-03-26T11:08:54.229255Z","subnet":"172.16.8.0/22","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"b06128e1-b918-4f09-b986-e01e50ebb31f","vpc_id":"420188e5-1c68-4d96-85fa-ab1564e31edf"},{"id":"0379f4e5-811d-465e-955d-1ccf56ec4caa","created_at":"2026-03-26T11:08:54.229255Z","updated_at":"2026-03-26T11:08:54.229255Z","subnet":"fd40:e277:fdde:2dd5::/64","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"b06128e1-b918-4f09-b986-e01e50ebb31f","vpc_id":"420188e5-1c68-4d96-85fa-ab1564e31edf"}],"vpc_id":"420188e5-1c68-4d96-85fa-ab1564e31edf","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1061"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:08:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 6dfa607b-c3b2-41fe-852c-4938558a3673
+        status: 200 OK
+        code: 200
+        duration: 79.32232ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 352
+        host: api.scaleway.com
+        body: '{"project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_update","description":"initial description","tags":["tag1"],"main":{"node_type":"DATALAB-SHARED-4C-8G"},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1},"has_notebook":false,"spark_version":"4.0.0","private_network_id":"b06128e1-b918-4f09-b986-e01e50ebb31f"}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 934
+        body: '{"id":"c144958a-3b89-4384-b70b-9f567cc61129","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_update","description":"initial description","tags":["tag1"],"created_at":"2026-03-26T11:08:56.309962Z","updated_at":"2026-03-26T11:08:56.309962Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://c144958a-3b89-4384-b70b-9f567cc61129.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-c144958a-3b89-4384-b70b-9f567cc61129.b06128e1-b918-4f09-b986-e01e50ebb31f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"b06128e1-b918-4f09-b986-e01e50ebb31f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "934"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:08:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - a36667b9-45bd-4542-b394-da6b385f4e05
+        status: 200 OK
+        code: 200
+        duration: 217.813262ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c144958a-3b89-4384-b70b-9f567cc61129
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 934
+        body: '{"id":"c144958a-3b89-4384-b70b-9f567cc61129","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_update","description":"initial description","tags":["tag1"],"created_at":"2026-03-26T11:08:56.309962Z","updated_at":"2026-03-26T11:08:56.309962Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://c144958a-3b89-4384-b70b-9f567cc61129.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-c144958a-3b89-4384-b70b-9f567cc61129.b06128e1-b918-4f09-b986-e01e50ebb31f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"b06128e1-b918-4f09-b986-e01e50ebb31f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "934"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:08:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 681fc390-37b7-40f4-93b0-2cf20015221f
+        status: 200 OK
+        code: 200
+        duration: 83.701668ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c144958a-3b89-4384-b70b-9f567cc61129
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 934
+        body: '{"id":"c144958a-3b89-4384-b70b-9f567cc61129","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_update","description":"initial description","tags":["tag1"],"created_at":"2026-03-26T11:08:56.309962Z","updated_at":"2026-03-26T11:08:56.309962Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://c144958a-3b89-4384-b70b-9f567cc61129.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-c144958a-3b89-4384-b70b-9f567cc61129.b06128e1-b918-4f09-b986-e01e50ebb31f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"b06128e1-b918-4f09-b986-e01e50ebb31f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "934"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:09:11 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - c4e1c78e-fde6-431d-afc1-042aed77ce51
+        status: 200 OK
+        code: 200
+        duration: 74.339887ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c144958a-3b89-4384-b70b-9f567cc61129
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 934
+        body: '{"id":"c144958a-3b89-4384-b70b-9f567cc61129","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_update","description":"initial description","tags":["tag1"],"created_at":"2026-03-26T11:08:56.309962Z","updated_at":"2026-03-26T11:08:56.309962Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://c144958a-3b89-4384-b70b-9f567cc61129.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-c144958a-3b89-4384-b70b-9f567cc61129.b06128e1-b918-4f09-b986-e01e50ebb31f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"b06128e1-b918-4f09-b986-e01e50ebb31f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "934"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:09:26 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 8f2d018c-7ce3-4353-ae48-e11fe2a4026c
+        status: 200 OK
+        code: 200
+        duration: 80.029302ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c144958a-3b89-4384-b70b-9f567cc61129
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 934
+        body: '{"id":"c144958a-3b89-4384-b70b-9f567cc61129","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_update","description":"initial description","tags":["tag1"],"created_at":"2026-03-26T11:08:56.309962Z","updated_at":"2026-03-26T11:08:56.309962Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://c144958a-3b89-4384-b70b-9f567cc61129.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-c144958a-3b89-4384-b70b-9f567cc61129.b06128e1-b918-4f09-b986-e01e50ebb31f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"b06128e1-b918-4f09-b986-e01e50ebb31f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "934"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:09:41 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 008dd069-78e6-40f4-90fc-bd13f765f1ee
+        status: 200 OK
+        code: 200
+        duration: 74.744147ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c144958a-3b89-4384-b70b-9f567cc61129
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 934
+        body: '{"id":"c144958a-3b89-4384-b70b-9f567cc61129","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_update","description":"initial description","tags":["tag1"],"created_at":"2026-03-26T11:08:56.309962Z","updated_at":"2026-03-26T11:08:56.309962Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://c144958a-3b89-4384-b70b-9f567cc61129.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-c144958a-3b89-4384-b70b-9f567cc61129.b06128e1-b918-4f09-b986-e01e50ebb31f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"b06128e1-b918-4f09-b986-e01e50ebb31f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "934"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:09:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - e8798be6-1294-499e-828c-68f86ec2a1b8
+        status: 200 OK
+        code: 200
+        duration: 85.381627ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c144958a-3b89-4384-b70b-9f567cc61129
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 934
+        body: '{"id":"c144958a-3b89-4384-b70b-9f567cc61129","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_update","description":"initial description","tags":["tag1"],"created_at":"2026-03-26T11:08:56.309962Z","updated_at":"2026-03-26T11:08:56.309962Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://c144958a-3b89-4384-b70b-9f567cc61129.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-c144958a-3b89-4384-b70b-9f567cc61129.b06128e1-b918-4f09-b986-e01e50ebb31f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"b06128e1-b918-4f09-b986-e01e50ebb31f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "934"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:10:11 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - b646e2d0-e07f-4606-a407-23ccb7ee3af6
+        status: 200 OK
+        code: 200
+        duration: 72.134485ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c144958a-3b89-4384-b70b-9f567cc61129
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 934
+        body: '{"id":"c144958a-3b89-4384-b70b-9f567cc61129","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_update","description":"initial description","tags":["tag1"],"created_at":"2026-03-26T11:08:56.309962Z","updated_at":"2026-03-26T11:08:56.309962Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://c144958a-3b89-4384-b70b-9f567cc61129.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-c144958a-3b89-4384-b70b-9f567cc61129.b06128e1-b918-4f09-b986-e01e50ebb31f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"b06128e1-b918-4f09-b986-e01e50ebb31f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "934"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:10:26 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - c911339b-2998-45bb-90db-de7f2ad41e05
+        status: 200 OK
+        code: 200
+        duration: 74.910884ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c144958a-3b89-4384-b70b-9f567cc61129
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 934
+        body: '{"id":"c144958a-3b89-4384-b70b-9f567cc61129","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_update","description":"initial description","tags":["tag1"],"created_at":"2026-03-26T11:08:56.309962Z","updated_at":"2026-03-26T11:08:56.309962Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://c144958a-3b89-4384-b70b-9f567cc61129.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-c144958a-3b89-4384-b70b-9f567cc61129.b06128e1-b918-4f09-b986-e01e50ebb31f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"b06128e1-b918-4f09-b986-e01e50ebb31f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "934"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:10:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 460e2581-19b4-46e7-b1d0-f4c8ab5b2661
+        status: 200 OK
+        code: 200
+        duration: 76.091565ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c144958a-3b89-4384-b70b-9f567cc61129
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 934
+        body: '{"id":"c144958a-3b89-4384-b70b-9f567cc61129","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_update","description":"initial description","tags":["tag1"],"created_at":"2026-03-26T11:08:56.309962Z","updated_at":"2026-03-26T11:08:56.309962Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://c144958a-3b89-4384-b70b-9f567cc61129.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-c144958a-3b89-4384-b70b-9f567cc61129.b06128e1-b918-4f09-b986-e01e50ebb31f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"b06128e1-b918-4f09-b986-e01e50ebb31f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "934"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:10:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 6eee8e85-8bd8-4500-b8a6-9a428a4a5ade
+        status: 200 OK
+        code: 200
+        duration: 89.29751ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c144958a-3b89-4384-b70b-9f567cc61129
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 934
+        body: '{"id":"c144958a-3b89-4384-b70b-9f567cc61129","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_update","description":"initial description","tags":["tag1"],"created_at":"2026-03-26T11:08:56.309962Z","updated_at":"2026-03-26T11:08:56.309962Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://c144958a-3b89-4384-b70b-9f567cc61129.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-c144958a-3b89-4384-b70b-9f567cc61129.b06128e1-b918-4f09-b986-e01e50ebb31f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"b06128e1-b918-4f09-b986-e01e50ebb31f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "934"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:11:12 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 0f9ce2e5-c3b5-4554-8617-b472d994aa23
+        status: 200 OK
+        code: 200
+        duration: 74.477676ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c144958a-3b89-4384-b70b-9f567cc61129
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 934
+        body: '{"id":"c144958a-3b89-4384-b70b-9f567cc61129","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_update","description":"initial description","tags":["tag1"],"created_at":"2026-03-26T11:08:56.309962Z","updated_at":"2026-03-26T11:08:56.309962Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://c144958a-3b89-4384-b70b-9f567cc61129.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-c144958a-3b89-4384-b70b-9f567cc61129.b06128e1-b918-4f09-b986-e01e50ebb31f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"b06128e1-b918-4f09-b986-e01e50ebb31f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "934"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:11:27 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - b33d8d6b-58ef-4f13-a5ae-33e5ce626a32
+        status: 200 OK
+        code: 200
+        duration: 91.156214ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c144958a-3b89-4384-b70b-9f567cc61129
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 934
+        body: '{"id":"c144958a-3b89-4384-b70b-9f567cc61129","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_update","description":"initial description","tags":["tag1"],"created_at":"2026-03-26T11:08:56.309962Z","updated_at":"2026-03-26T11:08:56.309962Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://c144958a-3b89-4384-b70b-9f567cc61129.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-c144958a-3b89-4384-b70b-9f567cc61129.b06128e1-b918-4f09-b986-e01e50ebb31f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"b06128e1-b918-4f09-b986-e01e50ebb31f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "934"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:11:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 0611cad4-2c90-4f08-a54d-b562426d2239
+        status: 200 OK
+        code: 200
+        duration: 74.294373ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c144958a-3b89-4384-b70b-9f567cc61129
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 934
+        body: '{"id":"c144958a-3b89-4384-b70b-9f567cc61129","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_update","description":"initial description","tags":["tag1"],"created_at":"2026-03-26T11:08:56.309962Z","updated_at":"2026-03-26T11:08:56.309962Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://c144958a-3b89-4384-b70b-9f567cc61129.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-c144958a-3b89-4384-b70b-9f567cc61129.b06128e1-b918-4f09-b986-e01e50ebb31f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"b06128e1-b918-4f09-b986-e01e50ebb31f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "934"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:11:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - dfdfca87-b666-47a8-84ec-5ea248d78fb0
+        status: 200 OK
+        code: 200
+        duration: 73.829115ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c144958a-3b89-4384-b70b-9f567cc61129
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 934
+        body: '{"id":"c144958a-3b89-4384-b70b-9f567cc61129","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_update","description":"initial description","tags":["tag1"],"created_at":"2026-03-26T11:08:56.309962Z","updated_at":"2026-03-26T11:08:56.309962Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://c144958a-3b89-4384-b70b-9f567cc61129.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-c144958a-3b89-4384-b70b-9f567cc61129.b06128e1-b918-4f09-b986-e01e50ebb31f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"b06128e1-b918-4f09-b986-e01e50ebb31f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "934"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:12:12 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - ac027451-6927-4da3-8a1c-ef2118ccf0a8
+        status: 200 OK
+        code: 200
+        duration: 83.649576ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c144958a-3b89-4384-b70b-9f567cc61129
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 934
+        body: '{"id":"c144958a-3b89-4384-b70b-9f567cc61129","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_update","description":"initial description","tags":["tag1"],"created_at":"2026-03-26T11:08:56.309962Z","updated_at":"2026-03-26T11:08:56.309962Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://c144958a-3b89-4384-b70b-9f567cc61129.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-c144958a-3b89-4384-b70b-9f567cc61129.b06128e1-b918-4f09-b986-e01e50ebb31f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"b06128e1-b918-4f09-b986-e01e50ebb31f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "934"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:12:27 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 3927731b-a945-4e19-8279-b82bf57273b7
+        status: 200 OK
+        code: 200
+        duration: 74.348973ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c144958a-3b89-4384-b70b-9f567cc61129
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 934
+        body: '{"id":"c144958a-3b89-4384-b70b-9f567cc61129","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_update","description":"initial description","tags":["tag1"],"created_at":"2026-03-26T11:08:56.309962Z","updated_at":"2026-03-26T11:08:56.309962Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://c144958a-3b89-4384-b70b-9f567cc61129.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-c144958a-3b89-4384-b70b-9f567cc61129.b06128e1-b918-4f09-b986-e01e50ebb31f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"b06128e1-b918-4f09-b986-e01e50ebb31f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "934"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:12:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 2d80bc28-526f-4877-b9f5-db623ff830c1
+        status: 200 OK
+        code: 200
+        duration: 70.023722ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c144958a-3b89-4384-b70b-9f567cc61129
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 934
+        body: '{"id":"c144958a-3b89-4384-b70b-9f567cc61129","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_update","description":"initial description","tags":["tag1"],"created_at":"2026-03-26T11:08:56.309962Z","updated_at":"2026-03-26T11:08:56.309962Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://c144958a-3b89-4384-b70b-9f567cc61129.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-c144958a-3b89-4384-b70b-9f567cc61129.b06128e1-b918-4f09-b986-e01e50ebb31f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"b06128e1-b918-4f09-b986-e01e50ebb31f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "934"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:12:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 6931067d-775e-4b6a-a8ce-2712c8b2f0f0
+        status: 200 OK
+        code: 200
+        duration: 71.875596ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c144958a-3b89-4384-b70b-9f567cc61129
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 934
+        body: '{"id":"c144958a-3b89-4384-b70b-9f567cc61129","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_update","description":"initial description","tags":["tag1"],"created_at":"2026-03-26T11:08:56.309962Z","updated_at":"2026-03-26T11:08:56.309962Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://c144958a-3b89-4384-b70b-9f567cc61129.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-c144958a-3b89-4384-b70b-9f567cc61129.b06128e1-b918-4f09-b986-e01e50ebb31f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"b06128e1-b918-4f09-b986-e01e50ebb31f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "934"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:13:12 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 7e42385e-2eb4-4a36-b6c3-116c35be1b7b
+        status: 200 OK
+        code: 200
+        duration: 70.298616ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c144958a-3b89-4384-b70b-9f567cc61129
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 934
+        body: '{"id":"c144958a-3b89-4384-b70b-9f567cc61129","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_update","description":"initial description","tags":["tag1"],"created_at":"2026-03-26T11:08:56.309962Z","updated_at":"2026-03-26T11:08:56.309962Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://c144958a-3b89-4384-b70b-9f567cc61129.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-c144958a-3b89-4384-b70b-9f567cc61129.b06128e1-b918-4f09-b986-e01e50ebb31f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"b06128e1-b918-4f09-b986-e01e50ebb31f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "934"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:13:27 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - ff501a58-8b75-4225-b303-303aa191841a
+        status: 200 OK
+        code: 200
+        duration: 72.671707ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c144958a-3b89-4384-b70b-9f567cc61129
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 934
+        body: '{"id":"c144958a-3b89-4384-b70b-9f567cc61129","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_update","description":"initial description","tags":["tag1"],"created_at":"2026-03-26T11:08:56.309962Z","updated_at":"2026-03-26T11:08:56.309962Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://c144958a-3b89-4384-b70b-9f567cc61129.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-c144958a-3b89-4384-b70b-9f567cc61129.b06128e1-b918-4f09-b986-e01e50ebb31f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"b06128e1-b918-4f09-b986-e01e50ebb31f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "934"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:13:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - c3799a93-767b-4c11-b9b0-f08435d68715
+        status: 200 OK
+        code: 200
+        duration: 72.157409ms
+    - id: 25
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c144958a-3b89-4384-b70b-9f567cc61129
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 934
+        body: '{"id":"c144958a-3b89-4384-b70b-9f567cc61129","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_update","description":"initial description","tags":["tag1"],"created_at":"2026-03-26T11:08:56.309962Z","updated_at":"2026-03-26T11:08:56.309962Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://c144958a-3b89-4384-b70b-9f567cc61129.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-c144958a-3b89-4384-b70b-9f567cc61129.b06128e1-b918-4f09-b986-e01e50ebb31f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"b06128e1-b918-4f09-b986-e01e50ebb31f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "934"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:13:58 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - c3e438a4-5175-4321-9159-56eaa0d8c043
+        status: 200 OK
+        code: 200
+        duration: 71.847608ms
+    - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c144958a-3b89-4384-b70b-9f567cc61129
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 934
+        body: '{"id":"c144958a-3b89-4384-b70b-9f567cc61129","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_update","description":"initial description","tags":["tag1"],"created_at":"2026-03-26T11:08:56.309962Z","updated_at":"2026-03-26T11:08:56.309962Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://c144958a-3b89-4384-b70b-9f567cc61129.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-c144958a-3b89-4384-b70b-9f567cc61129.b06128e1-b918-4f09-b986-e01e50ebb31f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"b06128e1-b918-4f09-b986-e01e50ebb31f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "934"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:14:13 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - d70a3a52-8b3c-45ab-8405-ecea5ffa4750
+        status: 200 OK
+        code: 200
+        duration: 68.012385ms
+    - id: 27
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c144958a-3b89-4384-b70b-9f567cc61129
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 934
+        body: '{"id":"c144958a-3b89-4384-b70b-9f567cc61129","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_update","description":"initial description","tags":["tag1"],"created_at":"2026-03-26T11:08:56.309962Z","updated_at":"2026-03-26T11:08:56.309962Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://c144958a-3b89-4384-b70b-9f567cc61129.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-c144958a-3b89-4384-b70b-9f567cc61129.b06128e1-b918-4f09-b986-e01e50ebb31f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"b06128e1-b918-4f09-b986-e01e50ebb31f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "934"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:14:28 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 4a9e6765-c89d-4243-b862-c8aced30350a
+        status: 200 OK
+        code: 200
+        duration: 86.36438ms
+    - id: 28
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c144958a-3b89-4384-b70b-9f567cc61129
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 931
+        body: '{"id":"c144958a-3b89-4384-b70b-9f567cc61129","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_update","description":"initial description","tags":["tag1"],"created_at":"2026-03-26T11:08:56.309962Z","updated_at":"2026-03-26T11:14:33.976780Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://c144958a-3b89-4384-b70b-9f567cc61129.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-c144958a-3b89-4384-b70b-9f567cc61129.b06128e1-b918-4f09-b986-e01e50ebb31f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"b06128e1-b918-4f09-b986-e01e50ebb31f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "931"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:14:43 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 27b972a8-6417-4c34-90f6-e81156900be9
+        status: 200 OK
+        code: 200
+        duration: 81.010146ms
+    - id: 29
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c144958a-3b89-4384-b70b-9f567cc61129
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 931
+        body: '{"id":"c144958a-3b89-4384-b70b-9f567cc61129","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_update","description":"initial description","tags":["tag1"],"created_at":"2026-03-26T11:08:56.309962Z","updated_at":"2026-03-26T11:14:33.976780Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://c144958a-3b89-4384-b70b-9f567cc61129.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-c144958a-3b89-4384-b70b-9f567cc61129.b06128e1-b918-4f09-b986-e01e50ebb31f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"b06128e1-b918-4f09-b986-e01e50ebb31f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "931"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:14:43 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 2f90b590-1baf-445d-a863-7212c8fc6a19
+        status: 200 OK
+        code: 200
+        duration: 74.820124ms
+    - id: 30
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/420188e5-1c68-4d96-85fa-ab1564e31edf
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 410
+        body: '{"id":"420188e5-1c68-4d96-85fa-ab1564e31edf","name":"tf_tests_datalab_update","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:08:52.536262Z","updated_at":"2026-03-26T11:08:52.536262Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","is_default":false,"private_network_count":1,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "410"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:14:43 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - ddbf065a-c096-49ee-93e2-da6b8d6e407e
+        status: 200 OK
+        code: 200
+        duration: 52.84369ms
+    - id: 31
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b06128e1-b918-4f09-b986-e01e50ebb31f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1061
+        body: '{"id":"b06128e1-b918-4f09-b986-e01e50ebb31f","name":"tf-pn-lucid-cerf","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:08:54.229255Z","updated_at":"2026-03-26T11:08:54.229255Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","subnets":[{"id":"70c806df-b79f-4fd1-a605-49d715cf7d23","created_at":"2026-03-26T11:08:54.229255Z","updated_at":"2026-03-26T11:08:54.229255Z","subnet":"172.16.8.0/22","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"b06128e1-b918-4f09-b986-e01e50ebb31f","vpc_id":"420188e5-1c68-4d96-85fa-ab1564e31edf"},{"id":"0379f4e5-811d-465e-955d-1ccf56ec4caa","created_at":"2026-03-26T11:08:54.229255Z","updated_at":"2026-03-26T11:08:54.229255Z","subnet":"fd40:e277:fdde:2dd5::/64","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"b06128e1-b918-4f09-b986-e01e50ebb31f","vpc_id":"420188e5-1c68-4d96-85fa-ab1564e31edf"}],"vpc_id":"420188e5-1c68-4d96-85fa-ab1564e31edf","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1061"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:14:43 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - a0efc059-d6a8-4361-b054-fb48958cfaeb
+        status: 200 OK
+        code: 200
+        duration: 78.4986ms
+    - id: 32
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c144958a-3b89-4384-b70b-9f567cc61129
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 931
+        body: '{"id":"c144958a-3b89-4384-b70b-9f567cc61129","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_update","description":"initial description","tags":["tag1"],"created_at":"2026-03-26T11:08:56.309962Z","updated_at":"2026-03-26T11:14:33.976780Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://c144958a-3b89-4384-b70b-9f567cc61129.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-c144958a-3b89-4384-b70b-9f567cc61129.b06128e1-b918-4f09-b986-e01e50ebb31f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"b06128e1-b918-4f09-b986-e01e50ebb31f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "931"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:14:43 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 8a2af2a0-8868-4981-b4c7-f509ee9f13ae
+        status: 200 OK
+        code: 200
+        duration: 66.623781ms
+    - id: 33
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/420188e5-1c68-4d96-85fa-ab1564e31edf
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 410
+        body: '{"id":"420188e5-1c68-4d96-85fa-ab1564e31edf","name":"tf_tests_datalab_update","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:08:52.536262Z","updated_at":"2026-03-26T11:08:52.536262Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","is_default":false,"private_network_count":1,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "410"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:14:43 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 40a6791a-5dda-4404-8675-67d2220daecf
+        status: 200 OK
+        code: 200
+        duration: 51.741388ms
+    - id: 34
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b06128e1-b918-4f09-b986-e01e50ebb31f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1061
+        body: '{"id":"b06128e1-b918-4f09-b986-e01e50ebb31f","name":"tf-pn-lucid-cerf","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:08:54.229255Z","updated_at":"2026-03-26T11:08:54.229255Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","subnets":[{"id":"70c806df-b79f-4fd1-a605-49d715cf7d23","created_at":"2026-03-26T11:08:54.229255Z","updated_at":"2026-03-26T11:08:54.229255Z","subnet":"172.16.8.0/22","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"b06128e1-b918-4f09-b986-e01e50ebb31f","vpc_id":"420188e5-1c68-4d96-85fa-ab1564e31edf"},{"id":"0379f4e5-811d-465e-955d-1ccf56ec4caa","created_at":"2026-03-26T11:08:54.229255Z","updated_at":"2026-03-26T11:08:54.229255Z","subnet":"fd40:e277:fdde:2dd5::/64","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"b06128e1-b918-4f09-b986-e01e50ebb31f","vpc_id":"420188e5-1c68-4d96-85fa-ab1564e31edf"}],"vpc_id":"420188e5-1c68-4d96-85fa-ab1564e31edf","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1061"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:14:43 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - e5bef88e-6e27-4d91-a679-223ac4f0e068
+        status: 200 OK
+        code: 200
+        duration: 57.19146ms
+    - id: 35
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c144958a-3b89-4384-b70b-9f567cc61129
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 931
+        body: '{"id":"c144958a-3b89-4384-b70b-9f567cc61129","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_update","description":"initial description","tags":["tag1"],"created_at":"2026-03-26T11:08:56.309962Z","updated_at":"2026-03-26T11:14:33.976780Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://c144958a-3b89-4384-b70b-9f567cc61129.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-c144958a-3b89-4384-b70b-9f567cc61129.b06128e1-b918-4f09-b986-e01e50ebb31f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"b06128e1-b918-4f09-b986-e01e50ebb31f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "931"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:14:44 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 419706e3-fc7c-4042-8a16-f1098448cd7b
+        status: 200 OK
+        code: 200
+        duration: 71.719322ms
+    - id: 36
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 101
+        host: api.scaleway.com
+        body: '{"name":"tf_tests_datalab_update_renamed","description":"updated description","tags":["tag1","tag2"]}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c144958a-3b89-4384-b70b-9f567cc61129
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 247
+        body: '{"id":"","status":"unknown_status","project_id":"","name":"","description":"","tags":[],"created_at":null,"updated_at":null,"main":null,"worker":null,"has_notebook":false,"spark_version":"","total_storage":null,"private_network_id":"","region":""}'
+        headers:
+            Content-Length:
+                - "247"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:14:44 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 41698a72-ade2-46cf-8f79-ca03b7627722
+        status: 200 OK
+        code: 200
+        duration: 94.166513ms
+    - id: 37
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c144958a-3b89-4384-b70b-9f567cc61129
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 934
+        body: '{"id":"c144958a-3b89-4384-b70b-9f567cc61129","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_update","description":"initial description","tags":["tag1"],"created_at":"2026-03-26T11:08:56.309962Z","updated_at":"2026-03-26T11:14:44.429472Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://c144958a-3b89-4384-b70b-9f567cc61129.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-c144958a-3b89-4384-b70b-9f567cc61129.b06128e1-b918-4f09-b986-e01e50ebb31f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"b06128e1-b918-4f09-b986-e01e50ebb31f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "934"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:14:44 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 6be6da2e-adca-4813-afc7-5614c2bf0b06
+        status: 200 OK
+        code: 200
+        duration: 138.144098ms
+    - id: 38
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c144958a-3b89-4384-b70b-9f567cc61129
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 934
+        body: '{"id":"c144958a-3b89-4384-b70b-9f567cc61129","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_update","description":"initial description","tags":["tag1"],"created_at":"2026-03-26T11:08:56.309962Z","updated_at":"2026-03-26T11:14:44.429472Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://c144958a-3b89-4384-b70b-9f567cc61129.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-c144958a-3b89-4384-b70b-9f567cc61129.b06128e1-b918-4f09-b986-e01e50ebb31f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"b06128e1-b918-4f09-b986-e01e50ebb31f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "934"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:14:44 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 8dcf2a11-b984-424e-a05c-5f4ba5153eee
+        status: 200 OK
+        code: 200
+        duration: 70.661939ms
+    - id: 39
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c144958a-3b89-4384-b70b-9f567cc61129
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 934
+        body: '{"id":"c144958a-3b89-4384-b70b-9f567cc61129","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_update","description":"initial description","tags":["tag1"],"created_at":"2026-03-26T11:08:56.309962Z","updated_at":"2026-03-26T11:14:44.429472Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://c144958a-3b89-4384-b70b-9f567cc61129.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-c144958a-3b89-4384-b70b-9f567cc61129.b06128e1-b918-4f09-b986-e01e50ebb31f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"b06128e1-b918-4f09-b986-e01e50ebb31f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "934"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:14:59 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 6b19d809-868b-48d2-a7cc-36dabd35b9ed
+        status: 200 OK
+        code: 200
+        duration: 71.03333ms
+    - id: 40
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c144958a-3b89-4384-b70b-9f567cc61129
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 934
+        body: '{"id":"c144958a-3b89-4384-b70b-9f567cc61129","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_update","description":"initial description","tags":["tag1"],"created_at":"2026-03-26T11:08:56.309962Z","updated_at":"2026-03-26T11:14:44.429472Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://c144958a-3b89-4384-b70b-9f567cc61129.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-c144958a-3b89-4384-b70b-9f567cc61129.b06128e1-b918-4f09-b986-e01e50ebb31f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"b06128e1-b918-4f09-b986-e01e50ebb31f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "934"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:15:14 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 508254f6-a75b-41fb-bd52-1672d005b24e
+        status: 200 OK
+        code: 200
+        duration: 69.463729ms
+    - id: 41
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c144958a-3b89-4384-b70b-9f567cc61129
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 934
+        body: '{"id":"c144958a-3b89-4384-b70b-9f567cc61129","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_update","description":"initial description","tags":["tag1"],"created_at":"2026-03-26T11:08:56.309962Z","updated_at":"2026-03-26T11:14:44.429472Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://c144958a-3b89-4384-b70b-9f567cc61129.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-c144958a-3b89-4384-b70b-9f567cc61129.b06128e1-b918-4f09-b986-e01e50ebb31f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"b06128e1-b918-4f09-b986-e01e50ebb31f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "934"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:15:29 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - c5cc4ec6-34ee-4034-b8a8-a7a68589ba30
+        status: 200 OK
+        code: 200
+        duration: 70.552212ms
+    - id: 42
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c144958a-3b89-4384-b70b-9f567cc61129
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 934
+        body: '{"id":"c144958a-3b89-4384-b70b-9f567cc61129","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_update","description":"initial description","tags":["tag1"],"created_at":"2026-03-26T11:08:56.309962Z","updated_at":"2026-03-26T11:14:44.429472Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://c144958a-3b89-4384-b70b-9f567cc61129.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-c144958a-3b89-4384-b70b-9f567cc61129.b06128e1-b918-4f09-b986-e01e50ebb31f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"b06128e1-b918-4f09-b986-e01e50ebb31f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "934"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:15:44 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - dad1ed4d-1492-43b1-a3e8-6935fe3656f4
+        status: 200 OK
+        code: 200
+        duration: 68.058636ms
+    - id: 43
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c144958a-3b89-4384-b70b-9f567cc61129
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 934
+        body: '{"id":"c144958a-3b89-4384-b70b-9f567cc61129","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_update","description":"initial description","tags":["tag1"],"created_at":"2026-03-26T11:08:56.309962Z","updated_at":"2026-03-26T11:14:44.429472Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://c144958a-3b89-4384-b70b-9f567cc61129.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-c144958a-3b89-4384-b70b-9f567cc61129.b06128e1-b918-4f09-b986-e01e50ebb31f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"b06128e1-b918-4f09-b986-e01e50ebb31f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "934"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:15:59 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 0cdddf50-87b7-44b1-8201-cbf5a3edebb5
+        status: 200 OK
+        code: 200
+        duration: 68.816266ms
+    - id: 44
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c144958a-3b89-4384-b70b-9f567cc61129
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 934
+        body: '{"id":"c144958a-3b89-4384-b70b-9f567cc61129","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_update","description":"initial description","tags":["tag1"],"created_at":"2026-03-26T11:08:56.309962Z","updated_at":"2026-03-26T11:14:44.429472Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://c144958a-3b89-4384-b70b-9f567cc61129.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-c144958a-3b89-4384-b70b-9f567cc61129.b06128e1-b918-4f09-b986-e01e50ebb31f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"b06128e1-b918-4f09-b986-e01e50ebb31f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "934"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:16:14 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 477db31e-6881-49a3-a500-1a8162a1182c
+        status: 200 OK
+        code: 200
+        duration: 70.628781ms
+    - id: 45
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c144958a-3b89-4384-b70b-9f567cc61129
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 934
+        body: '{"id":"c144958a-3b89-4384-b70b-9f567cc61129","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_update","description":"initial description","tags":["tag1"],"created_at":"2026-03-26T11:08:56.309962Z","updated_at":"2026-03-26T11:14:44.429472Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://c144958a-3b89-4384-b70b-9f567cc61129.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-c144958a-3b89-4384-b70b-9f567cc61129.b06128e1-b918-4f09-b986-e01e50ebb31f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"b06128e1-b918-4f09-b986-e01e50ebb31f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "934"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:16:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 32f415e5-6ec2-44d6-ac15-0651d829f55a
+        status: 200 OK
+        code: 200
+        duration: 89.310288ms
+    - id: 46
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c144958a-3b89-4384-b70b-9f567cc61129
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 934
+        body: '{"id":"c144958a-3b89-4384-b70b-9f567cc61129","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_update","description":"initial description","tags":["tag1"],"created_at":"2026-03-26T11:08:56.309962Z","updated_at":"2026-03-26T11:14:44.429472Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://c144958a-3b89-4384-b70b-9f567cc61129.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-c144958a-3b89-4384-b70b-9f567cc61129.b06128e1-b918-4f09-b986-e01e50ebb31f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"b06128e1-b918-4f09-b986-e01e50ebb31f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "934"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:16:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 03663a80-6adf-4676-abe1-4fceacf37088
+        status: 200 OK
+        code: 200
+        duration: 75.885008ms
+    - id: 47
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c144958a-3b89-4384-b70b-9f567cc61129
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 934
+        body: '{"id":"c144958a-3b89-4384-b70b-9f567cc61129","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_update","description":"initial description","tags":["tag1"],"created_at":"2026-03-26T11:08:56.309962Z","updated_at":"2026-03-26T11:14:44.429472Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://c144958a-3b89-4384-b70b-9f567cc61129.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-c144958a-3b89-4384-b70b-9f567cc61129.b06128e1-b918-4f09-b986-e01e50ebb31f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"b06128e1-b918-4f09-b986-e01e50ebb31f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "934"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:17:00 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 8706e5f5-d14f-4b73-a4ee-b7c14ca97d73
+        status: 200 OK
+        code: 200
+        duration: 80.17072ms
+    - id: 48
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c144958a-3b89-4384-b70b-9f567cc61129
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 934
+        body: '{"id":"c144958a-3b89-4384-b70b-9f567cc61129","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_update","description":"initial description","tags":["tag1"],"created_at":"2026-03-26T11:08:56.309962Z","updated_at":"2026-03-26T11:14:44.429472Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://c144958a-3b89-4384-b70b-9f567cc61129.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-c144958a-3b89-4384-b70b-9f567cc61129.b06128e1-b918-4f09-b986-e01e50ebb31f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"b06128e1-b918-4f09-b986-e01e50ebb31f","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "934"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:17:15 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - a31b9e9d-cce5-4729-8196-6e1b31bddd17
+        status: 200 OK
+        code: 200
+        duration: 67.959409ms
+    - id: 49
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c144958a-3b89-4384-b70b-9f567cc61129
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 128
+        body: '{"message":"resource is not found","resource":"datalab","resource_id":"c144958a-3b89-4384-b70b-9f567cc61129","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "128"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:17:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - a9916b66-8a8a-4200-8667-379e19e91a6a
+        status: 404 Not Found
+        code: 404
+        duration: 60.647454ms
+    - id: 50
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b06128e1-b918-4f09-b986-e01e50ebb31f
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:17:31 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - bfdfe447-43bb-409e-baf4-b538573cc2d5
+        status: 204 No Content
+        code: 204
+        duration: 1.490481774s
+    - id: 51
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/420188e5-1c68-4d96-85fa-ab1564e31edf
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:17:32 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 9e604717-c1ce-4174-b206-407f92717bdd
+        status: 204 No Content
+        code: 204
+        duration: 532.753482ms
+    - id: 52
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c144958a-3b89-4384-b70b-9f567cc61129
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 128
+        body: '{"message":"resource is not found","resource":"datalab","resource_id":"c144958a-3b89-4384-b70b-9f567cc61129","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "128"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:17:32 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 21eda8a2-f291-498f-aa36-e18ba15bdddf
+        status: 404 Not Found
+        code: 404
+        duration: 65.127601ms

--- a/internal/services/datalab/testdata/datalab-resource-with-worker.cassette.yaml
+++ b/internal/services/datalab/testdata/datalab-resource-with-worker.cassette.yaml
@@ -1,0 +1,2219 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 119
+        host: api.scaleway.com
+        body: '{"name":"tf_tests_datalab_worker","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","tags":[],"enable_routing":false}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 410
+        body: '{"id":"6f36cd90-e0d9-4549-a4d6-e70c03b7799c","name":"tf_tests_datalab_worker","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:08:52.686211Z","updated_at":"2026-03-26T11:08:52.686211Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","is_default":false,"private_network_count":0,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "410"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:08:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 7cff7ae2-40ed-46ed-9cb3-ed39fbd13560
+        status: 200 OK
+        code: 200
+        duration: 97.001929ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/6f36cd90-e0d9-4549-a4d6-e70c03b7799c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 410
+        body: '{"id":"6f36cd90-e0d9-4549-a4d6-e70c03b7799c","name":"tf_tests_datalab_worker","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:08:52.686211Z","updated_at":"2026-03-26T11:08:52.686211Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","is_default":false,"private_network_count":0,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "410"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:08:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - e10380ca-8e07-423f-92ad-f70f22b62c25
+        status: 200 OK
+        code: 200
+        duration: 72.982031ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 198
+        host: api.scaleway.com
+        body: '{"name":"tf-pn-gallant-galois","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","tags":[],"subnets":null,"vpc_id":"6f36cd90-e0d9-4549-a4d6-e70c03b7799c","default_route_propagation_enabled":false}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1066
+        body: '{"id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","name":"tf-pn-gallant-galois","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:08:53.834938Z","updated_at":"2026-03-26T11:08:53.834938Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","subnets":[{"id":"59b07c6a-ee87-4608-8055-10a27d42c58c","created_at":"2026-03-26T11:08:53.834938Z","updated_at":"2026-03-26T11:08:53.834938Z","subnet":"172.16.20.0/22","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","vpc_id":"6f36cd90-e0d9-4549-a4d6-e70c03b7799c"},{"id":"b6ef062a-a28d-4ee4-9714-4b54094b4cdf","created_at":"2026-03-26T11:08:53.834938Z","updated_at":"2026-03-26T11:08:53.834938Z","subnet":"fd40:e277:fdde:8a01::/64","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","vpc_id":"6f36cd90-e0d9-4549-a4d6-e70c03b7799c"}],"vpc_id":"6f36cd90-e0d9-4549-a4d6-e70c03b7799c","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1066"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:08:54 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 8b824842-d7c0-4f33-941d-aaf31e674ac2
+        status: 200 OK
+        code: 200
+        duration: 1.98893273s
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/7b913cf8-e4fb-42ca-89ff-c04b99838378
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1066
+        body: '{"id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","name":"tf-pn-gallant-galois","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:08:53.834938Z","updated_at":"2026-03-26T11:08:53.834938Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","subnets":[{"id":"59b07c6a-ee87-4608-8055-10a27d42c58c","created_at":"2026-03-26T11:08:53.834938Z","updated_at":"2026-03-26T11:08:53.834938Z","subnet":"172.16.20.0/22","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","vpc_id":"6f36cd90-e0d9-4549-a4d6-e70c03b7799c"},{"id":"b6ef062a-a28d-4ee4-9714-4b54094b4cdf","created_at":"2026-03-26T11:08:53.834938Z","updated_at":"2026-03-26T11:08:53.834938Z","subnet":"fd40:e277:fdde:8a01::/64","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","vpc_id":"6f36cd90-e0d9-4549-a4d6-e70c03b7799c"}],"vpc_id":"6f36cd90-e0d9-4549-a4d6-e70c03b7799c","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1066"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:08:54 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 1c06bc16-eb69-403f-b2d4-b86095a2d8e5
+        status: 200 OK
+        code: 200
+        duration: 60.924998ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 329
+        host: api.scaleway.com
+        body: '{"project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_worker","description":"","tags":null,"main":{"node_type":"DATALAB-SHARED-4C-8G"},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1},"has_notebook":false,"spark_version":"4.0.0","private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378"}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"617acbf0-ae58-4470-a541-1e0dadfe4351","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_worker","description":"","tags":[],"created_at":"2026-03-26T11:08:54.994916Z","updated_at":"2026-03-26T11:08:54.994916Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://617acbf0-ae58-4470-a541-1e0dadfe4351.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-617acbf0-ae58-4470-a541-1e0dadfe4351.7b913cf8-e4fb-42ca-89ff-c04b99838378.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:08:55 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 7e42a2f8-e11f-4beb-bdf3-6bd77917bb88
+        status: 200 OK
+        code: 200
+        duration: 465.673097ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/617acbf0-ae58-4470-a541-1e0dadfe4351
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"617acbf0-ae58-4470-a541-1e0dadfe4351","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_worker","description":"","tags":[],"created_at":"2026-03-26T11:08:54.994916Z","updated_at":"2026-03-26T11:08:54.994916Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://617acbf0-ae58-4470-a541-1e0dadfe4351.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-617acbf0-ae58-4470-a541-1e0dadfe4351.7b913cf8-e4fb-42ca-89ff-c04b99838378.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:08:55 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 92d8090b-b044-42a1-a67e-30fd3da9165d
+        status: 200 OK
+        code: 200
+        duration: 90.67588ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/617acbf0-ae58-4470-a541-1e0dadfe4351
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"617acbf0-ae58-4470-a541-1e0dadfe4351","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_worker","description":"","tags":[],"created_at":"2026-03-26T11:08:54.994916Z","updated_at":"2026-03-26T11:08:54.994916Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://617acbf0-ae58-4470-a541-1e0dadfe4351.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-617acbf0-ae58-4470-a541-1e0dadfe4351.7b913cf8-e4fb-42ca-89ff-c04b99838378.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:09:10 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - bcb8f2cc-f159-4151-beb8-18fa8f168160
+        status: 200 OK
+        code: 200
+        duration: 79.076516ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/617acbf0-ae58-4470-a541-1e0dadfe4351
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"617acbf0-ae58-4470-a541-1e0dadfe4351","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_worker","description":"","tags":[],"created_at":"2026-03-26T11:08:54.994916Z","updated_at":"2026-03-26T11:08:54.994916Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://617acbf0-ae58-4470-a541-1e0dadfe4351.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-617acbf0-ae58-4470-a541-1e0dadfe4351.7b913cf8-e4fb-42ca-89ff-c04b99838378.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:09:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - a73f52ce-de44-4e6e-aa06-367cf890e5b8
+        status: 200 OK
+        code: 200
+        duration: 77.540855ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/617acbf0-ae58-4470-a541-1e0dadfe4351
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"617acbf0-ae58-4470-a541-1e0dadfe4351","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_worker","description":"","tags":[],"created_at":"2026-03-26T11:08:54.994916Z","updated_at":"2026-03-26T11:08:54.994916Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://617acbf0-ae58-4470-a541-1e0dadfe4351.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-617acbf0-ae58-4470-a541-1e0dadfe4351.7b913cf8-e4fb-42ca-89ff-c04b99838378.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:09:40 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 005aa316-97ea-4891-a347-341d8e90f506
+        status: 200 OK
+        code: 200
+        duration: 73.611756ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/617acbf0-ae58-4470-a541-1e0dadfe4351
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"617acbf0-ae58-4470-a541-1e0dadfe4351","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_worker","description":"","tags":[],"created_at":"2026-03-26T11:08:54.994916Z","updated_at":"2026-03-26T11:08:54.994916Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://617acbf0-ae58-4470-a541-1e0dadfe4351.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-617acbf0-ae58-4470-a541-1e0dadfe4351.7b913cf8-e4fb-42ca-89ff-c04b99838378.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:09:55 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 99f336f8-0370-4084-9a6e-d3de87d5cb44
+        status: 200 OK
+        code: 200
+        duration: 83.101546ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/617acbf0-ae58-4470-a541-1e0dadfe4351
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"617acbf0-ae58-4470-a541-1e0dadfe4351","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_worker","description":"","tags":[],"created_at":"2026-03-26T11:08:54.994916Z","updated_at":"2026-03-26T11:08:54.994916Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://617acbf0-ae58-4470-a541-1e0dadfe4351.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-617acbf0-ae58-4470-a541-1e0dadfe4351.7b913cf8-e4fb-42ca-89ff-c04b99838378.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:10:10 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 34e27445-4211-4929-a85a-f18a59fe91d1
+        status: 200 OK
+        code: 200
+        duration: 73.177408ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/617acbf0-ae58-4470-a541-1e0dadfe4351
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"617acbf0-ae58-4470-a541-1e0dadfe4351","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_worker","description":"","tags":[],"created_at":"2026-03-26T11:08:54.994916Z","updated_at":"2026-03-26T11:08:54.994916Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://617acbf0-ae58-4470-a541-1e0dadfe4351.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-617acbf0-ae58-4470-a541-1e0dadfe4351.7b913cf8-e4fb-42ca-89ff-c04b99838378.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:10:25 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 283a38b8-2de6-44c8-a3e5-c3720679daa5
+        status: 200 OK
+        code: 200
+        duration: 76.519644ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/617acbf0-ae58-4470-a541-1e0dadfe4351
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"617acbf0-ae58-4470-a541-1e0dadfe4351","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_worker","description":"","tags":[],"created_at":"2026-03-26T11:08:54.994916Z","updated_at":"2026-03-26T11:08:54.994916Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://617acbf0-ae58-4470-a541-1e0dadfe4351.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-617acbf0-ae58-4470-a541-1e0dadfe4351.7b913cf8-e4fb-42ca-89ff-c04b99838378.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:10:40 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 8479024c-232c-4e85-89ca-3f413e3d913e
+        status: 200 OK
+        code: 200
+        duration: 79.515238ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/617acbf0-ae58-4470-a541-1e0dadfe4351
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"617acbf0-ae58-4470-a541-1e0dadfe4351","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_worker","description":"","tags":[],"created_at":"2026-03-26T11:08:54.994916Z","updated_at":"2026-03-26T11:08:54.994916Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://617acbf0-ae58-4470-a541-1e0dadfe4351.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-617acbf0-ae58-4470-a541-1e0dadfe4351.7b913cf8-e4fb-42ca-89ff-c04b99838378.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:10:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 4b432a07-0ca4-458e-b225-c40ee449e276
+        status: 200 OK
+        code: 200
+        duration: 78.462585ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/617acbf0-ae58-4470-a541-1e0dadfe4351
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"617acbf0-ae58-4470-a541-1e0dadfe4351","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_worker","description":"","tags":[],"created_at":"2026-03-26T11:08:54.994916Z","updated_at":"2026-03-26T11:08:54.994916Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://617acbf0-ae58-4470-a541-1e0dadfe4351.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-617acbf0-ae58-4470-a541-1e0dadfe4351.7b913cf8-e4fb-42ca-89ff-c04b99838378.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:11:11 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 88001cbe-61d3-45cf-97de-e77835abcdcb
+        status: 200 OK
+        code: 200
+        duration: 75.008434ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/617acbf0-ae58-4470-a541-1e0dadfe4351
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"617acbf0-ae58-4470-a541-1e0dadfe4351","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_worker","description":"","tags":[],"created_at":"2026-03-26T11:08:54.994916Z","updated_at":"2026-03-26T11:08:54.994916Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://617acbf0-ae58-4470-a541-1e0dadfe4351.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-617acbf0-ae58-4470-a541-1e0dadfe4351.7b913cf8-e4fb-42ca-89ff-c04b99838378.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:11:26 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 110a70d3-92cc-4804-890f-9de1fdb20097
+        status: 200 OK
+        code: 200
+        duration: 77.807283ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/617acbf0-ae58-4470-a541-1e0dadfe4351
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"617acbf0-ae58-4470-a541-1e0dadfe4351","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_worker","description":"","tags":[],"created_at":"2026-03-26T11:08:54.994916Z","updated_at":"2026-03-26T11:08:54.994916Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://617acbf0-ae58-4470-a541-1e0dadfe4351.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-617acbf0-ae58-4470-a541-1e0dadfe4351.7b913cf8-e4fb-42ca-89ff-c04b99838378.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:11:41 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 645620c1-5855-4223-a95b-aced503e5cbd
+        status: 200 OK
+        code: 200
+        duration: 70.216896ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/617acbf0-ae58-4470-a541-1e0dadfe4351
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"617acbf0-ae58-4470-a541-1e0dadfe4351","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_worker","description":"","tags":[],"created_at":"2026-03-26T11:08:54.994916Z","updated_at":"2026-03-26T11:08:54.994916Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://617acbf0-ae58-4470-a541-1e0dadfe4351.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-617acbf0-ae58-4470-a541-1e0dadfe4351.7b913cf8-e4fb-42ca-89ff-c04b99838378.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:11:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 8e89a1b8-c63f-4058-be92-8b78de89472b
+        status: 200 OK
+        code: 200
+        duration: 72.499118ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/617acbf0-ae58-4470-a541-1e0dadfe4351
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"617acbf0-ae58-4470-a541-1e0dadfe4351","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_worker","description":"","tags":[],"created_at":"2026-03-26T11:08:54.994916Z","updated_at":"2026-03-26T11:08:54.994916Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://617acbf0-ae58-4470-a541-1e0dadfe4351.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-617acbf0-ae58-4470-a541-1e0dadfe4351.7b913cf8-e4fb-42ca-89ff-c04b99838378.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:12:11 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - b7359902-89b0-4041-a8c9-87eb3aeb6af9
+        status: 200 OK
+        code: 200
+        duration: 64.254428ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/617acbf0-ae58-4470-a541-1e0dadfe4351
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"617acbf0-ae58-4470-a541-1e0dadfe4351","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_worker","description":"","tags":[],"created_at":"2026-03-26T11:08:54.994916Z","updated_at":"2026-03-26T11:08:54.994916Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://617acbf0-ae58-4470-a541-1e0dadfe4351.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-617acbf0-ae58-4470-a541-1e0dadfe4351.7b913cf8-e4fb-42ca-89ff-c04b99838378.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:12:26 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 74961563-152c-4593-b107-e0df2b1b65c4
+        status: 200 OK
+        code: 200
+        duration: 89.075318ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/617acbf0-ae58-4470-a541-1e0dadfe4351
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"617acbf0-ae58-4470-a541-1e0dadfe4351","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_worker","description":"","tags":[],"created_at":"2026-03-26T11:08:54.994916Z","updated_at":"2026-03-26T11:08:54.994916Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://617acbf0-ae58-4470-a541-1e0dadfe4351.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-617acbf0-ae58-4470-a541-1e0dadfe4351.7b913cf8-e4fb-42ca-89ff-c04b99838378.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:12:41 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - c3f6ba9a-ea75-4c2a-b22b-82d44163afc6
+        status: 200 OK
+        code: 200
+        duration: 72.08587ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/617acbf0-ae58-4470-a541-1e0dadfe4351
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"617acbf0-ae58-4470-a541-1e0dadfe4351","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_worker","description":"","tags":[],"created_at":"2026-03-26T11:08:54.994916Z","updated_at":"2026-03-26T11:08:54.994916Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://617acbf0-ae58-4470-a541-1e0dadfe4351.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-617acbf0-ae58-4470-a541-1e0dadfe4351.7b913cf8-e4fb-42ca-89ff-c04b99838378.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:12:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 8dd72736-f8e2-4b05-a38b-1b9a2bb0886a
+        status: 200 OK
+        code: 200
+        duration: 71.001508ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/617acbf0-ae58-4470-a541-1e0dadfe4351
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"617acbf0-ae58-4470-a541-1e0dadfe4351","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_worker","description":"","tags":[],"created_at":"2026-03-26T11:08:54.994916Z","updated_at":"2026-03-26T11:08:54.994916Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://617acbf0-ae58-4470-a541-1e0dadfe4351.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-617acbf0-ae58-4470-a541-1e0dadfe4351.7b913cf8-e4fb-42ca-89ff-c04b99838378.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:13:11 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 7ababcdc-c4b6-4e63-8763-39da899c547f
+        status: 200 OK
+        code: 200
+        duration: 78.163796ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/617acbf0-ae58-4470-a541-1e0dadfe4351
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"617acbf0-ae58-4470-a541-1e0dadfe4351","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_worker","description":"","tags":[],"created_at":"2026-03-26T11:08:54.994916Z","updated_at":"2026-03-26T11:08:54.994916Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://617acbf0-ae58-4470-a541-1e0dadfe4351.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-617acbf0-ae58-4470-a541-1e0dadfe4351.7b913cf8-e4fb-42ca-89ff-c04b99838378.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:13:26 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 46354ecd-7fa6-438a-a795-34d4fc6fd41c
+        status: 200 OK
+        code: 200
+        duration: 73.228682ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/617acbf0-ae58-4470-a541-1e0dadfe4351
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"617acbf0-ae58-4470-a541-1e0dadfe4351","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_worker","description":"","tags":[],"created_at":"2026-03-26T11:08:54.994916Z","updated_at":"2026-03-26T11:08:54.994916Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://617acbf0-ae58-4470-a541-1e0dadfe4351.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-617acbf0-ae58-4470-a541-1e0dadfe4351.7b913cf8-e4fb-42ca-89ff-c04b99838378.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:13:41 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - a060a75f-8fe5-4728-9677-7ee046366d8f
+        status: 200 OK
+        code: 200
+        duration: 78.015701ms
+    - id: 25
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/617acbf0-ae58-4470-a541-1e0dadfe4351
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"617acbf0-ae58-4470-a541-1e0dadfe4351","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_worker","description":"","tags":[],"created_at":"2026-03-26T11:08:54.994916Z","updated_at":"2026-03-26T11:08:54.994916Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://617acbf0-ae58-4470-a541-1e0dadfe4351.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-617acbf0-ae58-4470-a541-1e0dadfe4351.7b913cf8-e4fb-42ca-89ff-c04b99838378.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:13:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 6c83aa9f-1090-40fe-ad0f-32c74b040214
+        status: 200 OK
+        code: 200
+        duration: 71.819278ms
+    - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/617acbf0-ae58-4470-a541-1e0dadfe4351
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"617acbf0-ae58-4470-a541-1e0dadfe4351","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_worker","description":"","tags":[],"created_at":"2026-03-26T11:08:54.994916Z","updated_at":"2026-03-26T11:08:54.994916Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://617acbf0-ae58-4470-a541-1e0dadfe4351.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-617acbf0-ae58-4470-a541-1e0dadfe4351.7b913cf8-e4fb-42ca-89ff-c04b99838378.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:14:12 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 214771a3-839c-4bc0-9069-1746385c8aa7
+        status: 200 OK
+        code: 200
+        duration: 74.13513ms
+    - id: 27
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/617acbf0-ae58-4470-a541-1e0dadfe4351
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"617acbf0-ae58-4470-a541-1e0dadfe4351","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_worker","description":"","tags":[],"created_at":"2026-03-26T11:08:54.994916Z","updated_at":"2026-03-26T11:08:54.994916Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://617acbf0-ae58-4470-a541-1e0dadfe4351.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-617acbf0-ae58-4470-a541-1e0dadfe4351.7b913cf8-e4fb-42ca-89ff-c04b99838378.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:14:27 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 9578f9af-9895-4f2b-93e6-461205be4fd3
+        status: 200 OK
+        code: 200
+        duration: 78.188098ms
+    - id: 28
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/617acbf0-ae58-4470-a541-1e0dadfe4351
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"617acbf0-ae58-4470-a541-1e0dadfe4351","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_worker","description":"","tags":[],"created_at":"2026-03-26T11:08:54.994916Z","updated_at":"2026-03-26T11:08:54.994916Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://617acbf0-ae58-4470-a541-1e0dadfe4351.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-617acbf0-ae58-4470-a541-1e0dadfe4351.7b913cf8-e4fb-42ca-89ff-c04b99838378.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:14:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 712f4671-a137-4fd0-bfd1-3344fe969227
+        status: 200 OK
+        code: 200
+        duration: 85.081582ms
+    - id: 29
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/617acbf0-ae58-4470-a541-1e0dadfe4351
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 906
+        body: '{"id":"617acbf0-ae58-4470-a541-1e0dadfe4351","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_worker","description":"","tags":[],"created_at":"2026-03-26T11:08:54.994916Z","updated_at":"2026-03-26T11:14:44.414728Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://617acbf0-ae58-4470-a541-1e0dadfe4351.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-617acbf0-ae58-4470-a541-1e0dadfe4351.7b913cf8-e4fb-42ca-89ff-c04b99838378.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "906"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:14:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 1c4059c4-79f8-40b5-bbfe-5b4770a7da4f
+        status: 200 OK
+        code: 200
+        duration: 68.465435ms
+    - id: 30
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/617acbf0-ae58-4470-a541-1e0dadfe4351
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 906
+        body: '{"id":"617acbf0-ae58-4470-a541-1e0dadfe4351","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_worker","description":"","tags":[],"created_at":"2026-03-26T11:08:54.994916Z","updated_at":"2026-03-26T11:14:44.414728Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://617acbf0-ae58-4470-a541-1e0dadfe4351.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-617acbf0-ae58-4470-a541-1e0dadfe4351.7b913cf8-e4fb-42ca-89ff-c04b99838378.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "906"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:14:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 3019f1ee-807f-414a-b720-fd6d159008af
+        status: 200 OK
+        code: 200
+        duration: 73.438749ms
+    - id: 31
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/6f36cd90-e0d9-4549-a4d6-e70c03b7799c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 410
+        body: '{"id":"6f36cd90-e0d9-4549-a4d6-e70c03b7799c","name":"tf_tests_datalab_worker","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:08:52.686211Z","updated_at":"2026-03-26T11:08:52.686211Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","is_default":false,"private_network_count":1,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "410"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:14:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - b7c584f2-e045-47fd-b130-940dfdfcbfcd
+        status: 200 OK
+        code: 200
+        duration: 52.579997ms
+    - id: 32
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/7b913cf8-e4fb-42ca-89ff-c04b99838378
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1066
+        body: '{"id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","name":"tf-pn-gallant-galois","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:08:53.834938Z","updated_at":"2026-03-26T11:08:53.834938Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","subnets":[{"id":"59b07c6a-ee87-4608-8055-10a27d42c58c","created_at":"2026-03-26T11:08:53.834938Z","updated_at":"2026-03-26T11:08:53.834938Z","subnet":"172.16.20.0/22","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","vpc_id":"6f36cd90-e0d9-4549-a4d6-e70c03b7799c"},{"id":"b6ef062a-a28d-4ee4-9714-4b54094b4cdf","created_at":"2026-03-26T11:08:53.834938Z","updated_at":"2026-03-26T11:08:53.834938Z","subnet":"fd40:e277:fdde:8a01::/64","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","vpc_id":"6f36cd90-e0d9-4549-a4d6-e70c03b7799c"}],"vpc_id":"6f36cd90-e0d9-4549-a4d6-e70c03b7799c","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1066"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:14:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 83f118ad-ee71-4bc5-b4a4-7c0ac075080e
+        status: 200 OK
+        code: 200
+        duration: 53.887344ms
+    - id: 33
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/617acbf0-ae58-4470-a541-1e0dadfe4351
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 906
+        body: '{"id":"617acbf0-ae58-4470-a541-1e0dadfe4351","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_worker","description":"","tags":[],"created_at":"2026-03-26T11:08:54.994916Z","updated_at":"2026-03-26T11:14:44.414728Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://617acbf0-ae58-4470-a541-1e0dadfe4351.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-617acbf0-ae58-4470-a541-1e0dadfe4351.7b913cf8-e4fb-42ca-89ff-c04b99838378.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "906"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:14:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 6c138652-6d40-4c88-b64e-e33d749d09da
+        status: 200 OK
+        code: 200
+        duration: 73.589484ms
+    - id: 34
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/6f36cd90-e0d9-4549-a4d6-e70c03b7799c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 410
+        body: '{"id":"6f36cd90-e0d9-4549-a4d6-e70c03b7799c","name":"tf_tests_datalab_worker","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:08:52.686211Z","updated_at":"2026-03-26T11:08:52.686211Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","is_default":false,"private_network_count":1,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "410"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:14:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 047802e1-5acc-4065-b894-1b9fa1c032fb
+        status: 200 OK
+        code: 200
+        duration: 56.169866ms
+    - id: 35
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/7b913cf8-e4fb-42ca-89ff-c04b99838378
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1066
+        body: '{"id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","name":"tf-pn-gallant-galois","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:08:53.834938Z","updated_at":"2026-03-26T11:08:53.834938Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","subnets":[{"id":"59b07c6a-ee87-4608-8055-10a27d42c58c","created_at":"2026-03-26T11:08:53.834938Z","updated_at":"2026-03-26T11:08:53.834938Z","subnet":"172.16.20.0/22","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","vpc_id":"6f36cd90-e0d9-4549-a4d6-e70c03b7799c"},{"id":"b6ef062a-a28d-4ee4-9714-4b54094b4cdf","created_at":"2026-03-26T11:08:53.834938Z","updated_at":"2026-03-26T11:08:53.834938Z","subnet":"fd40:e277:fdde:8a01::/64","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","vpc_id":"6f36cd90-e0d9-4549-a4d6-e70c03b7799c"}],"vpc_id":"6f36cd90-e0d9-4549-a4d6-e70c03b7799c","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1066"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:14:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 15cce2c5-e73b-4c73-af74-3598fec93867
+        status: 200 OK
+        code: 200
+        duration: 61.998888ms
+    - id: 36
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/617acbf0-ae58-4470-a541-1e0dadfe4351
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 906
+        body: '{"id":"617acbf0-ae58-4470-a541-1e0dadfe4351","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_worker","description":"","tags":[],"created_at":"2026-03-26T11:08:54.994916Z","updated_at":"2026-03-26T11:14:44.414728Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://617acbf0-ae58-4470-a541-1e0dadfe4351.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-617acbf0-ae58-4470-a541-1e0dadfe4351.7b913cf8-e4fb-42ca-89ff-c04b99838378.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "906"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:14:58 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 52f46791-e012-4839-a15f-95cc5a47b9f7
+        status: 200 OK
+        code: 200
+        duration: 68.66114ms
+    - id: 37
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 28
+        host: api.scaleway.com
+        body: '{"tags":null,"node_count":2}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/617acbf0-ae58-4470-a541-1e0dadfe4351
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"617acbf0-ae58-4470-a541-1e0dadfe4351","status":"updating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_worker","description":"","tags":[],"created_at":"2026-03-26T11:08:54.994916Z","updated_at":"2026-03-26T11:14:58.175799Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://617acbf0-ae58-4470-a541-1e0dadfe4351.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-617acbf0-ae58-4470-a541-1e0dadfe4351.7b913cf8-e4fb-42ca-89ff-c04b99838378.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":2,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:14:58 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 42b65d8c-7fbe-4316-a826-63eba09c0ea4
+        status: 200 OK
+        code: 200
+        duration: 274.271178ms
+    - id: 38
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/617acbf0-ae58-4470-a541-1e0dadfe4351
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"617acbf0-ae58-4470-a541-1e0dadfe4351","status":"updating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_worker","description":"","tags":[],"created_at":"2026-03-26T11:08:54.994916Z","updated_at":"2026-03-26T11:14:58.175799Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://617acbf0-ae58-4470-a541-1e0dadfe4351.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-617acbf0-ae58-4470-a541-1e0dadfe4351.7b913cf8-e4fb-42ca-89ff-c04b99838378.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":2,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:14:58 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 6aa60518-ae13-4a63-bccb-226943c1f9ce
+        status: 200 OK
+        code: 200
+        duration: 70.023095ms
+    - id: 39
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/617acbf0-ae58-4470-a541-1e0dadfe4351
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"617acbf0-ae58-4470-a541-1e0dadfe4351","status":"updating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_worker","description":"","tags":[],"created_at":"2026-03-26T11:08:54.994916Z","updated_at":"2026-03-26T11:14:58.175799Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://617acbf0-ae58-4470-a541-1e0dadfe4351.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-617acbf0-ae58-4470-a541-1e0dadfe4351.7b913cf8-e4fb-42ca-89ff-c04b99838378.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":2,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:15:13 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - f640dcdb-284a-41cf-a309-631075ca2111
+        status: 200 OK
+        code: 200
+        duration: 78.226567ms
+    - id: 40
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/617acbf0-ae58-4470-a541-1e0dadfe4351
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"617acbf0-ae58-4470-a541-1e0dadfe4351","status":"updating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_worker","description":"","tags":[],"created_at":"2026-03-26T11:08:54.994916Z","updated_at":"2026-03-26T11:14:58.175799Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://617acbf0-ae58-4470-a541-1e0dadfe4351.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-617acbf0-ae58-4470-a541-1e0dadfe4351.7b913cf8-e4fb-42ca-89ff-c04b99838378.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":2,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:15:28 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 9a681af3-177c-4ff5-9df5-487b14b4bca1
+        status: 200 OK
+        code: 200
+        duration: 78.387024ms
+    - id: 41
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/617acbf0-ae58-4470-a541-1e0dadfe4351
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"617acbf0-ae58-4470-a541-1e0dadfe4351","status":"updating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_worker","description":"","tags":[],"created_at":"2026-03-26T11:08:54.994916Z","updated_at":"2026-03-26T11:14:58.175799Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://617acbf0-ae58-4470-a541-1e0dadfe4351.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-617acbf0-ae58-4470-a541-1e0dadfe4351.7b913cf8-e4fb-42ca-89ff-c04b99838378.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":2,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:15:43 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 14bbbc53-d3b0-40c4-ae25-0b8b135c446e
+        status: 200 OK
+        code: 200
+        duration: 75.973895ms
+    - id: 42
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/617acbf0-ae58-4470-a541-1e0dadfe4351
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"617acbf0-ae58-4470-a541-1e0dadfe4351","status":"updating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_worker","description":"","tags":[],"created_at":"2026-03-26T11:08:54.994916Z","updated_at":"2026-03-26T11:14:58.175799Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://617acbf0-ae58-4470-a541-1e0dadfe4351.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-617acbf0-ae58-4470-a541-1e0dadfe4351.7b913cf8-e4fb-42ca-89ff-c04b99838378.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":2,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:15:58 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 933cc9fe-096b-4a20-a203-c10f37b0f6da
+        status: 200 OK
+        code: 200
+        duration: 79.888246ms
+    - id: 43
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/617acbf0-ae58-4470-a541-1e0dadfe4351
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"617acbf0-ae58-4470-a541-1e0dadfe4351","status":"updating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_worker","description":"","tags":[],"created_at":"2026-03-26T11:08:54.994916Z","updated_at":"2026-03-26T11:14:58.175799Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://617acbf0-ae58-4470-a541-1e0dadfe4351.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-617acbf0-ae58-4470-a541-1e0dadfe4351.7b913cf8-e4fb-42ca-89ff-c04b99838378.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":2,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:16:13 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 0731b5f4-a08d-4565-954c-b353f7377118
+        status: 200 OK
+        code: 200
+        duration: 60.554036ms
+    - id: 44
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/617acbf0-ae58-4470-a541-1e0dadfe4351
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"617acbf0-ae58-4470-a541-1e0dadfe4351","status":"updating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_worker","description":"","tags":[],"created_at":"2026-03-26T11:08:54.994916Z","updated_at":"2026-03-26T11:14:58.175799Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://617acbf0-ae58-4470-a541-1e0dadfe4351.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-617acbf0-ae58-4470-a541-1e0dadfe4351.7b913cf8-e4fb-42ca-89ff-c04b99838378.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":2,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:16:28 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - af2740bc-1e74-4f68-bb3f-5876ab266aa7
+        status: 200 OK
+        code: 200
+        duration: 76.729116ms
+    - id: 45
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/617acbf0-ae58-4470-a541-1e0dadfe4351
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"617acbf0-ae58-4470-a541-1e0dadfe4351","status":"updating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_worker","description":"","tags":[],"created_at":"2026-03-26T11:08:54.994916Z","updated_at":"2026-03-26T11:14:58.175799Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://617acbf0-ae58-4470-a541-1e0dadfe4351.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-617acbf0-ae58-4470-a541-1e0dadfe4351.7b913cf8-e4fb-42ca-89ff-c04b99838378.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":2,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:16:44 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 1e27110e-67f6-462c-babd-20fda82aad3c
+        status: 200 OK
+        code: 200
+        duration: 100.654361ms
+    - id: 46
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/617acbf0-ae58-4470-a541-1e0dadfe4351
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 906
+        body: '{"id":"617acbf0-ae58-4470-a541-1e0dadfe4351","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_worker","description":"","tags":[],"created_at":"2026-03-26T11:08:54.994916Z","updated_at":"2026-03-26T11:16:48.863413Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://617acbf0-ae58-4470-a541-1e0dadfe4351.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-617acbf0-ae58-4470-a541-1e0dadfe4351.7b913cf8-e4fb-42ca-89ff-c04b99838378.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":2,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "906"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:16:59 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 937966cb-0077-4905-9523-c5ed1be3d0ee
+        status: 200 OK
+        code: 200
+        duration: 76.662659ms
+    - id: 47
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/617acbf0-ae58-4470-a541-1e0dadfe4351
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 906
+        body: '{"id":"617acbf0-ae58-4470-a541-1e0dadfe4351","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_worker","description":"","tags":[],"created_at":"2026-03-26T11:08:54.994916Z","updated_at":"2026-03-26T11:16:48.863413Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://617acbf0-ae58-4470-a541-1e0dadfe4351.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-617acbf0-ae58-4470-a541-1e0dadfe4351.7b913cf8-e4fb-42ca-89ff-c04b99838378.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":2,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "906"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:16:59 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 49acd6a6-f885-4a3e-b0bd-804e7880bc97
+        status: 200 OK
+        code: 200
+        duration: 73.04619ms
+    - id: 48
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/6f36cd90-e0d9-4549-a4d6-e70c03b7799c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 410
+        body: '{"id":"6f36cd90-e0d9-4549-a4d6-e70c03b7799c","name":"tf_tests_datalab_worker","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:08:52.686211Z","updated_at":"2026-03-26T11:08:52.686211Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","is_default":false,"private_network_count":1,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "410"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:16:59 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 8c5bc30d-45fc-4a42-b713-b3fff2cfdc20
+        status: 200 OK
+        code: 200
+        duration: 70.466526ms
+    - id: 49
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/7b913cf8-e4fb-42ca-89ff-c04b99838378
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1066
+        body: '{"id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","name":"tf-pn-gallant-galois","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:08:53.834938Z","updated_at":"2026-03-26T11:08:53.834938Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","subnets":[{"id":"59b07c6a-ee87-4608-8055-10a27d42c58c","created_at":"2026-03-26T11:08:53.834938Z","updated_at":"2026-03-26T11:08:53.834938Z","subnet":"172.16.20.0/22","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","vpc_id":"6f36cd90-e0d9-4549-a4d6-e70c03b7799c"},{"id":"b6ef062a-a28d-4ee4-9714-4b54094b4cdf","created_at":"2026-03-26T11:08:53.834938Z","updated_at":"2026-03-26T11:08:53.834938Z","subnet":"fd40:e277:fdde:8a01::/64","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","vpc_id":"6f36cd90-e0d9-4549-a4d6-e70c03b7799c"}],"vpc_id":"6f36cd90-e0d9-4549-a4d6-e70c03b7799c","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1066"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:16:59 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - e1cddbda-9143-4ce9-bfe8-d1ede659f6fd
+        status: 200 OK
+        code: 200
+        duration: 61.317407ms
+    - id: 50
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/617acbf0-ae58-4470-a541-1e0dadfe4351
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 906
+        body: '{"id":"617acbf0-ae58-4470-a541-1e0dadfe4351","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_worker","description":"","tags":[],"created_at":"2026-03-26T11:08:54.994916Z","updated_at":"2026-03-26T11:16:48.863413Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://617acbf0-ae58-4470-a541-1e0dadfe4351.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-617acbf0-ae58-4470-a541-1e0dadfe4351.7b913cf8-e4fb-42ca-89ff-c04b99838378.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":2,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "906"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:16:59 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 45682cc9-71e2-4258-918e-67208952a843
+        status: 200 OK
+        code: 200
+        duration: 63.402424ms
+    - id: 51
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/617acbf0-ae58-4470-a541-1e0dadfe4351
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"617acbf0-ae58-4470-a541-1e0dadfe4351","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_worker","description":"","tags":[],"created_at":"2026-03-26T11:08:54.994916Z","updated_at":"2026-03-26T11:16:59.793158Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://617acbf0-ae58-4470-a541-1e0dadfe4351.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-617acbf0-ae58-4470-a541-1e0dadfe4351.7b913cf8-e4fb-42ca-89ff-c04b99838378.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":2,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:16:59 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 6dee611e-c194-4fdf-a526-54dc38adda62
+        status: 200 OK
+        code: 200
+        duration: 145.212912ms
+    - id: 52
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/617acbf0-ae58-4470-a541-1e0dadfe4351
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"617acbf0-ae58-4470-a541-1e0dadfe4351","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_worker","description":"","tags":[],"created_at":"2026-03-26T11:08:54.994916Z","updated_at":"2026-03-26T11:16:59.793158Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://617acbf0-ae58-4470-a541-1e0dadfe4351.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-617acbf0-ae58-4470-a541-1e0dadfe4351.7b913cf8-e4fb-42ca-89ff-c04b99838378.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":2,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:16:59 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 7eb50541-c22a-418a-8df8-964156f5d918
+        status: 200 OK
+        code: 200
+        duration: 77.00082ms
+    - id: 53
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/617acbf0-ae58-4470-a541-1e0dadfe4351
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"617acbf0-ae58-4470-a541-1e0dadfe4351","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_worker","description":"","tags":[],"created_at":"2026-03-26T11:08:54.994916Z","updated_at":"2026-03-26T11:16:59.793158Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://617acbf0-ae58-4470-a541-1e0dadfe4351.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-617acbf0-ae58-4470-a541-1e0dadfe4351.7b913cf8-e4fb-42ca-89ff-c04b99838378.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":2,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:17:15 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - f394e798-9f03-4c57-8180-2fc0b3ffe02c
+        status: 200 OK
+        code: 200
+        duration: 69.285085ms
+    - id: 54
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/617acbf0-ae58-4470-a541-1e0dadfe4351
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"617acbf0-ae58-4470-a541-1e0dadfe4351","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_worker","description":"","tags":[],"created_at":"2026-03-26T11:08:54.994916Z","updated_at":"2026-03-26T11:16:59.793158Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://617acbf0-ae58-4470-a541-1e0dadfe4351.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-617acbf0-ae58-4470-a541-1e0dadfe4351.7b913cf8-e4fb-42ca-89ff-c04b99838378.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":2,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:17:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - f6d18bd8-0f5e-4fde-83c7-926bced9f478
+        status: 200 OK
+        code: 200
+        duration: 73.44912ms
+    - id: 55
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/617acbf0-ae58-4470-a541-1e0dadfe4351
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"617acbf0-ae58-4470-a541-1e0dadfe4351","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_worker","description":"","tags":[],"created_at":"2026-03-26T11:08:54.994916Z","updated_at":"2026-03-26T11:16:59.793158Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://617acbf0-ae58-4470-a541-1e0dadfe4351.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-617acbf0-ae58-4470-a541-1e0dadfe4351.7b913cf8-e4fb-42ca-89ff-c04b99838378.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":2,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:17:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - da93b2e6-7e96-47d0-bc85-4f0beda5f04e
+        status: 200 OK
+        code: 200
+        duration: 71.190728ms
+    - id: 56
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/617acbf0-ae58-4470-a541-1e0dadfe4351
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"617acbf0-ae58-4470-a541-1e0dadfe4351","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_worker","description":"","tags":[],"created_at":"2026-03-26T11:08:54.994916Z","updated_at":"2026-03-26T11:16:59.793158Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://617acbf0-ae58-4470-a541-1e0dadfe4351.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-617acbf0-ae58-4470-a541-1e0dadfe4351.7b913cf8-e4fb-42ca-89ff-c04b99838378.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":2,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:18:00 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 7fe522e9-6f98-4b4d-9d36-5b02b8b7128f
+        status: 200 OK
+        code: 200
+        duration: 74.529173ms
+    - id: 57
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/617acbf0-ae58-4470-a541-1e0dadfe4351
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"617acbf0-ae58-4470-a541-1e0dadfe4351","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_worker","description":"","tags":[],"created_at":"2026-03-26T11:08:54.994916Z","updated_at":"2026-03-26T11:16:59.793158Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://617acbf0-ae58-4470-a541-1e0dadfe4351.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-617acbf0-ae58-4470-a541-1e0dadfe4351.7b913cf8-e4fb-42ca-89ff-c04b99838378.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":2,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:18:15 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - f3fc2e62-2444-449a-b417-249cb20382c5
+        status: 200 OK
+        code: 200
+        duration: 89.695159ms
+    - id: 58
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/617acbf0-ae58-4470-a541-1e0dadfe4351
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"617acbf0-ae58-4470-a541-1e0dadfe4351","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_worker","description":"","tags":[],"created_at":"2026-03-26T11:08:54.994916Z","updated_at":"2026-03-26T11:16:59.793158Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://617acbf0-ae58-4470-a541-1e0dadfe4351.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-617acbf0-ae58-4470-a541-1e0dadfe4351.7b913cf8-e4fb-42ca-89ff-c04b99838378.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":2,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:18:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 91f1fd61-bc5d-4886-ac3c-8ccbf7975ebe
+        status: 200 OK
+        code: 200
+        duration: 71.665576ms
+    - id: 59
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/617acbf0-ae58-4470-a541-1e0dadfe4351
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"617acbf0-ae58-4470-a541-1e0dadfe4351","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_worker","description":"","tags":[],"created_at":"2026-03-26T11:08:54.994916Z","updated_at":"2026-03-26T11:16:59.793158Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://617acbf0-ae58-4470-a541-1e0dadfe4351.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-617acbf0-ae58-4470-a541-1e0dadfe4351.7b913cf8-e4fb-42ca-89ff-c04b99838378.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":2,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:18:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 14f13ee8-7370-4608-be69-ecb8e5f479bb
+        status: 200 OK
+        code: 200
+        duration: 77.241405ms
+    - id: 60
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/617acbf0-ae58-4470-a541-1e0dadfe4351
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"617acbf0-ae58-4470-a541-1e0dadfe4351","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_worker","description":"","tags":[],"created_at":"2026-03-26T11:08:54.994916Z","updated_at":"2026-03-26T11:16:59.793158Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://617acbf0-ae58-4470-a541-1e0dadfe4351.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-617acbf0-ae58-4470-a541-1e0dadfe4351.7b913cf8-e4fb-42ca-89ff-c04b99838378.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":2,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:19:00 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 2b8b3caa-7add-492a-a080-1903903003c4
+        status: 200 OK
+        code: 200
+        duration: 81.04638ms
+    - id: 61
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/617acbf0-ae58-4470-a541-1e0dadfe4351
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"617acbf0-ae58-4470-a541-1e0dadfe4351","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_worker","description":"","tags":[],"created_at":"2026-03-26T11:08:54.994916Z","updated_at":"2026-03-26T11:16:59.793158Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://617acbf0-ae58-4470-a541-1e0dadfe4351.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-617acbf0-ae58-4470-a541-1e0dadfe4351.7b913cf8-e4fb-42ca-89ff-c04b99838378.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":2,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:19:15 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 5a90c57c-d868-484a-b9b7-c4121998fd3a
+        status: 200 OK
+        code: 200
+        duration: 73.92242ms
+    - id: 62
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/617acbf0-ae58-4470-a541-1e0dadfe4351
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"617acbf0-ae58-4470-a541-1e0dadfe4351","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_worker","description":"","tags":[],"created_at":"2026-03-26T11:08:54.994916Z","updated_at":"2026-03-26T11:16:59.793158Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://617acbf0-ae58-4470-a541-1e0dadfe4351.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-617acbf0-ae58-4470-a541-1e0dadfe4351.7b913cf8-e4fb-42ca-89ff-c04b99838378.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":2,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:19:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - d6adce13-ffb0-4f0c-8ee8-b676eea9e165
+        status: 200 OK
+        code: 200
+        duration: 77.670385ms
+    - id: 63
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/617acbf0-ae58-4470-a541-1e0dadfe4351
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"617acbf0-ae58-4470-a541-1e0dadfe4351","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_worker","description":"","tags":[],"created_at":"2026-03-26T11:08:54.994916Z","updated_at":"2026-03-26T11:16:59.793158Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://617acbf0-ae58-4470-a541-1e0dadfe4351.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-617acbf0-ae58-4470-a541-1e0dadfe4351.7b913cf8-e4fb-42ca-89ff-c04b99838378.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":2,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:19:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - c7a4e646-70c4-4460-a692-c69d49370bfd
+        status: 200 OK
+        code: 200
+        duration: 77.620717ms
+    - id: 64
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/617acbf0-ae58-4470-a541-1e0dadfe4351
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"617acbf0-ae58-4470-a541-1e0dadfe4351","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_worker","description":"","tags":[],"created_at":"2026-03-26T11:08:54.994916Z","updated_at":"2026-03-26T11:16:59.793158Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://617acbf0-ae58-4470-a541-1e0dadfe4351.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-617acbf0-ae58-4470-a541-1e0dadfe4351.7b913cf8-e4fb-42ca-89ff-c04b99838378.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":2,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"7b913cf8-e4fb-42ca-89ff-c04b99838378","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:20:00 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - e4f17972-3322-4266-877d-d5cef85a79b5
+        status: 200 OK
+        code: 200
+        duration: 88.515791ms
+    - id: 65
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/617acbf0-ae58-4470-a541-1e0dadfe4351
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 128
+        body: '{"message":"resource is not found","resource":"datalab","resource_id":"617acbf0-ae58-4470-a541-1e0dadfe4351","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "128"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:20:15 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - c0df3dc9-3c61-4a28-986d-1f220601bd0c
+        status: 404 Not Found
+        code: 404
+        duration: 64.646945ms
+    - id: 66
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/7b913cf8-e4fb-42ca-89ff-c04b99838378
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:20:17 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - d9fc7da3-dcc0-4574-b233-260d8ed0f130
+        status: 204 No Content
+        code: 204
+        duration: 1.772690893s
+    - id: 67
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/6f36cd90-e0d9-4549-a4d6-e70c03b7799c
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:20:18 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - b4fa5f60-d6db-41a5-8005-8b455695032d
+        status: 204 No Content
+        code: 204
+        duration: 524.576722ms
+    - id: 68
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/617acbf0-ae58-4470-a541-1e0dadfe4351
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 128
+        body: '{"message":"resource is not found","resource":"datalab","resource_id":"617acbf0-ae58-4470-a541-1e0dadfe4351","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "128"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:20:18 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - d937499b-061b-4880-9c25-ed1ce81c2e88
+        status: 404 Not Found
+        code: 404
+        duration: 56.950529ms

--- a/internal/services/datalab/testdata/datalabs-data-source-basic.cassette.yaml
+++ b/internal/services/datalab/testdata/datalabs-data-source-basic.cassette.yaml
@@ -1,0 +1,1949 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 122
+        host: api.scaleway.com
+        body: '{"name":"tf_tests_datalabs_ds_basic","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","tags":[],"enable_routing":false}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 413
+        body: '{"id":"4eb78672-f8f2-436b-b87c-f3332f7b0265","name":"tf_tests_datalabs_ds_basic","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:30:00.558454Z","updated_at":"2026-03-26T11:30:00.558454Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","is_default":false,"private_network_count":0,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "413"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:30:00 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - eee34678-9ec2-4b51-9d04-86309d7da0e7
+        status: 200 OK
+        code: 200
+        duration: 340.068783ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/4eb78672-f8f2-436b-b87c-f3332f7b0265
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 413
+        body: '{"id":"4eb78672-f8f2-436b-b87c-f3332f7b0265","name":"tf_tests_datalabs_ds_basic","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:30:00.558454Z","updated_at":"2026-03-26T11:30:00.558454Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","is_default":false,"private_network_count":0,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "413"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:30:00 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - cd3613e6-46be-4285-877d-d6910b496729
+        status: 200 OK
+        code: 200
+        duration: 56.484444ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 202
+        host: api.scaleway.com
+        body: '{"name":"tf-pn-beautiful-lovelace","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","tags":[],"subnets":null,"vpc_id":"4eb78672-f8f2-436b-b87c-f3332f7b0265","default_route_propagation_enabled":false}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1069
+        body: '{"id":"6da7884d-b156-4286-a6c6-4106e34df100","name":"tf-pn-beautiful-lovelace","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:30:00.699375Z","updated_at":"2026-03-26T11:30:00.699375Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","subnets":[{"id":"6c49683f-81f0-4c57-99b1-c42c1477813d","created_at":"2026-03-26T11:30:00.699375Z","updated_at":"2026-03-26T11:30:00.699375Z","subnet":"172.16.12.0/22","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","vpc_id":"4eb78672-f8f2-436b-b87c-f3332f7b0265"},{"id":"b8089b94-73ab-4dce-82f7-a41f66231036","created_at":"2026-03-26T11:30:00.699375Z","updated_at":"2026-03-26T11:30:00.699375Z","subnet":"fd40:e277:fdde:bcd::/64","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","vpc_id":"4eb78672-f8f2-436b-b87c-f3332f7b0265"}],"vpc_id":"4eb78672-f8f2-436b-b87c-f3332f7b0265","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1069"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:30:01 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - cbd76870-6763-44e8-b57b-b1fdb9c023dc
+        status: 200 OK
+        code: 200
+        duration: 842.672093ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6da7884d-b156-4286-a6c6-4106e34df100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1069
+        body: '{"id":"6da7884d-b156-4286-a6c6-4106e34df100","name":"tf-pn-beautiful-lovelace","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:30:00.699375Z","updated_at":"2026-03-26T11:30:00.699375Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","subnets":[{"id":"6c49683f-81f0-4c57-99b1-c42c1477813d","created_at":"2026-03-26T11:30:00.699375Z","updated_at":"2026-03-26T11:30:00.699375Z","subnet":"172.16.12.0/22","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","vpc_id":"4eb78672-f8f2-436b-b87c-f3332f7b0265"},{"id":"b8089b94-73ab-4dce-82f7-a41f66231036","created_at":"2026-03-26T11:30:00.699375Z","updated_at":"2026-03-26T11:30:00.699375Z","subnet":"fd40:e277:fdde:bcd::/64","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","vpc_id":"4eb78672-f8f2-436b-b87c-f3332f7b0265"}],"vpc_id":"4eb78672-f8f2-436b-b87c-f3332f7b0265","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1069"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:30:01 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 60b41cc5-e655-4a4f-b98c-50e1a16886fe
+        status: 200 OK
+        code: 200
+        duration: 53.305254ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 332
+        host: api.scaleway.com
+        body: '{"project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":null,"main":{"node_type":"DATALAB-SHARED-4C-8G"},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1},"has_notebook":false,"spark_version":"4.0.0","private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100"}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 912
+        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:30:01.652478Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "912"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:30:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 4642ea79-81ac-4481-99ff-acdf9ec0413b
+        status: 200 OK
+        code: 200
+        duration: 667.629033ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 912
+        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:30:01.652478Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "912"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:30:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - eb0140cd-c419-4f8c-810b-be657fd0edb6
+        status: 200 OK
+        code: 200
+        duration: 72.907999ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 912
+        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:30:01.652478Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "912"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:30:17 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - ccd0543d-a8b5-4e92-8362-5bf664ff93d5
+        status: 200 OK
+        code: 200
+        duration: 73.363178ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 912
+        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:30:01.652478Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "912"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:30:32 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 0aaab327-fd72-4331-b6cc-a7de03070b86
+        status: 200 OK
+        code: 200
+        duration: 68.959749ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 912
+        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:30:01.652478Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "912"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:30:47 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - af14d1bd-d215-42fc-aced-e28acb732aeb
+        status: 200 OK
+        code: 200
+        duration: 72.622006ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 912
+        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:30:01.652478Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "912"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:31:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - d7ae6861-b9d6-4867-885f-9aec486eed03
+        status: 200 OK
+        code: 200
+        duration: 81.381415ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 912
+        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:30:01.652478Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "912"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:31:17 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - b5025b87-9b11-4062-a166-d0dcaec7a968
+        status: 200 OK
+        code: 200
+        duration: 81.074463ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 912
+        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:30:01.652478Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "912"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:31:32 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - a61b0485-480b-40d0-a79a-de35e397d461
+        status: 200 OK
+        code: 200
+        duration: 86.089366ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 912
+        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:30:01.652478Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "912"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:31:47 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - a7762043-897d-4e07-88aa-4e68b7ac556c
+        status: 200 OK
+        code: 200
+        duration: 64.935371ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 912
+        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:30:01.652478Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "912"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:32:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 29fb1e49-2405-4fba-96fd-2a9f6362b023
+        status: 200 OK
+        code: 200
+        duration: 71.472486ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 912
+        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:30:01.652478Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "912"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:32:17 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 0e03af0f-b269-4d48-b268-ed9fcc39f410
+        status: 200 OK
+        code: 200
+        duration: 93.847011ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 912
+        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:30:01.652478Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "912"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:32:33 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - aa135f7f-3304-4a9c-a337-952d5bfddc37
+        status: 200 OK
+        code: 200
+        duration: 97.491739ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 912
+        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:30:01.652478Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "912"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:32:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 9571775a-3e7e-4a87-b836-2685893037ed
+        status: 200 OK
+        code: 200
+        duration: 164.866318ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 912
+        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:30:01.652478Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "912"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:33:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 56a3e93b-c90e-4287-b04d-7b404b5d1201
+        status: 200 OK
+        code: 200
+        duration: 71.449197ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 912
+        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:30:01.652478Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "912"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:33:18 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 96c40346-ed5a-450a-9a99-6e6211f9ef83
+        status: 200 OK
+        code: 200
+        duration: 75.68529ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 912
+        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:30:01.652478Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "912"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:33:33 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - d8d91f76-bf86-48fe-a326-c970d8fd3266
+        status: 200 OK
+        code: 200
+        duration: 84.155295ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 912
+        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:30:01.652478Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "912"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:33:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 765a7924-1f13-47f7-afc9-792210e9fe33
+        status: 200 OK
+        code: 200
+        duration: 72.892121ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 912
+        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:30:01.652478Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "912"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:34:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - c81e628f-326d-4dc5-a1fb-360208a4ea4f
+        status: 200 OK
+        code: 200
+        duration: 79.399456ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 912
+        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:30:01.652478Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "912"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:34:18 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 2588458f-8c8a-4c5a-b9d4-3aa6ec69cb32
+        status: 200 OK
+        code: 200
+        duration: 72.142649ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 912
+        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:30:01.652478Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "912"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:34:33 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 9a995c6a-0682-4e3d-840f-d7881880ab26
+        status: 200 OK
+        code: 200
+        duration: 80.526697ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 912
+        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:30:01.652478Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "912"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:34:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 2e7c00af-db93-48de-a33c-855f2c854675
+        status: 200 OK
+        code: 200
+        duration: 81.735727ms
+    - id: 25
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 912
+        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:30:01.652478Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "912"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:35:04 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - d3134e6d-d1a5-4683-95c4-c92bed572f92
+        status: 200 OK
+        code: 200
+        duration: 85.755196ms
+    - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 912
+        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:30:01.652478Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "912"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:35:19 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 67ca1f6f-eee9-47ef-93c6-cec74864af84
+        status: 200 OK
+        code: 200
+        duration: 76.909189ms
+    - id: 27
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 912
+        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:30:01.652478Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "912"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:35:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 3d444a51-dfff-4b8c-b9f1-e7a61dad0ebc
+        status: 200 OK
+        code: 200
+        duration: 80.118308ms
+    - id: 28
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:35:45.524930Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:35:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 86752253-0725-4e83-8048-87f20627fddd
+        status: 200 OK
+        code: 200
+        duration: 98.835133ms
+    - id: 29
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:35:45.524930Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:35:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 70f1ced6-8dab-4267-831e-b2ac4889b2dd
+        status: 200 OK
+        code: 200
+        duration: 73.95113ms
+    - id: 30
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/4eb78672-f8f2-436b-b87c-f3332f7b0265
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 413
+        body: '{"id":"4eb78672-f8f2-436b-b87c-f3332f7b0265","name":"tf_tests_datalabs_ds_basic","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:30:00.558454Z","updated_at":"2026-03-26T11:30:00.558454Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","is_default":false,"private_network_count":1,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "413"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:35:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - dabdd51f-bc4b-40c4-b2c5-65c26653600d
+        status: 200 OK
+        code: 200
+        duration: 58.515716ms
+    - id: 31
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6da7884d-b156-4286-a6c6-4106e34df100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1069
+        body: '{"id":"6da7884d-b156-4286-a6c6-4106e34df100","name":"tf-pn-beautiful-lovelace","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:30:00.699375Z","updated_at":"2026-03-26T11:30:00.699375Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","subnets":[{"id":"6c49683f-81f0-4c57-99b1-c42c1477813d","created_at":"2026-03-26T11:30:00.699375Z","updated_at":"2026-03-26T11:30:00.699375Z","subnet":"172.16.12.0/22","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","vpc_id":"4eb78672-f8f2-436b-b87c-f3332f7b0265"},{"id":"b8089b94-73ab-4dce-82f7-a41f66231036","created_at":"2026-03-26T11:30:00.699375Z","updated_at":"2026-03-26T11:30:00.699375Z","subnet":"fd40:e277:fdde:bcd::/64","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","vpc_id":"4eb78672-f8f2-436b-b87c-f3332f7b0265"}],"vpc_id":"4eb78672-f8f2-436b-b87c-f3332f7b0265","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1069"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:35:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 3e24ed3e-6259-47e8-a43f-8d3b1afbcaee
+        status: 200 OK
+        code: 200
+        duration: 52.132232ms
+    - id: 32
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:35:45.524930Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:35:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 6e611da4-b726-45da-8216-9c17c0bd03db
+        status: 200 OK
+        code: 200
+        duration: 75.0175ms
+    - id: 33
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/4eb78672-f8f2-436b-b87c-f3332f7b0265
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 413
+        body: '{"id":"4eb78672-f8f2-436b-b87c-f3332f7b0265","name":"tf_tests_datalabs_ds_basic","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:30:00.558454Z","updated_at":"2026-03-26T11:30:00.558454Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","is_default":false,"private_network_count":1,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "413"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:35:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - fc0ccf73-34bb-4b76-9fb5-b097d02204b9
+        status: 200 OK
+        code: 200
+        duration: 59.166368ms
+    - id: 34
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - name_asc
+            page:
+                - "1"
+            page_size:
+                - "100"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs?order_by=name_asc&page=1&page_size=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 2787
+        body: '{"datalabs":[{"id":"a95f64a0-aac2-448d-8e6e-3e33ad795cd4","status":"error","project_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","name":"tf-test-lower","description":"","tags":[],"created_at":"2026-03-20T18:03:19.423808Z","updated_at":"2026-03-25T13:01:47.946037Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://a95f64a0-aac2-448d-8e6e-3e33ad795cd4.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-a95f64a0-aac2-448d-8e6e-3e33ad795cd4.08e54e14-d2a4-4020-b8d3-77a1aac8c40f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"08e54e14-d2a4-4020-b8d3-77a1aac8c40f","notebook_master_url":"","region":"fr-par"},{"id":"4d183142-c753-4c02-baa3-b5af60ecf718","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_name","description":"test datalab for data source by name","tags":[],"created_at":"2026-03-26T11:30:01.995071Z","updated_at":"2026-03-26T11:30:01.995071Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://4d183142-c753-4c02-baa3-b5af60ecf718.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-4d183142-c753-4c02-baa3-b5af60ecf718.434418ef-7ec2-41e7-a139-9f30d56acb6f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","notebook_master_url":"","region":"fr-par"},{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:35:45.524930Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}],"total_count":3}'
+        headers:
+            Content-Length:
+                - "2787"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:35:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 6c0c78a9-ed29-4260-aedc-5fbd2428f0ad
+        status: 200 OK
+        code: 200
+        duration: 92.686933ms
+    - id: 35
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6da7884d-b156-4286-a6c6-4106e34df100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1069
+        body: '{"id":"6da7884d-b156-4286-a6c6-4106e34df100","name":"tf-pn-beautiful-lovelace","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:30:00.699375Z","updated_at":"2026-03-26T11:30:00.699375Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","subnets":[{"id":"6c49683f-81f0-4c57-99b1-c42c1477813d","created_at":"2026-03-26T11:30:00.699375Z","updated_at":"2026-03-26T11:30:00.699375Z","subnet":"172.16.12.0/22","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","vpc_id":"4eb78672-f8f2-436b-b87c-f3332f7b0265"},{"id":"b8089b94-73ab-4dce-82f7-a41f66231036","created_at":"2026-03-26T11:30:00.699375Z","updated_at":"2026-03-26T11:30:00.699375Z","subnet":"fd40:e277:fdde:bcd::/64","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","vpc_id":"4eb78672-f8f2-436b-b87c-f3332f7b0265"}],"vpc_id":"4eb78672-f8f2-436b-b87c-f3332f7b0265","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1069"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:35:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 69042798-9b33-4550-8885-5a578508e0bd
+        status: 200 OK
+        code: 200
+        duration: 60.930259ms
+    - id: 36
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:35:45.524930Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:35:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - b1879487-5436-4fc5-b1e0-b798c2f34320
+        status: 200 OK
+        code: 200
+        duration: 72.1377ms
+    - id: 37
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:35:45.524930Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:35:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - c761967b-d556-4713-9598-05ad512a4ba9
+        status: 200 OK
+        code: 200
+        duration: 73.264799ms
+    - id: 38
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - name_asc
+            page:
+                - "1"
+            page_size:
+                - "100"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs?order_by=name_asc&page=1&page_size=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 2787
+        body: '{"datalabs":[{"id":"a95f64a0-aac2-448d-8e6e-3e33ad795cd4","status":"error","project_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","name":"tf-test-lower","description":"","tags":[],"created_at":"2026-03-20T18:03:19.423808Z","updated_at":"2026-03-25T13:01:47.946037Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://a95f64a0-aac2-448d-8e6e-3e33ad795cd4.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-a95f64a0-aac2-448d-8e6e-3e33ad795cd4.08e54e14-d2a4-4020-b8d3-77a1aac8c40f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"08e54e14-d2a4-4020-b8d3-77a1aac8c40f","notebook_master_url":"","region":"fr-par"},{"id":"4d183142-c753-4c02-baa3-b5af60ecf718","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_name","description":"test datalab for data source by name","tags":[],"created_at":"2026-03-26T11:30:01.995071Z","updated_at":"2026-03-26T11:30:01.995071Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://4d183142-c753-4c02-baa3-b5af60ecf718.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-4d183142-c753-4c02-baa3-b5af60ecf718.434418ef-7ec2-41e7-a139-9f30d56acb6f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","notebook_master_url":"","region":"fr-par"},{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:35:45.524930Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}],"total_count":3}'
+        headers:
+            Content-Length:
+                - "2787"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:35:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 264b0304-ab98-4e0b-97bb-7d5f1e7f6576
+        status: 200 OK
+        code: 200
+        duration: 81.790223ms
+    - id: 39
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/4eb78672-f8f2-436b-b87c-f3332f7b0265
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 413
+        body: '{"id":"4eb78672-f8f2-436b-b87c-f3332f7b0265","name":"tf_tests_datalabs_ds_basic","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:30:00.558454Z","updated_at":"2026-03-26T11:30:00.558454Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","is_default":false,"private_network_count":1,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "413"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:35:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 407166fe-56e6-4677-9ffb-e0686c6e81cd
+        status: 200 OK
+        code: 200
+        duration: 56.250259ms
+    - id: 40
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - name_asc
+            page:
+                - "1"
+            page_size:
+                - "100"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs?order_by=name_asc&page=1&page_size=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 2787
+        body: '{"datalabs":[{"id":"a95f64a0-aac2-448d-8e6e-3e33ad795cd4","status":"error","project_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","name":"tf-test-lower","description":"","tags":[],"created_at":"2026-03-20T18:03:19.423808Z","updated_at":"2026-03-25T13:01:47.946037Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://a95f64a0-aac2-448d-8e6e-3e33ad795cd4.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-a95f64a0-aac2-448d-8e6e-3e33ad795cd4.08e54e14-d2a4-4020-b8d3-77a1aac8c40f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"08e54e14-d2a4-4020-b8d3-77a1aac8c40f","notebook_master_url":"","region":"fr-par"},{"id":"4d183142-c753-4c02-baa3-b5af60ecf718","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_name","description":"test datalab for data source by name","tags":[],"created_at":"2026-03-26T11:30:01.995071Z","updated_at":"2026-03-26T11:30:01.995071Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://4d183142-c753-4c02-baa3-b5af60ecf718.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-4d183142-c753-4c02-baa3-b5af60ecf718.434418ef-7ec2-41e7-a139-9f30d56acb6f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","notebook_master_url":"","region":"fr-par"},{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:35:45.524930Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}],"total_count":3}'
+        headers:
+            Content-Length:
+                - "2787"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:35:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 02808493-e3e1-47cb-92bc-5009e028036f
+        status: 200 OK
+        code: 200
+        duration: 105.612266ms
+    - id: 41
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6da7884d-b156-4286-a6c6-4106e34df100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1069
+        body: '{"id":"6da7884d-b156-4286-a6c6-4106e34df100","name":"tf-pn-beautiful-lovelace","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:30:00.699375Z","updated_at":"2026-03-26T11:30:00.699375Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","subnets":[{"id":"6c49683f-81f0-4c57-99b1-c42c1477813d","created_at":"2026-03-26T11:30:00.699375Z","updated_at":"2026-03-26T11:30:00.699375Z","subnet":"172.16.12.0/22","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","vpc_id":"4eb78672-f8f2-436b-b87c-f3332f7b0265"},{"id":"b8089b94-73ab-4dce-82f7-a41f66231036","created_at":"2026-03-26T11:30:00.699375Z","updated_at":"2026-03-26T11:30:00.699375Z","subnet":"fd40:e277:fdde:bcd::/64","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","vpc_id":"4eb78672-f8f2-436b-b87c-f3332f7b0265"}],"vpc_id":"4eb78672-f8f2-436b-b87c-f3332f7b0265","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1069"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:35:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 677f131b-4886-433c-9239-5f629a31cdff
+        status: 200 OK
+        code: 200
+        duration: 49.875944ms
+    - id: 42
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 909
+        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:35:45.524930Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "909"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:35:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 8513c305-3976-48f5-8fc1-0640173a9837
+        status: 200 OK
+        code: 200
+        duration: 68.247477ms
+    - id: 43
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 912
+        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:35:50.865218Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "912"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:35:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 26d6e035-2e94-4b2d-bc62-86997a3714ee
+        status: 200 OK
+        code: 200
+        duration: 169.528763ms
+    - id: 44
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 912
+        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:35:50.865218Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "912"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:35:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 00dd9a7d-dbf2-47da-85de-95d6a3dfde42
+        status: 200 OK
+        code: 200
+        duration: 77.56076ms
+    - id: 45
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 912
+        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:35:50.865218Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "912"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:36:06 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 961ce20c-9933-4d1d-9495-e87b1ddec531
+        status: 200 OK
+        code: 200
+        duration: 63.831233ms
+    - id: 46
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 912
+        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:35:50.865218Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "912"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:36:21 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - c8c99fba-41ad-4add-ad33-6476c200acad
+        status: 200 OK
+        code: 200
+        duration: 66.031186ms
+    - id: 47
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 912
+        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:35:50.865218Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "912"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:36:36 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 19418d26-53fc-420b-a08f-566e9b7060a9
+        status: 200 OK
+        code: 200
+        duration: 80.194691ms
+    - id: 48
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 912
+        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:35:50.865218Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "912"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:36:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 6b41d34c-1531-4005-be05-a01eded32b2b
+        status: 200 OK
+        code: 200
+        duration: 71.302349ms
+    - id: 49
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 912
+        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:35:50.865218Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "912"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:37:06 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - c37d21c1-0fb2-48cc-b657-331e53261fd2
+        status: 200 OK
+        code: 200
+        duration: 83.655215ms
+    - id: 50
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 912
+        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:35:50.865218Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "912"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:37:21 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 32081aae-6874-4b03-a645-ce3e148422d7
+        status: 200 OK
+        code: 200
+        duration: 78.308835ms
+    - id: 51
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 912
+        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:35:50.865218Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "912"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:37:36 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - d06adcd0-057d-42b6-be37-fde6f5e142bc
+        status: 200 OK
+        code: 200
+        duration: 75.603432ms
+    - id: 52
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 912
+        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:35:50.865218Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "912"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:37:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - e05fd88e-33ae-4df2-b492-4bcb7e1a5d98
+        status: 200 OK
+        code: 200
+        duration: 69.743145ms
+    - id: 53
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 912
+        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:35:50.865218Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "912"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:38:06 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 31581d6e-137c-45ba-9b80-361e182c5887
+        status: 200 OK
+        code: 200
+        duration: 71.877561ms
+    - id: 54
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 912
+        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:35:50.865218Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "912"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:38:21 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - e789541b-66ee-46a2-8e61-9d8e641693f8
+        status: 200 OK
+        code: 200
+        duration: 78.803626ms
+    - id: 55
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 912
+        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:35:50.865218Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "912"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:38:36 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - c16c387d-c584-4df0-b16a-dfee517f3595
+        status: 200 OK
+        code: 200
+        duration: 76.846603ms
+    - id: 56
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 128
+        body: '{"message":"resource is not found","resource":"datalab","resource_id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "128"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:38:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - e1785cb9-bfcf-456b-a006-e77f521f531b
+        status: 404 Not Found
+        code: 404
+        duration: 68.696205ms
+    - id: 57
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6da7884d-b156-4286-a6c6-4106e34df100
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:38:53 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - 8d856c96-9906-475a-9cf3-52ed2672ee99
+        status: 204 No Content
+        code: 204
+        duration: 1.565141422s
+    - id: 58
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/4eb78672-f8f2-436b-b87c-f3332f7b0265
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:38:53 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - acc92c3f-da18-4ca7-8a89-4b0b03b97516
+        status: 204 No Content
+        code: 204
+        duration: 443.027032ms
+    - id: 59
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 128
+        body: '{"message":"resource is not found","resource":"datalab","resource_id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "128"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:38:54 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge03)
+            X-Request-Id:
+                - ab8a6f23-2e6c-4d51-978a-d2fc59d7a92e
+        status: 404 Not Found
+        code: 404
+        duration: 57.701752ms

--- a/internal/services/datalab/testdata/datalabs-data-source-basic.cassette.yaml
+++ b/internal/services/datalab/testdata/datalabs-data-source-basic.cassette.yaml
@@ -20,22 +20,22 @@ interactions:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 413
-        body: '{"id":"4eb78672-f8f2-436b-b87c-f3332f7b0265","name":"tf_tests_datalabs_ds_basic","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:30:00.558454Z","updated_at":"2026-03-26T11:30:00.558454Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","is_default":false,"private_network_count":0,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        content_length: 424
+        body: '{"id":"238e523d-a741-46c4-bb6c-a703314c0f40", "name":"tf_tests_datalabs_ds_basic", "tags":[], "organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8", "created_at":"2026-04-01T08:02:25.955095Z", "updated_at":"2026-04-01T08:02:25.955095Z", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "is_default":false, "private_network_count":0, "routing_enabled":true, "custom_routes_propagation_enabled":true, "region":"fr-par"}'
         headers:
             Content-Length:
-                - "413"
+                - "424"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:30:00 GMT
+                - Wed, 01 Apr 2026 08:02:25 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - eee34678-9ec2-4b51-9d04-86309d7da0e7
+                - ccea5153-42ee-4243-b571-d388cddc5fb2
         status: 200 OK
         code: 200
-        duration: 340.068783ms
+        duration: 239.738573ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -46,36 +46,36 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/4eb78672-f8f2-436b-b87c-f3332f7b0265
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/238e523d-a741-46c4-bb6c-a703314c0f40
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 413
-        body: '{"id":"4eb78672-f8f2-436b-b87c-f3332f7b0265","name":"tf_tests_datalabs_ds_basic","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:30:00.558454Z","updated_at":"2026-03-26T11:30:00.558454Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","is_default":false,"private_network_count":0,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        content_length: 424
+        body: '{"id":"238e523d-a741-46c4-bb6c-a703314c0f40", "name":"tf_tests_datalabs_ds_basic", "tags":[], "organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8", "created_at":"2026-04-01T08:02:25.955095Z", "updated_at":"2026-04-01T08:02:25.955095Z", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "is_default":false, "private_network_count":0, "routing_enabled":true, "custom_routes_propagation_enabled":true, "region":"fr-par"}'
         headers:
             Content-Length:
-                - "413"
+                - "424"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:30:00 GMT
+                - Wed, 01 Apr 2026 08:02:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - cd3613e6-46be-4285-877d-d6910b496729
+                - 8b59e98a-f9fc-4b3c-913d-1f011e81f0f7
         status: 200 OK
         code: 200
-        duration: 56.484444ms
+        duration: 87.95212ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 202
+        content_length: 204
         host: api.scaleway.com
-        body: '{"name":"tf-pn-beautiful-lovelace","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","tags":[],"subnets":null,"vpc_id":"4eb78672-f8f2-436b-b87c-f3332f7b0265","default_route_propagation_enabled":false}'
+        body: '{"name":"tf-pn-heuristic-mirzakhani","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","tags":[],"subnets":null,"vpc_id":"238e523d-a741-46c4-bb6c-a703314c0f40","default_route_propagation_enabled":false}'
         headers:
             Content-Type:
                 - application/json
@@ -87,22 +87,22 @@ interactions:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 1069
-        body: '{"id":"6da7884d-b156-4286-a6c6-4106e34df100","name":"tf-pn-beautiful-lovelace","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:30:00.699375Z","updated_at":"2026-03-26T11:30:00.699375Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","subnets":[{"id":"6c49683f-81f0-4c57-99b1-c42c1477813d","created_at":"2026-03-26T11:30:00.699375Z","updated_at":"2026-03-26T11:30:00.699375Z","subnet":"172.16.12.0/22","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","vpc_id":"4eb78672-f8f2-436b-b87c-f3332f7b0265"},{"id":"b8089b94-73ab-4dce-82f7-a41f66231036","created_at":"2026-03-26T11:30:00.699375Z","updated_at":"2026-03-26T11:30:00.699375Z","subnet":"fd40:e277:fdde:bcd::/64","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","vpc_id":"4eb78672-f8f2-436b-b87c-f3332f7b0265"}],"vpc_id":"4eb78672-f8f2-436b-b87c-f3332f7b0265","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        content_length: 1094
+        body: '{"id":"624d976f-2cea-41d2-9a24-9931db474a2b", "name":"tf-pn-heuristic-mirzakhani", "tags":[], "organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8", "created_at":"2026-04-01T08:02:26.313003Z", "updated_at":"2026-04-01T08:02:26.313003Z", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "subnets":[{"id":"fe2964f4-1744-4760-9726-167cf158f31d", "created_at":"2026-04-01T08:02:26.313003Z", "updated_at":"2026-04-01T08:02:26.313003Z", "subnet":"172.16.0.0/22", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "private_network_id":"624d976f-2cea-41d2-9a24-9931db474a2b", "vpc_id":"238e523d-a741-46c4-bb6c-a703314c0f40"}, {"id":"7fd9f017-4e13-439b-98d0-2f95c3c5577e", "created_at":"2026-04-01T08:02:26.313003Z", "updated_at":"2026-04-01T08:02:26.313003Z", "subnet":"fd40:e277:fdde:3bb::/64", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "private_network_id":"624d976f-2cea-41d2-9a24-9931db474a2b", "vpc_id":"238e523d-a741-46c4-bb6c-a703314c0f40"}], "vpc_id":"238e523d-a741-46c4-bb6c-a703314c0f40", "dhcp_enabled":true, "default_route_propagation_enabled":false, "region":"fr-par"}'
         headers:
             Content-Length:
-                - "1069"
+                - "1094"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:30:01 GMT
+                - Wed, 01 Apr 2026 08:02:26 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - cbd76870-6763-44e8-b57b-b1fdb9c023dc
+                - bd884b4f-e2f9-4cb4-bdc6-c48d378ad7cd
         status: 200 OK
         code: 200
-        duration: 842.672093ms
+        duration: 873.011632ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -113,28 +113,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6da7884d-b156-4286-a6c6-4106e34df100
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/624d976f-2cea-41d2-9a24-9931db474a2b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 1069
-        body: '{"id":"6da7884d-b156-4286-a6c6-4106e34df100","name":"tf-pn-beautiful-lovelace","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:30:00.699375Z","updated_at":"2026-03-26T11:30:00.699375Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","subnets":[{"id":"6c49683f-81f0-4c57-99b1-c42c1477813d","created_at":"2026-03-26T11:30:00.699375Z","updated_at":"2026-03-26T11:30:00.699375Z","subnet":"172.16.12.0/22","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","vpc_id":"4eb78672-f8f2-436b-b87c-f3332f7b0265"},{"id":"b8089b94-73ab-4dce-82f7-a41f66231036","created_at":"2026-03-26T11:30:00.699375Z","updated_at":"2026-03-26T11:30:00.699375Z","subnet":"fd40:e277:fdde:bcd::/64","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","vpc_id":"4eb78672-f8f2-436b-b87c-f3332f7b0265"}],"vpc_id":"4eb78672-f8f2-436b-b87c-f3332f7b0265","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        content_length: 1094
+        body: '{"id":"624d976f-2cea-41d2-9a24-9931db474a2b", "name":"tf-pn-heuristic-mirzakhani", "tags":[], "organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8", "created_at":"2026-04-01T08:02:26.313003Z", "updated_at":"2026-04-01T08:02:26.313003Z", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "subnets":[{"id":"fe2964f4-1744-4760-9726-167cf158f31d", "created_at":"2026-04-01T08:02:26.313003Z", "updated_at":"2026-04-01T08:02:26.313003Z", "subnet":"172.16.0.0/22", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "private_network_id":"624d976f-2cea-41d2-9a24-9931db474a2b", "vpc_id":"238e523d-a741-46c4-bb6c-a703314c0f40"}, {"id":"7fd9f017-4e13-439b-98d0-2f95c3c5577e", "created_at":"2026-04-01T08:02:26.313003Z", "updated_at":"2026-04-01T08:02:26.313003Z", "subnet":"fd40:e277:fdde:3bb::/64", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "private_network_id":"624d976f-2cea-41d2-9a24-9931db474a2b", "vpc_id":"238e523d-a741-46c4-bb6c-a703314c0f40"}], "vpc_id":"238e523d-a741-46c4-bb6c-a703314c0f40", "dhcp_enabled":true, "default_route_propagation_enabled":false, "region":"fr-par"}'
         headers:
             Content-Length:
-                - "1069"
+                - "1094"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:30:01 GMT
+                - Wed, 01 Apr 2026 08:02:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 60b41cc5-e655-4a4f-b98c-50e1a16886fe
+                - 38f3b24e-57c5-429b-9500-dec8ff915b96
         status: 200 OK
         code: 200
-        duration: 53.305254ms
+        duration: 78.067907ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -142,7 +142,7 @@ interactions:
         proto_minor: 1
         content_length: 332
         host: api.scaleway.com
-        body: '{"project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":null,"main":{"node_type":"DATALAB-SHARED-4C-8G"},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1},"has_notebook":false,"spark_version":"4.0.0","private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100"}'
+        body: '{"project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":null,"main":{"node_type":"DATALAB-SHARED-4C-8G"},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1},"has_notebook":false,"spark_version":"4.0.0","private_network_id":"624d976f-2cea-41d2-9a24-9931db474a2b"}'
         headers:
             Content-Type:
                 - application/json
@@ -154,22 +154,22 @@ interactions:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 912
-        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:30:01.652478Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        content_length: 936
+        body: '{"id":"33c4e902-0db5-4cff-9cde-086c86acdf5b", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_basic", "description":"", "tags":[], "created_at":"2026-04-01T08:02:27.165967Z", "updated_at":"2026-04-01T08:02:27.165967Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://33c4e902-0db5-4cff-9cde-086c86acdf5b.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-33c4e902-0db5-4cff-9cde-086c86acdf5b.624d976f-2cea-41d2-9a24-9931db474a2b.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"624d976f-2cea-41d2-9a24-9931db474a2b", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "912"
+                - "936"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:30:02 GMT
+                - Wed, 01 Apr 2026 08:02:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 4642ea79-81ac-4481-99ff-acdf9ec0413b
+                - 95fabb67-88da-4efb-90b6-c9f0f25c3078
         status: 200 OK
         code: 200
-        duration: 667.629033ms
+        duration: 701.956747ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -180,28 +180,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/33c4e902-0db5-4cff-9cde-086c86acdf5b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 912
-        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:30:01.652478Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        content_length: 936
+        body: '{"id":"33c4e902-0db5-4cff-9cde-086c86acdf5b", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_basic", "description":"", "tags":[], "created_at":"2026-04-01T08:02:27.165967Z", "updated_at":"2026-04-01T08:02:27.165967Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://33c4e902-0db5-4cff-9cde-086c86acdf5b.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-33c4e902-0db5-4cff-9cde-086c86acdf5b.624d976f-2cea-41d2-9a24-9931db474a2b.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"624d976f-2cea-41d2-9a24-9931db474a2b", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "912"
+                - "936"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:30:02 GMT
+                - Wed, 01 Apr 2026 08:02:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - eb0140cd-c419-4f8c-810b-be657fd0edb6
+                - 788406ec-2969-4462-91ab-2e93d4bc55b1
         status: 200 OK
         code: 200
-        duration: 72.907999ms
+        duration: 93.979389ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -212,28 +212,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/33c4e902-0db5-4cff-9cde-086c86acdf5b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 912
-        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:30:01.652478Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        content_length: 936
+        body: '{"id":"33c4e902-0db5-4cff-9cde-086c86acdf5b", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_basic", "description":"", "tags":[], "created_at":"2026-04-01T08:02:27.165967Z", "updated_at":"2026-04-01T08:02:27.165967Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://33c4e902-0db5-4cff-9cde-086c86acdf5b.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-33c4e902-0db5-4cff-9cde-086c86acdf5b.624d976f-2cea-41d2-9a24-9931db474a2b.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"624d976f-2cea-41d2-9a24-9931db474a2b", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "912"
+                - "936"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:30:17 GMT
+                - Wed, 01 Apr 2026 08:02:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - ccd0543d-a8b5-4e92-8362-5bf664ff93d5
+                - 193675bb-6f05-4ed2-beef-257b2deddf1a
         status: 200 OK
         code: 200
-        duration: 73.363178ms
+        duration: 78.553691ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -244,28 +244,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/33c4e902-0db5-4cff-9cde-086c86acdf5b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 912
-        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:30:01.652478Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        content_length: 936
+        body: '{"id":"33c4e902-0db5-4cff-9cde-086c86acdf5b", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_basic", "description":"", "tags":[], "created_at":"2026-04-01T08:02:27.165967Z", "updated_at":"2026-04-01T08:02:27.165967Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://33c4e902-0db5-4cff-9cde-086c86acdf5b.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-33c4e902-0db5-4cff-9cde-086c86acdf5b.624d976f-2cea-41d2-9a24-9931db474a2b.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"624d976f-2cea-41d2-9a24-9931db474a2b", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "912"
+                - "936"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:30:32 GMT
+                - Wed, 01 Apr 2026 08:02:57 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 0aaab327-fd72-4331-b6cc-a7de03070b86
+                - f0c89974-b99b-4aef-8a51-89c279024f89
         status: 200 OK
         code: 200
-        duration: 68.959749ms
+        duration: 81.391635ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -276,28 +276,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/33c4e902-0db5-4cff-9cde-086c86acdf5b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 912
-        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:30:01.652478Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        content_length: 936
+        body: '{"id":"33c4e902-0db5-4cff-9cde-086c86acdf5b", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_basic", "description":"", "tags":[], "created_at":"2026-04-01T08:02:27.165967Z", "updated_at":"2026-04-01T08:02:27.165967Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://33c4e902-0db5-4cff-9cde-086c86acdf5b.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-33c4e902-0db5-4cff-9cde-086c86acdf5b.624d976f-2cea-41d2-9a24-9931db474a2b.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"624d976f-2cea-41d2-9a24-9931db474a2b", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "912"
+                - "936"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:30:47 GMT
+                - Wed, 01 Apr 2026 08:03:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - af14d1bd-d215-42fc-aced-e28acb732aeb
+                - 26baca4d-83b3-4022-8a82-5501018700bd
         status: 200 OK
         code: 200
-        duration: 72.622006ms
+        duration: 78.997676ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -308,28 +308,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/33c4e902-0db5-4cff-9cde-086c86acdf5b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 912
-        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:30:01.652478Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        content_length: 936
+        body: '{"id":"33c4e902-0db5-4cff-9cde-086c86acdf5b", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_basic", "description":"", "tags":[], "created_at":"2026-04-01T08:02:27.165967Z", "updated_at":"2026-04-01T08:02:27.165967Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://33c4e902-0db5-4cff-9cde-086c86acdf5b.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-33c4e902-0db5-4cff-9cde-086c86acdf5b.624d976f-2cea-41d2-9a24-9931db474a2b.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"624d976f-2cea-41d2-9a24-9931db474a2b", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "912"
+                - "936"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:31:02 GMT
+                - Wed, 01 Apr 2026 08:03:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - d7ae6861-b9d6-4867-885f-9aec486eed03
+                - f354b936-0c4f-4aa6-9f5b-9e0f4fbeaede
         status: 200 OK
         code: 200
-        duration: 81.381415ms
+        duration: 105.476669ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -340,28 +340,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/33c4e902-0db5-4cff-9cde-086c86acdf5b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 912
-        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:30:01.652478Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        content_length: 936
+        body: '{"id":"33c4e902-0db5-4cff-9cde-086c86acdf5b", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_basic", "description":"", "tags":[], "created_at":"2026-04-01T08:02:27.165967Z", "updated_at":"2026-04-01T08:02:27.165967Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://33c4e902-0db5-4cff-9cde-086c86acdf5b.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-33c4e902-0db5-4cff-9cde-086c86acdf5b.624d976f-2cea-41d2-9a24-9931db474a2b.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"624d976f-2cea-41d2-9a24-9931db474a2b", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "912"
+                - "936"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:31:17 GMT
+                - Wed, 01 Apr 2026 08:03:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - b5025b87-9b11-4062-a166-d0dcaec7a968
+                - 91e3145a-11ce-488b-abd5-2ecf16b2d219
         status: 200 OK
         code: 200
-        duration: 81.074463ms
+        duration: 86.382483ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -372,28 +372,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/33c4e902-0db5-4cff-9cde-086c86acdf5b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 912
-        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:30:01.652478Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        content_length: 936
+        body: '{"id":"33c4e902-0db5-4cff-9cde-086c86acdf5b", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_basic", "description":"", "tags":[], "created_at":"2026-04-01T08:02:27.165967Z", "updated_at":"2026-04-01T08:02:27.165967Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://33c4e902-0db5-4cff-9cde-086c86acdf5b.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-33c4e902-0db5-4cff-9cde-086c86acdf5b.624d976f-2cea-41d2-9a24-9931db474a2b.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"624d976f-2cea-41d2-9a24-9931db474a2b", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "912"
+                - "936"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:31:32 GMT
+                - Wed, 01 Apr 2026 08:03:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - a61b0485-480b-40d0-a79a-de35e397d461
+                - cb8253e6-d59d-4b02-a630-95e058aa16d8
         status: 200 OK
         code: 200
-        duration: 86.089366ms
+        duration: 80.8069ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -404,28 +404,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/33c4e902-0db5-4cff-9cde-086c86acdf5b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 912
-        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:30:01.652478Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        content_length: 936
+        body: '{"id":"33c4e902-0db5-4cff-9cde-086c86acdf5b", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_basic", "description":"", "tags":[], "created_at":"2026-04-01T08:02:27.165967Z", "updated_at":"2026-04-01T08:02:27.165967Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://33c4e902-0db5-4cff-9cde-086c86acdf5b.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-33c4e902-0db5-4cff-9cde-086c86acdf5b.624d976f-2cea-41d2-9a24-9931db474a2b.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"624d976f-2cea-41d2-9a24-9931db474a2b", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "912"
+                - "936"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:31:47 GMT
+                - Wed, 01 Apr 2026 08:04:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - a7762043-897d-4e07-88aa-4e68b7ac556c
+                - 45107ac4-4782-451e-a9dc-a1ccbd9233cc
         status: 200 OK
         code: 200
-        duration: 64.935371ms
+        duration: 81.924106ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -436,28 +436,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/33c4e902-0db5-4cff-9cde-086c86acdf5b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 912
-        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:30:01.652478Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        content_length: 936
+        body: '{"id":"33c4e902-0db5-4cff-9cde-086c86acdf5b", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_basic", "description":"", "tags":[], "created_at":"2026-04-01T08:02:27.165967Z", "updated_at":"2026-04-01T08:02:27.165967Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://33c4e902-0db5-4cff-9cde-086c86acdf5b.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-33c4e902-0db5-4cff-9cde-086c86acdf5b.624d976f-2cea-41d2-9a24-9931db474a2b.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"624d976f-2cea-41d2-9a24-9931db474a2b", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "912"
+                - "936"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:32:02 GMT
+                - Wed, 01 Apr 2026 08:04:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 29fb1e49-2405-4fba-96fd-2a9f6362b023
+                - dc4fc07a-7e37-4c91-81e8-f95ca8cdfb14
         status: 200 OK
         code: 200
-        duration: 71.472486ms
+        duration: 81.815179ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -468,28 +468,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/33c4e902-0db5-4cff-9cde-086c86acdf5b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 912
-        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:30:01.652478Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        content_length: 936
+        body: '{"id":"33c4e902-0db5-4cff-9cde-086c86acdf5b", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_basic", "description":"", "tags":[], "created_at":"2026-04-01T08:02:27.165967Z", "updated_at":"2026-04-01T08:02:27.165967Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://33c4e902-0db5-4cff-9cde-086c86acdf5b.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-33c4e902-0db5-4cff-9cde-086c86acdf5b.624d976f-2cea-41d2-9a24-9931db474a2b.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"624d976f-2cea-41d2-9a24-9931db474a2b", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "912"
+                - "936"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:32:17 GMT
+                - Wed, 01 Apr 2026 08:04:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 0e03af0f-b269-4d48-b268-ed9fcc39f410
+                - 88d7d826-b308-4187-a770-d2adccf4864b
         status: 200 OK
         code: 200
-        duration: 93.847011ms
+        duration: 107.788125ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -500,28 +500,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/33c4e902-0db5-4cff-9cde-086c86acdf5b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 912
-        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:30:01.652478Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        content_length: 936
+        body: '{"id":"33c4e902-0db5-4cff-9cde-086c86acdf5b", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_basic", "description":"", "tags":[], "created_at":"2026-04-01T08:02:27.165967Z", "updated_at":"2026-04-01T08:02:27.165967Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://33c4e902-0db5-4cff-9cde-086c86acdf5b.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-33c4e902-0db5-4cff-9cde-086c86acdf5b.624d976f-2cea-41d2-9a24-9931db474a2b.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"624d976f-2cea-41d2-9a24-9931db474a2b", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "912"
+                - "936"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:32:33 GMT
+                - Wed, 01 Apr 2026 08:04:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - aa135f7f-3304-4a9c-a337-952d5bfddc37
+                - db4472d3-3d05-4d55-980a-e88b4a536c17
         status: 200 OK
         code: 200
-        duration: 97.491739ms
+        duration: 92.794926ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -532,28 +532,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/33c4e902-0db5-4cff-9cde-086c86acdf5b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 912
-        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:30:01.652478Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        content_length: 936
+        body: '{"id":"33c4e902-0db5-4cff-9cde-086c86acdf5b", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_basic", "description":"", "tags":[], "created_at":"2026-04-01T08:02:27.165967Z", "updated_at":"2026-04-01T08:02:27.165967Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://33c4e902-0db5-4cff-9cde-086c86acdf5b.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-33c4e902-0db5-4cff-9cde-086c86acdf5b.624d976f-2cea-41d2-9a24-9931db474a2b.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"624d976f-2cea-41d2-9a24-9931db474a2b", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "912"
+                - "936"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:32:48 GMT
+                - Wed, 01 Apr 2026 08:05:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 9571775a-3e7e-4a87-b836-2685893037ed
+                - 5a5a8cf1-a355-4cf7-bdc5-69745d45d237
         status: 200 OK
         code: 200
-        duration: 164.866318ms
+        duration: 80.441758ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -564,28 +564,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/33c4e902-0db5-4cff-9cde-086c86acdf5b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 912
-        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:30:01.652478Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        content_length: 936
+        body: '{"id":"33c4e902-0db5-4cff-9cde-086c86acdf5b", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_basic", "description":"", "tags":[], "created_at":"2026-04-01T08:02:27.165967Z", "updated_at":"2026-04-01T08:02:27.165967Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://33c4e902-0db5-4cff-9cde-086c86acdf5b.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-33c4e902-0db5-4cff-9cde-086c86acdf5b.624d976f-2cea-41d2-9a24-9931db474a2b.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"624d976f-2cea-41d2-9a24-9931db474a2b", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "912"
+                - "936"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:33:03 GMT
+                - Wed, 01 Apr 2026 08:05:28 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 56a3e93b-c90e-4287-b04d-7b404b5d1201
+                - bd15041e-01d2-425a-a8f2-7e5cc7da623d
         status: 200 OK
         code: 200
-        duration: 71.449197ms
+        duration: 85.3238ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -596,28 +596,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/33c4e902-0db5-4cff-9cde-086c86acdf5b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 912
-        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:30:01.652478Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        content_length: 936
+        body: '{"id":"33c4e902-0db5-4cff-9cde-086c86acdf5b", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_basic", "description":"", "tags":[], "created_at":"2026-04-01T08:02:27.165967Z", "updated_at":"2026-04-01T08:02:27.165967Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://33c4e902-0db5-4cff-9cde-086c86acdf5b.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-33c4e902-0db5-4cff-9cde-086c86acdf5b.624d976f-2cea-41d2-9a24-9931db474a2b.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"624d976f-2cea-41d2-9a24-9931db474a2b", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "912"
+                - "936"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:33:18 GMT
+                - Wed, 01 Apr 2026 08:05:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 96c40346-ed5a-450a-9a99-6e6211f9ef83
+                - 341acd9b-f9da-4476-b0f1-630c783aa4c7
         status: 200 OK
         code: 200
-        duration: 75.68529ms
+        duration: 108.824062ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -628,28 +628,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/33c4e902-0db5-4cff-9cde-086c86acdf5b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 912
-        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:30:01.652478Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        content_length: 936
+        body: '{"id":"33c4e902-0db5-4cff-9cde-086c86acdf5b", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_basic", "description":"", "tags":[], "created_at":"2026-04-01T08:02:27.165967Z", "updated_at":"2026-04-01T08:02:27.165967Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://33c4e902-0db5-4cff-9cde-086c86acdf5b.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-33c4e902-0db5-4cff-9cde-086c86acdf5b.624d976f-2cea-41d2-9a24-9931db474a2b.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"624d976f-2cea-41d2-9a24-9931db474a2b", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "912"
+                - "936"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:33:33 GMT
+                - Wed, 01 Apr 2026 08:05:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - d8d91f76-bf86-48fe-a326-c970d8fd3266
+                - 5c6f10b1-c462-4c26-86b9-65776da7a460
         status: 200 OK
         code: 200
-        duration: 84.155295ms
+        duration: 72.967842ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -660,28 +660,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/33c4e902-0db5-4cff-9cde-086c86acdf5b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 912
-        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:30:01.652478Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        content_length: 936
+        body: '{"id":"33c4e902-0db5-4cff-9cde-086c86acdf5b", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_basic", "description":"", "tags":[], "created_at":"2026-04-01T08:02:27.165967Z", "updated_at":"2026-04-01T08:02:27.165967Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://33c4e902-0db5-4cff-9cde-086c86acdf5b.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-33c4e902-0db5-4cff-9cde-086c86acdf5b.624d976f-2cea-41d2-9a24-9931db474a2b.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"624d976f-2cea-41d2-9a24-9931db474a2b", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "912"
+                - "936"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:33:48 GMT
+                - Wed, 01 Apr 2026 08:06:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 765a7924-1f13-47f7-afc9-792210e9fe33
+                - 0ea77019-cec2-425f-a445-556634502da1
         status: 200 OK
         code: 200
-        duration: 72.892121ms
+        duration: 92.749315ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -692,28 +692,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/33c4e902-0db5-4cff-9cde-086c86acdf5b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 912
-        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:30:01.652478Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        content_length: 936
+        body: '{"id":"33c4e902-0db5-4cff-9cde-086c86acdf5b", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_basic", "description":"", "tags":[], "created_at":"2026-04-01T08:02:27.165967Z", "updated_at":"2026-04-01T08:02:27.165967Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://33c4e902-0db5-4cff-9cde-086c86acdf5b.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-33c4e902-0db5-4cff-9cde-086c86acdf5b.624d976f-2cea-41d2-9a24-9931db474a2b.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"624d976f-2cea-41d2-9a24-9931db474a2b", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "912"
+                - "936"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:34:03 GMT
+                - Wed, 01 Apr 2026 08:06:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - c81e628f-326d-4dc5-a1fb-360208a4ea4f
+                - f497b594-1cbb-47c9-b295-c41dc33e6bc9
         status: 200 OK
         code: 200
-        duration: 79.399456ms
+        duration: 84.24121ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -724,28 +724,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/33c4e902-0db5-4cff-9cde-086c86acdf5b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 912
-        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:30:01.652478Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        content_length: 936
+        body: '{"id":"33c4e902-0db5-4cff-9cde-086c86acdf5b", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_basic", "description":"", "tags":[], "created_at":"2026-04-01T08:02:27.165967Z", "updated_at":"2026-04-01T08:02:27.165967Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://33c4e902-0db5-4cff-9cde-086c86acdf5b.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-33c4e902-0db5-4cff-9cde-086c86acdf5b.624d976f-2cea-41d2-9a24-9931db474a2b.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"624d976f-2cea-41d2-9a24-9931db474a2b", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "912"
+                - "936"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:34:18 GMT
+                - Wed, 01 Apr 2026 08:06:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 2588458f-8c8a-4c5a-b9d4-3aa6ec69cb32
+                - 2c117a71-8489-496f-a8c3-f63b30b76b00
         status: 200 OK
         code: 200
-        duration: 72.142649ms
+        duration: 78.639919ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -756,28 +756,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/33c4e902-0db5-4cff-9cde-086c86acdf5b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 912
-        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:30:01.652478Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        content_length: 936
+        body: '{"id":"33c4e902-0db5-4cff-9cde-086c86acdf5b", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_basic", "description":"", "tags":[], "created_at":"2026-04-01T08:02:27.165967Z", "updated_at":"2026-04-01T08:02:27.165967Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://33c4e902-0db5-4cff-9cde-086c86acdf5b.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-33c4e902-0db5-4cff-9cde-086c86acdf5b.624d976f-2cea-41d2-9a24-9931db474a2b.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"624d976f-2cea-41d2-9a24-9931db474a2b", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "912"
+                - "936"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:34:33 GMT
+                - Wed, 01 Apr 2026 08:06:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 9a995c6a-0682-4e3d-840f-d7881880ab26
+                - 85e9a6aa-4e53-4a6a-9006-26ca5e7312e4
         status: 200 OK
         code: 200
-        duration: 80.526697ms
+        duration: 89.240759ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -788,28 +788,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/33c4e902-0db5-4cff-9cde-086c86acdf5b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 912
-        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:30:01.652478Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        content_length: 936
+        body: '{"id":"33c4e902-0db5-4cff-9cde-086c86acdf5b", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_basic", "description":"", "tags":[], "created_at":"2026-04-01T08:02:27.165967Z", "updated_at":"2026-04-01T08:02:27.165967Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://33c4e902-0db5-4cff-9cde-086c86acdf5b.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-33c4e902-0db5-4cff-9cde-086c86acdf5b.624d976f-2cea-41d2-9a24-9931db474a2b.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"624d976f-2cea-41d2-9a24-9931db474a2b", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "912"
+                - "936"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:34:48 GMT
+                - Wed, 01 Apr 2026 08:07:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 2e7c00af-db93-48de-a33c-855f2c854675
+                - 5eae234b-104a-4610-b4ff-c8caf9592edd
         status: 200 OK
         code: 200
-        duration: 81.735727ms
+        duration: 83.664837ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -820,28 +820,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/33c4e902-0db5-4cff-9cde-086c86acdf5b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 912
-        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:30:01.652478Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        content_length: 936
+        body: '{"id":"33c4e902-0db5-4cff-9cde-086c86acdf5b", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_basic", "description":"", "tags":[], "created_at":"2026-04-01T08:02:27.165967Z", "updated_at":"2026-04-01T08:02:27.165967Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://33c4e902-0db5-4cff-9cde-086c86acdf5b.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-33c4e902-0db5-4cff-9cde-086c86acdf5b.624d976f-2cea-41d2-9a24-9931db474a2b.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"624d976f-2cea-41d2-9a24-9931db474a2b", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "912"
+                - "936"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:35:04 GMT
+                - Wed, 01 Apr 2026 08:07:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - d3134e6d-d1a5-4683-95c4-c92bed572f92
+                - 411f5486-0dec-4653-a5e2-40c72d5b5f31
         status: 200 OK
         code: 200
-        duration: 85.755196ms
+        duration: 80.619958ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -852,28 +852,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/33c4e902-0db5-4cff-9cde-086c86acdf5b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 912
-        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:30:01.652478Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        content_length: 936
+        body: '{"id":"33c4e902-0db5-4cff-9cde-086c86acdf5b", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_basic", "description":"", "tags":[], "created_at":"2026-04-01T08:02:27.165967Z", "updated_at":"2026-04-01T08:02:27.165967Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://33c4e902-0db5-4cff-9cde-086c86acdf5b.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-33c4e902-0db5-4cff-9cde-086c86acdf5b.624d976f-2cea-41d2-9a24-9931db474a2b.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"624d976f-2cea-41d2-9a24-9931db474a2b", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "912"
+                - "936"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:35:19 GMT
+                - Wed, 01 Apr 2026 08:07:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 67ca1f6f-eee9-47ef-93c6-cec74864af84
+                - 48f555a2-0bda-4c2f-928a-ca317ae4060a
         status: 200 OK
         code: 200
-        duration: 76.909189ms
+        duration: 85.51144ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -884,28 +884,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/33c4e902-0db5-4cff-9cde-086c86acdf5b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 912
-        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:30:01.652478Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        content_length: 936
+        body: '{"id":"33c4e902-0db5-4cff-9cde-086c86acdf5b", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_basic", "description":"", "tags":[], "created_at":"2026-04-01T08:02:27.165967Z", "updated_at":"2026-04-01T08:02:27.165967Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://33c4e902-0db5-4cff-9cde-086c86acdf5b.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-33c4e902-0db5-4cff-9cde-086c86acdf5b.624d976f-2cea-41d2-9a24-9931db474a2b.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"624d976f-2cea-41d2-9a24-9931db474a2b", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "912"
+                - "936"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:35:34 GMT
+                - Wed, 01 Apr 2026 08:07:59 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 3d444a51-dfff-4b8c-b9f1-e7a61dad0ebc
+                - 2713ee87-338e-4ac1-92d5-d220fad0db99
         status: 200 OK
         code: 200
-        duration: 80.118308ms
+        duration: 92.283745ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -916,28 +916,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/33c4e902-0db5-4cff-9cde-086c86acdf5b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 909
-        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:35:45.524930Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        content_length: 933
+        body: '{"id":"33c4e902-0db5-4cff-9cde-086c86acdf5b", "status":"ready", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_basic", "description":"", "tags":[], "created_at":"2026-04-01T08:02:27.165967Z", "updated_at":"2026-04-01T08:08:09.811606Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://33c4e902-0db5-4cff-9cde-086c86acdf5b.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-33c4e902-0db5-4cff-9cde-086c86acdf5b.624d976f-2cea-41d2-9a24-9931db474a2b.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"624d976f-2cea-41d2-9a24-9931db474a2b", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "909"
+                - "933"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:35:49 GMT
+                - Wed, 01 Apr 2026 08:08:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 86752253-0725-4e83-8048-87f20627fddd
+                - 8b1cdb4d-6448-440e-b7e3-adb26c39a815
         status: 200 OK
         code: 200
-        duration: 98.835133ms
+        duration: 90.820879ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -948,28 +948,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/33c4e902-0db5-4cff-9cde-086c86acdf5b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 909
-        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:35:45.524930Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        content_length: 933
+        body: '{"id":"33c4e902-0db5-4cff-9cde-086c86acdf5b", "status":"ready", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_basic", "description":"", "tags":[], "created_at":"2026-04-01T08:02:27.165967Z", "updated_at":"2026-04-01T08:08:09.811606Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://33c4e902-0db5-4cff-9cde-086c86acdf5b.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-33c4e902-0db5-4cff-9cde-086c86acdf5b.624d976f-2cea-41d2-9a24-9931db474a2b.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"624d976f-2cea-41d2-9a24-9931db474a2b", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "909"
+                - "933"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:35:49 GMT
+                - Wed, 01 Apr 2026 08:08:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 70f1ced6-8dab-4267-831e-b2ac4889b2dd
+                - 0718feb7-5300-42a2-9193-8cf48c2904f8
         status: 200 OK
         code: 200
-        duration: 73.95113ms
+        duration: 72.767963ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -980,28 +980,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/4eb78672-f8f2-436b-b87c-f3332f7b0265
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/238e523d-a741-46c4-bb6c-a703314c0f40
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 413
-        body: '{"id":"4eb78672-f8f2-436b-b87c-f3332f7b0265","name":"tf_tests_datalabs_ds_basic","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:30:00.558454Z","updated_at":"2026-03-26T11:30:00.558454Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","is_default":false,"private_network_count":1,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        content_length: 424
+        body: '{"id":"238e523d-a741-46c4-bb6c-a703314c0f40", "name":"tf_tests_datalabs_ds_basic", "tags":[], "organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8", "created_at":"2026-04-01T08:02:25.955095Z", "updated_at":"2026-04-01T08:02:25.955095Z", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "is_default":false, "private_network_count":1, "routing_enabled":true, "custom_routes_propagation_enabled":true, "region":"fr-par"}'
         headers:
             Content-Length:
-                - "413"
+                - "424"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:35:49 GMT
+                - Wed, 01 Apr 2026 08:08:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - dabdd51f-bc4b-40c4-b2c5-65c26653600d
+                - 1d544f80-5ba3-44d6-be83-ab4f3df3b586
         status: 200 OK
         code: 200
-        duration: 58.515716ms
+        duration: 74.711495ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1012,28 +1012,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6da7884d-b156-4286-a6c6-4106e34df100
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/624d976f-2cea-41d2-9a24-9931db474a2b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 1069
-        body: '{"id":"6da7884d-b156-4286-a6c6-4106e34df100","name":"tf-pn-beautiful-lovelace","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:30:00.699375Z","updated_at":"2026-03-26T11:30:00.699375Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","subnets":[{"id":"6c49683f-81f0-4c57-99b1-c42c1477813d","created_at":"2026-03-26T11:30:00.699375Z","updated_at":"2026-03-26T11:30:00.699375Z","subnet":"172.16.12.0/22","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","vpc_id":"4eb78672-f8f2-436b-b87c-f3332f7b0265"},{"id":"b8089b94-73ab-4dce-82f7-a41f66231036","created_at":"2026-03-26T11:30:00.699375Z","updated_at":"2026-03-26T11:30:00.699375Z","subnet":"fd40:e277:fdde:bcd::/64","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","vpc_id":"4eb78672-f8f2-436b-b87c-f3332f7b0265"}],"vpc_id":"4eb78672-f8f2-436b-b87c-f3332f7b0265","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        content_length: 1094
+        body: '{"id":"624d976f-2cea-41d2-9a24-9931db474a2b", "name":"tf-pn-heuristic-mirzakhani", "tags":[], "organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8", "created_at":"2026-04-01T08:02:26.313003Z", "updated_at":"2026-04-01T08:02:26.313003Z", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "subnets":[{"id":"fe2964f4-1744-4760-9726-167cf158f31d", "created_at":"2026-04-01T08:02:26.313003Z", "updated_at":"2026-04-01T08:02:26.313003Z", "subnet":"172.16.0.0/22", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "private_network_id":"624d976f-2cea-41d2-9a24-9931db474a2b", "vpc_id":"238e523d-a741-46c4-bb6c-a703314c0f40"}, {"id":"7fd9f017-4e13-439b-98d0-2f95c3c5577e", "created_at":"2026-04-01T08:02:26.313003Z", "updated_at":"2026-04-01T08:02:26.313003Z", "subnet":"fd40:e277:fdde:3bb::/64", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "private_network_id":"624d976f-2cea-41d2-9a24-9931db474a2b", "vpc_id":"238e523d-a741-46c4-bb6c-a703314c0f40"}], "vpc_id":"238e523d-a741-46c4-bb6c-a703314c0f40", "dhcp_enabled":true, "default_route_propagation_enabled":false, "region":"fr-par"}'
         headers:
             Content-Length:
-                - "1069"
+                - "1094"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:35:49 GMT
+                - Wed, 01 Apr 2026 08:08:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 3e24ed3e-6259-47e8-a43f-8d3b1afbcaee
+                - 12549ec7-bb31-4795-8e11-67533e50c09e
         status: 200 OK
         code: 200
-        duration: 52.132232ms
+        duration: 75.723455ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1044,28 +1044,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/33c4e902-0db5-4cff-9cde-086c86acdf5b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 909
-        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:35:45.524930Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        content_length: 933
+        body: '{"id":"33c4e902-0db5-4cff-9cde-086c86acdf5b", "status":"ready", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_basic", "description":"", "tags":[], "created_at":"2026-04-01T08:02:27.165967Z", "updated_at":"2026-04-01T08:08:09.811606Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://33c4e902-0db5-4cff-9cde-086c86acdf5b.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-33c4e902-0db5-4cff-9cde-086c86acdf5b.624d976f-2cea-41d2-9a24-9931db474a2b.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"624d976f-2cea-41d2-9a24-9931db474a2b", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "909"
+                - "933"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:35:49 GMT
+                - Wed, 01 Apr 2026 08:08:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 6e611da4-b726-45da-8216-9c17c0bd03db
+                - aae99f19-94eb-4a5c-a8a1-61646cfdcad6
         status: 200 OK
         code: 200
-        duration: 75.0175ms
+        duration: 83.444362ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1076,28 +1076,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/4eb78672-f8f2-436b-b87c-f3332f7b0265
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/238e523d-a741-46c4-bb6c-a703314c0f40
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 413
-        body: '{"id":"4eb78672-f8f2-436b-b87c-f3332f7b0265","name":"tf_tests_datalabs_ds_basic","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:30:00.558454Z","updated_at":"2026-03-26T11:30:00.558454Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","is_default":false,"private_network_count":1,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        content_length: 424
+        body: '{"id":"238e523d-a741-46c4-bb6c-a703314c0f40", "name":"tf_tests_datalabs_ds_basic", "tags":[], "organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8", "created_at":"2026-04-01T08:02:25.955095Z", "updated_at":"2026-04-01T08:02:25.955095Z", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "is_default":false, "private_network_count":1, "routing_enabled":true, "custom_routes_propagation_enabled":true, "region":"fr-par"}'
         headers:
             Content-Length:
-                - "413"
+                - "424"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:35:49 GMT
+                - Wed, 01 Apr 2026 08:08:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - fc0ccf73-34bb-4b76-9fb5-b097d02204b9
+                - 97eccf9f-185a-46dd-bd82-c94d41f193e6
         status: 200 OK
         code: 200
-        duration: 59.166368ms
+        duration: 76.589169ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1110,33 +1110,31 @@ interactions:
                 - name_asc
             page:
                 - "1"
-            page_size:
-                - "100"
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs?order_by=name_asc&page=1&page_size=100
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs?order_by=name_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 2787
-        body: '{"datalabs":[{"id":"a95f64a0-aac2-448d-8e6e-3e33ad795cd4","status":"error","project_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","name":"tf-test-lower","description":"","tags":[],"created_at":"2026-03-20T18:03:19.423808Z","updated_at":"2026-03-25T13:01:47.946037Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://a95f64a0-aac2-448d-8e6e-3e33ad795cd4.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-a95f64a0-aac2-448d-8e6e-3e33ad795cd4.08e54e14-d2a4-4020-b8d3-77a1aac8c40f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"08e54e14-d2a4-4020-b8d3-77a1aac8c40f","notebook_master_url":"","region":"fr-par"},{"id":"4d183142-c753-4c02-baa3-b5af60ecf718","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_name","description":"test datalab for data source by name","tags":[],"created_at":"2026-03-26T11:30:01.995071Z","updated_at":"2026-03-26T11:30:01.995071Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://4d183142-c753-4c02-baa3-b5af60ecf718.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-4d183142-c753-4c02-baa3-b5af60ecf718.434418ef-7ec2-41e7-a139-9f30d56acb6f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","notebook_master_url":"","region":"fr-par"},{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:35:45.524930Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}],"total_count":3}'
+        content_length: 2821
+        body: '{"datalabs":[{"id":"a95f64a0-aac2-448d-8e6e-3e33ad795cd4", "status":"error", "project_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8", "name":"tf-test-lower", "description":"", "tags":[], "created_at":"2026-03-20T18:03:19.423808Z", "updated_at":"2026-03-25T13:01:47.946037Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://a95f64a0-aac2-448d-8e6e-3e33ad795cd4.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-a95f64a0-aac2-448d-8e6e-3e33ad795cd4.08e54e14-d2a4-4020-b8d3-77a1aac8c40f.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"08e54e14-d2a4-4020-b8d3-77a1aac8c40f", "notebook_master_url":"", "region":"fr-par"}, {"id":"33c4e902-0db5-4cff-9cde-086c86acdf5b", "status":"ready", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_basic", "description":"", "tags":[], "created_at":"2026-04-01T08:02:27.165967Z", "updated_at":"2026-04-01T08:08:09.811606Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://33c4e902-0db5-4cff-9cde-086c86acdf5b.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-33c4e902-0db5-4cff-9cde-086c86acdf5b.624d976f-2cea-41d2-9a24-9931db474a2b.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"624d976f-2cea-41d2-9a24-9931db474a2b", "notebook_master_url":"", "region":"fr-par"}, {"id":"0047ff02-6953-4ef0-bfb1-c093796e0477", "status":"ready", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_name", "description":"", "tags":[], "created_at":"2026-04-01T08:02:27.052181Z", "updated_at":"2026-04-01T08:08:03.972492Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://0047ff02-6953-4ef0-bfb1-c093796e0477.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-0047ff02-6953-4ef0-bfb1-c093796e0477.593f0960-2d24-404e-88c5-af99a6454020.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"593f0960-2d24-404e-88c5-af99a6454020", "notebook_master_url":"", "region":"fr-par"}], "total_count":3}'
         headers:
             Content-Length:
-                - "2787"
+                - "2821"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:35:49 GMT
+                - Wed, 01 Apr 2026 08:08:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 6c0c78a9-ed29-4260-aedc-5fbd2428f0ad
+                - 701957ef-266d-491e-97f0-188c211042b6
         status: 200 OK
         code: 200
-        duration: 92.686933ms
+        duration: 101.272514ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1147,28 +1145,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6da7884d-b156-4286-a6c6-4106e34df100
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/624d976f-2cea-41d2-9a24-9931db474a2b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 1069
-        body: '{"id":"6da7884d-b156-4286-a6c6-4106e34df100","name":"tf-pn-beautiful-lovelace","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:30:00.699375Z","updated_at":"2026-03-26T11:30:00.699375Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","subnets":[{"id":"6c49683f-81f0-4c57-99b1-c42c1477813d","created_at":"2026-03-26T11:30:00.699375Z","updated_at":"2026-03-26T11:30:00.699375Z","subnet":"172.16.12.0/22","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","vpc_id":"4eb78672-f8f2-436b-b87c-f3332f7b0265"},{"id":"b8089b94-73ab-4dce-82f7-a41f66231036","created_at":"2026-03-26T11:30:00.699375Z","updated_at":"2026-03-26T11:30:00.699375Z","subnet":"fd40:e277:fdde:bcd::/64","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","vpc_id":"4eb78672-f8f2-436b-b87c-f3332f7b0265"}],"vpc_id":"4eb78672-f8f2-436b-b87c-f3332f7b0265","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        content_length: 1094
+        body: '{"id":"624d976f-2cea-41d2-9a24-9931db474a2b", "name":"tf-pn-heuristic-mirzakhani", "tags":[], "organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8", "created_at":"2026-04-01T08:02:26.313003Z", "updated_at":"2026-04-01T08:02:26.313003Z", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "subnets":[{"id":"fe2964f4-1744-4760-9726-167cf158f31d", "created_at":"2026-04-01T08:02:26.313003Z", "updated_at":"2026-04-01T08:02:26.313003Z", "subnet":"172.16.0.0/22", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "private_network_id":"624d976f-2cea-41d2-9a24-9931db474a2b", "vpc_id":"238e523d-a741-46c4-bb6c-a703314c0f40"}, {"id":"7fd9f017-4e13-439b-98d0-2f95c3c5577e", "created_at":"2026-04-01T08:02:26.313003Z", "updated_at":"2026-04-01T08:02:26.313003Z", "subnet":"fd40:e277:fdde:3bb::/64", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "private_network_id":"624d976f-2cea-41d2-9a24-9931db474a2b", "vpc_id":"238e523d-a741-46c4-bb6c-a703314c0f40"}], "vpc_id":"238e523d-a741-46c4-bb6c-a703314c0f40", "dhcp_enabled":true, "default_route_propagation_enabled":false, "region":"fr-par"}'
         headers:
             Content-Length:
-                - "1069"
+                - "1094"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:35:49 GMT
+                - Wed, 01 Apr 2026 08:08:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 69042798-9b33-4550-8885-5a578508e0bd
+                - ffdf9b16-a515-4327-80b1-eceac5f8c71d
         status: 200 OK
         code: 200
-        duration: 60.930259ms
+        duration: 56.492045ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1179,28 +1177,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/33c4e902-0db5-4cff-9cde-086c86acdf5b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 909
-        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:35:45.524930Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        content_length: 933
+        body: '{"id":"33c4e902-0db5-4cff-9cde-086c86acdf5b", "status":"ready", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_basic", "description":"", "tags":[], "created_at":"2026-04-01T08:02:27.165967Z", "updated_at":"2026-04-01T08:08:09.811606Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://33c4e902-0db5-4cff-9cde-086c86acdf5b.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-33c4e902-0db5-4cff-9cde-086c86acdf5b.624d976f-2cea-41d2-9a24-9931db474a2b.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"624d976f-2cea-41d2-9a24-9931db474a2b", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "909"
+                - "933"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:35:50 GMT
+                - Wed, 01 Apr 2026 08:08:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - b1879487-5436-4fc5-b1e0-b798c2f34320
+                - ac19f092-7f88-4336-b31b-63b4f1e52c7c
         status: 200 OK
         code: 200
-        duration: 72.1377ms
+        duration: 80.105543ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1211,28 +1209,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/33c4e902-0db5-4cff-9cde-086c86acdf5b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 909
-        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:35:45.524930Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        content_length: 933
+        body: '{"id":"33c4e902-0db5-4cff-9cde-086c86acdf5b", "status":"ready", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_basic", "description":"", "tags":[], "created_at":"2026-04-01T08:02:27.165967Z", "updated_at":"2026-04-01T08:08:09.811606Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://33c4e902-0db5-4cff-9cde-086c86acdf5b.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-33c4e902-0db5-4cff-9cde-086c86acdf5b.624d976f-2cea-41d2-9a24-9931db474a2b.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"624d976f-2cea-41d2-9a24-9931db474a2b", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "909"
+                - "933"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:35:50 GMT
+                - Wed, 01 Apr 2026 08:08:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - c761967b-d556-4713-9598-05ad512a4ba9
+                - ae8791f6-cc3c-464d-b201-99daf0dfebc2
         status: 200 OK
         code: 200
-        duration: 73.264799ms
+        duration: 71.986728ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1245,33 +1243,31 @@ interactions:
                 - name_asc
             page:
                 - "1"
-            page_size:
-                - "100"
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs?order_by=name_asc&page=1&page_size=100
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs?order_by=name_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 2787
-        body: '{"datalabs":[{"id":"a95f64a0-aac2-448d-8e6e-3e33ad795cd4","status":"error","project_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","name":"tf-test-lower","description":"","tags":[],"created_at":"2026-03-20T18:03:19.423808Z","updated_at":"2026-03-25T13:01:47.946037Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://a95f64a0-aac2-448d-8e6e-3e33ad795cd4.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-a95f64a0-aac2-448d-8e6e-3e33ad795cd4.08e54e14-d2a4-4020-b8d3-77a1aac8c40f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"08e54e14-d2a4-4020-b8d3-77a1aac8c40f","notebook_master_url":"","region":"fr-par"},{"id":"4d183142-c753-4c02-baa3-b5af60ecf718","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_name","description":"test datalab for data source by name","tags":[],"created_at":"2026-03-26T11:30:01.995071Z","updated_at":"2026-03-26T11:30:01.995071Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://4d183142-c753-4c02-baa3-b5af60ecf718.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-4d183142-c753-4c02-baa3-b5af60ecf718.434418ef-7ec2-41e7-a139-9f30d56acb6f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","notebook_master_url":"","region":"fr-par"},{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:35:45.524930Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}],"total_count":3}'
+        content_length: 2821
+        body: '{"datalabs":[{"id":"a95f64a0-aac2-448d-8e6e-3e33ad795cd4", "status":"error", "project_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8", "name":"tf-test-lower", "description":"", "tags":[], "created_at":"2026-03-20T18:03:19.423808Z", "updated_at":"2026-03-25T13:01:47.946037Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://a95f64a0-aac2-448d-8e6e-3e33ad795cd4.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-a95f64a0-aac2-448d-8e6e-3e33ad795cd4.08e54e14-d2a4-4020-b8d3-77a1aac8c40f.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"08e54e14-d2a4-4020-b8d3-77a1aac8c40f", "notebook_master_url":"", "region":"fr-par"}, {"id":"33c4e902-0db5-4cff-9cde-086c86acdf5b", "status":"ready", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_basic", "description":"", "tags":[], "created_at":"2026-04-01T08:02:27.165967Z", "updated_at":"2026-04-01T08:08:09.811606Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://33c4e902-0db5-4cff-9cde-086c86acdf5b.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-33c4e902-0db5-4cff-9cde-086c86acdf5b.624d976f-2cea-41d2-9a24-9931db474a2b.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"624d976f-2cea-41d2-9a24-9931db474a2b", "notebook_master_url":"", "region":"fr-par"}, {"id":"0047ff02-6953-4ef0-bfb1-c093796e0477", "status":"ready", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_name", "description":"", "tags":[], "created_at":"2026-04-01T08:02:27.052181Z", "updated_at":"2026-04-01T08:08:03.972492Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://0047ff02-6953-4ef0-bfb1-c093796e0477.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-0047ff02-6953-4ef0-bfb1-c093796e0477.593f0960-2d24-404e-88c5-af99a6454020.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"593f0960-2d24-404e-88c5-af99a6454020", "notebook_master_url":"", "region":"fr-par"}], "total_count":3}'
         headers:
             Content-Length:
-                - "2787"
+                - "2821"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:35:50 GMT
+                - Wed, 01 Apr 2026 08:08:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 264b0304-ab98-4e0b-97bb-7d5f1e7f6576
+                - 5a52e39e-b744-4bec-8080-a17e45b7e7cb
         status: 200 OK
         code: 200
-        duration: 81.790223ms
+        duration: 96.498368ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -1282,28 +1278,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/4eb78672-f8f2-436b-b87c-f3332f7b0265
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/238e523d-a741-46c4-bb6c-a703314c0f40
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 413
-        body: '{"id":"4eb78672-f8f2-436b-b87c-f3332f7b0265","name":"tf_tests_datalabs_ds_basic","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:30:00.558454Z","updated_at":"2026-03-26T11:30:00.558454Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","is_default":false,"private_network_count":1,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        content_length: 424
+        body: '{"id":"238e523d-a741-46c4-bb6c-a703314c0f40", "name":"tf_tests_datalabs_ds_basic", "tags":[], "organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8", "created_at":"2026-04-01T08:02:25.955095Z", "updated_at":"2026-04-01T08:02:25.955095Z", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "is_default":false, "private_network_count":1, "routing_enabled":true, "custom_routes_propagation_enabled":true, "region":"fr-par"}'
         headers:
             Content-Length:
-                - "413"
+                - "424"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:35:50 GMT
+                - Wed, 01 Apr 2026 08:08:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 407166fe-56e6-4677-9ffb-e0686c6e81cd
+                - 8ba5d3a8-4b19-415e-8d4c-975a28f37e91
         status: 200 OK
         code: 200
-        duration: 56.250259ms
+        duration: 72.491882ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -1316,33 +1312,31 @@ interactions:
                 - name_asc
             page:
                 - "1"
-            page_size:
-                - "100"
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs?order_by=name_asc&page=1&page_size=100
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs?order_by=name_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 2787
-        body: '{"datalabs":[{"id":"a95f64a0-aac2-448d-8e6e-3e33ad795cd4","status":"error","project_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","name":"tf-test-lower","description":"","tags":[],"created_at":"2026-03-20T18:03:19.423808Z","updated_at":"2026-03-25T13:01:47.946037Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://a95f64a0-aac2-448d-8e6e-3e33ad795cd4.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-a95f64a0-aac2-448d-8e6e-3e33ad795cd4.08e54e14-d2a4-4020-b8d3-77a1aac8c40f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"08e54e14-d2a4-4020-b8d3-77a1aac8c40f","notebook_master_url":"","region":"fr-par"},{"id":"4d183142-c753-4c02-baa3-b5af60ecf718","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalab_ds_by_name","description":"test datalab for data source by name","tags":[],"created_at":"2026-03-26T11:30:01.995071Z","updated_at":"2026-03-26T11:30:01.995071Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://4d183142-c753-4c02-baa3-b5af60ecf718.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-4d183142-c753-4c02-baa3-b5af60ecf718.434418ef-7ec2-41e7-a139-9f30d56acb6f.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"434418ef-7ec2-41e7-a139-9f30d56acb6f","notebook_master_url":"","region":"fr-par"},{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:35:45.524930Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}],"total_count":3}'
+        content_length: 2821
+        body: '{"datalabs":[{"id":"a95f64a0-aac2-448d-8e6e-3e33ad795cd4", "status":"error", "project_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8", "name":"tf-test-lower", "description":"", "tags":[], "created_at":"2026-03-20T18:03:19.423808Z", "updated_at":"2026-03-25T13:01:47.946037Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://a95f64a0-aac2-448d-8e6e-3e33ad795cd4.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-a95f64a0-aac2-448d-8e6e-3e33ad795cd4.08e54e14-d2a4-4020-b8d3-77a1aac8c40f.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"08e54e14-d2a4-4020-b8d3-77a1aac8c40f", "notebook_master_url":"", "region":"fr-par"}, {"id":"33c4e902-0db5-4cff-9cde-086c86acdf5b", "status":"ready", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_basic", "description":"", "tags":[], "created_at":"2026-04-01T08:02:27.165967Z", "updated_at":"2026-04-01T08:08:09.811606Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://33c4e902-0db5-4cff-9cde-086c86acdf5b.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-33c4e902-0db5-4cff-9cde-086c86acdf5b.624d976f-2cea-41d2-9a24-9931db474a2b.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"624d976f-2cea-41d2-9a24-9931db474a2b", "notebook_master_url":"", "region":"fr-par"}, {"id":"0047ff02-6953-4ef0-bfb1-c093796e0477", "status":"ready", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_name", "description":"", "tags":[], "created_at":"2026-04-01T08:02:27.052181Z", "updated_at":"2026-04-01T08:08:03.972492Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://0047ff02-6953-4ef0-bfb1-c093796e0477.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-0047ff02-6953-4ef0-bfb1-c093796e0477.593f0960-2d24-404e-88c5-af99a6454020.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"593f0960-2d24-404e-88c5-af99a6454020", "notebook_master_url":"", "region":"fr-par"}], "total_count":3}'
         headers:
             Content-Length:
-                - "2787"
+                - "2821"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:35:50 GMT
+                - Wed, 01 Apr 2026 08:08:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 02808493-e3e1-47cb-92bc-5009e028036f
+                - ca579078-311e-4c6e-aea2-9b2f7efd6c35
         status: 200 OK
         code: 200
-        duration: 105.612266ms
+        duration: 78.351985ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -1353,28 +1347,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6da7884d-b156-4286-a6c6-4106e34df100
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/624d976f-2cea-41d2-9a24-9931db474a2b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 1069
-        body: '{"id":"6da7884d-b156-4286-a6c6-4106e34df100","name":"tf-pn-beautiful-lovelace","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:30:00.699375Z","updated_at":"2026-03-26T11:30:00.699375Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","subnets":[{"id":"6c49683f-81f0-4c57-99b1-c42c1477813d","created_at":"2026-03-26T11:30:00.699375Z","updated_at":"2026-03-26T11:30:00.699375Z","subnet":"172.16.12.0/22","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","vpc_id":"4eb78672-f8f2-436b-b87c-f3332f7b0265"},{"id":"b8089b94-73ab-4dce-82f7-a41f66231036","created_at":"2026-03-26T11:30:00.699375Z","updated_at":"2026-03-26T11:30:00.699375Z","subnet":"fd40:e277:fdde:bcd::/64","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","vpc_id":"4eb78672-f8f2-436b-b87c-f3332f7b0265"}],"vpc_id":"4eb78672-f8f2-436b-b87c-f3332f7b0265","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        content_length: 1094
+        body: '{"id":"624d976f-2cea-41d2-9a24-9931db474a2b", "name":"tf-pn-heuristic-mirzakhani", "tags":[], "organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8", "created_at":"2026-04-01T08:02:26.313003Z", "updated_at":"2026-04-01T08:02:26.313003Z", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "subnets":[{"id":"fe2964f4-1744-4760-9726-167cf158f31d", "created_at":"2026-04-01T08:02:26.313003Z", "updated_at":"2026-04-01T08:02:26.313003Z", "subnet":"172.16.0.0/22", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "private_network_id":"624d976f-2cea-41d2-9a24-9931db474a2b", "vpc_id":"238e523d-a741-46c4-bb6c-a703314c0f40"}, {"id":"7fd9f017-4e13-439b-98d0-2f95c3c5577e", "created_at":"2026-04-01T08:02:26.313003Z", "updated_at":"2026-04-01T08:02:26.313003Z", "subnet":"fd40:e277:fdde:3bb::/64", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "private_network_id":"624d976f-2cea-41d2-9a24-9931db474a2b", "vpc_id":"238e523d-a741-46c4-bb6c-a703314c0f40"}], "vpc_id":"238e523d-a741-46c4-bb6c-a703314c0f40", "dhcp_enabled":true, "default_route_propagation_enabled":false, "region":"fr-par"}'
         headers:
             Content-Length:
-                - "1069"
+                - "1094"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:35:50 GMT
+                - Wed, 01 Apr 2026 08:08:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 677f131b-4886-433c-9239-5f629a31cdff
+                - df44b0f5-3606-4147-bbce-c1f0e832757c
         status: 200 OK
         code: 200
-        duration: 49.875944ms
+        duration: 80.18469ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -1385,28 +1379,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/33c4e902-0db5-4cff-9cde-086c86acdf5b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 909
-        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:35:45.524930Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        content_length: 933
+        body: '{"id":"33c4e902-0db5-4cff-9cde-086c86acdf5b", "status":"ready", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_basic", "description":"", "tags":[], "created_at":"2026-04-01T08:02:27.165967Z", "updated_at":"2026-04-01T08:08:09.811606Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://33c4e902-0db5-4cff-9cde-086c86acdf5b.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-33c4e902-0db5-4cff-9cde-086c86acdf5b.624d976f-2cea-41d2-9a24-9931db474a2b.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"624d976f-2cea-41d2-9a24-9931db474a2b", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "909"
+                - "933"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:35:50 GMT
+                - Wed, 01 Apr 2026 08:08:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 8513c305-3976-48f5-8fc1-0640173a9837
+                - d8cb5cb7-f516-435c-9793-9b7943974421
         status: 200 OK
         code: 200
-        duration: 68.247477ms
+        duration: 78.578819ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -1417,28 +1411,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/33c4e902-0db5-4cff-9cde-086c86acdf5b
         method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 912
-        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:35:50.865218Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        content_length: 936
+        body: '{"id":"33c4e902-0db5-4cff-9cde-086c86acdf5b", "status":"deleting", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_basic", "description":"", "tags":[], "created_at":"2026-04-01T08:02:27.165967Z", "updated_at":"2026-04-01T08:08:16.592879Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://33c4e902-0db5-4cff-9cde-086c86acdf5b.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-33c4e902-0db5-4cff-9cde-086c86acdf5b.624d976f-2cea-41d2-9a24-9931db474a2b.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"624d976f-2cea-41d2-9a24-9931db474a2b", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "912"
+                - "936"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:35:50 GMT
+                - Wed, 01 Apr 2026 08:08:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 26d6e035-2e94-4b2d-bc62-86997a3714ee
+                - 6b9c8e13-934f-4e31-86ae-1a088b6d8ff0
         status: 200 OK
         code: 200
-        duration: 169.528763ms
+        duration: 159.261534ms
     - id: 44
       request:
         proto: HTTP/1.1
@@ -1449,28 +1443,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/33c4e902-0db5-4cff-9cde-086c86acdf5b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 912
-        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:35:50.865218Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        content_length: 936
+        body: '{"id":"33c4e902-0db5-4cff-9cde-086c86acdf5b", "status":"deleting", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_basic", "description":"", "tags":[], "created_at":"2026-04-01T08:02:27.165967Z", "updated_at":"2026-04-01T08:08:16.592879Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://33c4e902-0db5-4cff-9cde-086c86acdf5b.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-33c4e902-0db5-4cff-9cde-086c86acdf5b.624d976f-2cea-41d2-9a24-9931db474a2b.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"624d976f-2cea-41d2-9a24-9931db474a2b", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "912"
+                - "936"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:35:51 GMT
+                - Wed, 01 Apr 2026 08:08:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 00dd9a7d-dbf2-47da-85de-95d6a3dfde42
+                - 06448445-dc40-417a-a23e-9f7212eb8d02
         status: 200 OK
         code: 200
-        duration: 77.56076ms
+        duration: 75.87612ms
     - id: 45
       request:
         proto: HTTP/1.1
@@ -1481,28 +1475,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/33c4e902-0db5-4cff-9cde-086c86acdf5b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 912
-        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:35:50.865218Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        content_length: 936
+        body: '{"id":"33c4e902-0db5-4cff-9cde-086c86acdf5b", "status":"deleting", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_basic", "description":"", "tags":[], "created_at":"2026-04-01T08:02:27.165967Z", "updated_at":"2026-04-01T08:08:16.592879Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://33c4e902-0db5-4cff-9cde-086c86acdf5b.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-33c4e902-0db5-4cff-9cde-086c86acdf5b.624d976f-2cea-41d2-9a24-9931db474a2b.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"624d976f-2cea-41d2-9a24-9931db474a2b", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "912"
+                - "936"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:36:06 GMT
+                - Wed, 01 Apr 2026 08:08:31 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 961ce20c-9933-4d1d-9495-e87b1ddec531
+                - 5d816315-0717-4448-a637-8c04fe369768
         status: 200 OK
         code: 200
-        duration: 63.831233ms
+        duration: 83.041594ms
     - id: 46
       request:
         proto: HTTP/1.1
@@ -1513,28 +1507,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/33c4e902-0db5-4cff-9cde-086c86acdf5b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 912
-        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:35:50.865218Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        content_length: 936
+        body: '{"id":"33c4e902-0db5-4cff-9cde-086c86acdf5b", "status":"deleting", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_basic", "description":"", "tags":[], "created_at":"2026-04-01T08:02:27.165967Z", "updated_at":"2026-04-01T08:08:16.592879Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://33c4e902-0db5-4cff-9cde-086c86acdf5b.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-33c4e902-0db5-4cff-9cde-086c86acdf5b.624d976f-2cea-41d2-9a24-9931db474a2b.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"624d976f-2cea-41d2-9a24-9931db474a2b", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "912"
+                - "936"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:36:21 GMT
+                - Wed, 01 Apr 2026 08:08:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - c8c99fba-41ad-4add-ad33-6476c200acad
+                - c09b15ad-9195-4f2c-842f-57db45225a5d
         status: 200 OK
         code: 200
-        duration: 66.031186ms
+        duration: 96.472258ms
     - id: 47
       request:
         proto: HTTP/1.1
@@ -1545,28 +1539,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/33c4e902-0db5-4cff-9cde-086c86acdf5b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 912
-        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:35:50.865218Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        content_length: 936
+        body: '{"id":"33c4e902-0db5-4cff-9cde-086c86acdf5b", "status":"deleting", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_basic", "description":"", "tags":[], "created_at":"2026-04-01T08:02:27.165967Z", "updated_at":"2026-04-01T08:08:16.592879Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://33c4e902-0db5-4cff-9cde-086c86acdf5b.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-33c4e902-0db5-4cff-9cde-086c86acdf5b.624d976f-2cea-41d2-9a24-9931db474a2b.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"624d976f-2cea-41d2-9a24-9931db474a2b", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "912"
+                - "936"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:36:36 GMT
+                - Wed, 01 Apr 2026 08:09:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 19418d26-53fc-420b-a08f-566e9b7060a9
+                - 7392bcf4-5194-43a7-8fbc-5a424c272cfb
         status: 200 OK
         code: 200
-        duration: 80.194691ms
+        duration: 93.160727ms
     - id: 48
       request:
         proto: HTTP/1.1
@@ -1577,28 +1571,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/33c4e902-0db5-4cff-9cde-086c86acdf5b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 912
-        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:35:50.865218Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        content_length: 936
+        body: '{"id":"33c4e902-0db5-4cff-9cde-086c86acdf5b", "status":"deleting", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_basic", "description":"", "tags":[], "created_at":"2026-04-01T08:02:27.165967Z", "updated_at":"2026-04-01T08:08:16.592879Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://33c4e902-0db5-4cff-9cde-086c86acdf5b.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-33c4e902-0db5-4cff-9cde-086c86acdf5b.624d976f-2cea-41d2-9a24-9931db474a2b.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"624d976f-2cea-41d2-9a24-9931db474a2b", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "912"
+                - "936"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:36:51 GMT
+                - Wed, 01 Apr 2026 08:09:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 6b41d34c-1531-4005-be05-a01eded32b2b
+                - 8b0e372c-c4d0-4160-8b02-4f569e06773f
         status: 200 OK
         code: 200
-        duration: 71.302349ms
+        duration: 88.285994ms
     - id: 49
       request:
         proto: HTTP/1.1
@@ -1609,28 +1603,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/33c4e902-0db5-4cff-9cde-086c86acdf5b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 912
-        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:35:50.865218Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        content_length: 936
+        body: '{"id":"33c4e902-0db5-4cff-9cde-086c86acdf5b", "status":"deleting", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_basic", "description":"", "tags":[], "created_at":"2026-04-01T08:02:27.165967Z", "updated_at":"2026-04-01T08:08:16.592879Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://33c4e902-0db5-4cff-9cde-086c86acdf5b.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-33c4e902-0db5-4cff-9cde-086c86acdf5b.624d976f-2cea-41d2-9a24-9931db474a2b.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"624d976f-2cea-41d2-9a24-9931db474a2b", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "912"
+                - "936"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:37:06 GMT
+                - Wed, 01 Apr 2026 08:09:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - c37d21c1-0fb2-48cc-b657-331e53261fd2
+                - 0993be87-3fc1-4918-8285-b4d814ca966e
         status: 200 OK
         code: 200
-        duration: 83.655215ms
+        duration: 86.489078ms
     - id: 50
       request:
         proto: HTTP/1.1
@@ -1641,28 +1635,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/33c4e902-0db5-4cff-9cde-086c86acdf5b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 912
-        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:35:50.865218Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        content_length: 936
+        body: '{"id":"33c4e902-0db5-4cff-9cde-086c86acdf5b", "status":"deleting", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_basic", "description":"", "tags":[], "created_at":"2026-04-01T08:02:27.165967Z", "updated_at":"2026-04-01T08:08:16.592879Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://33c4e902-0db5-4cff-9cde-086c86acdf5b.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-33c4e902-0db5-4cff-9cde-086c86acdf5b.624d976f-2cea-41d2-9a24-9931db474a2b.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"624d976f-2cea-41d2-9a24-9931db474a2b", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "912"
+                - "936"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:37:21 GMT
+                - Wed, 01 Apr 2026 08:09:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 32081aae-6874-4b03-a645-ce3e148422d7
+                - 4e5a1609-1a8c-44b5-b019-d8ebe21ca622
         status: 200 OK
         code: 200
-        duration: 78.308835ms
+        duration: 81.741471ms
     - id: 51
       request:
         proto: HTTP/1.1
@@ -1673,28 +1667,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/33c4e902-0db5-4cff-9cde-086c86acdf5b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 912
-        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:35:50.865218Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        content_length: 936
+        body: '{"id":"33c4e902-0db5-4cff-9cde-086c86acdf5b", "status":"deleting", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_basic", "description":"", "tags":[], "created_at":"2026-04-01T08:02:27.165967Z", "updated_at":"2026-04-01T08:08:16.592879Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://33c4e902-0db5-4cff-9cde-086c86acdf5b.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-33c4e902-0db5-4cff-9cde-086c86acdf5b.624d976f-2cea-41d2-9a24-9931db474a2b.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"624d976f-2cea-41d2-9a24-9931db474a2b", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "912"
+                - "936"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:37:36 GMT
+                - Wed, 01 Apr 2026 08:10:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - d06adcd0-057d-42b6-be37-fde6f5e142bc
+                - 7e8a87dc-288b-44a4-be57-384e07d793ab
         status: 200 OK
         code: 200
-        duration: 75.603432ms
+        duration: 82.662893ms
     - id: 52
       request:
         proto: HTTP/1.1
@@ -1705,28 +1699,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/33c4e902-0db5-4cff-9cde-086c86acdf5b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 912
-        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:35:50.865218Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        content_length: 936
+        body: '{"id":"33c4e902-0db5-4cff-9cde-086c86acdf5b", "status":"deleting", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_basic", "description":"", "tags":[], "created_at":"2026-04-01T08:02:27.165967Z", "updated_at":"2026-04-01T08:08:16.592879Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://33c4e902-0db5-4cff-9cde-086c86acdf5b.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-33c4e902-0db5-4cff-9cde-086c86acdf5b.624d976f-2cea-41d2-9a24-9931db474a2b.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"624d976f-2cea-41d2-9a24-9931db474a2b", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "912"
+                - "936"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:37:51 GMT
+                - Wed, 01 Apr 2026 08:10:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - e05fd88e-33ae-4df2-b492-4bcb7e1a5d98
+                - 99399a09-0a4d-419a-bd7c-c80c060aff09
         status: 200 OK
         code: 200
-        duration: 69.743145ms
+        duration: 84.247225ms
     - id: 53
       request:
         proto: HTTP/1.1
@@ -1737,28 +1731,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/33c4e902-0db5-4cff-9cde-086c86acdf5b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 912
-        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:35:50.865218Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        content_length: 936
+        body: '{"id":"33c4e902-0db5-4cff-9cde-086c86acdf5b", "status":"deleting", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_basic", "description":"", "tags":[], "created_at":"2026-04-01T08:02:27.165967Z", "updated_at":"2026-04-01T08:08:16.592879Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://33c4e902-0db5-4cff-9cde-086c86acdf5b.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-33c4e902-0db5-4cff-9cde-086c86acdf5b.624d976f-2cea-41d2-9a24-9931db474a2b.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"624d976f-2cea-41d2-9a24-9931db474a2b", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "912"
+                - "936"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:38:06 GMT
+                - Wed, 01 Apr 2026 08:10:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 31581d6e-137c-45ba-9b80-361e182c5887
+                - ba3b0b90-8c5e-49e3-8d8a-25b7348f20a9
         status: 200 OK
         code: 200
-        duration: 71.877561ms
+        duration: 94.30373ms
     - id: 54
       request:
         proto: HTTP/1.1
@@ -1769,28 +1763,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/33c4e902-0db5-4cff-9cde-086c86acdf5b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 912
-        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:35:50.865218Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        content_length: 936
+        body: '{"id":"33c4e902-0db5-4cff-9cde-086c86acdf5b", "status":"deleting", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_basic", "description":"", "tags":[], "created_at":"2026-04-01T08:02:27.165967Z", "updated_at":"2026-04-01T08:08:16.592879Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://33c4e902-0db5-4cff-9cde-086c86acdf5b.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-33c4e902-0db5-4cff-9cde-086c86acdf5b.624d976f-2cea-41d2-9a24-9931db474a2b.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"624d976f-2cea-41d2-9a24-9931db474a2b", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "912"
+                - "936"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:38:21 GMT
+                - Wed, 01 Apr 2026 08:10:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - e789541b-66ee-46a2-8e61-9d8e641693f8
+                - 7c4fab25-2878-4f22-8598-1f5a05ae3466
         status: 200 OK
         code: 200
-        duration: 78.803626ms
+        duration: 86.508046ms
     - id: 55
       request:
         proto: HTTP/1.1
@@ -1801,28 +1795,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/33c4e902-0db5-4cff-9cde-086c86acdf5b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 912
-        body: '{"id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_basic","description":"","tags":[],"created_at":"2026-03-26T11:30:01.652478Z","updated_at":"2026-03-26T11:35:50.865218Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://5eaf5a73-25f3-4cc6-9d82-70685974e831.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-5eaf5a73-25f3-4cc6-9d82-70685974e831.6da7884d-b156-4286-a6c6-4106e34df100.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"6da7884d-b156-4286-a6c6-4106e34df100","notebook_master_url":"","region":"fr-par"}'
+        content_length: 128
+        body: '{"message":"resource is not found","resource":"datalab","resource_id":"33c4e902-0db5-4cff-9cde-086c86acdf5b","type":"not_found"}'
         headers:
             Content-Length:
-                - "912"
+                - "128"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:38:36 GMT
+                - Wed, 01 Apr 2026 08:11:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - c16c387d-c584-4df0-b16a-dfee517f3595
-        status: 200 OK
-        code: 200
-        duration: 76.846603ms
+                - 6d3ae247-9bdb-47fa-b17f-a8f0c4ae3418
+        status: 404 Not Found
+        code: 404
+        duration: 63.819591ms
     - id: 56
       request:
         proto: HTTP/1.1
@@ -1833,28 +1827,26 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
-        method: GET
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/624d976f-2cea-41d2-9a24-9931db474a2b
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 128
-        body: '{"message":"resource is not found","resource":"datalab","resource_id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","type":"not_found"}'
+        content_length: 0
+        body: ""
         headers:
-            Content-Length:
-                - "128"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:38:51 GMT
+                - Wed, 01 Apr 2026 08:11:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - e1785cb9-bfcf-456b-a006-e77f521f531b
-        status: 404 Not Found
-        code: 404
-        duration: 68.696205ms
+                - 690a5c4f-c67c-40c4-82f2-b850973c1638
+        status: 204 No Content
+        code: 204
+        duration: 1.571708345s
     - id: 57
       request:
         proto: HTTP/1.1
@@ -1865,7 +1857,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6da7884d-b156-4286-a6c6-4106e34df100
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/238e523d-a741-46c4-bb6c-a703314c0f40
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1877,14 +1869,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:38:53 GMT
+                - Wed, 01 Apr 2026 08:11:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 8d856c96-9906-475a-9cf3-52ed2672ee99
+                - 53c1313f-ffb9-4f7f-8d9c-0195e42e9f9b
         status: 204 No Content
         code: 204
-        duration: 1.565141422s
+        duration: 440.02139ms
     - id: 58
       request:
         proto: HTTP/1.1
@@ -1895,55 +1887,25 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/4eb78672-f8f2-436b-b87c-f3332f7b0265
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 0
-        body: ""
-        headers:
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 26 Mar 2026 11:38:53 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
-            X-Request-Id:
-                - acc92c3f-da18-4ca7-8a89-4b0b03b97516
-        status: 204 No Content
-        code: 204
-        duration: 443.027032ms
-    - id: 59
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/5eaf5a73-25f3-4cc6-9d82-70685974e831
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/33c4e902-0db5-4cff-9cde-086c86acdf5b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 128
-        body: '{"message":"resource is not found","resource":"datalab","resource_id":"5eaf5a73-25f3-4cc6-9d82-70685974e831","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"datalab","resource_id":"33c4e902-0db5-4cff-9cde-086c86acdf5b","type":"not_found"}'
         headers:
             Content-Length:
                 - "128"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:38:54 GMT
+                - Wed, 01 Apr 2026 08:11:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge03)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - ab8a6f23-2e6c-4d51-978a-d2fc59d7a92e
+                - 2a610109-b048-4901-b85c-14c13057056c
         status: 404 Not Found
         code: 404
-        duration: 57.701752ms
+        duration: 58.431084ms

--- a/internal/services/datalab/testdata/datalabs-data-source-filter-by-name.cassette.yaml
+++ b/internal/services/datalab/testdata/datalabs-data-source-filter-by-name.cassette.yaml
@@ -1,0 +1,1923 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 121
+        host: api.scaleway.com
+        body: '{"name":"tf_tests_datalabs_ds_name","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","tags":[],"enable_routing":false}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 412
+        body: '{"id":"8e81a4c5-69ad-44f4-98e8-2e7f99bff562","name":"tf_tests_datalabs_ds_name","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:39:01.632082Z","updated_at":"2026-03-26T11:39:01.632082Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","is_default":false,"private_network_count":0,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "412"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:39:01 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 02ccf7f4-be2e-4916-b050-4fab5dac16a9
+        status: 200 OK
+        code: 200
+        duration: 244.523815ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/8e81a4c5-69ad-44f4-98e8-2e7f99bff562
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 412
+        body: '{"id":"8e81a4c5-69ad-44f4-98e8-2e7f99bff562","name":"tf_tests_datalabs_ds_name","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:39:01.632082Z","updated_at":"2026-03-26T11:39:01.632082Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","is_default":false,"private_network_count":0,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "412"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:39:01 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - c6c88f90-0356-4afc-a49c-337ec98276d6
+        status: 200 OK
+        code: 200
+        duration: 53.076488ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 198
+        host: api.scaleway.com
+        body: '{"name":"tf-pn-magical-spence","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","tags":[],"subnets":null,"vpc_id":"8e81a4c5-69ad-44f4-98e8-2e7f99bff562","default_route_propagation_enabled":false}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1065
+        body: '{"id":"d0432486-ef71-414c-9fcc-021be4d0e690","name":"tf-pn-magical-spence","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:39:01.791069Z","updated_at":"2026-03-26T11:39:01.791069Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","subnets":[{"id":"f1f9a42e-347f-40f4-af69-3389174d2d6b","created_at":"2026-03-26T11:39:01.791069Z","updated_at":"2026-03-26T11:39:01.791069Z","subnet":"172.16.8.0/22","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","vpc_id":"8e81a4c5-69ad-44f4-98e8-2e7f99bff562"},{"id":"65278186-e46c-4714-9d84-ac2e5df4024a","created_at":"2026-03-26T11:39:01.791069Z","updated_at":"2026-03-26T11:39:01.791069Z","subnet":"fd40:e277:fdde:b157::/64","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","vpc_id":"8e81a4c5-69ad-44f4-98e8-2e7f99bff562"}],"vpc_id":"8e81a4c5-69ad-44f4-98e8-2e7f99bff562","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1065"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:39:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 307280f5-355c-4796-a280-08416ed93fee
+        status: 200 OK
+        code: 200
+        duration: 940.543786ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d0432486-ef71-414c-9fcc-021be4d0e690
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1065
+        body: '{"id":"d0432486-ef71-414c-9fcc-021be4d0e690","name":"tf-pn-magical-spence","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:39:01.791069Z","updated_at":"2026-03-26T11:39:01.791069Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","subnets":[{"id":"f1f9a42e-347f-40f4-af69-3389174d2d6b","created_at":"2026-03-26T11:39:01.791069Z","updated_at":"2026-03-26T11:39:01.791069Z","subnet":"172.16.8.0/22","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","vpc_id":"8e81a4c5-69ad-44f4-98e8-2e7f99bff562"},{"id":"65278186-e46c-4714-9d84-ac2e5df4024a","created_at":"2026-03-26T11:39:01.791069Z","updated_at":"2026-03-26T11:39:01.791069Z","subnet":"fd40:e277:fdde:b157::/64","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","vpc_id":"8e81a4c5-69ad-44f4-98e8-2e7f99bff562"}],"vpc_id":"8e81a4c5-69ad-44f4-98e8-2e7f99bff562","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1065"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:39:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - d640a6ec-b107-4b7a-8303-9ddae0ed0d6a
+        status: 200 OK
+        code: 200
+        duration: 60.926938ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 331
+        host: api.scaleway.com
+        body: '{"project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":null,"main":{"node_type":"DATALAB-SHARED-4C-8G"},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1},"has_notebook":false,"spark_version":"4.0.0","private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690"}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 911
+        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:39:02.860650Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "911"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:39:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 50ee6dbb-ec8c-45b1-bb68-789b8216d90f
+        status: 200 OK
+        code: 200
+        duration: 1.263914788s
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 911
+        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:39:02.860650Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "911"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:39:04 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - b694ea47-f023-4256-81d7-e26a83fc2654
+        status: 200 OK
+        code: 200
+        duration: 71.97726ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 911
+        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:39:02.860650Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "911"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:39:19 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 8058ce7e-8b8f-4f40-950d-4b29ee0790ca
+        status: 200 OK
+        code: 200
+        duration: 85.493178ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 911
+        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:39:02.860650Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "911"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:39:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - f1220291-eda1-42c0-a3f8-275e7b86e338
+        status: 200 OK
+        code: 200
+        duration: 67.949183ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 911
+        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:39:02.860650Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "911"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:39:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - bd2b4b48-2971-4d23-84c1-02325433d504
+        status: 200 OK
+        code: 200
+        duration: 79.175064ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 911
+        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:39:02.860650Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "911"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:40:04 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 58cbe6fe-4c77-4d4a-a705-f0d776b9874a
+        status: 200 OK
+        code: 200
+        duration: 97.289112ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 911
+        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:39:02.860650Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "911"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:40:19 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 4550a506-4977-48de-ae68-2fb3ea949ce0
+        status: 200 OK
+        code: 200
+        duration: 78.06676ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 911
+        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:39:02.860650Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "911"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:40:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - f72d2048-69fb-4098-9df0-2670be19e8bd
+        status: 200 OK
+        code: 200
+        duration: 82.552033ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 911
+        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:39:02.860650Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "911"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:40:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - f0da7c17-4f24-4e09-84c4-52e5a74677e3
+        status: 200 OK
+        code: 200
+        duration: 67.633104ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 911
+        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:39:02.860650Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "911"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:41:04 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 1d3f511f-4def-4309-93b3-98aee7e6a6cc
+        status: 200 OK
+        code: 200
+        duration: 87.950704ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 911
+        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:39:02.860650Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "911"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:41:19 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - fd5f2b80-e8d7-4d15-a461-34f990e9d970
+        status: 200 OK
+        code: 200
+        duration: 96.528038ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 911
+        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:39:02.860650Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "911"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:41:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 0da448c6-1e6a-4b61-b106-cbddbd2bf779
+        status: 200 OK
+        code: 200
+        duration: 72.246627ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 911
+        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:39:02.860650Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "911"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:41:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - c90b0653-f9b8-4537-b52b-93e02db8d6be
+        status: 200 OK
+        code: 200
+        duration: 71.991056ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 911
+        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:39:02.860650Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "911"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:42:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - ec54bcb1-fa14-4173-aef2-0c306e6d6d9f
+        status: 200 OK
+        code: 200
+        duration: 78.290671ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 911
+        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:39:02.860650Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "911"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:42:20 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 461de162-b0c6-49b8-a03e-f4e21bdb9a1a
+        status: 200 OK
+        code: 200
+        duration: 73.048272ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 911
+        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:39:02.860650Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "911"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:42:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 108f8441-bf3f-43fd-8f19-f472ccc794ed
+        status: 200 OK
+        code: 200
+        duration: 72.596126ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 911
+        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:39:02.860650Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "911"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:42:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - d99e92b2-7b69-41bf-8b69-c30534c604c0
+        status: 200 OK
+        code: 200
+        duration: 75.192269ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 911
+        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:39:02.860650Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "911"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:43:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 8b24ef25-85c3-4b3b-9f5c-fddb3ba8feec
+        status: 200 OK
+        code: 200
+        duration: 76.801899ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 911
+        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:39:02.860650Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "911"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:43:20 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 1b2b5233-2f85-4c81-bf8e-4b367919295d
+        status: 200 OK
+        code: 200
+        duration: 89.66782ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 911
+        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:39:02.860650Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "911"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:43:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - b7f0e540-65f4-4cc0-a7e9-bdb8086889c4
+        status: 200 OK
+        code: 200
+        duration: 76.586198ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 911
+        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:39:02.860650Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "911"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:43:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 6e6054fc-bc04-4cfc-b520-b69b944b5e2d
+        status: 200 OK
+        code: 200
+        duration: 76.5711ms
+    - id: 25
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 911
+        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:39:02.860650Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "911"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:44:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - bfc6f00b-7262-46e4-a887-e5f62458d808
+        status: 200 OK
+        code: 200
+        duration: 86.076101ms
+    - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 911
+        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:39:02.860650Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "911"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:44:20 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - c78af912-053d-45cd-a05f-6ab94d0372eb
+        status: 200 OK
+        code: 200
+        duration: 75.462592ms
+    - id: 27
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 911
+        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:39:02.860650Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "911"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:44:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - f5b0465e-cd52-4bf9-bf5f-906b39a2e322
+        status: 200 OK
+        code: 200
+        duration: 74.563528ms
+    - id: 28
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 908
+        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:44:46.213359Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "908"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:44:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 38ba2b1c-2c01-49f6-9c49-eaa6a1f01703
+        status: 200 OK
+        code: 200
+        duration: 73.125417ms
+    - id: 29
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 908
+        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:44:46.213359Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "908"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:44:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 4717c5a9-5db1-437e-89c5-198b47b381f4
+        status: 200 OK
+        code: 200
+        duration: 68.013462ms
+    - id: 30
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/8e81a4c5-69ad-44f4-98e8-2e7f99bff562
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 412
+        body: '{"id":"8e81a4c5-69ad-44f4-98e8-2e7f99bff562","name":"tf_tests_datalabs_ds_name","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:39:01.632082Z","updated_at":"2026-03-26T11:39:01.632082Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","is_default":false,"private_network_count":1,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "412"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:44:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - d3b8fe70-d597-4ce3-86e6-dee4f5ce6c76
+        status: 200 OK
+        code: 200
+        duration: 67.346819ms
+    - id: 31
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d0432486-ef71-414c-9fcc-021be4d0e690
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1065
+        body: '{"id":"d0432486-ef71-414c-9fcc-021be4d0e690","name":"tf-pn-magical-spence","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:39:01.791069Z","updated_at":"2026-03-26T11:39:01.791069Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","subnets":[{"id":"f1f9a42e-347f-40f4-af69-3389174d2d6b","created_at":"2026-03-26T11:39:01.791069Z","updated_at":"2026-03-26T11:39:01.791069Z","subnet":"172.16.8.0/22","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","vpc_id":"8e81a4c5-69ad-44f4-98e8-2e7f99bff562"},{"id":"65278186-e46c-4714-9d84-ac2e5df4024a","created_at":"2026-03-26T11:39:01.791069Z","updated_at":"2026-03-26T11:39:01.791069Z","subnet":"fd40:e277:fdde:b157::/64","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","vpc_id":"8e81a4c5-69ad-44f4-98e8-2e7f99bff562"}],"vpc_id":"8e81a4c5-69ad-44f4-98e8-2e7f99bff562","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1065"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:44:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 77eadb8c-fbcc-45f6-a714-31230895211a
+        status: 200 OK
+        code: 200
+        duration: 68.573217ms
+    - id: 32
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 908
+        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:44:46.213359Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "908"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:44:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - b315dddb-fb55-496e-984d-8a101ee2204e
+        status: 200 OK
+        code: 200
+        duration: 71.378363ms
+    - id: 33
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/8e81a4c5-69ad-44f4-98e8-2e7f99bff562
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 412
+        body: '{"id":"8e81a4c5-69ad-44f4-98e8-2e7f99bff562","name":"tf_tests_datalabs_ds_name","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:39:01.632082Z","updated_at":"2026-03-26T11:39:01.632082Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","is_default":false,"private_network_count":1,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "412"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:44:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 457ae8c9-7f1c-41af-9339-a139e3ce22fc
+        status: 200 OK
+        code: 200
+        duration: 70.73464ms
+    - id: 34
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d0432486-ef71-414c-9fcc-021be4d0e690
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1065
+        body: '{"id":"d0432486-ef71-414c-9fcc-021be4d0e690","name":"tf-pn-magical-spence","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:39:01.791069Z","updated_at":"2026-03-26T11:39:01.791069Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","subnets":[{"id":"f1f9a42e-347f-40f4-af69-3389174d2d6b","created_at":"2026-03-26T11:39:01.791069Z","updated_at":"2026-03-26T11:39:01.791069Z","subnet":"172.16.8.0/22","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","vpc_id":"8e81a4c5-69ad-44f4-98e8-2e7f99bff562"},{"id":"65278186-e46c-4714-9d84-ac2e5df4024a","created_at":"2026-03-26T11:39:01.791069Z","updated_at":"2026-03-26T11:39:01.791069Z","subnet":"fd40:e277:fdde:b157::/64","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","vpc_id":"8e81a4c5-69ad-44f4-98e8-2e7f99bff562"}],"vpc_id":"8e81a4c5-69ad-44f4-98e8-2e7f99bff562","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1065"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:44:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - e840c687-5e88-45da-85ca-79258b5fbff3
+        status: 200 OK
+        code: 200
+        duration: 66.635638ms
+    - id: 35
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 908
+        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:44:46.213359Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "908"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:44:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - cf9f6b4a-34f4-4424-9d92-590f3df77180
+        status: 200 OK
+        code: 200
+        duration: 76.651945ms
+    - id: 36
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            name:
+                - tf_tests_datalabs_ds_name
+            order_by:
+                - name_asc
+            page:
+                - "1"
+            page_size:
+                - "100"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs?name=tf_tests_datalabs_ds_name&order_by=name_asc&page=1&page_size=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 939
+        body: '{"datalabs":[{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:44:46.213359Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "939"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:44:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 7d54f358-71bf-41dc-9069-3d4d09d6cfcd
+        status: 200 OK
+        code: 200
+        duration: 73.37248ms
+    - id: 37
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 908
+        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:44:46.213359Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "908"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:44:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 92ff618f-1aff-48ec-bf55-7e9f4d34ede3
+        status: 200 OK
+        code: 200
+        duration: 72.632681ms
+    - id: 38
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            name:
+                - tf_tests_datalabs_ds_name
+            order_by:
+                - name_asc
+            page:
+                - "1"
+            page_size:
+                - "100"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs?name=tf_tests_datalabs_ds_name&order_by=name_asc&page=1&page_size=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 939
+        body: '{"datalabs":[{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:44:46.213359Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "939"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:44:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 6237cbb1-f37d-44fd-bdb1-a035ce83dddc
+        status: 200 OK
+        code: 200
+        duration: 80.749127ms
+    - id: 39
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/8e81a4c5-69ad-44f4-98e8-2e7f99bff562
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 412
+        body: '{"id":"8e81a4c5-69ad-44f4-98e8-2e7f99bff562","name":"tf_tests_datalabs_ds_name","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:39:01.632082Z","updated_at":"2026-03-26T11:39:01.632082Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","is_default":false,"private_network_count":1,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "412"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:44:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 5b21ae9a-5d6a-4a3c-aad4-1c4044ca1b5a
+        status: 200 OK
+        code: 200
+        duration: 56.330219ms
+    - id: 40
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d0432486-ef71-414c-9fcc-021be4d0e690
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1065
+        body: '{"id":"d0432486-ef71-414c-9fcc-021be4d0e690","name":"tf-pn-magical-spence","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:39:01.791069Z","updated_at":"2026-03-26T11:39:01.791069Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","subnets":[{"id":"f1f9a42e-347f-40f4-af69-3389174d2d6b","created_at":"2026-03-26T11:39:01.791069Z","updated_at":"2026-03-26T11:39:01.791069Z","subnet":"172.16.8.0/22","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","vpc_id":"8e81a4c5-69ad-44f4-98e8-2e7f99bff562"},{"id":"65278186-e46c-4714-9d84-ac2e5df4024a","created_at":"2026-03-26T11:39:01.791069Z","updated_at":"2026-03-26T11:39:01.791069Z","subnet":"fd40:e277:fdde:b157::/64","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","vpc_id":"8e81a4c5-69ad-44f4-98e8-2e7f99bff562"}],"vpc_id":"8e81a4c5-69ad-44f4-98e8-2e7f99bff562","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1065"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:44:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 927371b9-f2b1-4b88-be22-cde3349f6f71
+        status: 200 OK
+        code: 200
+        duration: 59.546424ms
+    - id: 41
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 908
+        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:44:46.213359Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "908"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:44:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - e241ff3a-d549-4ea9-b1d6-9d05a8ace0f6
+        status: 200 OK
+        code: 200
+        duration: 72.789556ms
+    - id: 42
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            name:
+                - tf_tests_datalabs_ds_name
+            order_by:
+                - name_asc
+            page:
+                - "1"
+            page_size:
+                - "100"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs?name=tf_tests_datalabs_ds_name&order_by=name_asc&page=1&page_size=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 939
+        body: '{"datalabs":[{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:44:46.213359Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "939"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:44:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 7fb9cc44-cf8b-45a3-a751-fb916d9c3039
+        status: 200 OK
+        code: 200
+        duration: 75.143594ms
+    - id: 43
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 911
+        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:44:52.714779Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "911"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:44:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 9357efec-5323-4157-b618-e57f47881fe1
+        status: 200 OK
+        code: 200
+        duration: 147.913711ms
+    - id: 44
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 911
+        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:44:52.714779Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "911"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:44:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - b8888b9a-da73-491a-a4c1-40db72e2fe03
+        status: 200 OK
+        code: 200
+        duration: 63.830402ms
+    - id: 45
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 911
+        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:44:52.714779Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "911"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:45:07 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 1f166e45-b538-42bb-a1e2-dba4850bcca3
+        status: 200 OK
+        code: 200
+        duration: 67.501086ms
+    - id: 46
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 911
+        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:44:52.714779Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "911"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:45:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 79b4acbf-16ae-4113-994c-fd365f004f3e
+        status: 200 OK
+        code: 200
+        duration: 70.348153ms
+    - id: 47
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 911
+        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:44:52.714779Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "911"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:45:38 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 1f383adc-8188-4f6d-a982-9303fd00ab47
+        status: 200 OK
+        code: 200
+        duration: 79.125175ms
+    - id: 48
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 911
+        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:44:52.714779Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "911"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:45:53 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - b585dbf0-e5bd-472b-9361-da5a6ec3a98b
+        status: 200 OK
+        code: 200
+        duration: 69.851579ms
+    - id: 49
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 911
+        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:44:52.714779Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "911"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:46:08 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 4339768c-67bc-4b22-b6c7-7c4193f988e8
+        status: 200 OK
+        code: 200
+        duration: 77.539399ms
+    - id: 50
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 911
+        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:44:52.714779Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "911"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:46:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 89e4573a-5159-405a-9f67-97d35615e258
+        status: 200 OK
+        code: 200
+        duration: 78.811837ms
+    - id: 51
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 911
+        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:44:52.714779Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "911"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:46:38 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 0dd2804c-8725-4598-ab69-55defdc4ab74
+        status: 200 OK
+        code: 200
+        duration: 70.784908ms
+    - id: 52
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 911
+        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:44:52.714779Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "911"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:46:53 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 54e4bee2-84f2-4e4b-a395-a68d888e7b5e
+        status: 200 OK
+        code: 200
+        duration: 68.477759ms
+    - id: 53
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 911
+        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:44:52.714779Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "911"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:47:08 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - cb5a6c52-a2a3-4f89-b289-38c07d0ab7bb
+        status: 200 OK
+        code: 200
+        duration: 73.805331ms
+    - id: 54
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 911
+        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:44:52.714779Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "911"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:47:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - c32f2d32-b40e-493d-9590-8c8e86fdeb72
+        status: 200 OK
+        code: 200
+        duration: 72.593074ms
+    - id: 55
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 128
+        body: '{"message":"resource is not found","resource":"datalab","resource_id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "128"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:47:38 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 876f2a08-2a86-41f1-a355-fcb4472b89f4
+        status: 404 Not Found
+        code: 404
+        duration: 69.938955ms
+    - id: 56
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d0432486-ef71-414c-9fcc-021be4d0e690
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:47:40 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 52b7b97c-75a1-4821-87a5-d54915711182
+        status: 204 No Content
+        code: 204
+        duration: 1.593517347s
+    - id: 57
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/8e81a4c5-69ad-44f4-98e8-2e7f99bff562
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:47:40 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - ac93a1ab-065f-4319-9c82-c4501bb7c6cf
+        status: 204 No Content
+        code: 204
+        duration: 709.975829ms
+    - id: 58
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 128
+        body: '{"message":"resource is not found","resource":"datalab","resource_id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "128"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:47:41 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - f394038d-0ddc-4c9e-ac58-c714127a4881
+        status: 404 Not Found
+        code: 404
+        duration: 60.949699ms

--- a/internal/services/datalab/testdata/datalabs-data-source-filter-by-name.cassette.yaml
+++ b/internal/services/datalab/testdata/datalabs-data-source-filter-by-name.cassette.yaml
@@ -20,22 +20,22 @@ interactions:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 412
-        body: '{"id":"8e81a4c5-69ad-44f4-98e8-2e7f99bff562","name":"tf_tests_datalabs_ds_name","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:39:01.632082Z","updated_at":"2026-03-26T11:39:01.632082Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","is_default":false,"private_network_count":0,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        content_length: 423
+        body: '{"id":"030c3bf4-c4a8-4021-94af-42e80bd4039b", "name":"tf_tests_datalabs_ds_name", "tags":[], "organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8", "created_at":"2026-04-01T08:11:17.051818Z", "updated_at":"2026-04-01T08:11:17.051818Z", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "is_default":false, "private_network_count":0, "routing_enabled":true, "custom_routes_propagation_enabled":true, "region":"fr-par"}'
         headers:
             Content-Length:
-                - "412"
+                - "423"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:39:01 GMT
+                - Wed, 01 Apr 2026 08:11:17 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 02ccf7f4-be2e-4916-b050-4fab5dac16a9
+                - db969d65-d542-4a07-97f0-ec23229686c3
         status: 200 OK
         code: 200
-        duration: 244.523815ms
+        duration: 223.923461ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -46,36 +46,36 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/8e81a4c5-69ad-44f4-98e8-2e7f99bff562
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/030c3bf4-c4a8-4021-94af-42e80bd4039b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 412
-        body: '{"id":"8e81a4c5-69ad-44f4-98e8-2e7f99bff562","name":"tf_tests_datalabs_ds_name","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:39:01.632082Z","updated_at":"2026-03-26T11:39:01.632082Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","is_default":false,"private_network_count":0,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        content_length: 423
+        body: '{"id":"030c3bf4-c4a8-4021-94af-42e80bd4039b", "name":"tf_tests_datalabs_ds_name", "tags":[], "organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8", "created_at":"2026-04-01T08:11:17.051818Z", "updated_at":"2026-04-01T08:11:17.051818Z", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "is_default":false, "private_network_count":0, "routing_enabled":true, "custom_routes_propagation_enabled":true, "region":"fr-par"}'
         headers:
             Content-Length:
-                - "412"
+                - "423"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:39:01 GMT
+                - Wed, 01 Apr 2026 08:11:17 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - c6c88f90-0356-4afc-a49c-337ec98276d6
+                - 70e5bce9-a77a-44d7-8105-a83c798c9860
         status: 200 OK
         code: 200
-        duration: 53.076488ms
+        duration: 63.808512ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 198
+        content_length: 197
         host: api.scaleway.com
-        body: '{"name":"tf-pn-magical-spence","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","tags":[],"subnets":null,"vpc_id":"8e81a4c5-69ad-44f4-98e8-2e7f99bff562","default_route_propagation_enabled":false}'
+        body: '{"name":"tf-pn-angry-germain","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","tags":[],"subnets":null,"vpc_id":"030c3bf4-c4a8-4021-94af-42e80bd4039b","default_route_propagation_enabled":false}'
         headers:
             Content-Type:
                 - application/json
@@ -87,22 +87,22 @@ interactions:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 1065
-        body: '{"id":"d0432486-ef71-414c-9fcc-021be4d0e690","name":"tf-pn-magical-spence","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:39:01.791069Z","updated_at":"2026-03-26T11:39:01.791069Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","subnets":[{"id":"f1f9a42e-347f-40f4-af69-3389174d2d6b","created_at":"2026-03-26T11:39:01.791069Z","updated_at":"2026-03-26T11:39:01.791069Z","subnet":"172.16.8.0/22","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","vpc_id":"8e81a4c5-69ad-44f4-98e8-2e7f99bff562"},{"id":"65278186-e46c-4714-9d84-ac2e5df4024a","created_at":"2026-03-26T11:39:01.791069Z","updated_at":"2026-03-26T11:39:01.791069Z","subnet":"fd40:e277:fdde:b157::/64","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","vpc_id":"8e81a4c5-69ad-44f4-98e8-2e7f99bff562"}],"vpc_id":"8e81a4c5-69ad-44f4-98e8-2e7f99bff562","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        content_length: 1089
+        body: '{"id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "name":"tf-pn-angry-germain", "tags":[], "organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8", "created_at":"2026-04-01T08:11:17.912814Z", "updated_at":"2026-04-01T08:11:17.912814Z", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "subnets":[{"id":"3dfa3e4f-0021-4ebd-97d3-6d7e75facb29", "created_at":"2026-04-01T08:11:17.912814Z", "updated_at":"2026-04-01T08:11:17.912814Z", "subnet":"172.16.20.0/22", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "private_network_id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "vpc_id":"030c3bf4-c4a8-4021-94af-42e80bd4039b"}, {"id":"87a8bd6e-857a-4524-b035-300f7b2738c2", "created_at":"2026-04-01T08:11:17.912814Z", "updated_at":"2026-04-01T08:11:17.912814Z", "subnet":"fd40:e277:fdde:323c::/64", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "private_network_id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "vpc_id":"030c3bf4-c4a8-4021-94af-42e80bd4039b"}], "vpc_id":"030c3bf4-c4a8-4021-94af-42e80bd4039b", "dhcp_enabled":true, "default_route_propagation_enabled":false, "region":"fr-par"}'
         headers:
             Content-Length:
-                - "1065"
+                - "1089"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:39:02 GMT
+                - Wed, 01 Apr 2026 08:11:18 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 307280f5-355c-4796-a280-08416ed93fee
+                - 826b8e3e-22b9-41cc-9a3e-403c157da3d9
         status: 200 OK
         code: 200
-        duration: 940.543786ms
+        duration: 1.409791895s
     - id: 3
       request:
         proto: HTTP/1.1
@@ -113,28 +113,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d0432486-ef71-414c-9fcc-021be4d0e690
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/ebcf14ad-0c72-4ff9-b741-d26bee430b14
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 1065
-        body: '{"id":"d0432486-ef71-414c-9fcc-021be4d0e690","name":"tf-pn-magical-spence","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:39:01.791069Z","updated_at":"2026-03-26T11:39:01.791069Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","subnets":[{"id":"f1f9a42e-347f-40f4-af69-3389174d2d6b","created_at":"2026-03-26T11:39:01.791069Z","updated_at":"2026-03-26T11:39:01.791069Z","subnet":"172.16.8.0/22","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","vpc_id":"8e81a4c5-69ad-44f4-98e8-2e7f99bff562"},{"id":"65278186-e46c-4714-9d84-ac2e5df4024a","created_at":"2026-03-26T11:39:01.791069Z","updated_at":"2026-03-26T11:39:01.791069Z","subnet":"fd40:e277:fdde:b157::/64","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","vpc_id":"8e81a4c5-69ad-44f4-98e8-2e7f99bff562"}],"vpc_id":"8e81a4c5-69ad-44f4-98e8-2e7f99bff562","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        content_length: 1089
+        body: '{"id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "name":"tf-pn-angry-germain", "tags":[], "organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8", "created_at":"2026-04-01T08:11:17.912814Z", "updated_at":"2026-04-01T08:11:17.912814Z", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "subnets":[{"id":"3dfa3e4f-0021-4ebd-97d3-6d7e75facb29", "created_at":"2026-04-01T08:11:17.912814Z", "updated_at":"2026-04-01T08:11:17.912814Z", "subnet":"172.16.20.0/22", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "private_network_id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "vpc_id":"030c3bf4-c4a8-4021-94af-42e80bd4039b"}, {"id":"87a8bd6e-857a-4524-b035-300f7b2738c2", "created_at":"2026-04-01T08:11:17.912814Z", "updated_at":"2026-04-01T08:11:17.912814Z", "subnet":"fd40:e277:fdde:323c::/64", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "private_network_id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "vpc_id":"030c3bf4-c4a8-4021-94af-42e80bd4039b"}], "vpc_id":"030c3bf4-c4a8-4021-94af-42e80bd4039b", "dhcp_enabled":true, "default_route_propagation_enabled":false, "region":"fr-par"}'
         headers:
             Content-Length:
-                - "1065"
+                - "1089"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:39:02 GMT
+                - Wed, 01 Apr 2026 08:11:18 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - d640a6ec-b107-4b7a-8303-9ddae0ed0d6a
+                - 0f712916-5baa-446a-998b-53cc6227482d
         status: 200 OK
         code: 200
-        duration: 60.926938ms
+        duration: 56.814403ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -142,7 +142,7 @@ interactions:
         proto_minor: 1
         content_length: 331
         host: api.scaleway.com
-        body: '{"project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":null,"main":{"node_type":"DATALAB-SHARED-4C-8G"},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1},"has_notebook":false,"spark_version":"4.0.0","private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690"}'
+        body: '{"project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":null,"main":{"node_type":"DATALAB-SHARED-4C-8G"},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1},"has_notebook":false,"spark_version":"4.0.0","private_network_id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14"}'
         headers:
             Content-Type:
                 - application/json
@@ -154,22 +154,22 @@ interactions:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 911
-        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:39:02.860650Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        content_length: 935
+        body: '{"id":"c31a7c2b-27df-479c-847b-4e0f5ff288bf", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_name", "description":"", "tags":[], "created_at":"2026-04-01T08:11:18.734699Z", "updated_at":"2026-04-01T08:11:18.734699Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://c31a7c2b-27df-479c-847b-4e0f5ff288bf.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-c31a7c2b-27df-479c-847b-4e0f5ff288bf.ebcf14ad-0c72-4ff9-b741-d26bee430b14.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "911"
+                - "935"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:39:03 GMT
+                - Wed, 01 Apr 2026 08:11:19 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 50ee6dbb-ec8c-45b1-bb68-789b8216d90f
+                - 7f3f1b68-c1b0-479c-a2ef-c2a4ad1cc383
         status: 200 OK
         code: 200
-        duration: 1.263914788s
+        duration: 1.337452411s
     - id: 5
       request:
         proto: HTTP/1.1
@@ -180,28 +180,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c31a7c2b-27df-479c-847b-4e0f5ff288bf
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 911
-        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:39:02.860650Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        content_length: 935
+        body: '{"id":"c31a7c2b-27df-479c-847b-4e0f5ff288bf", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_name", "description":"", "tags":[], "created_at":"2026-04-01T08:11:18.734699Z", "updated_at":"2026-04-01T08:11:18.734699Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://c31a7c2b-27df-479c-847b-4e0f5ff288bf.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-c31a7c2b-27df-479c-847b-4e0f5ff288bf.ebcf14ad-0c72-4ff9-b741-d26bee430b14.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "911"
+                - "935"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:39:04 GMT
+                - Wed, 01 Apr 2026 08:11:20 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - b694ea47-f023-4256-81d7-e26a83fc2654
+                - 0989752e-e18e-4232-9d81-7dfaabb7c7a1
         status: 200 OK
         code: 200
-        duration: 71.97726ms
+        duration: 78.656602ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -212,28 +212,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c31a7c2b-27df-479c-847b-4e0f5ff288bf
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 911
-        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:39:02.860650Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        content_length: 935
+        body: '{"id":"c31a7c2b-27df-479c-847b-4e0f5ff288bf", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_name", "description":"", "tags":[], "created_at":"2026-04-01T08:11:18.734699Z", "updated_at":"2026-04-01T08:11:18.734699Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://c31a7c2b-27df-479c-847b-4e0f5ff288bf.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-c31a7c2b-27df-479c-847b-4e0f5ff288bf.ebcf14ad-0c72-4ff9-b741-d26bee430b14.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "911"
+                - "935"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:39:19 GMT
+                - Wed, 01 Apr 2026 08:11:35 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 8058ce7e-8b8f-4f40-950d-4b29ee0790ca
+                - 87d0b84c-f8b7-48eb-875a-a6ee25f6adad
         status: 200 OK
         code: 200
-        duration: 85.493178ms
+        duration: 82.347261ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -244,28 +244,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c31a7c2b-27df-479c-847b-4e0f5ff288bf
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 911
-        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:39:02.860650Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        content_length: 935
+        body: '{"id":"c31a7c2b-27df-479c-847b-4e0f5ff288bf", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_name", "description":"", "tags":[], "created_at":"2026-04-01T08:11:18.734699Z", "updated_at":"2026-04-01T08:11:18.734699Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://c31a7c2b-27df-479c-847b-4e0f5ff288bf.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-c31a7c2b-27df-479c-847b-4e0f5ff288bf.ebcf14ad-0c72-4ff9-b741-d26bee430b14.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "911"
+                - "935"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:39:34 GMT
+                - Wed, 01 Apr 2026 08:11:50 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - f1220291-eda1-42c0-a3f8-275e7b86e338
+                - 741963ae-2783-49da-8122-373d822e3b60
         status: 200 OK
         code: 200
-        duration: 67.949183ms
+        duration: 72.152208ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -276,28 +276,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c31a7c2b-27df-479c-847b-4e0f5ff288bf
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 911
-        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:39:02.860650Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        content_length: 935
+        body: '{"id":"c31a7c2b-27df-479c-847b-4e0f5ff288bf", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_name", "description":"", "tags":[], "created_at":"2026-04-01T08:11:18.734699Z", "updated_at":"2026-04-01T08:11:18.734699Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://c31a7c2b-27df-479c-847b-4e0f5ff288bf.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-c31a7c2b-27df-479c-847b-4e0f5ff288bf.ebcf14ad-0c72-4ff9-b741-d26bee430b14.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "911"
+                - "935"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:39:49 GMT
+                - Wed, 01 Apr 2026 08:12:05 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - bd2b4b48-2971-4d23-84c1-02325433d504
+                - 2dfb2ab6-f8ac-4008-9d6a-cde96474353b
         status: 200 OK
         code: 200
-        duration: 79.175064ms
+        duration: 88.400327ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -308,28 +308,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c31a7c2b-27df-479c-847b-4e0f5ff288bf
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 911
-        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:39:02.860650Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        content_length: 935
+        body: '{"id":"c31a7c2b-27df-479c-847b-4e0f5ff288bf", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_name", "description":"", "tags":[], "created_at":"2026-04-01T08:11:18.734699Z", "updated_at":"2026-04-01T08:11:18.734699Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://c31a7c2b-27df-479c-847b-4e0f5ff288bf.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-c31a7c2b-27df-479c-847b-4e0f5ff288bf.ebcf14ad-0c72-4ff9-b741-d26bee430b14.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "911"
+                - "935"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:40:04 GMT
+                - Wed, 01 Apr 2026 08:12:20 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 58cbe6fe-4c77-4d4a-a705-f0d776b9874a
+                - dd4d0dac-39de-474b-aac5-1704a57d8505
         status: 200 OK
         code: 200
-        duration: 97.289112ms
+        duration: 78.222394ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -340,28 +340,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c31a7c2b-27df-479c-847b-4e0f5ff288bf
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 911
-        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:39:02.860650Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        content_length: 935
+        body: '{"id":"c31a7c2b-27df-479c-847b-4e0f5ff288bf", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_name", "description":"", "tags":[], "created_at":"2026-04-01T08:11:18.734699Z", "updated_at":"2026-04-01T08:11:18.734699Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://c31a7c2b-27df-479c-847b-4e0f5ff288bf.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-c31a7c2b-27df-479c-847b-4e0f5ff288bf.ebcf14ad-0c72-4ff9-b741-d26bee430b14.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "911"
+                - "935"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:40:19 GMT
+                - Wed, 01 Apr 2026 08:12:35 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 4550a506-4977-48de-ae68-2fb3ea949ce0
+                - c6cdf533-dcb4-46f6-b14b-ebdefbb8a5e0
         status: 200 OK
         code: 200
-        duration: 78.06676ms
+        duration: 85.927021ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -372,28 +372,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c31a7c2b-27df-479c-847b-4e0f5ff288bf
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 911
-        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:39:02.860650Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        content_length: 935
+        body: '{"id":"c31a7c2b-27df-479c-847b-4e0f5ff288bf", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_name", "description":"", "tags":[], "created_at":"2026-04-01T08:11:18.734699Z", "updated_at":"2026-04-01T08:11:18.734699Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://c31a7c2b-27df-479c-847b-4e0f5ff288bf.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-c31a7c2b-27df-479c-847b-4e0f5ff288bf.ebcf14ad-0c72-4ff9-b741-d26bee430b14.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "911"
+                - "935"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:40:34 GMT
+                - Wed, 01 Apr 2026 08:12:50 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - f72d2048-69fb-4098-9df0-2670be19e8bd
+                - 3625d012-40ab-4f30-af96-8430ea30adf6
         status: 200 OK
         code: 200
-        duration: 82.552033ms
+        duration: 75.768188ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -404,28 +404,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c31a7c2b-27df-479c-847b-4e0f5ff288bf
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 911
-        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:39:02.860650Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        content_length: 935
+        body: '{"id":"c31a7c2b-27df-479c-847b-4e0f5ff288bf", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_name", "description":"", "tags":[], "created_at":"2026-04-01T08:11:18.734699Z", "updated_at":"2026-04-01T08:11:18.734699Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://c31a7c2b-27df-479c-847b-4e0f5ff288bf.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-c31a7c2b-27df-479c-847b-4e0f5ff288bf.ebcf14ad-0c72-4ff9-b741-d26bee430b14.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "911"
+                - "935"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:40:49 GMT
+                - Wed, 01 Apr 2026 08:13:05 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - f0da7c17-4f24-4e09-84c4-52e5a74677e3
+                - 71540c83-beb5-4cfd-80d8-66add11f3d8d
         status: 200 OK
         code: 200
-        duration: 67.633104ms
+        duration: 81.417677ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -436,28 +436,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c31a7c2b-27df-479c-847b-4e0f5ff288bf
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 911
-        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:39:02.860650Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        content_length: 935
+        body: '{"id":"c31a7c2b-27df-479c-847b-4e0f5ff288bf", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_name", "description":"", "tags":[], "created_at":"2026-04-01T08:11:18.734699Z", "updated_at":"2026-04-01T08:11:18.734699Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://c31a7c2b-27df-479c-847b-4e0f5ff288bf.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-c31a7c2b-27df-479c-847b-4e0f5ff288bf.ebcf14ad-0c72-4ff9-b741-d26bee430b14.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "911"
+                - "935"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:41:04 GMT
+                - Wed, 01 Apr 2026 08:13:20 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 1d3f511f-4def-4309-93b3-98aee7e6a6cc
+                - 866cb150-5f9f-4454-a057-179b9cec953d
         status: 200 OK
         code: 200
-        duration: 87.950704ms
+        duration: 78.796226ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -468,28 +468,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c31a7c2b-27df-479c-847b-4e0f5ff288bf
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 911
-        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:39:02.860650Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        content_length: 935
+        body: '{"id":"c31a7c2b-27df-479c-847b-4e0f5ff288bf", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_name", "description":"", "tags":[], "created_at":"2026-04-01T08:11:18.734699Z", "updated_at":"2026-04-01T08:11:18.734699Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://c31a7c2b-27df-479c-847b-4e0f5ff288bf.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-c31a7c2b-27df-479c-847b-4e0f5ff288bf.ebcf14ad-0c72-4ff9-b741-d26bee430b14.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "911"
+                - "935"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:41:19 GMT
+                - Wed, 01 Apr 2026 08:13:35 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - fd5f2b80-e8d7-4d15-a461-34f990e9d970
+                - 0b76799d-05f5-4aa9-b4f8-b813323fe2aa
         status: 200 OK
         code: 200
-        duration: 96.528038ms
+        duration: 90.679896ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -500,28 +500,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c31a7c2b-27df-479c-847b-4e0f5ff288bf
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 911
-        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:39:02.860650Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        content_length: 935
+        body: '{"id":"c31a7c2b-27df-479c-847b-4e0f5ff288bf", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_name", "description":"", "tags":[], "created_at":"2026-04-01T08:11:18.734699Z", "updated_at":"2026-04-01T08:11:18.734699Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://c31a7c2b-27df-479c-847b-4e0f5ff288bf.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-c31a7c2b-27df-479c-847b-4e0f5ff288bf.ebcf14ad-0c72-4ff9-b741-d26bee430b14.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "911"
+                - "935"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:41:34 GMT
+                - Wed, 01 Apr 2026 08:13:50 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 0da448c6-1e6a-4b61-b106-cbddbd2bf779
+                - d10620e6-0252-4db0-9485-7affde6f349c
         status: 200 OK
         code: 200
-        duration: 72.246627ms
+        duration: 65.889606ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -532,28 +532,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c31a7c2b-27df-479c-847b-4e0f5ff288bf
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 911
-        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:39:02.860650Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        content_length: 935
+        body: '{"id":"c31a7c2b-27df-479c-847b-4e0f5ff288bf", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_name", "description":"", "tags":[], "created_at":"2026-04-01T08:11:18.734699Z", "updated_at":"2026-04-01T08:11:18.734699Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://c31a7c2b-27df-479c-847b-4e0f5ff288bf.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-c31a7c2b-27df-479c-847b-4e0f5ff288bf.ebcf14ad-0c72-4ff9-b741-d26bee430b14.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "911"
+                - "935"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:41:49 GMT
+                - Wed, 01 Apr 2026 08:14:05 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - c90b0653-f9b8-4537-b52b-93e02db8d6be
+                - 719a0c23-313d-4489-9960-ee244fbe553d
         status: 200 OK
         code: 200
-        duration: 71.991056ms
+        duration: 71.72488ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -564,28 +564,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c31a7c2b-27df-479c-847b-4e0f5ff288bf
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 911
-        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:39:02.860650Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        content_length: 935
+        body: '{"id":"c31a7c2b-27df-479c-847b-4e0f5ff288bf", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_name", "description":"", "tags":[], "created_at":"2026-04-01T08:11:18.734699Z", "updated_at":"2026-04-01T08:11:18.734699Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://c31a7c2b-27df-479c-847b-4e0f5ff288bf.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-c31a7c2b-27df-479c-847b-4e0f5ff288bf.ebcf14ad-0c72-4ff9-b741-d26bee430b14.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "911"
+                - "935"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:42:05 GMT
+                - Wed, 01 Apr 2026 08:14:20 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - ec54bcb1-fa14-4173-aef2-0c306e6d6d9f
+                - 787efd7d-3146-457e-aaac-aa674d44f530
         status: 200 OK
         code: 200
-        duration: 78.290671ms
+        duration: 72.510828ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -596,28 +596,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c31a7c2b-27df-479c-847b-4e0f5ff288bf
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 911
-        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:39:02.860650Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        content_length: 935
+        body: '{"id":"c31a7c2b-27df-479c-847b-4e0f5ff288bf", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_name", "description":"", "tags":[], "created_at":"2026-04-01T08:11:18.734699Z", "updated_at":"2026-04-01T08:11:18.734699Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://c31a7c2b-27df-479c-847b-4e0f5ff288bf.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-c31a7c2b-27df-479c-847b-4e0f5ff288bf.ebcf14ad-0c72-4ff9-b741-d26bee430b14.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "911"
+                - "935"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:42:20 GMT
+                - Wed, 01 Apr 2026 08:14:36 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 461de162-b0c6-49b8-a03e-f4e21bdb9a1a
+                - 9ad73741-dcf3-4888-880f-0e6332ac4726
         status: 200 OK
         code: 200
-        duration: 73.048272ms
+        duration: 71.69859ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -628,28 +628,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c31a7c2b-27df-479c-847b-4e0f5ff288bf
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 911
-        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:39:02.860650Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        content_length: 935
+        body: '{"id":"c31a7c2b-27df-479c-847b-4e0f5ff288bf", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_name", "description":"", "tags":[], "created_at":"2026-04-01T08:11:18.734699Z", "updated_at":"2026-04-01T08:11:18.734699Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://c31a7c2b-27df-479c-847b-4e0f5ff288bf.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-c31a7c2b-27df-479c-847b-4e0f5ff288bf.ebcf14ad-0c72-4ff9-b741-d26bee430b14.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "911"
+                - "935"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:42:35 GMT
+                - Wed, 01 Apr 2026 08:14:51 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 108f8441-bf3f-43fd-8f19-f472ccc794ed
+                - 67e8382e-0849-4724-8193-82638afc6b1f
         status: 200 OK
         code: 200
-        duration: 72.596126ms
+        duration: 84.939273ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -660,28 +660,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c31a7c2b-27df-479c-847b-4e0f5ff288bf
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 911
-        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:39:02.860650Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        content_length: 935
+        body: '{"id":"c31a7c2b-27df-479c-847b-4e0f5ff288bf", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_name", "description":"", "tags":[], "created_at":"2026-04-01T08:11:18.734699Z", "updated_at":"2026-04-01T08:11:18.734699Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://c31a7c2b-27df-479c-847b-4e0f5ff288bf.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-c31a7c2b-27df-479c-847b-4e0f5ff288bf.ebcf14ad-0c72-4ff9-b741-d26bee430b14.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "911"
+                - "935"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:42:50 GMT
+                - Wed, 01 Apr 2026 08:15:06 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - d99e92b2-7b69-41bf-8b69-c30534c604c0
+                - de65bb7d-9994-47ce-817f-6ceea608243c
         status: 200 OK
         code: 200
-        duration: 75.192269ms
+        duration: 76.166264ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -692,28 +692,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c31a7c2b-27df-479c-847b-4e0f5ff288bf
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 911
-        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:39:02.860650Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        content_length: 935
+        body: '{"id":"c31a7c2b-27df-479c-847b-4e0f5ff288bf", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_name", "description":"", "tags":[], "created_at":"2026-04-01T08:11:18.734699Z", "updated_at":"2026-04-01T08:11:18.734699Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://c31a7c2b-27df-479c-847b-4e0f5ff288bf.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-c31a7c2b-27df-479c-847b-4e0f5ff288bf.ebcf14ad-0c72-4ff9-b741-d26bee430b14.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "911"
+                - "935"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:43:05 GMT
+                - Wed, 01 Apr 2026 08:15:21 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 8b24ef25-85c3-4b3b-9f5c-fddb3ba8feec
+                - 00e65dd8-fa30-49cc-961d-313b7682f616
         status: 200 OK
         code: 200
-        duration: 76.801899ms
+        duration: 73.270932ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -724,28 +724,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c31a7c2b-27df-479c-847b-4e0f5ff288bf
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 911
-        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:39:02.860650Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        content_length: 935
+        body: '{"id":"c31a7c2b-27df-479c-847b-4e0f5ff288bf", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_name", "description":"", "tags":[], "created_at":"2026-04-01T08:11:18.734699Z", "updated_at":"2026-04-01T08:11:18.734699Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://c31a7c2b-27df-479c-847b-4e0f5ff288bf.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-c31a7c2b-27df-479c-847b-4e0f5ff288bf.ebcf14ad-0c72-4ff9-b741-d26bee430b14.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "911"
+                - "935"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:43:20 GMT
+                - Wed, 01 Apr 2026 08:15:36 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 1b2b5233-2f85-4c81-bf8e-4b367919295d
+                - fe427110-1a27-409e-a548-d09d70511904
         status: 200 OK
         code: 200
-        duration: 89.66782ms
+        duration: 75.162406ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -756,28 +756,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c31a7c2b-27df-479c-847b-4e0f5ff288bf
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 911
-        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:39:02.860650Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        content_length: 935
+        body: '{"id":"c31a7c2b-27df-479c-847b-4e0f5ff288bf", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_name", "description":"", "tags":[], "created_at":"2026-04-01T08:11:18.734699Z", "updated_at":"2026-04-01T08:11:18.734699Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://c31a7c2b-27df-479c-847b-4e0f5ff288bf.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-c31a7c2b-27df-479c-847b-4e0f5ff288bf.ebcf14ad-0c72-4ff9-b741-d26bee430b14.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "911"
+                - "935"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:43:35 GMT
+                - Wed, 01 Apr 2026 08:15:51 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - b7f0e540-65f4-4cc0-a7e9-bdb8086889c4
+                - ee97662b-122b-462c-b9bd-e365521bf888
         status: 200 OK
         code: 200
-        duration: 76.586198ms
+        duration: 89.458943ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -788,28 +788,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c31a7c2b-27df-479c-847b-4e0f5ff288bf
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 911
-        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:39:02.860650Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        content_length: 935
+        body: '{"id":"c31a7c2b-27df-479c-847b-4e0f5ff288bf", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_name", "description":"", "tags":[], "created_at":"2026-04-01T08:11:18.734699Z", "updated_at":"2026-04-01T08:11:18.734699Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://c31a7c2b-27df-479c-847b-4e0f5ff288bf.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-c31a7c2b-27df-479c-847b-4e0f5ff288bf.ebcf14ad-0c72-4ff9-b741-d26bee430b14.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "911"
+                - "935"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:43:50 GMT
+                - Wed, 01 Apr 2026 08:16:06 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 6e6054fc-bc04-4cfc-b520-b69b944b5e2d
+                - ebd045d0-822a-4041-99e3-29012623f389
         status: 200 OK
         code: 200
-        duration: 76.5711ms
+        duration: 82.372746ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -820,28 +820,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c31a7c2b-27df-479c-847b-4e0f5ff288bf
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 911
-        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:39:02.860650Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        content_length: 935
+        body: '{"id":"c31a7c2b-27df-479c-847b-4e0f5ff288bf", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_name", "description":"", "tags":[], "created_at":"2026-04-01T08:11:18.734699Z", "updated_at":"2026-04-01T08:11:18.734699Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://c31a7c2b-27df-479c-847b-4e0f5ff288bf.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-c31a7c2b-27df-479c-847b-4e0f5ff288bf.ebcf14ad-0c72-4ff9-b741-d26bee430b14.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "911"
+                - "935"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:44:05 GMT
+                - Wed, 01 Apr 2026 08:16:21 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - bfc6f00b-7262-46e4-a887-e5f62458d808
+                - d0df0d87-6ccf-461e-8224-a7b0d8167a6f
         status: 200 OK
         code: 200
-        duration: 86.076101ms
+        duration: 76.428125ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -852,28 +852,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c31a7c2b-27df-479c-847b-4e0f5ff288bf
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 911
-        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:39:02.860650Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        content_length: 935
+        body: '{"id":"c31a7c2b-27df-479c-847b-4e0f5ff288bf", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_name", "description":"", "tags":[], "created_at":"2026-04-01T08:11:18.734699Z", "updated_at":"2026-04-01T08:11:18.734699Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://c31a7c2b-27df-479c-847b-4e0f5ff288bf.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-c31a7c2b-27df-479c-847b-4e0f5ff288bf.ebcf14ad-0c72-4ff9-b741-d26bee430b14.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "911"
+                - "935"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:44:20 GMT
+                - Wed, 01 Apr 2026 08:16:36 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - c78af912-053d-45cd-a05f-6ab94d0372eb
+                - 065c77b4-1146-484f-ba54-f77df09f4791
         status: 200 OK
         code: 200
-        duration: 75.462592ms
+        duration: 78.251029ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -884,28 +884,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c31a7c2b-27df-479c-847b-4e0f5ff288bf
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 911
-        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:39:02.860650Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        content_length: 935
+        body: '{"id":"c31a7c2b-27df-479c-847b-4e0f5ff288bf", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_name", "description":"", "tags":[], "created_at":"2026-04-01T08:11:18.734699Z", "updated_at":"2026-04-01T08:11:18.734699Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://c31a7c2b-27df-479c-847b-4e0f5ff288bf.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-c31a7c2b-27df-479c-847b-4e0f5ff288bf.ebcf14ad-0c72-4ff9-b741-d26bee430b14.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "911"
+                - "935"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:44:35 GMT
+                - Wed, 01 Apr 2026 08:16:51 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - f5b0465e-cd52-4bf9-bf5f-906b39a2e322
+                - 85578451-372a-458d-9862-3a7fd9474d8c
         status: 200 OK
         code: 200
-        duration: 74.563528ms
+        duration: 82.619523ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -916,28 +916,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c31a7c2b-27df-479c-847b-4e0f5ff288bf
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 908
-        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:44:46.213359Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        content_length: 935
+        body: '{"id":"c31a7c2b-27df-479c-847b-4e0f5ff288bf", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_name", "description":"", "tags":[], "created_at":"2026-04-01T08:11:18.734699Z", "updated_at":"2026-04-01T08:11:18.734699Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://c31a7c2b-27df-479c-847b-4e0f5ff288bf.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-c31a7c2b-27df-479c-847b-4e0f5ff288bf.ebcf14ad-0c72-4ff9-b741-d26bee430b14.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "908"
+                - "935"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:44:50 GMT
+                - Wed, 01 Apr 2026 08:17:06 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 38ba2b1c-2c01-49f6-9c49-eaa6a1f01703
+                - 4dc2c195-2635-4f9a-ad02-74157a42dab5
         status: 200 OK
         code: 200
-        duration: 73.125417ms
+        duration: 80.476414ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -948,28 +948,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c31a7c2b-27df-479c-847b-4e0f5ff288bf
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 908
-        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:44:46.213359Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        content_length: 932
+        body: '{"id":"c31a7c2b-27df-479c-847b-4e0f5ff288bf", "status":"ready", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_name", "description":"", "tags":[], "created_at":"2026-04-01T08:11:18.734699Z", "updated_at":"2026-04-01T08:17:11.517615Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://c31a7c2b-27df-479c-847b-4e0f5ff288bf.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-c31a7c2b-27df-479c-847b-4e0f5ff288bf.ebcf14ad-0c72-4ff9-b741-d26bee430b14.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "908"
+                - "932"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:44:51 GMT
+                - Wed, 01 Apr 2026 08:17:21 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 4717c5a9-5db1-437e-89c5-198b47b381f4
+                - dcd5715a-6b90-4190-aa41-2fea31e044b0
         status: 200 OK
         code: 200
-        duration: 68.013462ms
+        duration: 84.958634ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -980,28 +980,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/8e81a4c5-69ad-44f4-98e8-2e7f99bff562
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c31a7c2b-27df-479c-847b-4e0f5ff288bf
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 412
-        body: '{"id":"8e81a4c5-69ad-44f4-98e8-2e7f99bff562","name":"tf_tests_datalabs_ds_name","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:39:01.632082Z","updated_at":"2026-03-26T11:39:01.632082Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","is_default":false,"private_network_count":1,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        content_length: 932
+        body: '{"id":"c31a7c2b-27df-479c-847b-4e0f5ff288bf", "status":"ready", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_name", "description":"", "tags":[], "created_at":"2026-04-01T08:11:18.734699Z", "updated_at":"2026-04-01T08:17:11.517615Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://c31a7c2b-27df-479c-847b-4e0f5ff288bf.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-c31a7c2b-27df-479c-847b-4e0f5ff288bf.ebcf14ad-0c72-4ff9-b741-d26bee430b14.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "412"
+                - "932"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:44:51 GMT
+                - Wed, 01 Apr 2026 08:17:22 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - d3b8fe70-d597-4ce3-86e6-dee4f5ce6c76
+                - d74e7cd1-cb0e-4cf1-9dfd-9f968c5e4cfc
         status: 200 OK
         code: 200
-        duration: 67.346819ms
+        duration: 70.36478ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1012,28 +1012,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d0432486-ef71-414c-9fcc-021be4d0e690
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/030c3bf4-c4a8-4021-94af-42e80bd4039b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 1065
-        body: '{"id":"d0432486-ef71-414c-9fcc-021be4d0e690","name":"tf-pn-magical-spence","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:39:01.791069Z","updated_at":"2026-03-26T11:39:01.791069Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","subnets":[{"id":"f1f9a42e-347f-40f4-af69-3389174d2d6b","created_at":"2026-03-26T11:39:01.791069Z","updated_at":"2026-03-26T11:39:01.791069Z","subnet":"172.16.8.0/22","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","vpc_id":"8e81a4c5-69ad-44f4-98e8-2e7f99bff562"},{"id":"65278186-e46c-4714-9d84-ac2e5df4024a","created_at":"2026-03-26T11:39:01.791069Z","updated_at":"2026-03-26T11:39:01.791069Z","subnet":"fd40:e277:fdde:b157::/64","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","vpc_id":"8e81a4c5-69ad-44f4-98e8-2e7f99bff562"}],"vpc_id":"8e81a4c5-69ad-44f4-98e8-2e7f99bff562","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        content_length: 423
+        body: '{"id":"030c3bf4-c4a8-4021-94af-42e80bd4039b", "name":"tf_tests_datalabs_ds_name", "tags":[], "organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8", "created_at":"2026-04-01T08:11:17.051818Z", "updated_at":"2026-04-01T08:11:17.051818Z", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "is_default":false, "private_network_count":1, "routing_enabled":true, "custom_routes_propagation_enabled":true, "region":"fr-par"}'
         headers:
             Content-Length:
-                - "1065"
+                - "423"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:44:51 GMT
+                - Wed, 01 Apr 2026 08:17:22 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 77eadb8c-fbcc-45f6-a714-31230895211a
+                - 3d4dd327-e025-4746-9a2c-0b488c8adb28
         status: 200 OK
         code: 200
-        duration: 68.573217ms
+        duration: 55.905467ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1044,28 +1044,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/ebcf14ad-0c72-4ff9-b741-d26bee430b14
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 908
-        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:44:46.213359Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        content_length: 1089
+        body: '{"id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "name":"tf-pn-angry-germain", "tags":[], "organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8", "created_at":"2026-04-01T08:11:17.912814Z", "updated_at":"2026-04-01T08:11:17.912814Z", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "subnets":[{"id":"3dfa3e4f-0021-4ebd-97d3-6d7e75facb29", "created_at":"2026-04-01T08:11:17.912814Z", "updated_at":"2026-04-01T08:11:17.912814Z", "subnet":"172.16.20.0/22", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "private_network_id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "vpc_id":"030c3bf4-c4a8-4021-94af-42e80bd4039b"}, {"id":"87a8bd6e-857a-4524-b035-300f7b2738c2", "created_at":"2026-04-01T08:11:17.912814Z", "updated_at":"2026-04-01T08:11:17.912814Z", "subnet":"fd40:e277:fdde:323c::/64", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "private_network_id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "vpc_id":"030c3bf4-c4a8-4021-94af-42e80bd4039b"}], "vpc_id":"030c3bf4-c4a8-4021-94af-42e80bd4039b", "dhcp_enabled":true, "default_route_propagation_enabled":false, "region":"fr-par"}'
         headers:
             Content-Length:
-                - "908"
+                - "1089"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:44:51 GMT
+                - Wed, 01 Apr 2026 08:17:22 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - b315dddb-fb55-496e-984d-8a101ee2204e
+                - a12929b4-2400-4d7c-bce9-ead32faa4aab
         status: 200 OK
         code: 200
-        duration: 71.378363ms
+        duration: 61.87305ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1076,28 +1076,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/8e81a4c5-69ad-44f4-98e8-2e7f99bff562
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c31a7c2b-27df-479c-847b-4e0f5ff288bf
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 412
-        body: '{"id":"8e81a4c5-69ad-44f4-98e8-2e7f99bff562","name":"tf_tests_datalabs_ds_name","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:39:01.632082Z","updated_at":"2026-03-26T11:39:01.632082Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","is_default":false,"private_network_count":1,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        content_length: 932
+        body: '{"id":"c31a7c2b-27df-479c-847b-4e0f5ff288bf", "status":"ready", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_name", "description":"", "tags":[], "created_at":"2026-04-01T08:11:18.734699Z", "updated_at":"2026-04-01T08:17:11.517615Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://c31a7c2b-27df-479c-847b-4e0f5ff288bf.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-c31a7c2b-27df-479c-847b-4e0f5ff288bf.ebcf14ad-0c72-4ff9-b741-d26bee430b14.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "412"
+                - "932"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:44:51 GMT
+                - Wed, 01 Apr 2026 08:17:22 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 457ae8c9-7f1c-41af-9339-a139e3ce22fc
+                - 59f90e33-466f-4680-acd3-702f9a56fe49
         status: 200 OK
         code: 200
-        duration: 70.73464ms
+        duration: 71.622194ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1108,28 +1108,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d0432486-ef71-414c-9fcc-021be4d0e690
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/030c3bf4-c4a8-4021-94af-42e80bd4039b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 1065
-        body: '{"id":"d0432486-ef71-414c-9fcc-021be4d0e690","name":"tf-pn-magical-spence","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:39:01.791069Z","updated_at":"2026-03-26T11:39:01.791069Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","subnets":[{"id":"f1f9a42e-347f-40f4-af69-3389174d2d6b","created_at":"2026-03-26T11:39:01.791069Z","updated_at":"2026-03-26T11:39:01.791069Z","subnet":"172.16.8.0/22","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","vpc_id":"8e81a4c5-69ad-44f4-98e8-2e7f99bff562"},{"id":"65278186-e46c-4714-9d84-ac2e5df4024a","created_at":"2026-03-26T11:39:01.791069Z","updated_at":"2026-03-26T11:39:01.791069Z","subnet":"fd40:e277:fdde:b157::/64","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","vpc_id":"8e81a4c5-69ad-44f4-98e8-2e7f99bff562"}],"vpc_id":"8e81a4c5-69ad-44f4-98e8-2e7f99bff562","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        content_length: 423
+        body: '{"id":"030c3bf4-c4a8-4021-94af-42e80bd4039b", "name":"tf_tests_datalabs_ds_name", "tags":[], "organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8", "created_at":"2026-04-01T08:11:17.051818Z", "updated_at":"2026-04-01T08:11:17.051818Z", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "is_default":false, "private_network_count":1, "routing_enabled":true, "custom_routes_propagation_enabled":true, "region":"fr-par"}'
         headers:
             Content-Length:
-                - "1065"
+                - "423"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:44:51 GMT
+                - Wed, 01 Apr 2026 08:17:22 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - e840c687-5e88-45da-85ca-79258b5fbff3
+                - 3c7c2ac4-0e9f-4d84-bde7-12c79b9c470f
         status: 200 OK
         code: 200
-        duration: 66.635638ms
+        duration: 65.71879ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1140,28 +1140,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/ebcf14ad-0c72-4ff9-b741-d26bee430b14
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 908
-        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:44:46.213359Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        content_length: 1089
+        body: '{"id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "name":"tf-pn-angry-germain", "tags":[], "organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8", "created_at":"2026-04-01T08:11:17.912814Z", "updated_at":"2026-04-01T08:11:17.912814Z", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "subnets":[{"id":"3dfa3e4f-0021-4ebd-97d3-6d7e75facb29", "created_at":"2026-04-01T08:11:17.912814Z", "updated_at":"2026-04-01T08:11:17.912814Z", "subnet":"172.16.20.0/22", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "private_network_id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "vpc_id":"030c3bf4-c4a8-4021-94af-42e80bd4039b"}, {"id":"87a8bd6e-857a-4524-b035-300f7b2738c2", "created_at":"2026-04-01T08:11:17.912814Z", "updated_at":"2026-04-01T08:11:17.912814Z", "subnet":"fd40:e277:fdde:323c::/64", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "private_network_id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "vpc_id":"030c3bf4-c4a8-4021-94af-42e80bd4039b"}], "vpc_id":"030c3bf4-c4a8-4021-94af-42e80bd4039b", "dhcp_enabled":true, "default_route_propagation_enabled":false, "region":"fr-par"}'
         headers:
             Content-Length:
-                - "908"
+                - "1089"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:44:51 GMT
+                - Wed, 01 Apr 2026 08:17:22 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - cf9f6b4a-34f4-4424-9d92-590f3df77180
+                - fea6a1d8-711a-4521-bce9-8c02206b37cf
         status: 200 OK
         code: 200
-        duration: 76.651945ms
+        duration: 69.846246ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1169,40 +1169,31 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: api.scaleway.com
-        form:
-            name:
-                - tf_tests_datalabs_ds_name
-            order_by:
-                - name_asc
-            page:
-                - "1"
-            page_size:
-                - "100"
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs?name=tf_tests_datalabs_ds_name&order_by=name_asc&page=1&page_size=100
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c31a7c2b-27df-479c-847b-4e0f5ff288bf
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 939
-        body: '{"datalabs":[{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:44:46.213359Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}],"total_count":1}'
+        content_length: 932
+        body: '{"id":"c31a7c2b-27df-479c-847b-4e0f5ff288bf", "status":"ready", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_name", "description":"", "tags":[], "created_at":"2026-04-01T08:11:18.734699Z", "updated_at":"2026-04-01T08:17:11.517615Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://c31a7c2b-27df-479c-847b-4e0f5ff288bf.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-c31a7c2b-27df-479c-847b-4e0f5ff288bf.ebcf14ad-0c72-4ff9-b741-d26bee430b14.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "939"
+                - "932"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:44:51 GMT
+                - Wed, 01 Apr 2026 08:17:22 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 7d54f358-71bf-41dc-9069-3d4d09d6cfcd
+                - e6718122-6b16-49b5-8b9a-139ced3a90b3
         status: 200 OK
         code: 200
-        duration: 73.37248ms
+        duration: 81.554135ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1210,32 +1201,71 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: api.scaleway.com
+        form:
+            name:
+                - tf_tests_datalabs_ds_name
+            order_by:
+                - name_asc
+            page:
+                - "1"
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs?name=tf_tests_datalabs_ds_name&order_by=name_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 908
-        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:44:46.213359Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        content_length: 1898
+        body: '{"datalabs":[{"id":"0047ff02-6953-4ef0-bfb1-c093796e0477", "status":"ready", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_name", "description":"", "tags":[], "created_at":"2026-04-01T08:02:27.052181Z", "updated_at":"2026-04-01T08:08:03.972492Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://0047ff02-6953-4ef0-bfb1-c093796e0477.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-0047ff02-6953-4ef0-bfb1-c093796e0477.593f0960-2d24-404e-88c5-af99a6454020.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"593f0960-2d24-404e-88c5-af99a6454020", "notebook_master_url":"", "region":"fr-par"}, {"id":"c31a7c2b-27df-479c-847b-4e0f5ff288bf", "status":"ready", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_name", "description":"", "tags":[], "created_at":"2026-04-01T08:11:18.734699Z", "updated_at":"2026-04-01T08:17:11.517615Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://c31a7c2b-27df-479c-847b-4e0f5ff288bf.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-c31a7c2b-27df-479c-847b-4e0f5ff288bf.ebcf14ad-0c72-4ff9-b741-d26bee430b14.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "notebook_master_url":"", "region":"fr-par"}], "total_count":2}'
         headers:
             Content-Length:
-                - "908"
+                - "1898"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:44:51 GMT
+                - Wed, 01 Apr 2026 08:17:22 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 92ff618f-1aff-48ec-bf55-7e9f4d34ede3
+                - b6212f2f-26cf-41fc-8ecd-22d54a10a127
         status: 200 OK
         code: 200
-        duration: 72.632681ms
+        duration: 96.806819ms
     - id: 38
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c31a7c2b-27df-479c-847b-4e0f5ff288bf
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 932
+        body: '{"id":"c31a7c2b-27df-479c-847b-4e0f5ff288bf", "status":"ready", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_name", "description":"", "tags":[], "created_at":"2026-04-01T08:11:18.734699Z", "updated_at":"2026-04-01T08:17:11.517615Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://c31a7c2b-27df-479c-847b-4e0f5ff288bf.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-c31a7c2b-27df-479c-847b-4e0f5ff288bf.ebcf14ad-0c72-4ff9-b741-d26bee430b14.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "notebook_master_url":"", "region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "932"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 01 Apr 2026 08:17:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 3d2ff629-8ab3-485e-a7a0-29faadb91ecb
+        status: 200 OK
+        code: 200
+        duration: 68.097208ms
+    - id: 39
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1249,65 +1279,31 @@ interactions:
                 - name_asc
             page:
                 - "1"
-            page_size:
-                - "100"
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs?name=tf_tests_datalabs_ds_name&order_by=name_asc&page=1&page_size=100
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs?name=tf_tests_datalabs_ds_name&order_by=name_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 939
-        body: '{"datalabs":[{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:44:46.213359Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}],"total_count":1}'
+        content_length: 1898
+        body: '{"datalabs":[{"id":"0047ff02-6953-4ef0-bfb1-c093796e0477", "status":"ready", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_name", "description":"", "tags":[], "created_at":"2026-04-01T08:02:27.052181Z", "updated_at":"2026-04-01T08:08:03.972492Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://0047ff02-6953-4ef0-bfb1-c093796e0477.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-0047ff02-6953-4ef0-bfb1-c093796e0477.593f0960-2d24-404e-88c5-af99a6454020.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"593f0960-2d24-404e-88c5-af99a6454020", "notebook_master_url":"", "region":"fr-par"}, {"id":"c31a7c2b-27df-479c-847b-4e0f5ff288bf", "status":"ready", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_name", "description":"", "tags":[], "created_at":"2026-04-01T08:11:18.734699Z", "updated_at":"2026-04-01T08:17:11.517615Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://c31a7c2b-27df-479c-847b-4e0f5ff288bf.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-c31a7c2b-27df-479c-847b-4e0f5ff288bf.ebcf14ad-0c72-4ff9-b741-d26bee430b14.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "notebook_master_url":"", "region":"fr-par"}], "total_count":2}'
         headers:
             Content-Length:
-                - "939"
+                - "1898"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:44:52 GMT
+                - Wed, 01 Apr 2026 08:17:23 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 6237cbb1-f37d-44fd-bdb1-a035ce83dddc
+                - 21121c95-c958-4200-9a59-9ca39e8c4a95
         status: 200 OK
         code: 200
-        duration: 80.749127ms
-    - id: 39
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/8e81a4c5-69ad-44f4-98e8-2e7f99bff562
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 412
-        body: '{"id":"8e81a4c5-69ad-44f4-98e8-2e7f99bff562","name":"tf_tests_datalabs_ds_name","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:39:01.632082Z","updated_at":"2026-03-26T11:39:01.632082Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","is_default":false,"private_network_count":1,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
-        headers:
-            Content-Length:
-                - "412"
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 26 Mar 2026 11:44:52 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
-            X-Request-Id:
-                - 5b21ae9a-5d6a-4a3c-aad4-1c4044ca1b5a
-        status: 200 OK
-        code: 200
-        duration: 56.330219ms
+        duration: 73.813984ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -1318,28 +1314,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d0432486-ef71-414c-9fcc-021be4d0e690
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/030c3bf4-c4a8-4021-94af-42e80bd4039b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 1065
-        body: '{"id":"d0432486-ef71-414c-9fcc-021be4d0e690","name":"tf-pn-magical-spence","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:39:01.791069Z","updated_at":"2026-03-26T11:39:01.791069Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","subnets":[{"id":"f1f9a42e-347f-40f4-af69-3389174d2d6b","created_at":"2026-03-26T11:39:01.791069Z","updated_at":"2026-03-26T11:39:01.791069Z","subnet":"172.16.8.0/22","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","vpc_id":"8e81a4c5-69ad-44f4-98e8-2e7f99bff562"},{"id":"65278186-e46c-4714-9d84-ac2e5df4024a","created_at":"2026-03-26T11:39:01.791069Z","updated_at":"2026-03-26T11:39:01.791069Z","subnet":"fd40:e277:fdde:b157::/64","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","vpc_id":"8e81a4c5-69ad-44f4-98e8-2e7f99bff562"}],"vpc_id":"8e81a4c5-69ad-44f4-98e8-2e7f99bff562","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        content_length: 423
+        body: '{"id":"030c3bf4-c4a8-4021-94af-42e80bd4039b", "name":"tf_tests_datalabs_ds_name", "tags":[], "organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8", "created_at":"2026-04-01T08:11:17.051818Z", "updated_at":"2026-04-01T08:11:17.051818Z", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "is_default":false, "private_network_count":1, "routing_enabled":true, "custom_routes_propagation_enabled":true, "region":"fr-par"}'
         headers:
             Content-Length:
-                - "1065"
+                - "423"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:44:52 GMT
+                - Wed, 01 Apr 2026 08:17:23 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 927371b9-f2b1-4b88-be22-cde3349f6f71
+                - 39f0f7bb-80eb-4cf7-8a37-db6e3479be49
         status: 200 OK
         code: 200
-        duration: 59.546424ms
+        duration: 58.719639ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -1350,29 +1346,61 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/ebcf14ad-0c72-4ff9-b741-d26bee430b14
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 908
-        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:44:46.213359Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        content_length: 1089
+        body: '{"id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "name":"tf-pn-angry-germain", "tags":[], "organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8", "created_at":"2026-04-01T08:11:17.912814Z", "updated_at":"2026-04-01T08:11:17.912814Z", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "subnets":[{"id":"3dfa3e4f-0021-4ebd-97d3-6d7e75facb29", "created_at":"2026-04-01T08:11:17.912814Z", "updated_at":"2026-04-01T08:11:17.912814Z", "subnet":"172.16.20.0/22", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "private_network_id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "vpc_id":"030c3bf4-c4a8-4021-94af-42e80bd4039b"}, {"id":"87a8bd6e-857a-4524-b035-300f7b2738c2", "created_at":"2026-04-01T08:11:17.912814Z", "updated_at":"2026-04-01T08:11:17.912814Z", "subnet":"fd40:e277:fdde:323c::/64", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "private_network_id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "vpc_id":"030c3bf4-c4a8-4021-94af-42e80bd4039b"}], "vpc_id":"030c3bf4-c4a8-4021-94af-42e80bd4039b", "dhcp_enabled":true, "default_route_propagation_enabled":false, "region":"fr-par"}'
         headers:
             Content-Length:
-                - "908"
+                - "1089"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:44:52 GMT
+                - Wed, 01 Apr 2026 08:17:23 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - e241ff3a-d549-4ea9-b1d6-9d05a8ace0f6
+                - fb7e11be-662f-4a3f-8a95-9c8f35603dfa
         status: 200 OK
         code: 200
-        duration: 72.789556ms
+        duration: 58.815498ms
     - id: 42
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c31a7c2b-27df-479c-847b-4e0f5ff288bf
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 932
+        body: '{"id":"c31a7c2b-27df-479c-847b-4e0f5ff288bf", "status":"ready", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_name", "description":"", "tags":[], "created_at":"2026-04-01T08:11:18.734699Z", "updated_at":"2026-04-01T08:17:11.517615Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://c31a7c2b-27df-479c-847b-4e0f5ff288bf.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-c31a7c2b-27df-479c-847b-4e0f5ff288bf.ebcf14ad-0c72-4ff9-b741-d26bee430b14.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "notebook_master_url":"", "region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "932"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 01 Apr 2026 08:17:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 0a0b78db-7304-4c0c-baca-4b4e454d15ad
+        status: 200 OK
+        code: 200
+        duration: 66.963443ms
+    - id: 43
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1386,65 +1414,31 @@ interactions:
                 - name_asc
             page:
                 - "1"
-            page_size:
-                - "100"
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs?name=tf_tests_datalabs_ds_name&order_by=name_asc&page=1&page_size=100
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs?name=tf_tests_datalabs_ds_name&order_by=name_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 939
-        body: '{"datalabs":[{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:44:46.213359Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}],"total_count":1}'
+        content_length: 1898
+        body: '{"datalabs":[{"id":"0047ff02-6953-4ef0-bfb1-c093796e0477", "status":"ready", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_name", "description":"", "tags":[], "created_at":"2026-04-01T08:02:27.052181Z", "updated_at":"2026-04-01T08:08:03.972492Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://0047ff02-6953-4ef0-bfb1-c093796e0477.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-0047ff02-6953-4ef0-bfb1-c093796e0477.593f0960-2d24-404e-88c5-af99a6454020.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"593f0960-2d24-404e-88c5-af99a6454020", "notebook_master_url":"", "region":"fr-par"}, {"id":"c31a7c2b-27df-479c-847b-4e0f5ff288bf", "status":"ready", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_name", "description":"", "tags":[], "created_at":"2026-04-01T08:11:18.734699Z", "updated_at":"2026-04-01T08:17:11.517615Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://c31a7c2b-27df-479c-847b-4e0f5ff288bf.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-c31a7c2b-27df-479c-847b-4e0f5ff288bf.ebcf14ad-0c72-4ff9-b741-d26bee430b14.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "notebook_master_url":"", "region":"fr-par"}], "total_count":2}'
         headers:
             Content-Length:
-                - "939"
+                - "1898"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:44:52 GMT
+                - Wed, 01 Apr 2026 08:17:23 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 7fb9cc44-cf8b-45a3-a751-fb916d9c3039
+                - f94d7f12-97ab-4f12-b1d1-1f459e0239bc
         status: 200 OK
         code: 200
-        duration: 75.143594ms
-    - id: 43
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 911
-        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:44:52.714779Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
-        headers:
-            Content-Length:
-                - "911"
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 26 Mar 2026 11:44:52 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
-            X-Request-Id:
-                - 9357efec-5323-4157-b618-e57f47881fe1
-        status: 200 OK
-        code: 200
-        duration: 147.913711ms
+        duration: 94.389077ms
     - id: 44
       request:
         proto: HTTP/1.1
@@ -1455,28 +1449,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
-        method: GET
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c31a7c2b-27df-479c-847b-4e0f5ff288bf
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 911
-        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:44:52.714779Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        content_length: 935
+        body: '{"id":"c31a7c2b-27df-479c-847b-4e0f5ff288bf", "status":"deleting", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_name", "description":"", "tags":[], "created_at":"2026-04-01T08:11:18.734699Z", "updated_at":"2026-04-01T08:17:23.777707Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://c31a7c2b-27df-479c-847b-4e0f5ff288bf.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-c31a7c2b-27df-479c-847b-4e0f5ff288bf.ebcf14ad-0c72-4ff9-b741-d26bee430b14.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "911"
+                - "935"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:44:52 GMT
+                - Wed, 01 Apr 2026 08:17:23 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - b8888b9a-da73-491a-a4c1-40db72e2fe03
+                - fb17dc8c-e71f-479f-8f6c-c257d044a647
         status: 200 OK
         code: 200
-        duration: 63.830402ms
+        duration: 159.862199ms
     - id: 45
       request:
         proto: HTTP/1.1
@@ -1487,28 +1481,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c31a7c2b-27df-479c-847b-4e0f5ff288bf
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 911
-        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:44:52.714779Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        content_length: 935
+        body: '{"id":"c31a7c2b-27df-479c-847b-4e0f5ff288bf", "status":"deleting", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_name", "description":"", "tags":[], "created_at":"2026-04-01T08:11:18.734699Z", "updated_at":"2026-04-01T08:17:23.777707Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://c31a7c2b-27df-479c-847b-4e0f5ff288bf.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-c31a7c2b-27df-479c-847b-4e0f5ff288bf.ebcf14ad-0c72-4ff9-b741-d26bee430b14.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "911"
+                - "935"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:45:07 GMT
+                - Wed, 01 Apr 2026 08:17:23 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 1f166e45-b538-42bb-a1e2-dba4850bcca3
+                - 17d95598-7562-4cbf-89af-8bda6b17ae41
         status: 200 OK
         code: 200
-        duration: 67.501086ms
+        duration: 68.520072ms
     - id: 46
       request:
         proto: HTTP/1.1
@@ -1519,28 +1513,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c31a7c2b-27df-479c-847b-4e0f5ff288bf
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 911
-        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:44:52.714779Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        content_length: 935
+        body: '{"id":"c31a7c2b-27df-479c-847b-4e0f5ff288bf", "status":"deleting", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_name", "description":"", "tags":[], "created_at":"2026-04-01T08:11:18.734699Z", "updated_at":"2026-04-01T08:17:23.777707Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://c31a7c2b-27df-479c-847b-4e0f5ff288bf.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-c31a7c2b-27df-479c-847b-4e0f5ff288bf.ebcf14ad-0c72-4ff9-b741-d26bee430b14.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "911"
+                - "935"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:45:23 GMT
+                - Wed, 01 Apr 2026 08:17:39 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 79b4acbf-16ae-4113-994c-fd365f004f3e
+                - ea865701-f58d-423b-8c55-89181f186c8c
         status: 200 OK
         code: 200
-        duration: 70.348153ms
+        duration: 79.898792ms
     - id: 47
       request:
         proto: HTTP/1.1
@@ -1551,28 +1545,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c31a7c2b-27df-479c-847b-4e0f5ff288bf
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 911
-        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:44:52.714779Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        content_length: 935
+        body: '{"id":"c31a7c2b-27df-479c-847b-4e0f5ff288bf", "status":"deleting", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_name", "description":"", "tags":[], "created_at":"2026-04-01T08:11:18.734699Z", "updated_at":"2026-04-01T08:17:23.777707Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://c31a7c2b-27df-479c-847b-4e0f5ff288bf.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-c31a7c2b-27df-479c-847b-4e0f5ff288bf.ebcf14ad-0c72-4ff9-b741-d26bee430b14.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "911"
+                - "935"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:45:38 GMT
+                - Wed, 01 Apr 2026 08:17:54 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 1f383adc-8188-4f6d-a982-9303fd00ab47
+                - 7c9bfd19-5a83-4c75-b27a-8af60d440c79
         status: 200 OK
         code: 200
-        duration: 79.125175ms
+        duration: 67.978615ms
     - id: 48
       request:
         proto: HTTP/1.1
@@ -1583,28 +1577,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c31a7c2b-27df-479c-847b-4e0f5ff288bf
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 911
-        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:44:52.714779Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        content_length: 935
+        body: '{"id":"c31a7c2b-27df-479c-847b-4e0f5ff288bf", "status":"deleting", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_name", "description":"", "tags":[], "created_at":"2026-04-01T08:11:18.734699Z", "updated_at":"2026-04-01T08:17:23.777707Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://c31a7c2b-27df-479c-847b-4e0f5ff288bf.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-c31a7c2b-27df-479c-847b-4e0f5ff288bf.ebcf14ad-0c72-4ff9-b741-d26bee430b14.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "911"
+                - "935"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:45:53 GMT
+                - Wed, 01 Apr 2026 08:18:09 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - b585dbf0-e5bd-472b-9361-da5a6ec3a98b
+                - ed243b7f-03ec-479d-89d0-783bcc0ae17e
         status: 200 OK
         code: 200
-        duration: 69.851579ms
+        duration: 70.721391ms
     - id: 49
       request:
         proto: HTTP/1.1
@@ -1615,28 +1609,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c31a7c2b-27df-479c-847b-4e0f5ff288bf
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 911
-        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:44:52.714779Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        content_length: 935
+        body: '{"id":"c31a7c2b-27df-479c-847b-4e0f5ff288bf", "status":"deleting", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_name", "description":"", "tags":[], "created_at":"2026-04-01T08:11:18.734699Z", "updated_at":"2026-04-01T08:17:23.777707Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://c31a7c2b-27df-479c-847b-4e0f5ff288bf.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-c31a7c2b-27df-479c-847b-4e0f5ff288bf.ebcf14ad-0c72-4ff9-b741-d26bee430b14.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "911"
+                - "935"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:46:08 GMT
+                - Wed, 01 Apr 2026 08:18:24 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 4339768c-67bc-4b22-b6c7-7c4193f988e8
+                - e31e9132-7c77-4644-8762-d457d54da258
         status: 200 OK
         code: 200
-        duration: 77.539399ms
+        duration: 65.079156ms
     - id: 50
       request:
         proto: HTTP/1.1
@@ -1647,28 +1641,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c31a7c2b-27df-479c-847b-4e0f5ff288bf
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 911
-        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:44:52.714779Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        content_length: 935
+        body: '{"id":"c31a7c2b-27df-479c-847b-4e0f5ff288bf", "status":"deleting", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_name", "description":"", "tags":[], "created_at":"2026-04-01T08:11:18.734699Z", "updated_at":"2026-04-01T08:17:23.777707Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://c31a7c2b-27df-479c-847b-4e0f5ff288bf.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-c31a7c2b-27df-479c-847b-4e0f5ff288bf.ebcf14ad-0c72-4ff9-b741-d26bee430b14.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "911"
+                - "935"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:46:23 GMT
+                - Wed, 01 Apr 2026 08:18:39 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 89e4573a-5159-405a-9f67-97d35615e258
+                - 24a2d182-9292-46da-bfe5-9b73a24e95b0
         status: 200 OK
         code: 200
-        duration: 78.811837ms
+        duration: 87.073117ms
     - id: 51
       request:
         proto: HTTP/1.1
@@ -1679,28 +1673,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c31a7c2b-27df-479c-847b-4e0f5ff288bf
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 911
-        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:44:52.714779Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        content_length: 935
+        body: '{"id":"c31a7c2b-27df-479c-847b-4e0f5ff288bf", "status":"deleting", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_name", "description":"", "tags":[], "created_at":"2026-04-01T08:11:18.734699Z", "updated_at":"2026-04-01T08:17:23.777707Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://c31a7c2b-27df-479c-847b-4e0f5ff288bf.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-c31a7c2b-27df-479c-847b-4e0f5ff288bf.ebcf14ad-0c72-4ff9-b741-d26bee430b14.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "911"
+                - "935"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:46:38 GMT
+                - Wed, 01 Apr 2026 08:18:54 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 0dd2804c-8725-4598-ab69-55defdc4ab74
+                - 379b1d33-0a7e-4897-8423-ad8b47320630
         status: 200 OK
         code: 200
-        duration: 70.784908ms
+        duration: 104.363995ms
     - id: 52
       request:
         proto: HTTP/1.1
@@ -1711,28 +1705,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c31a7c2b-27df-479c-847b-4e0f5ff288bf
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 911
-        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:44:52.714779Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        content_length: 935
+        body: '{"id":"c31a7c2b-27df-479c-847b-4e0f5ff288bf", "status":"deleting", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_name", "description":"", "tags":[], "created_at":"2026-04-01T08:11:18.734699Z", "updated_at":"2026-04-01T08:17:23.777707Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://c31a7c2b-27df-479c-847b-4e0f5ff288bf.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-c31a7c2b-27df-479c-847b-4e0f5ff288bf.ebcf14ad-0c72-4ff9-b741-d26bee430b14.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "911"
+                - "935"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:46:53 GMT
+                - Wed, 01 Apr 2026 08:19:09 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 54e4bee2-84f2-4e4b-a395-a68d888e7b5e
+                - 13b22bbb-4a4c-4d6b-ae3d-3c6e7135e8e6
         status: 200 OK
         code: 200
-        duration: 68.477759ms
+        duration: 82.380251ms
     - id: 53
       request:
         proto: HTTP/1.1
@@ -1743,28 +1737,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c31a7c2b-27df-479c-847b-4e0f5ff288bf
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 911
-        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:44:52.714779Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        content_length: 935
+        body: '{"id":"c31a7c2b-27df-479c-847b-4e0f5ff288bf", "status":"deleting", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_name", "description":"", "tags":[], "created_at":"2026-04-01T08:11:18.734699Z", "updated_at":"2026-04-01T08:17:23.777707Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://c31a7c2b-27df-479c-847b-4e0f5ff288bf.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-c31a7c2b-27df-479c-847b-4e0f5ff288bf.ebcf14ad-0c72-4ff9-b741-d26bee430b14.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "911"
+                - "935"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:47:08 GMT
+                - Wed, 01 Apr 2026 08:19:24 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - cb5a6c52-a2a3-4f89-b289-38c07d0ab7bb
+                - 6df19a2d-d6cc-4c31-9f53-9122aa311052
         status: 200 OK
         code: 200
-        duration: 73.805331ms
+        duration: 77.225376ms
     - id: 54
       request:
         proto: HTTP/1.1
@@ -1775,28 +1769,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c31a7c2b-27df-479c-847b-4e0f5ff288bf
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 911
-        body: '{"id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_name","description":"","tags":[],"created_at":"2026-03-26T11:39:02.860650Z","updated_at":"2026-03-26T11:44:52.714779Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://1c0a7701-764b-49f7-9d79-3ad797c3dff7.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-1c0a7701-764b-49f7-9d79-3ad797c3dff7.d0432486-ef71-414c-9fcc-021be4d0e690.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"d0432486-ef71-414c-9fcc-021be4d0e690","notebook_master_url":"","region":"fr-par"}'
+        content_length: 935
+        body: '{"id":"c31a7c2b-27df-479c-847b-4e0f5ff288bf", "status":"deleting", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_name", "description":"", "tags":[], "created_at":"2026-04-01T08:11:18.734699Z", "updated_at":"2026-04-01T08:17:23.777707Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://c31a7c2b-27df-479c-847b-4e0f5ff288bf.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-c31a7c2b-27df-479c-847b-4e0f5ff288bf.ebcf14ad-0c72-4ff9-b741-d26bee430b14.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "911"
+                - "935"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:47:23 GMT
+                - Wed, 01 Apr 2026 08:19:39 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - c32f2d32-b40e-493d-9590-8c8e86fdeb72
+                - c519233a-660d-40a0-8ec3-0f4605f7ea8d
         status: 200 OK
         code: 200
-        duration: 72.593074ms
+        duration: 97.034842ms
     - id: 55
       request:
         proto: HTTP/1.1
@@ -1807,28 +1801,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c31a7c2b-27df-479c-847b-4e0f5ff288bf
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 128
-        body: '{"message":"resource is not found","resource":"datalab","resource_id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","type":"not_found"}'
+        content_length: 935
+        body: '{"id":"c31a7c2b-27df-479c-847b-4e0f5ff288bf", "status":"deleting", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_name", "description":"", "tags":[], "created_at":"2026-04-01T08:11:18.734699Z", "updated_at":"2026-04-01T08:17:23.777707Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://c31a7c2b-27df-479c-847b-4e0f5ff288bf.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-c31a7c2b-27df-479c-847b-4e0f5ff288bf.ebcf14ad-0c72-4ff9-b741-d26bee430b14.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "128"
+                - "935"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:47:38 GMT
+                - Wed, 01 Apr 2026 08:19:54 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 876f2a08-2a86-41f1-a355-fcb4472b89f4
-        status: 404 Not Found
-        code: 404
-        duration: 69.938955ms
+                - bb726579-5602-44c8-bfc8-01edffb9873a
+        status: 200 OK
+        code: 200
+        duration: 81.948681ms
     - id: 56
       request:
         proto: HTTP/1.1
@@ -1839,26 +1833,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d0432486-ef71-414c-9fcc-021be4d0e690
-        method: DELETE
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c31a7c2b-27df-479c-847b-4e0f5ff288bf
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 0
-        body: ""
+        content_length: 935
+        body: '{"id":"c31a7c2b-27df-479c-847b-4e0f5ff288bf", "status":"deleting", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_name", "description":"", "tags":[], "created_at":"2026-04-01T08:11:18.734699Z", "updated_at":"2026-04-01T08:17:23.777707Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://c31a7c2b-27df-479c-847b-4e0f5ff288bf.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-c31a7c2b-27df-479c-847b-4e0f5ff288bf.ebcf14ad-0c72-4ff9-b741-d26bee430b14.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"ebcf14ad-0c72-4ff9-b741-d26bee430b14", "notebook_master_url":"", "region":"fr-par"}'
         headers:
+            Content-Length:
+                - "935"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:47:40 GMT
+                - Wed, 01 Apr 2026 08:20:09 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 52b7b97c-75a1-4821-87a5-d54915711182
-        status: 204 No Content
-        code: 204
-        duration: 1.593517347s
+                - ee9b3d19-d43e-4dc3-ab27-5fe57742569b
+        status: 200 OK
+        code: 200
+        duration: 95.552889ms
     - id: 57
       request:
         proto: HTTP/1.1
@@ -1869,7 +1865,39 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/8e81a4c5-69ad-44f4-98e8-2e7f99bff562
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c31a7c2b-27df-479c-847b-4e0f5ff288bf
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 128
+        body: '{"message":"resource is not found","resource":"datalab","resource_id":"c31a7c2b-27df-479c-847b-4e0f5ff288bf","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "128"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 01 Apr 2026 08:20:24 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 6bc08304-3889-4bf0-a7da-461803efda36
+        status: 404 Not Found
+        code: 404
+        duration: 75.054021ms
+    - id: 58
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/ebcf14ad-0c72-4ff9-b741-d26bee430b14
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1881,15 +1909,15 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:47:40 GMT
+                - Wed, 01 Apr 2026 08:20:26 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - ac93a1ab-065f-4319-9c82-c4501bb7c6cf
+                - 833f9b40-f286-48ac-917c-562d20a067d3
         status: 204 No Content
         code: 204
-        duration: 709.975829ms
-    - id: 58
+        duration: 1.5494626s
+    - id: 59
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1899,25 +1927,55 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/1c0a7701-764b-49f7-9d79-3ad797c3dff7
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/030c3bf4-c4a8-4021-94af-42e80bd4039b
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 01 Apr 2026 08:20:27 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - e6009bd1-a314-4df7-85e5-82ae435c849b
+        status: 204 No Content
+        code: 204
+        duration: 501.857569ms
+    - id: 60
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/c31a7c2b-27df-479c-847b-4e0f5ff288bf
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 128
-        body: '{"message":"resource is not found","resource":"datalab","resource_id":"1c0a7701-764b-49f7-9d79-3ad797c3dff7","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"datalab","resource_id":"c31a7c2b-27df-479c-847b-4e0f5ff288bf","type":"not_found"}'
         headers:
             Content-Length:
                 - "128"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:47:41 GMT
+                - Wed, 01 Apr 2026 08:20:27 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - f394038d-0ddc-4c9e-ac58-c714127a4881
+                - 38bdfc04-a562-43a5-8dea-4dc07bf9e049
         status: 404 Not Found
         code: 404
-        duration: 60.949699ms
+        duration: 79.803716ms

--- a/internal/services/datalab/testdata/datalabs-data-source-filter-by-tags.cassette.yaml
+++ b/internal/services/datalab/testdata/datalabs-data-source-filter-by-tags.cassette.yaml
@@ -1,0 +1,1923 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 121
+        host: api.scaleway.com
+        body: '{"name":"tf_tests_datalabs_ds_tags","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","tags":[],"enable_routing":false}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 412
+        body: '{"id":"9a2c31ba-023d-426c-8f47-d73348a4df86","name":"tf_tests_datalabs_ds_tags","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:39:01.611217Z","updated_at":"2026-03-26T11:39:01.611217Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","is_default":false,"private_network_count":0,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "412"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:39:01 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - d36667bf-c0ec-4bb8-8618-52bf97554451
+        status: 200 OK
+        code: 200
+        duration: 228.4118ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/9a2c31ba-023d-426c-8f47-d73348a4df86
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 412
+        body: '{"id":"9a2c31ba-023d-426c-8f47-d73348a4df86","name":"tf_tests_datalabs_ds_tags","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:39:01.611217Z","updated_at":"2026-03-26T11:39:01.611217Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","is_default":false,"private_network_count":0,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "412"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:39:01 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 2f48db33-a268-4f22-9011-f05dd7fcffde
+        status: 200 OK
+        code: 200
+        duration: 78.567561ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 198
+        host: api.scaleway.com
+        body: '{"name":"tf-pn-sharp-franklin","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","tags":[],"subnets":null,"vpc_id":"9a2c31ba-023d-426c-8f47-d73348a4df86","default_route_propagation_enabled":false}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1066
+        body: '{"id":"8ea78e26-d683-4221-a7fd-29fad84deed0","name":"tf-pn-sharp-franklin","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:39:01.988433Z","updated_at":"2026-03-26T11:39:01.988433Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","subnets":[{"id":"36388d9c-cd3f-43ac-bc13-706505327306","created_at":"2026-03-26T11:39:01.988433Z","updated_at":"2026-03-26T11:39:01.988433Z","subnet":"172.16.20.0/22","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","vpc_id":"9a2c31ba-023d-426c-8f47-d73348a4df86"},{"id":"d7e8677f-daf5-4ba9-915f-7ccb30b81723","created_at":"2026-03-26T11:39:01.988433Z","updated_at":"2026-03-26T11:39:01.988433Z","subnet":"fd40:e277:fdde:adc4::/64","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","vpc_id":"9a2c31ba-023d-426c-8f47-d73348a4df86"}],"vpc_id":"9a2c31ba-023d-426c-8f47-d73348a4df86","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1066"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:39:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 1fef9d1a-1e7c-4acc-81c7-0d0d73e79e23
+        status: 200 OK
+        code: 200
+        duration: 935.986719ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8ea78e26-d683-4221-a7fd-29fad84deed0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1066
+        body: '{"id":"8ea78e26-d683-4221-a7fd-29fad84deed0","name":"tf-pn-sharp-franklin","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:39:01.988433Z","updated_at":"2026-03-26T11:39:01.988433Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","subnets":[{"id":"36388d9c-cd3f-43ac-bc13-706505327306","created_at":"2026-03-26T11:39:01.988433Z","updated_at":"2026-03-26T11:39:01.988433Z","subnet":"172.16.20.0/22","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","vpc_id":"9a2c31ba-023d-426c-8f47-d73348a4df86"},{"id":"d7e8677f-daf5-4ba9-915f-7ccb30b81723","created_at":"2026-03-26T11:39:01.988433Z","updated_at":"2026-03-26T11:39:01.988433Z","subnet":"fd40:e277:fdde:adc4::/64","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","vpc_id":"9a2c31ba-023d-426c-8f47-d73348a4df86"}],"vpc_id":"9a2c31ba-023d-426c-8f47-d73348a4df86","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1066"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:39:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - ae609869-209d-4461-a4f8-4868b29c846e
+        status: 200 OK
+        code: 200
+        duration: 62.916864ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 356
+        host: api.scaleway.com
+        body: '{"project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"main":{"node_type":"DATALAB-SHARED-4C-8G"},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1},"has_notebook":false,"spark_version":"4.0.0","private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0"}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 938
+        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:39:02.854954Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "938"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:39:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - c588dbbb-9a1b-4e63-b282-02ff45ed6e43
+        status: 200 OK
+        code: 200
+        duration: 749.707654ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 938
+        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:39:02.854954Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "938"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:39:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 64fd698e-cf3c-4249-8e8f-a6500b961c55
+        status: 200 OK
+        code: 200
+        duration: 74.740655ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 938
+        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:39:02.854954Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "938"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:39:18 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 7f359f08-1ca4-4b71-8bee-56a2bb40f5d3
+        status: 200 OK
+        code: 200
+        duration: 92.707304ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 938
+        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:39:02.854954Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "938"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:39:33 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - a0c85cae-2285-43d7-a056-b072cb5d12b9
+        status: 200 OK
+        code: 200
+        duration: 84.470019ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 938
+        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:39:02.854954Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "938"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:39:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 275f2529-4654-4b7f-9d5e-c5c41afe5ba6
+        status: 200 OK
+        code: 200
+        duration: 77.145018ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 938
+        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:39:02.854954Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "938"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:40:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 49371998-41c9-46b6-9cb3-b48132b2f73c
+        status: 200 OK
+        code: 200
+        duration: 79.608606ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 938
+        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:39:02.854954Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "938"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:40:18 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 5aaa6b1c-274d-4771-bfe7-fc50f24094e3
+        status: 200 OK
+        code: 200
+        duration: 72.037961ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 938
+        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:39:02.854954Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "938"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:40:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 173cb754-4b7a-45c8-879d-7c50fb400a8c
+        status: 200 OK
+        code: 200
+        duration: 72.363735ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 938
+        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:39:02.854954Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "938"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:40:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - ee9ea9b9-4cb4-471f-8755-44ed45a3f1ee
+        status: 200 OK
+        code: 200
+        duration: 83.429562ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 938
+        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:39:02.854954Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "938"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:41:04 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 7667bb6a-8474-4c1b-8514-e14f07c8cc5b
+        status: 200 OK
+        code: 200
+        duration: 72.34213ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 938
+        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:39:02.854954Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "938"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:41:19 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - a4b3cb9e-4cac-40c5-a22d-2c6a4609c766
+        status: 200 OK
+        code: 200
+        duration: 86.358399ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 938
+        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:39:02.854954Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "938"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:41:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - d1207b80-d4ff-432a-a9ba-1b811e76a5e4
+        status: 200 OK
+        code: 200
+        duration: 79.073606ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 938
+        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:39:02.854954Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "938"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:41:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - dcbd17f0-fb35-4306-9b6c-13043cce5a8c
+        status: 200 OK
+        code: 200
+        duration: 80.073361ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 938
+        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:39:02.854954Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "938"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:42:04 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 35b42ed1-3ab6-4ef6-977b-0f0893b8b498
+        status: 200 OK
+        code: 200
+        duration: 78.365098ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 938
+        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:39:02.854954Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "938"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:42:19 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 632f31c2-1282-407b-8358-4d3a6646a7ec
+        status: 200 OK
+        code: 200
+        duration: 90.730443ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 938
+        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:39:02.854954Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "938"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:42:34 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 658e729f-c2be-4628-a03c-70b2ff90968e
+        status: 200 OK
+        code: 200
+        duration: 69.780581ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 938
+        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:39:02.854954Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "938"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:42:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 77341d06-132b-4920-bc33-c768dcaaf9d8
+        status: 200 OK
+        code: 200
+        duration: 66.47688ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 938
+        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:39:02.854954Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "938"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:43:04 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 5d6643b8-cf72-496e-b7ea-705a4e7c6c1f
+        status: 200 OK
+        code: 200
+        duration: 88.870859ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 938
+        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:39:02.854954Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "938"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:43:19 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 115a92c2-be74-429e-836a-92600287e847
+        status: 200 OK
+        code: 200
+        duration: 75.538794ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 938
+        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:39:02.854954Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "938"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:43:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 710bae9b-cd19-4e82-b720-46eb2045656f
+        status: 200 OK
+        code: 200
+        duration: 81.554137ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 938
+        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:39:02.854954Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "938"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:43:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 019a975a-2175-475a-b698-625a99d2d21f
+        status: 200 OK
+        code: 200
+        duration: 82.969391ms
+    - id: 25
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 938
+        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:39:02.854954Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "938"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:44:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 41eae38a-9e59-4121-9664-238f01ef8c57
+        status: 200 OK
+        code: 200
+        duration: 87.024896ms
+    - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 938
+        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:39:02.854954Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "938"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:44:20 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 216c8df4-77a4-4a99-8775-eaf3f48d7bbe
+        status: 200 OK
+        code: 200
+        duration: 73.619801ms
+    - id: 27
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 938
+        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:39:02.854954Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "938"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:44:35 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 1d58805e-4491-4d96-b8a8-f3bcc26316b9
+        status: 200 OK
+        code: 200
+        duration: 69.848152ms
+    - id: 28
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 935
+        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:44:38.291481Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "935"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:44:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 934d8419-0193-4418-bcf0-d47fb73e53a5
+        status: 200 OK
+        code: 200
+        duration: 85.16546ms
+    - id: 29
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 935
+        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:44:38.291481Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "935"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:44:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - fca86355-9af6-4be2-ac1f-4313ba1dd669
+        status: 200 OK
+        code: 200
+        duration: 74.871841ms
+    - id: 30
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/9a2c31ba-023d-426c-8f47-d73348a4df86
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 412
+        body: '{"id":"9a2c31ba-023d-426c-8f47-d73348a4df86","name":"tf_tests_datalabs_ds_tags","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:39:01.611217Z","updated_at":"2026-03-26T11:39:01.611217Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","is_default":false,"private_network_count":1,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "412"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:44:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 25940631-9cb5-4cd1-998b-9e54bd75d7e2
+        status: 200 OK
+        code: 200
+        duration: 62.74694ms
+    - id: 31
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8ea78e26-d683-4221-a7fd-29fad84deed0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1066
+        body: '{"id":"8ea78e26-d683-4221-a7fd-29fad84deed0","name":"tf-pn-sharp-franklin","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:39:01.988433Z","updated_at":"2026-03-26T11:39:01.988433Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","subnets":[{"id":"36388d9c-cd3f-43ac-bc13-706505327306","created_at":"2026-03-26T11:39:01.988433Z","updated_at":"2026-03-26T11:39:01.988433Z","subnet":"172.16.20.0/22","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","vpc_id":"9a2c31ba-023d-426c-8f47-d73348a4df86"},{"id":"d7e8677f-daf5-4ba9-915f-7ccb30b81723","created_at":"2026-03-26T11:39:01.988433Z","updated_at":"2026-03-26T11:39:01.988433Z","subnet":"fd40:e277:fdde:adc4::/64","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","vpc_id":"9a2c31ba-023d-426c-8f47-d73348a4df86"}],"vpc_id":"9a2c31ba-023d-426c-8f47-d73348a4df86","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1066"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:44:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - d7318007-c0ba-4b7e-b884-c5b4ea4bdbac
+        status: 200 OK
+        code: 200
+        duration: 108.799789ms
+    - id: 32
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 935
+        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:44:38.291481Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "935"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:44:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 9376cf26-8051-49fd-b561-0eaf2ae2fafd
+        status: 200 OK
+        code: 200
+        duration: 88.137592ms
+    - id: 33
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/9a2c31ba-023d-426c-8f47-d73348a4df86
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 412
+        body: '{"id":"9a2c31ba-023d-426c-8f47-d73348a4df86","name":"tf_tests_datalabs_ds_tags","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:39:01.611217Z","updated_at":"2026-03-26T11:39:01.611217Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","is_default":false,"private_network_count":1,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "412"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:44:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - d274e134-66fe-476d-aff1-63c0d4211f9a
+        status: 200 OK
+        code: 200
+        duration: 79.463271ms
+    - id: 34
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - name_asc
+            page:
+                - "1"
+            page_size:
+                - "100"
+            tags:
+                - ds-filter-test
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs?order_by=name_asc&page=1&page_size=100&tags=ds-filter-test
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 966
+        body: '{"datalabs":[{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:44:38.291481Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "966"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:44:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - c056011f-378b-493d-8528-c22ec41626c7
+        status: 200 OK
+        code: 200
+        duration: 84.725892ms
+    - id: 35
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8ea78e26-d683-4221-a7fd-29fad84deed0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1066
+        body: '{"id":"8ea78e26-d683-4221-a7fd-29fad84deed0","name":"tf-pn-sharp-franklin","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:39:01.988433Z","updated_at":"2026-03-26T11:39:01.988433Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","subnets":[{"id":"36388d9c-cd3f-43ac-bc13-706505327306","created_at":"2026-03-26T11:39:01.988433Z","updated_at":"2026-03-26T11:39:01.988433Z","subnet":"172.16.20.0/22","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","vpc_id":"9a2c31ba-023d-426c-8f47-d73348a4df86"},{"id":"d7e8677f-daf5-4ba9-915f-7ccb30b81723","created_at":"2026-03-26T11:39:01.988433Z","updated_at":"2026-03-26T11:39:01.988433Z","subnet":"fd40:e277:fdde:adc4::/64","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","vpc_id":"9a2c31ba-023d-426c-8f47-d73348a4df86"}],"vpc_id":"9a2c31ba-023d-426c-8f47-d73348a4df86","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1066"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:44:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 7ebd4ed4-9247-42fb-a45d-cd9d6d97af1e
+        status: 200 OK
+        code: 200
+        duration: 70.409258ms
+    - id: 36
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 935
+        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:44:38.291481Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "935"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:44:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 9e8a51a4-bebf-46fa-92c3-1edd739bfeb2
+        status: 200 OK
+        code: 200
+        duration: 70.101806ms
+    - id: 37
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 935
+        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:44:38.291481Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "935"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:44:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - ef441ee3-db3b-405d-9dbe-214a90048e26
+        status: 200 OK
+        code: 200
+        duration: 59.245782ms
+    - id: 38
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - name_asc
+            page:
+                - "1"
+            page_size:
+                - "100"
+            tags:
+                - ds-filter-test
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs?order_by=name_asc&page=1&page_size=100&tags=ds-filter-test
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 966
+        body: '{"datalabs":[{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:44:38.291481Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "966"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:44:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 6fb6c803-32ba-4ce6-8cb8-059b20a42c7d
+        status: 200 OK
+        code: 200
+        duration: 80.081404ms
+    - id: 39
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/9a2c31ba-023d-426c-8f47-d73348a4df86
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 412
+        body: '{"id":"9a2c31ba-023d-426c-8f47-d73348a4df86","name":"tf_tests_datalabs_ds_tags","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:39:01.611217Z","updated_at":"2026-03-26T11:39:01.611217Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","is_default":false,"private_network_count":1,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "412"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:44:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 762e8baa-0605-4edd-90ab-d9f62945cfc8
+        status: 200 OK
+        code: 200
+        duration: 57.228305ms
+    - id: 40
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - name_asc
+            page:
+                - "1"
+            page_size:
+                - "100"
+            tags:
+                - ds-filter-test
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs?order_by=name_asc&page=1&page_size=100&tags=ds-filter-test
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 966
+        body: '{"datalabs":[{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:44:38.291481Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "966"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:44:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 722d185d-223e-4502-bdd9-2179a83cce31
+        status: 200 OK
+        code: 200
+        duration: 82.849802ms
+    - id: 41
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8ea78e26-d683-4221-a7fd-29fad84deed0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1066
+        body: '{"id":"8ea78e26-d683-4221-a7fd-29fad84deed0","name":"tf-pn-sharp-franklin","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:39:01.988433Z","updated_at":"2026-03-26T11:39:01.988433Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","subnets":[{"id":"36388d9c-cd3f-43ac-bc13-706505327306","created_at":"2026-03-26T11:39:01.988433Z","updated_at":"2026-03-26T11:39:01.988433Z","subnet":"172.16.20.0/22","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","vpc_id":"9a2c31ba-023d-426c-8f47-d73348a4df86"},{"id":"d7e8677f-daf5-4ba9-915f-7ccb30b81723","created_at":"2026-03-26T11:39:01.988433Z","updated_at":"2026-03-26T11:39:01.988433Z","subnet":"fd40:e277:fdde:adc4::/64","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","vpc_id":"9a2c31ba-023d-426c-8f47-d73348a4df86"}],"vpc_id":"9a2c31ba-023d-426c-8f47-d73348a4df86","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1066"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:44:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - b03e696f-760b-4380-aeb6-214f2dade665
+        status: 200 OK
+        code: 200
+        duration: 56.989562ms
+    - id: 42
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 935
+        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:44:38.291481Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "935"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:44:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 1d3a20f0-50ff-49ed-8608-27aa783bb884
+        status: 200 OK
+        code: 200
+        duration: 62.313771ms
+    - id: 43
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 938
+        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:44:52.139003Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "938"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:44:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 9ad28d68-f17b-414d-a452-98ecf1a3631d
+        status: 200 OK
+        code: 200
+        duration: 140.000919ms
+    - id: 44
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 938
+        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:44:52.139003Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "938"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:44:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 3fc53096-3b66-4538-a773-5c036ce12199
+        status: 200 OK
+        code: 200
+        duration: 66.245828ms
+    - id: 45
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 938
+        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:44:52.139003Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "938"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:45:07 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 6806e6f0-e10f-4fbc-bb2e-ea21d70cda7c
+        status: 200 OK
+        code: 200
+        duration: 61.035216ms
+    - id: 46
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 938
+        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:44:52.139003Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "938"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:45:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 83701eb8-c1e3-4e64-b287-a4e0501ef250
+        status: 200 OK
+        code: 200
+        duration: 83.252344ms
+    - id: 47
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 938
+        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:44:52.139003Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "938"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:45:37 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - ead105c6-8603-4eac-ab61-582e346747c2
+        status: 200 OK
+        code: 200
+        duration: 60.839484ms
+    - id: 48
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 938
+        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:44:52.139003Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "938"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:45:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - a76bdccb-d54c-44e1-a7fc-b132665d8a72
+        status: 200 OK
+        code: 200
+        duration: 82.897827ms
+    - id: 49
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 938
+        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:44:52.139003Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "938"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:46:07 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 1a09e74c-ac43-4c3a-a9f2-67653bddc909
+        status: 200 OK
+        code: 200
+        duration: 74.379521ms
+    - id: 50
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 938
+        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:44:52.139003Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "938"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:46:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 7c8a07bf-d3ff-475f-bdae-e8b1a9ef70f4
+        status: 200 OK
+        code: 200
+        duration: 71.607435ms
+    - id: 51
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 938
+        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:44:52.139003Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "938"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:46:37 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 4498575f-20f3-4dad-980a-81a96d961554
+        status: 200 OK
+        code: 200
+        duration: 71.972007ms
+    - id: 52
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 938
+        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:44:52.139003Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "938"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:46:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - f2a0cef1-a8c1-4820-a001-dd8462c8678c
+        status: 200 OK
+        code: 200
+        duration: 82.099713ms
+    - id: 53
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 938
+        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:44:52.139003Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "938"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:47:07 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - b8446210-c9e1-4202-b97b-a397f4497ef5
+        status: 200 OK
+        code: 200
+        duration: 74.506983ms
+    - id: 54
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 938
+        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:44:52.139003Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "938"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:47:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 53604809-8562-4e6c-97c1-3df37b7e8e96
+        status: 200 OK
+        code: 200
+        duration: 78.132059ms
+    - id: 55
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 128
+        body: '{"message":"resource is not found","resource":"datalab","resource_id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "128"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:47:38 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 28e94b02-9935-4f46-8b05-6025cbdec319
+        status: 404 Not Found
+        code: 404
+        duration: 66.687569ms
+    - id: 56
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8ea78e26-d683-4221-a7fd-29fad84deed0
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:47:39 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 70f272d7-1a69-4bd1-af89-b2b8fe36a472
+        status: 204 No Content
+        code: 204
+        duration: 1.634089287s
+    - id: 57
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/9a2c31ba-023d-426c-8f47-d73348a4df86
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:47:40 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 2916f300-907f-448d-af0d-462f2365de96
+        status: 204 No Content
+        code: 204
+        duration: 503.103219ms
+    - id: 58
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 128
+        body: '{"message":"resource is not found","resource":"datalab","resource_id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "128"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 26 Mar 2026 11:47:40 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - c9240693-5c4e-455e-9aa3-b2e1580bfc79
+        status: 404 Not Found
+        code: 404
+        duration: 63.369686ms

--- a/internal/services/datalab/testdata/datalabs-data-source-filter-by-tags.cassette.yaml
+++ b/internal/services/datalab/testdata/datalabs-data-source-filter-by-tags.cassette.yaml
@@ -20,22 +20,22 @@ interactions:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 412
-        body: '{"id":"9a2c31ba-023d-426c-8f47-d73348a4df86","name":"tf_tests_datalabs_ds_tags","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:39:01.611217Z","updated_at":"2026-03-26T11:39:01.611217Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","is_default":false,"private_network_count":0,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        content_length: 423
+        body: '{"id":"16a6c4e4-63d1-4161-967f-274ce1acb20d", "name":"tf_tests_datalabs_ds_tags", "tags":[], "organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8", "created_at":"2026-04-01T08:11:17.038619Z", "updated_at":"2026-04-01T08:11:17.038619Z", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "is_default":false, "private_network_count":0, "routing_enabled":true, "custom_routes_propagation_enabled":true, "region":"fr-par"}'
         headers:
             Content-Length:
-                - "412"
+                - "423"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:39:01 GMT
+                - Wed, 01 Apr 2026 08:11:17 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - d36667bf-c0ec-4bb8-8618-52bf97554451
+                - a0e36ccd-47dd-4fe9-a869-069f141226b8
         status: 200 OK
         code: 200
-        duration: 228.4118ms
+        duration: 206.005913ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -46,28 +46,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/9a2c31ba-023d-426c-8f47-d73348a4df86
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/16a6c4e4-63d1-4161-967f-274ce1acb20d
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 412
-        body: '{"id":"9a2c31ba-023d-426c-8f47-d73348a4df86","name":"tf_tests_datalabs_ds_tags","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:39:01.611217Z","updated_at":"2026-03-26T11:39:01.611217Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","is_default":false,"private_network_count":0,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        content_length: 423
+        body: '{"id":"16a6c4e4-63d1-4161-967f-274ce1acb20d", "name":"tf_tests_datalabs_ds_tags", "tags":[], "organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8", "created_at":"2026-04-01T08:11:17.038619Z", "updated_at":"2026-04-01T08:11:17.038619Z", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "is_default":false, "private_network_count":0, "routing_enabled":true, "custom_routes_propagation_enabled":true, "region":"fr-par"}'
         headers:
             Content-Length:
-                - "412"
+                - "423"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:39:01 GMT
+                - Wed, 01 Apr 2026 08:11:17 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 2f48db33-a268-4f22-9011-f05dd7fcffde
+                - a6f7bbb0-cecf-4f32-a9c2-cd91ecfe7f71
         status: 200 OK
         code: 200
-        duration: 78.567561ms
+        duration: 92.840453ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -75,7 +75,7 @@ interactions:
         proto_minor: 1
         content_length: 198
         host: api.scaleway.com
-        body: '{"name":"tf-pn-sharp-franklin","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","tags":[],"subnets":null,"vpc_id":"9a2c31ba-023d-426c-8f47-d73348a4df86","default_route_propagation_enabled":false}'
+        body: '{"name":"tf-pn-jovial-gagarin","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","tags":[],"subnets":null,"vpc_id":"16a6c4e4-63d1-4161-967f-274ce1acb20d","default_route_propagation_enabled":false}'
         headers:
             Content-Type:
                 - application/json
@@ -87,22 +87,22 @@ interactions:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 1066
-        body: '{"id":"8ea78e26-d683-4221-a7fd-29fad84deed0","name":"tf-pn-sharp-franklin","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:39:01.988433Z","updated_at":"2026-03-26T11:39:01.988433Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","subnets":[{"id":"36388d9c-cd3f-43ac-bc13-706505327306","created_at":"2026-03-26T11:39:01.988433Z","updated_at":"2026-03-26T11:39:01.988433Z","subnet":"172.16.20.0/22","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","vpc_id":"9a2c31ba-023d-426c-8f47-d73348a4df86"},{"id":"d7e8677f-daf5-4ba9-915f-7ccb30b81723","created_at":"2026-03-26T11:39:01.988433Z","updated_at":"2026-03-26T11:39:01.988433Z","subnet":"fd40:e277:fdde:adc4::/64","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","vpc_id":"9a2c31ba-023d-426c-8f47-d73348a4df86"}],"vpc_id":"9a2c31ba-023d-426c-8f47-d73348a4df86","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        content_length: 1089
+        body: '{"id":"60b434b2-3457-47f5-a569-33ec437ae1c0", "name":"tf-pn-jovial-gagarin", "tags":[], "organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8", "created_at":"2026-04-01T08:11:17.252046Z", "updated_at":"2026-04-01T08:11:17.252046Z", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "subnets":[{"id":"54296e22-01ca-4ea8-982d-eb185f8f7978", "created_at":"2026-04-01T08:11:17.252046Z", "updated_at":"2026-04-01T08:11:17.252046Z", "subnet":"172.16.0.0/22", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "private_network_id":"60b434b2-3457-47f5-a569-33ec437ae1c0", "vpc_id":"16a6c4e4-63d1-4161-967f-274ce1acb20d"}, {"id":"9cefcd2b-8c0d-4e93-8aa0-3b97786e2369", "created_at":"2026-04-01T08:11:17.252046Z", "updated_at":"2026-04-01T08:11:17.252046Z", "subnet":"fd40:e277:fdde:ebef::/64", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "private_network_id":"60b434b2-3457-47f5-a569-33ec437ae1c0", "vpc_id":"16a6c4e4-63d1-4161-967f-274ce1acb20d"}], "vpc_id":"16a6c4e4-63d1-4161-967f-274ce1acb20d", "dhcp_enabled":true, "default_route_propagation_enabled":false, "region":"fr-par"}'
         headers:
             Content-Length:
-                - "1066"
+                - "1089"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:39:02 GMT
+                - Wed, 01 Apr 2026 08:11:18 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 1fef9d1a-1e7c-4acc-81c7-0d0d73e79e23
+                - 9cba50cf-4261-4962-a8a3-1b2c92b791a2
         status: 200 OK
         code: 200
-        duration: 935.986719ms
+        duration: 1.2339477s
     - id: 3
       request:
         proto: HTTP/1.1
@@ -113,28 +113,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8ea78e26-d683-4221-a7fd-29fad84deed0
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/60b434b2-3457-47f5-a569-33ec437ae1c0
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 1066
-        body: '{"id":"8ea78e26-d683-4221-a7fd-29fad84deed0","name":"tf-pn-sharp-franklin","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:39:01.988433Z","updated_at":"2026-03-26T11:39:01.988433Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","subnets":[{"id":"36388d9c-cd3f-43ac-bc13-706505327306","created_at":"2026-03-26T11:39:01.988433Z","updated_at":"2026-03-26T11:39:01.988433Z","subnet":"172.16.20.0/22","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","vpc_id":"9a2c31ba-023d-426c-8f47-d73348a4df86"},{"id":"d7e8677f-daf5-4ba9-915f-7ccb30b81723","created_at":"2026-03-26T11:39:01.988433Z","updated_at":"2026-03-26T11:39:01.988433Z","subnet":"fd40:e277:fdde:adc4::/64","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","vpc_id":"9a2c31ba-023d-426c-8f47-d73348a4df86"}],"vpc_id":"9a2c31ba-023d-426c-8f47-d73348a4df86","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        content_length: 1089
+        body: '{"id":"60b434b2-3457-47f5-a569-33ec437ae1c0", "name":"tf-pn-jovial-gagarin", "tags":[], "organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8", "created_at":"2026-04-01T08:11:17.252046Z", "updated_at":"2026-04-01T08:11:17.252046Z", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "subnets":[{"id":"54296e22-01ca-4ea8-982d-eb185f8f7978", "created_at":"2026-04-01T08:11:17.252046Z", "updated_at":"2026-04-01T08:11:17.252046Z", "subnet":"172.16.0.0/22", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "private_network_id":"60b434b2-3457-47f5-a569-33ec437ae1c0", "vpc_id":"16a6c4e4-63d1-4161-967f-274ce1acb20d"}, {"id":"9cefcd2b-8c0d-4e93-8aa0-3b97786e2369", "created_at":"2026-04-01T08:11:17.252046Z", "updated_at":"2026-04-01T08:11:17.252046Z", "subnet":"fd40:e277:fdde:ebef::/64", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "private_network_id":"60b434b2-3457-47f5-a569-33ec437ae1c0", "vpc_id":"16a6c4e4-63d1-4161-967f-274ce1acb20d"}], "vpc_id":"16a6c4e4-63d1-4161-967f-274ce1acb20d", "dhcp_enabled":true, "default_route_propagation_enabled":false, "region":"fr-par"}'
         headers:
             Content-Length:
-                - "1066"
+                - "1089"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:39:02 GMT
+                - Wed, 01 Apr 2026 08:11:18 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - ae609869-209d-4461-a4f8-4868b29c846e
+                - 6e935d01-dfa3-4e3b-b88f-9a9b43916449
         status: 200 OK
         code: 200
-        duration: 62.916864ms
+        duration: 57.57118ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -142,7 +142,7 @@ interactions:
         proto_minor: 1
         content_length: 356
         host: api.scaleway.com
-        body: '{"project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"main":{"node_type":"DATALAB-SHARED-4C-8G"},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1},"has_notebook":false,"spark_version":"4.0.0","private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0"}'
+        body: '{"project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"main":{"node_type":"DATALAB-SHARED-4C-8G"},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1},"has_notebook":false,"spark_version":"4.0.0","private_network_id":"60b434b2-3457-47f5-a569-33ec437ae1c0"}'
         headers:
             Content-Type:
                 - application/json
@@ -154,22 +154,22 @@ interactions:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 938
-        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:39:02.854954Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        content_length: 963
+        body: '{"id":"8648bc98-cfe9-4002-8979-43f67bd1259a", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_tags", "description":"", "tags":["ds-filter-test", "env:test"], "created_at":"2026-04-01T08:11:18.608362Z", "updated_at":"2026-04-01T08:11:18.608362Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://8648bc98-cfe9-4002-8979-43f67bd1259a.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-8648bc98-cfe9-4002-8979-43f67bd1259a.60b434b2-3457-47f5-a569-33ec437ae1c0.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"60b434b2-3457-47f5-a569-33ec437ae1c0", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "938"
+                - "963"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:39:03 GMT
+                - Wed, 01 Apr 2026 08:11:19 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - c588dbbb-9a1b-4e63-b282-02ff45ed6e43
+                - 42c98c19-6fe8-45d6-b449-00143c1ddf69
         status: 200 OK
         code: 200
-        duration: 749.707654ms
+        duration: 728.171129ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -180,28 +180,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/8648bc98-cfe9-4002-8979-43f67bd1259a
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 938
-        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:39:02.854954Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        content_length: 963
+        body: '{"id":"8648bc98-cfe9-4002-8979-43f67bd1259a", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_tags", "description":"", "tags":["ds-filter-test", "env:test"], "created_at":"2026-04-01T08:11:18.608362Z", "updated_at":"2026-04-01T08:11:18.608362Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://8648bc98-cfe9-4002-8979-43f67bd1259a.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-8648bc98-cfe9-4002-8979-43f67bd1259a.60b434b2-3457-47f5-a569-33ec437ae1c0.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"60b434b2-3457-47f5-a569-33ec437ae1c0", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "938"
+                - "963"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:39:03 GMT
+                - Wed, 01 Apr 2026 08:11:19 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 64fd698e-cf3c-4249-8e8f-a6500b961c55
+                - f8f923de-dbcf-4c7b-8007-2090eebc7273
         status: 200 OK
         code: 200
-        duration: 74.740655ms
+        duration: 89.265502ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -212,28 +212,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/8648bc98-cfe9-4002-8979-43f67bd1259a
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 938
-        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:39:02.854954Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        content_length: 963
+        body: '{"id":"8648bc98-cfe9-4002-8979-43f67bd1259a", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_tags", "description":"", "tags":["ds-filter-test", "env:test"], "created_at":"2026-04-01T08:11:18.608362Z", "updated_at":"2026-04-01T08:11:18.608362Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://8648bc98-cfe9-4002-8979-43f67bd1259a.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-8648bc98-cfe9-4002-8979-43f67bd1259a.60b434b2-3457-47f5-a569-33ec437ae1c0.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"60b434b2-3457-47f5-a569-33ec437ae1c0", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "938"
+                - "963"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:39:18 GMT
+                - Wed, 01 Apr 2026 08:11:34 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 7f359f08-1ca4-4b71-8bee-56a2bb40f5d3
+                - 131c137b-2de6-44de-8994-c0abbec50709
         status: 200 OK
         code: 200
-        duration: 92.707304ms
+        duration: 78.677721ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -244,28 +244,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/8648bc98-cfe9-4002-8979-43f67bd1259a
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 938
-        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:39:02.854954Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        content_length: 963
+        body: '{"id":"8648bc98-cfe9-4002-8979-43f67bd1259a", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_tags", "description":"", "tags":["ds-filter-test", "env:test"], "created_at":"2026-04-01T08:11:18.608362Z", "updated_at":"2026-04-01T08:11:18.608362Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://8648bc98-cfe9-4002-8979-43f67bd1259a.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-8648bc98-cfe9-4002-8979-43f67bd1259a.60b434b2-3457-47f5-a569-33ec437ae1c0.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"60b434b2-3457-47f5-a569-33ec437ae1c0", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "938"
+                - "963"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:39:33 GMT
+                - Wed, 01 Apr 2026 08:11:49 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - a0c85cae-2285-43d7-a056-b072cb5d12b9
+                - c5e9c847-fb80-4296-b0a5-bab6b7e37095
         status: 200 OK
         code: 200
-        duration: 84.470019ms
+        duration: 79.646622ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -276,28 +276,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/8648bc98-cfe9-4002-8979-43f67bd1259a
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 938
-        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:39:02.854954Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        content_length: 963
+        body: '{"id":"8648bc98-cfe9-4002-8979-43f67bd1259a", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_tags", "description":"", "tags":["ds-filter-test", "env:test"], "created_at":"2026-04-01T08:11:18.608362Z", "updated_at":"2026-04-01T08:11:18.608362Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://8648bc98-cfe9-4002-8979-43f67bd1259a.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-8648bc98-cfe9-4002-8979-43f67bd1259a.60b434b2-3457-47f5-a569-33ec437ae1c0.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"60b434b2-3457-47f5-a569-33ec437ae1c0", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "938"
+                - "963"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:39:48 GMT
+                - Wed, 01 Apr 2026 08:12:04 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 275f2529-4654-4b7f-9d5e-c5c41afe5ba6
+                - be9b691d-ec51-4ce4-bb93-94eb8ab350e4
         status: 200 OK
         code: 200
-        duration: 77.145018ms
+        duration: 75.445838ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -308,28 +308,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/8648bc98-cfe9-4002-8979-43f67bd1259a
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 938
-        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:39:02.854954Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        content_length: 963
+        body: '{"id":"8648bc98-cfe9-4002-8979-43f67bd1259a", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_tags", "description":"", "tags":["ds-filter-test", "env:test"], "created_at":"2026-04-01T08:11:18.608362Z", "updated_at":"2026-04-01T08:11:18.608362Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://8648bc98-cfe9-4002-8979-43f67bd1259a.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-8648bc98-cfe9-4002-8979-43f67bd1259a.60b434b2-3457-47f5-a569-33ec437ae1c0.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"60b434b2-3457-47f5-a569-33ec437ae1c0", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "938"
+                - "963"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:40:03 GMT
+                - Wed, 01 Apr 2026 08:12:19 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 49371998-41c9-46b6-9cb3-b48132b2f73c
+                - 47d5e118-7617-426f-af1f-100495857d88
         status: 200 OK
         code: 200
-        duration: 79.608606ms
+        duration: 78.960912ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -340,28 +340,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/8648bc98-cfe9-4002-8979-43f67bd1259a
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 938
-        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:39:02.854954Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        content_length: 963
+        body: '{"id":"8648bc98-cfe9-4002-8979-43f67bd1259a", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_tags", "description":"", "tags":["ds-filter-test", "env:test"], "created_at":"2026-04-01T08:11:18.608362Z", "updated_at":"2026-04-01T08:11:18.608362Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://8648bc98-cfe9-4002-8979-43f67bd1259a.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-8648bc98-cfe9-4002-8979-43f67bd1259a.60b434b2-3457-47f5-a569-33ec437ae1c0.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"60b434b2-3457-47f5-a569-33ec437ae1c0", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "938"
+                - "963"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:40:18 GMT
+                - Wed, 01 Apr 2026 08:12:34 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 5aaa6b1c-274d-4771-bfe7-fc50f24094e3
+                - 9549205e-cfca-4c6e-b5d9-74ac076f71eb
         status: 200 OK
         code: 200
-        duration: 72.037961ms
+        duration: 75.246784ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -372,28 +372,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/8648bc98-cfe9-4002-8979-43f67bd1259a
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 938
-        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:39:02.854954Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        content_length: 963
+        body: '{"id":"8648bc98-cfe9-4002-8979-43f67bd1259a", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_tags", "description":"", "tags":["ds-filter-test", "env:test"], "created_at":"2026-04-01T08:11:18.608362Z", "updated_at":"2026-04-01T08:11:18.608362Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://8648bc98-cfe9-4002-8979-43f67bd1259a.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-8648bc98-cfe9-4002-8979-43f67bd1259a.60b434b2-3457-47f5-a569-33ec437ae1c0.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"60b434b2-3457-47f5-a569-33ec437ae1c0", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "938"
+                - "963"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:40:34 GMT
+                - Wed, 01 Apr 2026 08:12:49 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 173cb754-4b7a-45c8-879d-7c50fb400a8c
+                - 2e90838f-507a-4c23-81d4-2e9f11bc8161
         status: 200 OK
         code: 200
-        duration: 72.363735ms
+        duration: 72.674352ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -404,28 +404,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/8648bc98-cfe9-4002-8979-43f67bd1259a
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 938
-        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:39:02.854954Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        content_length: 963
+        body: '{"id":"8648bc98-cfe9-4002-8979-43f67bd1259a", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_tags", "description":"", "tags":["ds-filter-test", "env:test"], "created_at":"2026-04-01T08:11:18.608362Z", "updated_at":"2026-04-01T08:11:18.608362Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://8648bc98-cfe9-4002-8979-43f67bd1259a.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-8648bc98-cfe9-4002-8979-43f67bd1259a.60b434b2-3457-47f5-a569-33ec437ae1c0.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"60b434b2-3457-47f5-a569-33ec437ae1c0", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "938"
+                - "963"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:40:49 GMT
+                - Wed, 01 Apr 2026 08:13:04 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - ee9ea9b9-4cb4-471f-8755-44ed45a3f1ee
+                - c3a0fdae-7f76-434d-adc2-822806b9fbb3
         status: 200 OK
         code: 200
-        duration: 83.429562ms
+        duration: 66.244366ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -436,28 +436,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/8648bc98-cfe9-4002-8979-43f67bd1259a
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 938
-        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:39:02.854954Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        content_length: 963
+        body: '{"id":"8648bc98-cfe9-4002-8979-43f67bd1259a", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_tags", "description":"", "tags":["ds-filter-test", "env:test"], "created_at":"2026-04-01T08:11:18.608362Z", "updated_at":"2026-04-01T08:11:18.608362Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://8648bc98-cfe9-4002-8979-43f67bd1259a.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-8648bc98-cfe9-4002-8979-43f67bd1259a.60b434b2-3457-47f5-a569-33ec437ae1c0.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"60b434b2-3457-47f5-a569-33ec437ae1c0", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "938"
+                - "963"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:41:04 GMT
+                - Wed, 01 Apr 2026 08:13:19 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 7667bb6a-8474-4c1b-8514-e14f07c8cc5b
+                - c907b70d-c82f-4c8a-b975-a8370b830c06
         status: 200 OK
         code: 200
-        duration: 72.34213ms
+        duration: 87.645409ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -468,28 +468,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/8648bc98-cfe9-4002-8979-43f67bd1259a
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 938
-        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:39:02.854954Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        content_length: 963
+        body: '{"id":"8648bc98-cfe9-4002-8979-43f67bd1259a", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_tags", "description":"", "tags":["ds-filter-test", "env:test"], "created_at":"2026-04-01T08:11:18.608362Z", "updated_at":"2026-04-01T08:11:18.608362Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://8648bc98-cfe9-4002-8979-43f67bd1259a.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-8648bc98-cfe9-4002-8979-43f67bd1259a.60b434b2-3457-47f5-a569-33ec437ae1c0.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"60b434b2-3457-47f5-a569-33ec437ae1c0", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "938"
+                - "963"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:41:19 GMT
+                - Wed, 01 Apr 2026 08:13:34 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - a4b3cb9e-4cac-40c5-a22d-2c6a4609c766
+                - d64fa560-78a7-40ba-bb33-5d48aa64ff76
         status: 200 OK
         code: 200
-        duration: 86.358399ms
+        duration: 73.290583ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -500,28 +500,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/8648bc98-cfe9-4002-8979-43f67bd1259a
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 938
-        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:39:02.854954Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        content_length: 963
+        body: '{"id":"8648bc98-cfe9-4002-8979-43f67bd1259a", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_tags", "description":"", "tags":["ds-filter-test", "env:test"], "created_at":"2026-04-01T08:11:18.608362Z", "updated_at":"2026-04-01T08:11:18.608362Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://8648bc98-cfe9-4002-8979-43f67bd1259a.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-8648bc98-cfe9-4002-8979-43f67bd1259a.60b434b2-3457-47f5-a569-33ec437ae1c0.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"60b434b2-3457-47f5-a569-33ec437ae1c0", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "938"
+                - "963"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:41:34 GMT
+                - Wed, 01 Apr 2026 08:13:50 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - d1207b80-d4ff-432a-a9ba-1b811e76a5e4
+                - 0499af68-55f0-477d-9f03-99a8e2e97618
         status: 200 OK
         code: 200
-        duration: 79.073606ms
+        duration: 70.652202ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -532,28 +532,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/8648bc98-cfe9-4002-8979-43f67bd1259a
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 938
-        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:39:02.854954Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        content_length: 963
+        body: '{"id":"8648bc98-cfe9-4002-8979-43f67bd1259a", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_tags", "description":"", "tags":["ds-filter-test", "env:test"], "created_at":"2026-04-01T08:11:18.608362Z", "updated_at":"2026-04-01T08:11:18.608362Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://8648bc98-cfe9-4002-8979-43f67bd1259a.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-8648bc98-cfe9-4002-8979-43f67bd1259a.60b434b2-3457-47f5-a569-33ec437ae1c0.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"60b434b2-3457-47f5-a569-33ec437ae1c0", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "938"
+                - "963"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:41:49 GMT
+                - Wed, 01 Apr 2026 08:14:05 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - dcbd17f0-fb35-4306-9b6c-13043cce5a8c
+                - 5cc8d0a3-a75a-4d83-98d9-1268290342fc
         status: 200 OK
         code: 200
-        duration: 80.073361ms
+        duration: 93.698454ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -564,28 +564,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/8648bc98-cfe9-4002-8979-43f67bd1259a
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 938
-        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:39:02.854954Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        content_length: 963
+        body: '{"id":"8648bc98-cfe9-4002-8979-43f67bd1259a", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_tags", "description":"", "tags":["ds-filter-test", "env:test"], "created_at":"2026-04-01T08:11:18.608362Z", "updated_at":"2026-04-01T08:11:18.608362Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://8648bc98-cfe9-4002-8979-43f67bd1259a.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-8648bc98-cfe9-4002-8979-43f67bd1259a.60b434b2-3457-47f5-a569-33ec437ae1c0.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"60b434b2-3457-47f5-a569-33ec437ae1c0", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "938"
+                - "963"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:42:04 GMT
+                - Wed, 01 Apr 2026 08:14:20 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 35b42ed1-3ab6-4ef6-977b-0f0893b8b498
+                - db358e60-3a00-485d-a2be-4aa45bc613c9
         status: 200 OK
         code: 200
-        duration: 78.365098ms
+        duration: 83.699159ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -596,28 +596,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/8648bc98-cfe9-4002-8979-43f67bd1259a
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 938
-        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:39:02.854954Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        content_length: 963
+        body: '{"id":"8648bc98-cfe9-4002-8979-43f67bd1259a", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_tags", "description":"", "tags":["ds-filter-test", "env:test"], "created_at":"2026-04-01T08:11:18.608362Z", "updated_at":"2026-04-01T08:11:18.608362Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://8648bc98-cfe9-4002-8979-43f67bd1259a.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-8648bc98-cfe9-4002-8979-43f67bd1259a.60b434b2-3457-47f5-a569-33ec437ae1c0.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"60b434b2-3457-47f5-a569-33ec437ae1c0", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "938"
+                - "963"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:42:19 GMT
+                - Wed, 01 Apr 2026 08:14:35 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 632f31c2-1282-407b-8358-4d3a6646a7ec
+                - c67efcb8-1b7a-4818-9c03-1f6e8b050f15
         status: 200 OK
         code: 200
-        duration: 90.730443ms
+        duration: 73.45593ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -628,28 +628,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/8648bc98-cfe9-4002-8979-43f67bd1259a
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 938
-        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:39:02.854954Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        content_length: 963
+        body: '{"id":"8648bc98-cfe9-4002-8979-43f67bd1259a", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_tags", "description":"", "tags":["ds-filter-test", "env:test"], "created_at":"2026-04-01T08:11:18.608362Z", "updated_at":"2026-04-01T08:11:18.608362Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://8648bc98-cfe9-4002-8979-43f67bd1259a.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-8648bc98-cfe9-4002-8979-43f67bd1259a.60b434b2-3457-47f5-a569-33ec437ae1c0.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"60b434b2-3457-47f5-a569-33ec437ae1c0", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "938"
+                - "963"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:42:34 GMT
+                - Wed, 01 Apr 2026 08:14:50 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 658e729f-c2be-4628-a03c-70b2ff90968e
+                - 1ef6f635-4161-46ec-a347-ac223dbb3c91
         status: 200 OK
         code: 200
-        duration: 69.780581ms
+        duration: 78.941235ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -660,28 +660,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/8648bc98-cfe9-4002-8979-43f67bd1259a
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 938
-        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:39:02.854954Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        content_length: 963
+        body: '{"id":"8648bc98-cfe9-4002-8979-43f67bd1259a", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_tags", "description":"", "tags":["ds-filter-test", "env:test"], "created_at":"2026-04-01T08:11:18.608362Z", "updated_at":"2026-04-01T08:11:18.608362Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://8648bc98-cfe9-4002-8979-43f67bd1259a.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-8648bc98-cfe9-4002-8979-43f67bd1259a.60b434b2-3457-47f5-a569-33ec437ae1c0.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"60b434b2-3457-47f5-a569-33ec437ae1c0", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "938"
+                - "963"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:42:49 GMT
+                - Wed, 01 Apr 2026 08:15:05 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 77341d06-132b-4920-bc33-c768dcaaf9d8
+                - 5a09f309-3006-4889-8fdb-aa04dbdc2df3
         status: 200 OK
         code: 200
-        duration: 66.47688ms
+        duration: 81.916796ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -692,28 +692,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/8648bc98-cfe9-4002-8979-43f67bd1259a
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 938
-        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:39:02.854954Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        content_length: 963
+        body: '{"id":"8648bc98-cfe9-4002-8979-43f67bd1259a", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_tags", "description":"", "tags":["ds-filter-test", "env:test"], "created_at":"2026-04-01T08:11:18.608362Z", "updated_at":"2026-04-01T08:11:18.608362Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://8648bc98-cfe9-4002-8979-43f67bd1259a.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-8648bc98-cfe9-4002-8979-43f67bd1259a.60b434b2-3457-47f5-a569-33ec437ae1c0.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"60b434b2-3457-47f5-a569-33ec437ae1c0", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "938"
+                - "963"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:43:04 GMT
+                - Wed, 01 Apr 2026 08:15:20 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 5d6643b8-cf72-496e-b7ea-705a4e7c6c1f
+                - 79e4f239-77c9-4eba-8f38-a8301310ab95
         status: 200 OK
         code: 200
-        duration: 88.870859ms
+        duration: 71.691958ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -724,28 +724,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/8648bc98-cfe9-4002-8979-43f67bd1259a
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 938
-        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:39:02.854954Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        content_length: 963
+        body: '{"id":"8648bc98-cfe9-4002-8979-43f67bd1259a", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_tags", "description":"", "tags":["ds-filter-test", "env:test"], "created_at":"2026-04-01T08:11:18.608362Z", "updated_at":"2026-04-01T08:11:18.608362Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://8648bc98-cfe9-4002-8979-43f67bd1259a.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-8648bc98-cfe9-4002-8979-43f67bd1259a.60b434b2-3457-47f5-a569-33ec437ae1c0.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"60b434b2-3457-47f5-a569-33ec437ae1c0", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "938"
+                - "963"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:43:19 GMT
+                - Wed, 01 Apr 2026 08:15:35 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 115a92c2-be74-429e-836a-92600287e847
+                - e1063a88-4257-4d0b-b8ac-067625fbca97
         status: 200 OK
         code: 200
-        duration: 75.538794ms
+        duration: 75.222047ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -756,28 +756,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/8648bc98-cfe9-4002-8979-43f67bd1259a
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 938
-        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:39:02.854954Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        content_length: 963
+        body: '{"id":"8648bc98-cfe9-4002-8979-43f67bd1259a", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_tags", "description":"", "tags":["ds-filter-test", "env:test"], "created_at":"2026-04-01T08:11:18.608362Z", "updated_at":"2026-04-01T08:11:18.608362Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://8648bc98-cfe9-4002-8979-43f67bd1259a.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-8648bc98-cfe9-4002-8979-43f67bd1259a.60b434b2-3457-47f5-a569-33ec437ae1c0.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"60b434b2-3457-47f5-a569-33ec437ae1c0", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "938"
+                - "963"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:43:35 GMT
+                - Wed, 01 Apr 2026 08:15:50 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 710bae9b-cd19-4e82-b720-46eb2045656f
+                - bc169a72-63b3-4617-9512-12815d1e82dd
         status: 200 OK
         code: 200
-        duration: 81.554137ms
+        duration: 94.095048ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -788,28 +788,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/8648bc98-cfe9-4002-8979-43f67bd1259a
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 938
-        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:39:02.854954Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        content_length: 963
+        body: '{"id":"8648bc98-cfe9-4002-8979-43f67bd1259a", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_tags", "description":"", "tags":["ds-filter-test", "env:test"], "created_at":"2026-04-01T08:11:18.608362Z", "updated_at":"2026-04-01T08:11:18.608362Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://8648bc98-cfe9-4002-8979-43f67bd1259a.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-8648bc98-cfe9-4002-8979-43f67bd1259a.60b434b2-3457-47f5-a569-33ec437ae1c0.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"60b434b2-3457-47f5-a569-33ec437ae1c0", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "938"
+                - "963"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:43:50 GMT
+                - Wed, 01 Apr 2026 08:16:05 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 019a975a-2175-475a-b698-625a99d2d21f
+                - 331790ca-aec5-49f7-8209-cbd50ccbb4c2
         status: 200 OK
         code: 200
-        duration: 82.969391ms
+        duration: 92.927266ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -820,28 +820,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/8648bc98-cfe9-4002-8979-43f67bd1259a
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 938
-        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:39:02.854954Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        content_length: 963
+        body: '{"id":"8648bc98-cfe9-4002-8979-43f67bd1259a", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_tags", "description":"", "tags":["ds-filter-test", "env:test"], "created_at":"2026-04-01T08:11:18.608362Z", "updated_at":"2026-04-01T08:11:18.608362Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://8648bc98-cfe9-4002-8979-43f67bd1259a.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-8648bc98-cfe9-4002-8979-43f67bd1259a.60b434b2-3457-47f5-a569-33ec437ae1c0.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"60b434b2-3457-47f5-a569-33ec437ae1c0", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "938"
+                - "963"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:44:05 GMT
+                - Wed, 01 Apr 2026 08:16:20 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 41eae38a-9e59-4121-9664-238f01ef8c57
+                - 4b91d36f-ff2a-492b-ae0b-f5db5a3e857d
         status: 200 OK
         code: 200
-        duration: 87.024896ms
+        duration: 75.507257ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -852,28 +852,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/8648bc98-cfe9-4002-8979-43f67bd1259a
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 938
-        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:39:02.854954Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        content_length: 963
+        body: '{"id":"8648bc98-cfe9-4002-8979-43f67bd1259a", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_tags", "description":"", "tags":["ds-filter-test", "env:test"], "created_at":"2026-04-01T08:11:18.608362Z", "updated_at":"2026-04-01T08:11:18.608362Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://8648bc98-cfe9-4002-8979-43f67bd1259a.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-8648bc98-cfe9-4002-8979-43f67bd1259a.60b434b2-3457-47f5-a569-33ec437ae1c0.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"60b434b2-3457-47f5-a569-33ec437ae1c0", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "938"
+                - "963"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:44:20 GMT
+                - Wed, 01 Apr 2026 08:16:35 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 216c8df4-77a4-4a99-8775-eaf3f48d7bbe
+                - 4c817137-53c2-4559-a9c8-49455f21b833
         status: 200 OK
         code: 200
-        duration: 73.619801ms
+        duration: 75.401935ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -884,28 +884,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/8648bc98-cfe9-4002-8979-43f67bd1259a
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 938
-        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"creating","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:39:02.854954Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        content_length: 963
+        body: '{"id":"8648bc98-cfe9-4002-8979-43f67bd1259a", "status":"creating", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_tags", "description":"", "tags":["ds-filter-test", "env:test"], "created_at":"2026-04-01T08:11:18.608362Z", "updated_at":"2026-04-01T08:11:18.608362Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://8648bc98-cfe9-4002-8979-43f67bd1259a.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-8648bc98-cfe9-4002-8979-43f67bd1259a.60b434b2-3457-47f5-a569-33ec437ae1c0.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"60b434b2-3457-47f5-a569-33ec437ae1c0", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "938"
+                - "963"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:44:35 GMT
+                - Wed, 01 Apr 2026 08:16:51 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 1d58805e-4491-4d96-b8a8-f3bcc26316b9
+                - 8ac3ba98-4119-4fa0-b432-4682e2d486e8
         status: 200 OK
         code: 200
-        duration: 69.848152ms
+        duration: 80.532148ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -916,28 +916,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/8648bc98-cfe9-4002-8979-43f67bd1259a
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 935
-        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:44:38.291481Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        content_length: 960
+        body: '{"id":"8648bc98-cfe9-4002-8979-43f67bd1259a", "status":"ready", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_tags", "description":"", "tags":["ds-filter-test", "env:test"], "created_at":"2026-04-01T08:11:18.608362Z", "updated_at":"2026-04-01T08:17:04.165220Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://8648bc98-cfe9-4002-8979-43f67bd1259a.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-8648bc98-cfe9-4002-8979-43f67bd1259a.60b434b2-3457-47f5-a569-33ec437ae1c0.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"60b434b2-3457-47f5-a569-33ec437ae1c0", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "935"
+                - "960"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:44:50 GMT
+                - Wed, 01 Apr 2026 08:17:06 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 934d8419-0193-4418-bcf0-d47fb73e53a5
+                - a96beb93-89b7-46b6-8e10-a86ab3621a96
         status: 200 OK
         code: 200
-        duration: 85.16546ms
+        duration: 92.239268ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -948,28 +948,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/8648bc98-cfe9-4002-8979-43f67bd1259a
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 935
-        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:44:38.291481Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        content_length: 960
+        body: '{"id":"8648bc98-cfe9-4002-8979-43f67bd1259a", "status":"ready", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_tags", "description":"", "tags":["ds-filter-test", "env:test"], "created_at":"2026-04-01T08:11:18.608362Z", "updated_at":"2026-04-01T08:17:04.165220Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://8648bc98-cfe9-4002-8979-43f67bd1259a.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-8648bc98-cfe9-4002-8979-43f67bd1259a.60b434b2-3457-47f5-a569-33ec437ae1c0.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"60b434b2-3457-47f5-a569-33ec437ae1c0", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "935"
+                - "960"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:44:50 GMT
+                - Wed, 01 Apr 2026 08:17:06 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - fca86355-9af6-4be2-ac1f-4313ba1dd669
+                - 6caf7908-3e05-4b49-840b-6f25990b3c5c
         status: 200 OK
         code: 200
-        duration: 74.871841ms
+        duration: 65.226145ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -980,28 +980,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/9a2c31ba-023d-426c-8f47-d73348a4df86
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/16a6c4e4-63d1-4161-967f-274ce1acb20d
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 412
-        body: '{"id":"9a2c31ba-023d-426c-8f47-d73348a4df86","name":"tf_tests_datalabs_ds_tags","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:39:01.611217Z","updated_at":"2026-03-26T11:39:01.611217Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","is_default":false,"private_network_count":1,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        content_length: 423
+        body: '{"id":"16a6c4e4-63d1-4161-967f-274ce1acb20d", "name":"tf_tests_datalabs_ds_tags", "tags":[], "organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8", "created_at":"2026-04-01T08:11:17.038619Z", "updated_at":"2026-04-01T08:11:17.038619Z", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "is_default":false, "private_network_count":1, "routing_enabled":true, "custom_routes_propagation_enabled":true, "region":"fr-par"}'
         headers:
             Content-Length:
-                - "412"
+                - "423"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:44:50 GMT
+                - Wed, 01 Apr 2026 08:17:06 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 25940631-9cb5-4cd1-998b-9e54bd75d7e2
+                - 41a3bb7b-a6af-410d-b050-e8b077c86948
         status: 200 OK
         code: 200
-        duration: 62.74694ms
+        duration: 62.929404ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1012,28 +1012,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8ea78e26-d683-4221-a7fd-29fad84deed0
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/60b434b2-3457-47f5-a569-33ec437ae1c0
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 1066
-        body: '{"id":"8ea78e26-d683-4221-a7fd-29fad84deed0","name":"tf-pn-sharp-franklin","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:39:01.988433Z","updated_at":"2026-03-26T11:39:01.988433Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","subnets":[{"id":"36388d9c-cd3f-43ac-bc13-706505327306","created_at":"2026-03-26T11:39:01.988433Z","updated_at":"2026-03-26T11:39:01.988433Z","subnet":"172.16.20.0/22","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","vpc_id":"9a2c31ba-023d-426c-8f47-d73348a4df86"},{"id":"d7e8677f-daf5-4ba9-915f-7ccb30b81723","created_at":"2026-03-26T11:39:01.988433Z","updated_at":"2026-03-26T11:39:01.988433Z","subnet":"fd40:e277:fdde:adc4::/64","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","vpc_id":"9a2c31ba-023d-426c-8f47-d73348a4df86"}],"vpc_id":"9a2c31ba-023d-426c-8f47-d73348a4df86","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        content_length: 1089
+        body: '{"id":"60b434b2-3457-47f5-a569-33ec437ae1c0", "name":"tf-pn-jovial-gagarin", "tags":[], "organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8", "created_at":"2026-04-01T08:11:17.252046Z", "updated_at":"2026-04-01T08:11:17.252046Z", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "subnets":[{"id":"54296e22-01ca-4ea8-982d-eb185f8f7978", "created_at":"2026-04-01T08:11:17.252046Z", "updated_at":"2026-04-01T08:11:17.252046Z", "subnet":"172.16.0.0/22", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "private_network_id":"60b434b2-3457-47f5-a569-33ec437ae1c0", "vpc_id":"16a6c4e4-63d1-4161-967f-274ce1acb20d"}, {"id":"9cefcd2b-8c0d-4e93-8aa0-3b97786e2369", "created_at":"2026-04-01T08:11:17.252046Z", "updated_at":"2026-04-01T08:11:17.252046Z", "subnet":"fd40:e277:fdde:ebef::/64", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "private_network_id":"60b434b2-3457-47f5-a569-33ec437ae1c0", "vpc_id":"16a6c4e4-63d1-4161-967f-274ce1acb20d"}], "vpc_id":"16a6c4e4-63d1-4161-967f-274ce1acb20d", "dhcp_enabled":true, "default_route_propagation_enabled":false, "region":"fr-par"}'
         headers:
             Content-Length:
-                - "1066"
+                - "1089"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:44:50 GMT
+                - Wed, 01 Apr 2026 08:17:06 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - d7318007-c0ba-4b7e-b884-c5b4ea4bdbac
+                - 5fb0dd16-026c-4f73-bd75-c651a90be069
         status: 200 OK
         code: 200
-        duration: 108.799789ms
+        duration: 68.070499ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1044,28 +1044,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/8648bc98-cfe9-4002-8979-43f67bd1259a
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 935
-        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:44:38.291481Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        content_length: 960
+        body: '{"id":"8648bc98-cfe9-4002-8979-43f67bd1259a", "status":"ready", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_tags", "description":"", "tags":["ds-filter-test", "env:test"], "created_at":"2026-04-01T08:11:18.608362Z", "updated_at":"2026-04-01T08:17:04.165220Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://8648bc98-cfe9-4002-8979-43f67bd1259a.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-8648bc98-cfe9-4002-8979-43f67bd1259a.60b434b2-3457-47f5-a569-33ec437ae1c0.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"60b434b2-3457-47f5-a569-33ec437ae1c0", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "935"
+                - "960"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:44:51 GMT
+                - Wed, 01 Apr 2026 08:17:06 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 9376cf26-8051-49fd-b561-0eaf2ae2fafd
+                - 2d7d2214-8c47-4315-9d0c-ac90800361f8
         status: 200 OK
         code: 200
-        duration: 88.137592ms
+        duration: 71.081172ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1076,28 +1076,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/9a2c31ba-023d-426c-8f47-d73348a4df86
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/16a6c4e4-63d1-4161-967f-274ce1acb20d
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 412
-        body: '{"id":"9a2c31ba-023d-426c-8f47-d73348a4df86","name":"tf_tests_datalabs_ds_tags","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:39:01.611217Z","updated_at":"2026-03-26T11:39:01.611217Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","is_default":false,"private_network_count":1,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        content_length: 423
+        body: '{"id":"16a6c4e4-63d1-4161-967f-274ce1acb20d", "name":"tf_tests_datalabs_ds_tags", "tags":[], "organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8", "created_at":"2026-04-01T08:11:17.038619Z", "updated_at":"2026-04-01T08:11:17.038619Z", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "is_default":false, "private_network_count":1, "routing_enabled":true, "custom_routes_propagation_enabled":true, "region":"fr-par"}'
         headers:
             Content-Length:
-                - "412"
+                - "423"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:44:51 GMT
+                - Wed, 01 Apr 2026 08:17:06 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - d274e134-66fe-476d-aff1-63c0d4211f9a
+                - ca1a86ad-50e2-495e-9a8c-3f961abdda9e
         status: 200 OK
         code: 200
-        duration: 79.463271ms
+        duration: 52.109859ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1110,35 +1110,33 @@ interactions:
                 - name_asc
             page:
                 - "1"
-            page_size:
-                - "100"
             tags:
                 - ds-filter-test
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs?order_by=name_asc&page=1&page_size=100&tags=ds-filter-test
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs?order_by=name_asc&page=1&tags=ds-filter-test
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 966
-        body: '{"datalabs":[{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:44:38.291481Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}],"total_count":1}'
+        content_length: 992
+        body: '{"datalabs":[{"id":"8648bc98-cfe9-4002-8979-43f67bd1259a", "status":"ready", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_tags", "description":"", "tags":["ds-filter-test", "env:test"], "created_at":"2026-04-01T08:11:18.608362Z", "updated_at":"2026-04-01T08:17:04.165220Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://8648bc98-cfe9-4002-8979-43f67bd1259a.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-8648bc98-cfe9-4002-8979-43f67bd1259a.60b434b2-3457-47f5-a569-33ec437ae1c0.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"60b434b2-3457-47f5-a569-33ec437ae1c0", "notebook_master_url":"", "region":"fr-par"}], "total_count":1}'
         headers:
             Content-Length:
-                - "966"
+                - "992"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:44:51 GMT
+                - Wed, 01 Apr 2026 08:17:06 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - c056011f-378b-493d-8528-c22ec41626c7
+                - feb7038e-094a-4725-8bbe-64bef811b5b6
         status: 200 OK
         code: 200
-        duration: 84.725892ms
+        duration: 86.415971ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1149,28 +1147,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8ea78e26-d683-4221-a7fd-29fad84deed0
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/60b434b2-3457-47f5-a569-33ec437ae1c0
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 1066
-        body: '{"id":"8ea78e26-d683-4221-a7fd-29fad84deed0","name":"tf-pn-sharp-franklin","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:39:01.988433Z","updated_at":"2026-03-26T11:39:01.988433Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","subnets":[{"id":"36388d9c-cd3f-43ac-bc13-706505327306","created_at":"2026-03-26T11:39:01.988433Z","updated_at":"2026-03-26T11:39:01.988433Z","subnet":"172.16.20.0/22","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","vpc_id":"9a2c31ba-023d-426c-8f47-d73348a4df86"},{"id":"d7e8677f-daf5-4ba9-915f-7ccb30b81723","created_at":"2026-03-26T11:39:01.988433Z","updated_at":"2026-03-26T11:39:01.988433Z","subnet":"fd40:e277:fdde:adc4::/64","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","vpc_id":"9a2c31ba-023d-426c-8f47-d73348a4df86"}],"vpc_id":"9a2c31ba-023d-426c-8f47-d73348a4df86","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        content_length: 1089
+        body: '{"id":"60b434b2-3457-47f5-a569-33ec437ae1c0", "name":"tf-pn-jovial-gagarin", "tags":[], "organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8", "created_at":"2026-04-01T08:11:17.252046Z", "updated_at":"2026-04-01T08:11:17.252046Z", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "subnets":[{"id":"54296e22-01ca-4ea8-982d-eb185f8f7978", "created_at":"2026-04-01T08:11:17.252046Z", "updated_at":"2026-04-01T08:11:17.252046Z", "subnet":"172.16.0.0/22", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "private_network_id":"60b434b2-3457-47f5-a569-33ec437ae1c0", "vpc_id":"16a6c4e4-63d1-4161-967f-274ce1acb20d"}, {"id":"9cefcd2b-8c0d-4e93-8aa0-3b97786e2369", "created_at":"2026-04-01T08:11:17.252046Z", "updated_at":"2026-04-01T08:11:17.252046Z", "subnet":"fd40:e277:fdde:ebef::/64", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "private_network_id":"60b434b2-3457-47f5-a569-33ec437ae1c0", "vpc_id":"16a6c4e4-63d1-4161-967f-274ce1acb20d"}], "vpc_id":"16a6c4e4-63d1-4161-967f-274ce1acb20d", "dhcp_enabled":true, "default_route_propagation_enabled":false, "region":"fr-par"}'
         headers:
             Content-Length:
-                - "1066"
+                - "1089"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:44:51 GMT
+                - Wed, 01 Apr 2026 08:17:06 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 7ebd4ed4-9247-42fb-a45d-cd9d6d97af1e
+                - bf369482-a669-41fa-9f92-cbb5dcfa8102
         status: 200 OK
         code: 200
-        duration: 70.409258ms
+        duration: 60.190288ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1181,28 +1179,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/8648bc98-cfe9-4002-8979-43f67bd1259a
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 935
-        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:44:38.291481Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        content_length: 960
+        body: '{"id":"8648bc98-cfe9-4002-8979-43f67bd1259a", "status":"ready", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_tags", "description":"", "tags":["ds-filter-test", "env:test"], "created_at":"2026-04-01T08:11:18.608362Z", "updated_at":"2026-04-01T08:17:04.165220Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://8648bc98-cfe9-4002-8979-43f67bd1259a.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-8648bc98-cfe9-4002-8979-43f67bd1259a.60b434b2-3457-47f5-a569-33ec437ae1c0.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"60b434b2-3457-47f5-a569-33ec437ae1c0", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "935"
+                - "960"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:44:51 GMT
+                - Wed, 01 Apr 2026 08:17:06 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 9e8a51a4-bebf-46fa-92c3-1edd739bfeb2
+                - 96b18082-aea9-4a2d-85ab-78c7c32c6953
         status: 200 OK
         code: 200
-        duration: 70.101806ms
+        duration: 76.160788ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1213,28 +1211,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/8648bc98-cfe9-4002-8979-43f67bd1259a
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 935
-        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:44:38.291481Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        content_length: 960
+        body: '{"id":"8648bc98-cfe9-4002-8979-43f67bd1259a", "status":"ready", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_tags", "description":"", "tags":["ds-filter-test", "env:test"], "created_at":"2026-04-01T08:11:18.608362Z", "updated_at":"2026-04-01T08:17:04.165220Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://8648bc98-cfe9-4002-8979-43f67bd1259a.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-8648bc98-cfe9-4002-8979-43f67bd1259a.60b434b2-3457-47f5-a569-33ec437ae1c0.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"60b434b2-3457-47f5-a569-33ec437ae1c0", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "935"
+                - "960"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:44:51 GMT
+                - Wed, 01 Apr 2026 08:17:07 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - ef441ee3-db3b-405d-9dbe-214a90048e26
+                - 84b3321d-d7b4-48ad-b1d5-91f0fd2807bd
         status: 200 OK
         code: 200
-        duration: 59.245782ms
+        duration: 71.290398ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1247,35 +1245,33 @@ interactions:
                 - name_asc
             page:
                 - "1"
-            page_size:
-                - "100"
             tags:
                 - ds-filter-test
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs?order_by=name_asc&page=1&page_size=100&tags=ds-filter-test
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs?order_by=name_asc&page=1&tags=ds-filter-test
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 966
-        body: '{"datalabs":[{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:44:38.291481Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}],"total_count":1}'
+        content_length: 992
+        body: '{"datalabs":[{"id":"8648bc98-cfe9-4002-8979-43f67bd1259a", "status":"ready", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_tags", "description":"", "tags":["ds-filter-test", "env:test"], "created_at":"2026-04-01T08:11:18.608362Z", "updated_at":"2026-04-01T08:17:04.165220Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://8648bc98-cfe9-4002-8979-43f67bd1259a.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-8648bc98-cfe9-4002-8979-43f67bd1259a.60b434b2-3457-47f5-a569-33ec437ae1c0.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"60b434b2-3457-47f5-a569-33ec437ae1c0", "notebook_master_url":"", "region":"fr-par"}], "total_count":1}'
         headers:
             Content-Length:
-                - "966"
+                - "992"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:44:51 GMT
+                - Wed, 01 Apr 2026 08:17:07 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 6fb6c803-32ba-4ce6-8cb8-059b20a42c7d
+                - 49ce4dbd-13fb-47ce-96f9-ce2550a3b680
         status: 200 OK
         code: 200
-        duration: 80.081404ms
+        duration: 92.136036ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -1286,28 +1282,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/9a2c31ba-023d-426c-8f47-d73348a4df86
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/16a6c4e4-63d1-4161-967f-274ce1acb20d
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 412
-        body: '{"id":"9a2c31ba-023d-426c-8f47-d73348a4df86","name":"tf_tests_datalabs_ds_tags","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:39:01.611217Z","updated_at":"2026-03-26T11:39:01.611217Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","is_default":false,"private_network_count":1,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        content_length: 423
+        body: '{"id":"16a6c4e4-63d1-4161-967f-274ce1acb20d", "name":"tf_tests_datalabs_ds_tags", "tags":[], "organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8", "created_at":"2026-04-01T08:11:17.038619Z", "updated_at":"2026-04-01T08:11:17.038619Z", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "is_default":false, "private_network_count":1, "routing_enabled":true, "custom_routes_propagation_enabled":true, "region":"fr-par"}'
         headers:
             Content-Length:
-                - "412"
+                - "423"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:44:51 GMT
+                - Wed, 01 Apr 2026 08:17:07 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 762e8baa-0605-4edd-90ab-d9f62945cfc8
+                - 05257900-94e6-47d7-b681-13e744e88047
         status: 200 OK
         code: 200
-        duration: 57.228305ms
+        duration: 55.792071ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -1320,35 +1316,33 @@ interactions:
                 - name_asc
             page:
                 - "1"
-            page_size:
-                - "100"
             tags:
                 - ds-filter-test
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs?order_by=name_asc&page=1&page_size=100&tags=ds-filter-test
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs?order_by=name_asc&page=1&tags=ds-filter-test
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 966
-        body: '{"datalabs":[{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:44:38.291481Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}],"total_count":1}'
+        content_length: 992
+        body: '{"datalabs":[{"id":"8648bc98-cfe9-4002-8979-43f67bd1259a", "status":"ready", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_tags", "description":"", "tags":["ds-filter-test", "env:test"], "created_at":"2026-04-01T08:11:18.608362Z", "updated_at":"2026-04-01T08:17:04.165220Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://8648bc98-cfe9-4002-8979-43f67bd1259a.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-8648bc98-cfe9-4002-8979-43f67bd1259a.60b434b2-3457-47f5-a569-33ec437ae1c0.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"60b434b2-3457-47f5-a569-33ec437ae1c0", "notebook_master_url":"", "region":"fr-par"}], "total_count":1}'
         headers:
             Content-Length:
-                - "966"
+                - "992"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:44:51 GMT
+                - Wed, 01 Apr 2026 08:17:07 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 722d185d-223e-4502-bdd9-2179a83cce31
+                - 2fcad005-f985-4a87-9a70-206c025f8bcd
         status: 200 OK
         code: 200
-        duration: 82.849802ms
+        duration: 87.408336ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -1359,28 +1353,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8ea78e26-d683-4221-a7fd-29fad84deed0
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/60b434b2-3457-47f5-a569-33ec437ae1c0
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 1066
-        body: '{"id":"8ea78e26-d683-4221-a7fd-29fad84deed0","name":"tf-pn-sharp-franklin","tags":[],"organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8","created_at":"2026-03-26T11:39:01.988433Z","updated_at":"2026-03-26T11:39:01.988433Z","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","subnets":[{"id":"36388d9c-cd3f-43ac-bc13-706505327306","created_at":"2026-03-26T11:39:01.988433Z","updated_at":"2026-03-26T11:39:01.988433Z","subnet":"172.16.20.0/22","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","vpc_id":"9a2c31ba-023d-426c-8f47-d73348a4df86"},{"id":"d7e8677f-daf5-4ba9-915f-7ccb30b81723","created_at":"2026-03-26T11:39:01.988433Z","updated_at":"2026-03-26T11:39:01.988433Z","subnet":"fd40:e277:fdde:adc4::/64","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","vpc_id":"9a2c31ba-023d-426c-8f47-d73348a4df86"}],"vpc_id":"9a2c31ba-023d-426c-8f47-d73348a4df86","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        content_length: 1089
+        body: '{"id":"60b434b2-3457-47f5-a569-33ec437ae1c0", "name":"tf-pn-jovial-gagarin", "tags":[], "organization_id":"6c298059-5271-47b4-a5ff-06b50cfa0ea8", "created_at":"2026-04-01T08:11:17.252046Z", "updated_at":"2026-04-01T08:11:17.252046Z", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "subnets":[{"id":"54296e22-01ca-4ea8-982d-eb185f8f7978", "created_at":"2026-04-01T08:11:17.252046Z", "updated_at":"2026-04-01T08:11:17.252046Z", "subnet":"172.16.0.0/22", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "private_network_id":"60b434b2-3457-47f5-a569-33ec437ae1c0", "vpc_id":"16a6c4e4-63d1-4161-967f-274ce1acb20d"}, {"id":"9cefcd2b-8c0d-4e93-8aa0-3b97786e2369", "created_at":"2026-04-01T08:11:17.252046Z", "updated_at":"2026-04-01T08:11:17.252046Z", "subnet":"fd40:e277:fdde:ebef::/64", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "private_network_id":"60b434b2-3457-47f5-a569-33ec437ae1c0", "vpc_id":"16a6c4e4-63d1-4161-967f-274ce1acb20d"}], "vpc_id":"16a6c4e4-63d1-4161-967f-274ce1acb20d", "dhcp_enabled":true, "default_route_propagation_enabled":false, "region":"fr-par"}'
         headers:
             Content-Length:
-                - "1066"
+                - "1089"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:44:51 GMT
+                - Wed, 01 Apr 2026 08:17:07 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - b03e696f-760b-4380-aeb6-214f2dade665
+                - 558372fa-cf68-42e7-bcbf-5182657a16e9
         status: 200 OK
         code: 200
-        duration: 56.989562ms
+        duration: 56.292835ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -1391,28 +1385,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/8648bc98-cfe9-4002-8979-43f67bd1259a
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 935
-        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"ready","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:44:38.291481Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        content_length: 960
+        body: '{"id":"8648bc98-cfe9-4002-8979-43f67bd1259a", "status":"ready", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_tags", "description":"", "tags":["ds-filter-test", "env:test"], "created_at":"2026-04-01T08:11:18.608362Z", "updated_at":"2026-04-01T08:17:04.165220Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://8648bc98-cfe9-4002-8979-43f67bd1259a.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-8648bc98-cfe9-4002-8979-43f67bd1259a.60b434b2-3457-47f5-a569-33ec437ae1c0.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"60b434b2-3457-47f5-a569-33ec437ae1c0", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "935"
+                - "960"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:44:51 GMT
+                - Wed, 01 Apr 2026 08:17:07 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 1d3a20f0-50ff-49ed-8608-27aa783bb884
+                - daa7a86a-9de6-4ade-be53-4b4214bc86b2
         status: 200 OK
         code: 200
-        duration: 62.313771ms
+        duration: 67.90088ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -1423,28 +1417,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/8648bc98-cfe9-4002-8979-43f67bd1259a
         method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 938
-        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:44:52.139003Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        content_length: 963
+        body: '{"id":"8648bc98-cfe9-4002-8979-43f67bd1259a", "status":"deleting", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_tags", "description":"", "tags":["ds-filter-test", "env:test"], "created_at":"2026-04-01T08:11:18.608362Z", "updated_at":"2026-04-01T08:17:07.789789Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://8648bc98-cfe9-4002-8979-43f67bd1259a.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-8648bc98-cfe9-4002-8979-43f67bd1259a.60b434b2-3457-47f5-a569-33ec437ae1c0.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"60b434b2-3457-47f5-a569-33ec437ae1c0", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "938"
+                - "963"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:44:52 GMT
+                - Wed, 01 Apr 2026 08:17:07 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 9ad28d68-f17b-414d-a452-98ecf1a3631d
+                - 1b9e0a0d-162b-4c65-af15-814ea1f1878d
         status: 200 OK
         code: 200
-        duration: 140.000919ms
+        duration: 156.413531ms
     - id: 44
       request:
         proto: HTTP/1.1
@@ -1455,28 +1449,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/8648bc98-cfe9-4002-8979-43f67bd1259a
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 938
-        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:44:52.139003Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        content_length: 963
+        body: '{"id":"8648bc98-cfe9-4002-8979-43f67bd1259a", "status":"deleting", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_tags", "description":"", "tags":["ds-filter-test", "env:test"], "created_at":"2026-04-01T08:11:18.608362Z", "updated_at":"2026-04-01T08:17:07.789789Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://8648bc98-cfe9-4002-8979-43f67bd1259a.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-8648bc98-cfe9-4002-8979-43f67bd1259a.60b434b2-3457-47f5-a569-33ec437ae1c0.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"60b434b2-3457-47f5-a569-33ec437ae1c0", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "938"
+                - "963"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:44:52 GMT
+                - Wed, 01 Apr 2026 08:17:07 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 3fc53096-3b66-4538-a773-5c036ce12199
+                - c9172e58-4df9-41ac-a5af-1eda2adacd7c
         status: 200 OK
         code: 200
-        duration: 66.245828ms
+        duration: 67.08578ms
     - id: 45
       request:
         proto: HTTP/1.1
@@ -1487,28 +1481,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/8648bc98-cfe9-4002-8979-43f67bd1259a
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 938
-        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:44:52.139003Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        content_length: 963
+        body: '{"id":"8648bc98-cfe9-4002-8979-43f67bd1259a", "status":"deleting", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_tags", "description":"", "tags":["ds-filter-test", "env:test"], "created_at":"2026-04-01T08:11:18.608362Z", "updated_at":"2026-04-01T08:17:07.789789Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://8648bc98-cfe9-4002-8979-43f67bd1259a.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-8648bc98-cfe9-4002-8979-43f67bd1259a.60b434b2-3457-47f5-a569-33ec437ae1c0.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"60b434b2-3457-47f5-a569-33ec437ae1c0", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "938"
+                - "963"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:45:07 GMT
+                - Wed, 01 Apr 2026 08:17:23 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 6806e6f0-e10f-4fbc-bb2e-ea21d70cda7c
+                - 0bdf54a7-6b3e-4730-ab76-a4fb90d1c9c9
         status: 200 OK
         code: 200
-        duration: 61.035216ms
+        duration: 70.904962ms
     - id: 46
       request:
         proto: HTTP/1.1
@@ -1519,28 +1513,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/8648bc98-cfe9-4002-8979-43f67bd1259a
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 938
-        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:44:52.139003Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        content_length: 963
+        body: '{"id":"8648bc98-cfe9-4002-8979-43f67bd1259a", "status":"deleting", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_tags", "description":"", "tags":["ds-filter-test", "env:test"], "created_at":"2026-04-01T08:11:18.608362Z", "updated_at":"2026-04-01T08:17:07.789789Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://8648bc98-cfe9-4002-8979-43f67bd1259a.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-8648bc98-cfe9-4002-8979-43f67bd1259a.60b434b2-3457-47f5-a569-33ec437ae1c0.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"60b434b2-3457-47f5-a569-33ec437ae1c0", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "938"
+                - "963"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:45:22 GMT
+                - Wed, 01 Apr 2026 08:17:38 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 83701eb8-c1e3-4e64-b287-a4e0501ef250
+                - e06ce037-f227-42d5-950d-f56914428ada
         status: 200 OK
         code: 200
-        duration: 83.252344ms
+        duration: 89.006022ms
     - id: 47
       request:
         proto: HTTP/1.1
@@ -1551,28 +1545,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/8648bc98-cfe9-4002-8979-43f67bd1259a
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 938
-        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:44:52.139003Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        content_length: 963
+        body: '{"id":"8648bc98-cfe9-4002-8979-43f67bd1259a", "status":"deleting", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_tags", "description":"", "tags":["ds-filter-test", "env:test"], "created_at":"2026-04-01T08:11:18.608362Z", "updated_at":"2026-04-01T08:17:07.789789Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://8648bc98-cfe9-4002-8979-43f67bd1259a.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-8648bc98-cfe9-4002-8979-43f67bd1259a.60b434b2-3457-47f5-a569-33ec437ae1c0.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"60b434b2-3457-47f5-a569-33ec437ae1c0", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "938"
+                - "963"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:45:37 GMT
+                - Wed, 01 Apr 2026 08:17:53 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - ead105c6-8603-4eac-ab61-582e346747c2
+                - 7cbbd3e2-7e26-4b92-b646-26a50e384bff
         status: 200 OK
         code: 200
-        duration: 60.839484ms
+        duration: 73.753047ms
     - id: 48
       request:
         proto: HTTP/1.1
@@ -1583,28 +1577,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/8648bc98-cfe9-4002-8979-43f67bd1259a
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 938
-        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:44:52.139003Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        content_length: 963
+        body: '{"id":"8648bc98-cfe9-4002-8979-43f67bd1259a", "status":"deleting", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_tags", "description":"", "tags":["ds-filter-test", "env:test"], "created_at":"2026-04-01T08:11:18.608362Z", "updated_at":"2026-04-01T08:17:07.789789Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://8648bc98-cfe9-4002-8979-43f67bd1259a.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-8648bc98-cfe9-4002-8979-43f67bd1259a.60b434b2-3457-47f5-a569-33ec437ae1c0.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"60b434b2-3457-47f5-a569-33ec437ae1c0", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "938"
+                - "963"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:45:52 GMT
+                - Wed, 01 Apr 2026 08:18:08 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - a76bdccb-d54c-44e1-a7fc-b132665d8a72
+                - 085f3ece-5252-4168-9e7e-ee7e94bab78b
         status: 200 OK
         code: 200
-        duration: 82.897827ms
+        duration: 81.411751ms
     - id: 49
       request:
         proto: HTTP/1.1
@@ -1615,28 +1609,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/8648bc98-cfe9-4002-8979-43f67bd1259a
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 938
-        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:44:52.139003Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        content_length: 963
+        body: '{"id":"8648bc98-cfe9-4002-8979-43f67bd1259a", "status":"deleting", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_tags", "description":"", "tags":["ds-filter-test", "env:test"], "created_at":"2026-04-01T08:11:18.608362Z", "updated_at":"2026-04-01T08:17:07.789789Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://8648bc98-cfe9-4002-8979-43f67bd1259a.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-8648bc98-cfe9-4002-8979-43f67bd1259a.60b434b2-3457-47f5-a569-33ec437ae1c0.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"60b434b2-3457-47f5-a569-33ec437ae1c0", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "938"
+                - "963"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:46:07 GMT
+                - Wed, 01 Apr 2026 08:18:23 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 1a09e74c-ac43-4c3a-a9f2-67653bddc909
+                - eab99a6a-ca32-4526-b58e-af1f0b3e5642
         status: 200 OK
         code: 200
-        duration: 74.379521ms
+        duration: 68.554888ms
     - id: 50
       request:
         proto: HTTP/1.1
@@ -1647,28 +1641,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/8648bc98-cfe9-4002-8979-43f67bd1259a
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 938
-        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:44:52.139003Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        content_length: 963
+        body: '{"id":"8648bc98-cfe9-4002-8979-43f67bd1259a", "status":"deleting", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_tags", "description":"", "tags":["ds-filter-test", "env:test"], "created_at":"2026-04-01T08:11:18.608362Z", "updated_at":"2026-04-01T08:17:07.789789Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://8648bc98-cfe9-4002-8979-43f67bd1259a.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-8648bc98-cfe9-4002-8979-43f67bd1259a.60b434b2-3457-47f5-a569-33ec437ae1c0.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"60b434b2-3457-47f5-a569-33ec437ae1c0", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "938"
+                - "963"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:46:22 GMT
+                - Wed, 01 Apr 2026 08:18:38 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 7c8a07bf-d3ff-475f-bdae-e8b1a9ef70f4
+                - f0e894d1-ed19-42d7-84da-40abc17be29e
         status: 200 OK
         code: 200
-        duration: 71.607435ms
+        duration: 82.612986ms
     - id: 51
       request:
         proto: HTTP/1.1
@@ -1679,28 +1673,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/8648bc98-cfe9-4002-8979-43f67bd1259a
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 938
-        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:44:52.139003Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        content_length: 963
+        body: '{"id":"8648bc98-cfe9-4002-8979-43f67bd1259a", "status":"deleting", "project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1", "name":"tf_tests_datalabs_ds_tags", "description":"", "tags":["ds-filter-test", "env:test"], "created_at":"2026-04-01T08:11:18.608362Z", "updated_at":"2026-04-01T08:17:07.789789Z", "main":{"node_type":"DATALAB-SHARED-4C-8G", "spark_ui_url":"https://8648bc98-cfe9-4002-8979-43f67bd1259a.ddl.fr-par.scw.cloud:4040", "spark_master_url":"spark://master-datalab-8648bc98-cfe9-4002-8979-43f67bd1259a.60b434b2-3457-47f5-a569-33ec437ae1c0.internal:7077", "root_volume":{"type":"sbs_5k", "size":50000000000}}, "worker":{"node_type":"DATALAB-DEDICATED2-2C-8G", "node_count":1, "root_volume":{"type":"sbs_5k", "size":50000000000}}, "has_notebook":false, "notebook_url":"", "spark_version":"4.0.0", "total_storage":{"type":"unknown_type", "size":0}, "private_network_id":"60b434b2-3457-47f5-a569-33ec437ae1c0", "notebook_master_url":"", "region":"fr-par"}'
         headers:
             Content-Length:
-                - "938"
+                - "963"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:46:37 GMT
+                - Wed, 01 Apr 2026 08:18:53 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 4498575f-20f3-4dad-980a-81a96d961554
+                - b223dd0f-6bba-4eb1-8383-5644ff34e129
         status: 200 OK
         code: 200
-        duration: 71.972007ms
+        duration: 70.620269ms
     - id: 52
       request:
         proto: HTTP/1.1
@@ -1711,28 +1705,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/8648bc98-cfe9-4002-8979-43f67bd1259a
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 938
-        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:44:52.139003Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        content_length: 128
+        body: '{"message":"resource is not found","resource":"datalab","resource_id":"8648bc98-cfe9-4002-8979-43f67bd1259a","type":"not_found"}'
         headers:
             Content-Length:
-                - "938"
+                - "128"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:46:52 GMT
+                - Wed, 01 Apr 2026 08:19:08 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - f2a0cef1-a8c1-4820-a001-dd8462c8678c
-        status: 200 OK
-        code: 200
-        duration: 82.099713ms
+                - 7b88be9c-ddc4-4f46-85c7-053cd1ddcb38
+        status: 404 Not Found
+        code: 404
+        duration: 61.587945ms
     - id: 53
       request:
         proto: HTTP/1.1
@@ -1743,28 +1737,26 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
-        method: GET
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/60b434b2-3457-47f5-a569-33ec437ae1c0
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 938
-        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:44:52.139003Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        content_length: 0
+        body: ""
         headers:
-            Content-Length:
-                - "938"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:47:07 GMT
+                - Wed, 01 Apr 2026 08:19:10 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - b8446210-c9e1-4202-b97b-a397f4497ef5
-        status: 200 OK
-        code: 200
-        duration: 74.506983ms
+                - 12ed6f80-9b76-4300-b6dd-0defe1688d59
+        status: 204 No Content
+        code: 204
+        duration: 1.534104077s
     - id: 54
       request:
         proto: HTTP/1.1
@@ -1775,28 +1767,26 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
-        method: GET
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/16a6c4e4-63d1-4161-967f-274ce1acb20d
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 938
-        body: '{"id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","status":"deleting","project_id":"473b66fe-d8f4-4cc5-a3ff-0e98eab4b3f1","name":"tf_tests_datalabs_ds_tags","description":"","tags":["ds-filter-test","env:test"],"created_at":"2026-03-26T11:39:02.854954Z","updated_at":"2026-03-26T11:44:52.139003Z","main":{"node_type":"DATALAB-SHARED-4C-8G","spark_ui_url":"https://dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.ddl.fr-par.scw.cloud:4040","spark_master_url":"spark://master-datalab-dd60f6d3-d5d5-42f5-8c94-e11f13458bbd.8ea78e26-d683-4221-a7fd-29fad84deed0.internal:7077","root_volume":{"type":"sbs_5k","size":50000000000}},"worker":{"node_type":"DATALAB-DEDICATED2-2C-8G","node_count":1,"root_volume":{"type":"sbs_5k","size":50000000000}},"has_notebook":false,"notebook_url":"","spark_version":"4.0.0","total_storage":{"type":"unknown_type","size":0},"private_network_id":"8ea78e26-d683-4221-a7fd-29fad84deed0","notebook_master_url":"","region":"fr-par"}'
+        content_length: 0
+        body: ""
         headers:
-            Content-Length:
-                - "938"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:47:23 GMT
+                - Wed, 01 Apr 2026 08:19:10 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 53604809-8562-4e6c-97c1-3df37b7e8e96
-        status: 200 OK
-        code: 200
-        duration: 78.132059ms
+                - 899eef31-3d57-4c3c-be66-c5122281e4b9
+        status: 204 No Content
+        code: 204
+        duration: 407.153632ms
     - id: 55
       request:
         proto: HTTP/1.1
@@ -1807,117 +1797,25 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
+        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/8648bc98-cfe9-4002-8979-43f67bd1259a
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 128
-        body: '{"message":"resource is not found","resource":"datalab","resource_id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"datalab","resource_id":"8648bc98-cfe9-4002-8979-43f67bd1259a","type":"not_found"}'
         headers:
             Content-Length:
                 - "128"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Mar 2026 11:47:38 GMT
+                - Wed, 01 Apr 2026 08:19:10 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 28e94b02-9935-4f46-8b05-6025cbdec319
+                - 389cb985-e050-49f9-bf86-0a860ff11157
         status: 404 Not Found
         code: 404
-        duration: 66.687569ms
-    - id: 56
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8ea78e26-d683-4221-a7fd-29fad84deed0
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 0
-        body: ""
-        headers:
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 26 Mar 2026 11:47:39 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
-            X-Request-Id:
-                - 70f272d7-1a69-4bd1-af89-b2b8fe36a472
-        status: 204 No Content
-        code: 204
-        duration: 1.634089287s
-    - id: 57
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/9a2c31ba-023d-426c-8f47-d73348a4df86
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 0
-        body: ""
-        headers:
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 26 Mar 2026 11:47:40 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
-            X-Request-Id:
-                - 2916f300-907f-448d-af0d-462f2365de96
-        status: 204 No Content
-        code: 204
-        duration: 503.103219ms
-    - id: 58
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/datalab/v1beta1/regions/fr-par/datalabs/dd60f6d3-d5d5-42f5-8c94-e11f13458bbd
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 128
-        body: '{"message":"resource is not found","resource":"datalab","resource_id":"dd60f6d3-d5d5-42f5-8c94-e11f13458bbd","type":"not_found"}'
-        headers:
-            Content-Length:
-                - "128"
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 26 Mar 2026 11:47:40 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
-            X-Request-Id:
-                - c9240693-5c4e-455e-9aa3-b2e1580bfc79
-        status: 404 Not Found
-        code: 404
-        duration: 63.369686ms
+        duration: 57.985449ms

--- a/internal/types/framework.go
+++ b/internal/types/framework.go
@@ -1,0 +1,24 @@
+package types
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func FlattenFrameworkStringValue(s string) types.String {
+	if s == "" {
+		return types.StringNull()
+	}
+
+	return types.StringValue(s)
+}
+
+func FlattenFrameworkStringList(ctx context.Context, items []string) (types.List, diag.Diagnostics) {
+	if len(items) == 0 {
+		return types.ListNull(types.StringType), nil
+	}
+
+	return types.ListValueFrom(ctx, types.StringType, items)
+}

--- a/internal/types/framework_test.go
+++ b/internal/types/framework_test.go
@@ -1,0 +1,65 @@
+package types_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	scwtypes "github.com/scaleway/terraform-provider-scaleway/v2/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFlattenFrameworkStringValue(t *testing.T) {
+	t.Run("empty string returns null", func(t *testing.T) {
+		result := scwtypes.FlattenFrameworkStringValue("")
+		assert.True(t, result.IsNull(), "expected null for empty string")
+	})
+
+	t.Run("non-empty string returns value", func(t *testing.T) {
+		result := scwtypes.FlattenFrameworkStringValue("hello")
+		assert.False(t, result.IsNull())
+		assert.Equal(t, "hello", result.ValueString())
+	})
+}
+
+func TestFlattenFrameworkStringList(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("nil slice returns null list", func(t *testing.T) {
+		result, diags := scwtypes.FlattenFrameworkStringList(ctx, nil)
+		require.False(t, diags.HasError(), "unexpected diagnostics: %s", diags)
+		assert.True(t, result.IsNull(), "expected null for nil slice")
+	})
+
+	t.Run("empty slice returns null list", func(t *testing.T) {
+		result, diags := scwtypes.FlattenFrameworkStringList(ctx, []string{})
+		require.False(t, diags.HasError(), "unexpected diagnostics: %s", diags)
+		assert.True(t, result.IsNull(), "expected null for empty slice")
+	})
+
+	t.Run("populated slice returns list value", func(t *testing.T) {
+		items := []string{"a", "b", "c"}
+		result, diags := scwtypes.FlattenFrameworkStringList(ctx, items)
+		require.False(t, diags.HasError(), "unexpected diagnostics: %s", diags)
+		assert.False(t, result.IsNull())
+		assert.Len(t, result.Elements(), 3)
+
+		var got []string
+
+		diags = result.ElementsAs(ctx, &got, false)
+		require.False(t, diags.HasError())
+		assert.Equal(t, items, got)
+	})
+
+	t.Run("single element slice", func(t *testing.T) {
+		items := []string{"only"}
+		result, diags := scwtypes.FlattenFrameworkStringList(ctx, items)
+		require.False(t, diags.HasError())
+		assert.False(t, result.IsNull())
+		assert.Len(t, result.Elements(), 1)
+
+		expected := types.StringValue("only")
+		assert.Equal(t, expected, result.Elements()[0])
+	})
+}

--- a/internal/verify/enum.go
+++ b/internal/verify/enum.go
@@ -3,6 +3,8 @@ package verify
 import (
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -24,6 +26,18 @@ func ValidateEnumIgnoreCase[T EnumValues[T]]() schema.SchemaValidateDiagFunc {
 	values := filterUnknownValues(getValues[T]())
 
 	return validation.ToDiagFunc(validation.StringInSlice(values, true))
+}
+
+func FrameworkValidateEnum[T EnumValues[T]]() validator.String {
+	values := filterUnknownValues(getValues[T]())
+
+	return stringvalidator.OneOf(values...)
+}
+
+func FrameworkValidateEnumIgnoreCase[T EnumValues[T]]() validator.String {
+	values := filterUnknownValues(getValues[T]())
+
+	return stringvalidator.OneOfCaseInsensitive(values...)
 }
 
 func getValues[T EnumValues[T]]() []string {

--- a/internal/verify/enum_framework_test.go
+++ b/internal/verify/enum_framework_test.go
@@ -1,0 +1,149 @@
+package verify_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/verify"
+)
+
+type testEnum string
+
+const (
+	testEnumUnknownValue testEnum = "unknown_value"
+	testEnumAlpha        testEnum = "alpha"
+	testEnumBeta         testEnum = "beta"
+)
+
+func (e testEnum) Values() []testEnum {
+	return []testEnum{
+		testEnumUnknownValue,
+		testEnumAlpha,
+		testEnumBeta,
+	}
+}
+
+func TestFrameworkValidateEnum(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	v := verify.FrameworkValidateEnum[testEnum]()
+
+	testCases := map[string]struct {
+		value   string
+		wantErr bool
+	}{
+		"valid value alpha": {
+			value:   "alpha",
+			wantErr: false,
+		},
+		"valid value beta": {
+			value:   "beta",
+			wantErr: false,
+		},
+		"invalid value": {
+			value:   "gamma",
+			wantErr: true,
+		},
+		"unknown value is filtered and rejected": {
+			value:   "unknown_value",
+			wantErr: true,
+		},
+		"case mismatch is rejected": {
+			value:   "Alpha",
+			wantErr: true,
+		},
+		"empty string is rejected": {
+			value:   "",
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			req := validator.StringRequest{
+				ConfigValue: types.StringValue(tc.value),
+			}
+
+			resp := validator.StringResponse{}
+			v.ValidateString(ctx, req, &resp)
+
+			if tc.wantErr && !resp.Diagnostics.HasError() {
+				t.Fatalf("expected error for value %q, got none", tc.value)
+			}
+
+			if !tc.wantErr && resp.Diagnostics.HasError() {
+				t.Fatalf("unexpected error for value %q: %s", tc.value, resp.Diagnostics[0].Summary())
+			}
+		})
+	}
+}
+
+func TestFrameworkValidateEnumIgnoreCase(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	v := verify.FrameworkValidateEnumIgnoreCase[testEnum]()
+
+	testCases := map[string]struct {
+		value   string
+		wantErr bool
+	}{
+		"valid value alpha": {
+			value:   "alpha",
+			wantErr: false,
+		},
+		"valid value beta": {
+			value:   "beta",
+			wantErr: false,
+		},
+		"mixed case Alpha accepted": {
+			value:   "Alpha",
+			wantErr: false,
+		},
+		"upper case BETA accepted": {
+			value:   "BETA",
+			wantErr: false,
+		},
+		"invalid value": {
+			value:   "gamma",
+			wantErr: true,
+		},
+		"unknown value is filtered and rejected": {
+			value:   "unknown_value",
+			wantErr: true,
+		},
+		"unknown value case-insensitive is rejected": {
+			value:   "UNKNOWN_VALUE",
+			wantErr: true,
+		},
+		"empty string is rejected": {
+			value:   "",
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			req := validator.StringRequest{
+				ConfigValue: types.StringValue(tc.value),
+			}
+
+			resp := validator.StringResponse{}
+			v.ValidateString(ctx, req, &resp)
+
+			if tc.wantErr && !resp.Diagnostics.HasError() {
+				t.Fatalf("expected error for value %q, got none", tc.value)
+			}
+
+			if !tc.wantErr && resp.Diagnostics.HasError() {
+				t.Fatalf("unexpected error for value %q: %s", tc.value, resp.Diagnostics[0].Summary())
+			}
+		})
+	}
+}

--- a/provider/framework.go
+++ b/provider/framework.go
@@ -19,6 +19,7 @@ import (
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/services/baremetal"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/services/block"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/services/cockpit"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/services/datalab"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/services/iam"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/services/instance"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/services/jobs"
@@ -191,6 +192,7 @@ func (p *ScalewayProvider) Configure(ctx context.Context, req provider.Configure
 
 func (p *ScalewayProvider) Resources(_ context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
+		datalab.NewDatalabResource,
 		iam.NewSamlResource,
 		iam.NewSamlCertificateResource,
 	}
@@ -210,6 +212,8 @@ func (p *ScalewayProvider) EphemeralResources(_ context.Context) []func() epheme
 
 func (p *ScalewayProvider) DataSources(_ context.Context) []func() datasource.DataSource {
 	return []func() datasource.DataSource{
+		datalab.NewDatalabDataSource,
+		datalab.NewDatalabsDataSource,
 		iam.NewSamlDataSource,
 		iam.NewSamlCertificateDataSource,
 	}


### PR DESCRIPTION
What's inside:
  - `scaleway_datalab` resource - create, read, update, and delete `Datalab` instances
  - `scaleway_datalab` data source - look up a single Datalab by ID or name
  - `scaleway_datalabs` data source - list and filter Datalabs by name or tags
  - Acceptance tests with cassette recordings for all resources and data sources
  - Test sweeper for cleanup
  - Shared `FlattenFrameworkStringValue` and `FlattenFrameworkStringList` helpers for null-safe state handling
  - `FrameworkValidateEnum` helper for Plugin Framework schema validation

> [!CAUTION]
> blocked by scaleway/scaleway-sdk-go#3002.