### PR TITLE
feat(k8s): add pool specs validation

### DIFF
--- a/docs/resources/k8s_pool.md
+++ b/docs/resources/k8s_pool.md
@@ -29,6 +29,11 @@ resource "scaleway_k8s_pool" "main" {
   autohealing        = true
   container_runtime  = "containerd"
   placement_group_id = "1267e3fd-a51c-49ed-ad12-857092ee3a3d"
+
+  # Make sure that the new resource is created before destroying the old one on changes that require replacement
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 ```
 
@@ -53,7 +58,7 @@ The following arguments are supported:
 
 ~> **Important:** This field will only be used at creation if autoscaling is enabled.
 
-- `min_size` - (Defaults to `1`) The minimum size of the pool, used by the autoscaling feature.
+- `min_size` - (Defaults to `1` if `size` > 0, or `0` otherwise) The minimum size of the pool, used by the autoscaling feature.
 
 - `max_size` - (Defaults to `size`) The maximum size of the pool, used by the autoscaling feature.
 
@@ -86,6 +91,8 @@ The following arguments are supported:
 - `root_volume_type` - (Optional) System volume type of the nodes composing the pool
 
 - `root_volume_size_in_gb` - (Optional) The size of the system volume of the nodes in gigabyte
+
+-> Note: The minimal volume size of a node is 20GB.
 
 - `zone` - (Defaults to [provider](../index.md#zone) `zone`) The [zone](../guides/regions_and_zones.md#regions) in which the pool should be created.
 

--- a/examples/resources/scaleway_k8s_pool/resource-basic.tf
+++ b/examples/resources/scaleway_k8s_pool/resource-basic.tf
@@ -13,4 +13,9 @@ resource "scaleway_k8s_pool" "main" {
   autohealing        = true
   container_runtime  = "containerd"
   placement_group_id = "1267e3fd-a51c-49ed-ad12-857092ee3a3d"
+
+  # Make sure that the new resource is created before destroying the old one on changes that require replacement
+  lifecycle {
+    create_before_destroy = true
+  }
 }

--- a/internal/services/k8s/pool.go
+++ b/internal/services/k8s/pool.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
+	"strings"
 	"time"
 
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/scaleway/scaleway-sdk-go/api/instance/v1"
 	"github.com/scaleway/scaleway-sdk-go/api/k8s/v1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/dsf"
@@ -19,6 +22,11 @@ import (
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/services/ipam"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/types"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/verify"
+)
+
+const (
+	nodeMinVolumeSize = 20 * scw.GB
+	nodeMaxVolumeSize = 10 * scw.TB
 )
 
 //go:embed descriptions/pool.md
@@ -57,7 +65,7 @@ func poolSchema() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Required:    true,
 			ForceNew:    true,
-			Description: "The name of the cluster",
+			Description: "The name of the pool",
 		},
 		"node_type": {
 			Type:             schema.TypeString,
@@ -86,7 +94,7 @@ func poolSchema() map[string]*schema.Schema {
 		"min_size": {
 			Type:        schema.TypeInt,
 			Optional:    true,
-			Default:     1,
+			Computed:    true,
 			Description: "Minimum size of the pool",
 		},
 		"max_size": {
@@ -309,6 +317,10 @@ func ResourceK8SPoolCreate(ctx context.Context, d *schema.ResourceData, m any) d
 
 	if minSize, ok := d.GetOk("min_size"); ok {
 		req.MinSize = new(uint32(minSize.(int)))
+	} else if req.Size == 0 {
+		req.MinSize = new(uint32(0))
+	} else {
+		req.MinSize = new(uint32(1))
 	}
 
 	if maxSize, ok := d.GetOk("max_size"); ok {
@@ -345,25 +357,38 @@ func ResourceK8SPoolCreate(ctx context.Context, d *schema.ResourceData, m any) d
 		req.SecurityGroupID = types.ExpandStringPtr(locality.ExpandID(securityGroupID.(string)))
 	}
 
-	// check if the cluster is waiting for a pool
+	// Validate pool configuration
+	diags := validateRootVolumeSpecs(ctx, m.(*meta.Meta).ScwClient(), req)
+	if diags.HasError() {
+		return diags
+	}
+
+	clusterID := locality.ExpandID(d.Get("cluster_id"))
+
 	cluster, err := k8sAPI.GetCluster(&k8s.GetClusterRequest{
-		ClusterID: locality.ExpandID(d.Get("cluster_id")),
+		ClusterID: clusterID,
 		Region:    region,
 	}, scw.WithContext(ctx))
 	if err != nil {
-		return diag.FromErr(err)
+		return append(diags, diag.FromErr(err)...)
 	}
 
+	diags = append(diags, validatePoolSize(ctx, k8sAPI, cluster, "", req)...)
+	if diags.HasError() {
+		return diags
+	}
+
+	// Check if the cluster is waiting for a pool
 	if cluster.Status == k8s.ClusterStatusCreating {
 		_, err = waitClusterStatus(ctx, k8sAPI, cluster, k8s.ClusterStatusReady, d.Timeout(schema.TimeoutCreate))
 		if err != nil {
-			return diag.FromErr(err)
+			return append(diags, diag.FromErr(err)...)
 		}
 	}
 
 	res, err := k8sAPI.CreatePool(req, scw.WithContext(ctx))
 	if err != nil {
-		return diag.FromErr(err)
+		return append(diags, diag.FromErr(err)...)
 	}
 
 	d.SetId(regional.NewIDString(region, res.ID))
@@ -567,9 +592,23 @@ func ResourceK8SPoolUpdate(ctx context.Context, d *schema.ResourceData, m any) d
 		updateRequest.SecurityGroupID = types.ExpandStringPtr(locality.ExpandID(d.Get("security_group_id").(string)))
 	}
 
-	res, err := k8sAPI.UpdatePool(updateRequest, scw.WithContext(ctx))
+	// Validate pool configuration
+	cluster, err := k8sAPI.GetCluster(&k8s.GetClusterRequest{
+		ClusterID: locality.ExpandID(d.Get("cluster_id")),
+		Region:    region,
+	}, scw.WithContext(ctx))
 	if err != nil {
 		return diag.FromErr(err)
+	}
+
+	diags := validatePoolSize(ctx, k8sAPI, cluster, poolID, updateRequest)
+	if diags.HasError() {
+		return diags
+	}
+
+	res, err := k8sAPI.UpdatePool(updateRequest, scw.WithContext(ctx))
+	if err != nil {
+		return append(diags, diag.FromErr(err)...)
 	}
 
 	if d.Get("wait_for_pool_ready").(bool) { // wait for the pool to be ready if specified (including all its nodes)
@@ -621,6 +660,176 @@ func ResourceK8SPoolCustomDiff(_ context.Context, diff *schema.ResourceDiff, _ a
 		err := diff.SetNewComputed("nodes")
 		if err != nil {
 			return err
+		}
+	}
+
+	return nil
+}
+
+func validatePoolSize(ctx context.Context, k8sAPI *k8s.API, cluster *k8s.Cluster, poolID string, requestRaw any) diag.Diagnostics {
+	var requestedSize, requestedMaxSize *uint32
+
+	switch req := requestRaw.(type) {
+	case *k8s.CreatePoolRequest:
+		requestedSize = new(req.Size)
+		requestedMaxSize = req.MaxSize
+	case *k8s.UpdatePoolRequest:
+		requestedSize = req.Size
+		requestedMaxSize = req.MaxSize
+	}
+
+	// If cluster is mutualized, we check that it has at least one other node
+	if !strings.Contains(cluster.Type, "dedicated") && requestedSize != nil && *requestedSize == 0 {
+		pools, err := k8sAPI.ListPools(&k8s.ListPoolsRequest{
+			Region:    cluster.Region,
+			ClusterID: cluster.ID,
+		}, scw.WithAllPages(), scw.WithContext(ctx))
+		if err != nil {
+			return diag.Diagnostics{
+				diag.Diagnostic{
+					Severity: diag.Warning,
+					Summary:  "Could not validate pool size",
+					Detail:   fmt.Sprintf("failed to list cluster pools: %v", err),
+				},
+			}
+		}
+
+		for _, pool := range pools.Pools {
+			if pool.ID == poolID {
+				continue
+			}
+
+			if pool.Size >= 1 {
+				return nil
+			}
+		}
+
+		return diag.Diagnostics{
+			diag.Diagnostic{
+				Severity:      diag.Error,
+				Summary:       "Invalid pool size",
+				Detail:        "a mutualized cluster cannot have less than 1 node",
+				AttributePath: cty.GetAttrPath("size"),
+			},
+		}
+	}
+
+	if requestedMaxSize != nil && *requestedMaxSize < 1 {
+		return diag.Diagnostics{
+			diag.Diagnostic{
+				Severity:      diag.Error,
+				Summary:       "Invalid pool max_size",
+				Detail:        "Pool's max size must be at least 1. If max_size is unset but size is set to 0, max_size will also be automatically set to 0. In this case, please set max_size to at least 1.",
+				AttributePath: cty.GetAttrPath("max_size"),
+			},
+		}
+	}
+
+	return nil
+}
+
+func validateRootVolumeSpecs(ctx context.Context, scwClient *scw.Client, req *k8s.CreatePoolRequest) diag.Diagnostics {
+	instanceAPI := instance.NewAPI(scwClient)
+	requestedNodeType := strings.ToUpper(strings.ReplaceAll(req.NodeType, "_", "-"))
+	found := false
+
+	serverTypes, err := instanceAPI.ListServersTypes(&instance.ListServersTypesRequest{
+		Zone: req.Zone,
+	}, scw.WithContext(ctx), scw.WithAllPages())
+	if err != nil {
+		return diag.Diagnostics{
+			diag.Diagnostic{
+				Severity: diag.Warning,
+				Summary:  "Could not validate root volume specs",
+				Detail:   fmt.Sprintf("failed to list server types for comparison: %v", err),
+			},
+		}
+	}
+
+	for serverTypeName, serverTypeSpecs := range serverTypes.Servers {
+		if requestedNodeType != serverTypeName {
+			continue
+		}
+
+		found = true
+
+		if serverTypeSpecs.VolumesConstraint == nil {
+			return diag.Diagnostics{
+				diag.Diagnostic{
+					Severity: diag.Warning,
+					Summary:  "Could not validate root volume specs",
+					Detail:   "Server type had no volume constraints to check",
+				},
+			}
+		}
+
+		if req.RootVolumeSize != nil && *req.RootVolumeSize < nodeMinVolumeSize {
+			return diag.Diagnostics{
+				diag.Diagnostic{
+					Severity: diag.Error,
+					Summary:  "Invalid root volume size",
+					Detail: fmt.Sprintf("requested size must be at least %dGB, got: %d,",
+						nodeMinVolumeSize/scw.GB, *req.RootVolumeSize/scw.GB),
+					AttributePath: cty.GetAttrPath("root_volume_size"),
+				},
+			}
+		}
+
+		switch req.RootVolumeType {
+		case k8s.PoolVolumeTypeLSSD:
+			if serverTypeSpecs.VolumesConstraint.MaxSize == 0 {
+				return diag.Diagnostics{
+					diag.Diagnostic{
+						Severity: diag.Error,
+						Summary:  "Invalid root volume type",
+						Detail: fmt.Sprintf("unsupported volume type %q for node type %q",
+							req.RootVolumeType, req.NodeType),
+						AttributePath: cty.GetAttrPath("root_volume_type"),
+					},
+				}
+			}
+
+			if req.RootVolumeSize != nil && *req.RootVolumeSize > serverTypeSpecs.VolumesConstraint.MaxSize {
+				return diag.Diagnostics{
+					diag.Diagnostic{
+						Severity: diag.Error,
+						Summary:  "Invalid root volume size",
+						Detail: fmt.Sprintf("local volume size must be between %dGB and %dGB, got: %d",
+							nodeMinVolumeSize/scw.GB, serverTypeSpecs.VolumesConstraint.MaxSize/scw.GB, *req.RootVolumeSize/scw.GB),
+						AttributePath: cty.GetAttrPath("root_volume_size"),
+					},
+				}
+			}
+		case k8s.PoolVolumeTypeSbs5k, k8s.PoolVolumeTypeSbs15k:
+			if req.RootVolumeSize != nil && *req.RootVolumeSize > nodeMaxVolumeSize {
+				return diag.Diagnostics{
+					diag.Diagnostic{
+						Severity: diag.Error,
+						Summary:  "Invalid root volume size",
+						Detail: fmt.Sprintf("block volume size must be between %dGB and %dGB, got: %d",
+							nodeMinVolumeSize/scw.GB, nodeMaxVolumeSize/scw.GB, *req.RootVolumeSize/scw.GB),
+						AttributePath: cty.GetAttrPath("root_volume_size"),
+					},
+				}
+			}
+		default:
+			return diag.Diagnostics{
+				diag.Diagnostic{
+					Severity: diag.Warning,
+					Summary:  "Could not validate root volume specs",
+					Detail:   fmt.Sprintf("unknown root_volume_type %q", req.RootVolumeType),
+				},
+			}
+		}
+	}
+
+	if !found {
+		return diag.Diagnostics{
+			diag.Diagnostic{
+				Severity: diag.Warning,
+				Summary:  "Could not validate root volume specs",
+				Detail:   fmt.Sprintf("could not find node type %q in server types list", req.NodeType),
+			},
 		}
 	}
 

--- a/internal/services/k8s/pool_test.go
+++ b/internal/services/k8s/pool_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -574,6 +575,229 @@ func TestAccPool_PublicIPDisabled(t *testing.T) {
 					testAccCheckK8SPoolExists(tt, "scaleway_k8s_pool.public_ip"),
 					resource.TestCheckResourceAttr("scaleway_k8s_pool.public_ip", "public_ip_disabled", "true"),
 					testAccCheckK8SPoolPublicIP(tt, "scaleway_k8s_cluster.public_ip", "scaleway_k8s_pool.public_ip", true),
+				),
+			},
+		},
+	})
+}
+
+func TestAccPool_ValidateRootVolume(t *testing.T) {
+	tt := acctest.NewTestTools(t)
+	defer tt.Cleanup()
+
+	latestK8SVersion := testAccK8SClusterGetLatestK8SVersion(tt)
+	poolID := ""
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: tt.ProviderFactories,
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			testAccCheckK8SPoolDestroy(tt, "scaleway_k8s_pool.main"),
+			testAccCheckK8SClusterDestroy(tt),
+			vpcchecks.CheckPrivateNetworkDestroy(tt),
+		),
+		Steps: []resource.TestStep{
+			{
+				// Valid configuration
+				Config: kapsuleClusterConfigForPoolTests("validate-root-volume", latestK8SVersion) + `
+					resource "scaleway_k8s_pool" "main" {
+					    name = "test-pool-validate-root-volume"
+						cluster_id = scaleway_k8s_cluster.main.id
+						size = 1
+						tags = [ "terraform-test", "scaleway_k8s_pool", "validate-root-volume" ]
+
+						node_type = "PRO2_XXS"
+						root_volume_size_in_gb = 20
+					}`,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckK8SClusterExists(tt, "scaleway_k8s_cluster.main"),
+					testAccCheckK8SPoolExists(tt, "scaleway_k8s_pool.main"),
+					acctest.CheckResourceIDPersisted("scaleway_k8s_pool.main", &poolID),
+				),
+			},
+			{
+				// Root volume size should be at least 20GB
+				Config: kapsuleClusterConfigForPoolTests("validate-root-volume", latestK8SVersion) + `
+					resource "scaleway_k8s_pool" "main" {
+					    name = "test-pool-validate-root-volume"
+						cluster_id = scaleway_k8s_cluster.main.id
+						size = 1
+						tags = [ "terraform-test", "scaleway_k8s_pool", "validate-root-volume" ]
+
+						node_type = "PRO2_XXS"
+						root_volume_size_in_gb = 15
+
+						lifecycle {
+							create_before_destroy = true
+						}
+					}`,
+				ExpectError: regexp.MustCompile("requested size must be at least 20GB, got: 15"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckK8SClusterExists(tt, "scaleway_k8s_cluster.main"),
+					testAccCheckK8SPoolExists(tt, "scaleway_k8s_pool.main"),
+					acctest.CheckResourceIDPersisted("scaleway_k8s_pool.main", &poolID),
+				),
+			},
+			{
+				// Root volume type should be compatible with the type of storage supported by the node
+				Config: kapsuleClusterConfigForPoolTests("validate-root-volume", latestK8SVersion) + `
+					resource "scaleway_k8s_pool" "main" {
+					    name = "test-pool-validate-root-volume"
+						cluster_id = scaleway_k8s_cluster.main.id
+						size = 1
+						tags = [ "terraform-test", "scaleway_k8s_pool", "validate-root-volume" ]
+
+						node_type = "PRO2-XXS"   	# supports only block volumes
+						root_volume_type = "l_ssd"
+						root_volume_size_in_gb = 20
+
+						lifecycle {
+							create_before_destroy = true
+						}
+					}`,
+				ExpectError: regexp.MustCompile("unsupported volume type \"l_ssd\" for node type \"PRO2-XXS\""),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckK8SClusterExists(tt, "scaleway_k8s_cluster.main"),
+					testAccCheckK8SPoolExists(tt, "scaleway_k8s_pool.main"),
+					acctest.CheckResourceIDPersisted("scaleway_k8s_pool.main", &poolID),
+				),
+			},
+			{
+				// Local volume: Root size should not exceed the max volume size for the node type
+				Config: kapsuleClusterConfigForPoolTests("validate-root-volume", latestK8SVersion) + `
+					resource "scaleway_k8s_pool" "main" {
+					    name = "test-pool-validate-root-volume"
+						cluster_id = scaleway_k8s_cluster.main.id
+						size = 1
+						tags = [ "terraform-test", "scaleway_k8s_pool", "validate-root-volume" ]
+
+						node_type = "dev1-m"
+						root_volume_type = "l_ssd"
+						root_volume_size_in_gb = 100
+
+						lifecycle {
+							create_before_destroy = true
+						}
+					}`,
+				ExpectError: regexp.MustCompile("local volume size must be between 20GB and 40GB, got: 100"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckK8SClusterExists(tt, "scaleway_k8s_cluster.main"),
+					testAccCheckK8SPoolExists(tt, "scaleway_k8s_pool.main"),
+					acctest.CheckResourceIDPersisted("scaleway_k8s_pool.main", &poolID),
+				),
+			},
+		},
+	})
+}
+
+func TestAccPool_ValidateSizeMutualized(t *testing.T) {
+	tt := acctest.NewTestTools(t)
+	defer tt.Cleanup()
+
+	latestK8SVersion := testAccK8SClusterGetLatestK8SVersion(tt)
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: tt.ProviderFactories,
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			testAccCheckK8SPoolDestroy(tt, "scaleway_k8s_pool.main"),
+			testAccCheckK8SClusterDestroy(tt),
+			vpcchecks.CheckPrivateNetworkDestroy(tt),
+		),
+		Steps: []resource.TestStep{
+			{
+				// Should not be able to resize the pool to 0 for a mutualized cluster with no other node
+				Config: kapsuleClusterConfigForPoolTests("validate-size-mutu", latestK8SVersion) + `
+					resource "scaleway_k8s_pool" "main" {
+					    name = "test-pool-validate-size-mutu"
+						cluster_id = scaleway_k8s_cluster.main.id
+						node_type = "pro2_xxs"
+						tags = [ "terraform-test", "scaleway_k8s_pool", "validate-size-mutu" ]
+
+						size = 0
+					}`,
+				ExpectError: regexp.MustCompile("a mutualized cluster cannot have less than 1 node"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckK8SClusterExists(tt, "scaleway_k8s_cluster.main"),
+					testAccCheckK8SPoolExists(tt, "scaleway_k8s_pool.main"),
+				),
+			},
+			{
+				// Should be able to resize the pool to 0 for a mutualized cluster with at least 1 other node
+				Config: kapsuleClusterConfigForPoolTests("validate-size-mutu", latestK8SVersion) + `
+					resource "scaleway_k8s_pool" "other" {
+					    name = "test-pool-validate-size-mutu-other"
+						cluster_id = scaleway_k8s_cluster.main.id
+						node_type = "pro2_xxs"
+						tags = [ "terraform-test", "scaleway_k8s_pool", "validate-size-mutu" ]
+						wait_for_pool_ready = true
+
+						size = 1
+					}
+
+					resource "scaleway_k8s_pool" "main" {
+					    name = "test-pool-validate-size-mutu"
+						cluster_id = scaleway_k8s_cluster.main.id
+						node_type = "pro2_xxs"
+						tags = [ "terraform-test", "scaleway_k8s_pool", "validate-size-mutu" ]
+						depends_on = [ scaleway_k8s_pool.other ]
+
+						size = 0
+					}`,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckK8SClusterExists(tt, "scaleway_k8s_cluster.main"),
+					testAccCheckK8SPoolExists(tt, "scaleway_k8s_pool.other"),
+					testAccCheckK8SPoolExists(tt, "scaleway_k8s_pool.main"),
+					resource.TestCheckResourceAttr("scaleway_k8s_pool.main", "size", "0"),
+					resource.TestCheckResourceAttr("scaleway_k8s_cluster.main", "type", "kapsule"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccPool_ValidateSizeDedicated(t *testing.T) {
+	tt := acctest.NewTestTools(t)
+	defer tt.Cleanup()
+
+	latestK8SVersion := testAccK8SClusterGetLatestK8SVersion(tt)
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: tt.ProviderFactories,
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			testAccCheckK8SPoolDestroy(tt, "scaleway_k8s_pool.main"),
+			testAccCheckK8SClusterDestroy(tt),
+			vpcchecks.CheckPrivateNetworkDestroy(tt),
+		),
+		Steps: []resource.TestStep{
+			{
+				// Should not be able to create a pool with max_size 0 (max_size will implicitly be set to size's value)
+				Config: kapsuleDedicatedClusterConfigForPoolTests("validate-size-dedi", latestK8SVersion) + `
+					resource "scaleway_k8s_pool" "main" {
+					    name = "test-pool-validate-size-dedi"
+						cluster_id = scaleway_k8s_cluster.main.id
+						node_type = "pro2_xxs"
+						tags = [ "terraform-test", "scaleway_k8s_pool", "validate-size-dedi" ]
+
+						size = 0
+					}`,
+				ExpectError: regexp.MustCompile("Pool's max size must be at least 1. If max_size is unset"),
+			},
+			{
+				// Should be able to create a pool of size 0 for a dedicated cluster, if max_size is set to a different value
+				Config: kapsuleDedicatedClusterConfigForPoolTests("validate-size-dedi", latestK8SVersion) + `
+					resource "scaleway_k8s_pool" "main" {
+					    name = "test-pool-validate-size-dedi"
+						cluster_id = scaleway_k8s_cluster.main.id
+						node_type = "pro2_xxs"
+						tags = [ "terraform-test", "scaleway_k8s_pool", "validate-size-dedi" ]
+
+						size     = 0
+						max_size = 1
+					}`,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckK8SClusterExists(tt, "scaleway_k8s_cluster.main"),
+					testAccCheckK8SPoolExists(tt, "scaleway_k8s_pool.main"),
+					resource.TestCheckResourceAttr("scaleway_k8s_pool.main", "size", "0"),
+					resource.TestCheckResourceAttr("scaleway_k8s_cluster.main", "type", "kapsule-dedicated-4"),
 				),
 			},
 		},
@@ -1189,4 +1413,43 @@ func testAccCheckK8SPoolNodesOneOfIsDeleting(name string) resource.TestCheckFunc
 
 		return fmt.Errorf("nodes status were not as expected: got %q for nodes.0 and %q for nodes.1", nodesZeroStatus, nodesOneStatus)
 	}
+}
+
+func kapsuleDedicatedClusterConfigForPoolTests(testName string, version string) string {
+	return fmt.Sprintf(`
+		resource "scaleway_vpc" "main" {}
+
+		resource "scaleway_vpc_private_network" "main" {
+			name = "test-pool-%[1]s"
+			vpc_id = scaleway_vpc.main.id
+		}
+
+		resource "scaleway_k8s_cluster" "main" {
+		    name = "test-pool-%[1]s"
+			type = "kapsule-dedicated-4"
+			cni = "cilium"
+			version = "%[2]s"
+			tags = [ "terraform-test", "scaleway_k8s_pool", "%[1]s" ]
+			delete_additional_resources = false
+			private_network_id = scaleway_vpc_private_network.main.id
+		}`, testName, version)
+}
+
+func kapsuleClusterConfigForPoolTests(testName string, version string) string {
+	return fmt.Sprintf(`
+		resource "scaleway_vpc" "main" {}
+
+		resource "scaleway_vpc_private_network" "main" {
+			name = "test-pool-%[1]s"
+			vpc_id = scaleway_vpc.main.id
+		}
+
+		resource "scaleway_k8s_cluster" "main" {
+		    name = "test-pool-%[1]s"
+			cni = "cilium"
+			version = "%[2]s"
+			tags = [ "terraform-test", "scaleway_k8s_pool", "%[1]s" ]
+			delete_additional_resources = false
+			private_network_id = scaleway_vpc_private_network.main.id
+		}`, testName, version)
 }

--- a/internal/services/k8s/testdata/pool-validate-root-volume.cassette.yaml
+++ b/internal/services/k8s/testdata/pool-validate-root-volume.cassette.yaml
@@ -1,0 +1,2659 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/versions
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 4355
+        body: '{"versions":[{"region":"fr-par","name":"1.35.3","label":"Kubernetes 1.35.3","available_cnis":["cilium","cilium_native","calico","kilo","none"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","CPUManagerPolicyAlphaOptions","ImageVolume","MutatingAdmissionPolicy"],"available_admission_plugins":["AlwaysPullImages","PodNodeSelector","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","cpuManagerPolicyOptions":"map[string]string","enableDebuggingHandlers":"bool","evictionHard":"map[string]string","evictionMinimumReclaim":"map[string]string","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxParallelImagePulls":"int32","maxPods":"uint16","registryBurst":"int32","registryPullQPS":"int32","serializeImagePulls":"bool"},"deprecated_at":"2027-01-19T00:00:00Z","end_of_life_at":"2027-03-19T00:00:00Z","released_at":"2026-01-19T00:00:00Z"},{"region":"fr-par","name":"1.34.6","label":"Kubernetes 1.34.6","available_cnis":["cilium","cilium_native","calico","kilo","none"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","CPUManagerPolicyAlphaOptions","ImageVolume","MutatingAdmissionPolicy"],"available_admission_plugins":["AlwaysPullImages","PodNodeSelector","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","cpuManagerPolicyOptions":"map[string]string","enableDebuggingHandlers":"bool","evictionHard":"map[string]string","evictionMinimumReclaim":"map[string]string","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxParallelImagePulls":"int32","maxPods":"uint16","registryBurst":"int32","registryPullQPS":"int32","serializeImagePulls":"bool"},"deprecated_at":"2026-09-29T00:00:00Z","end_of_life_at":"2026-11-29T00:00:00Z","released_at":"2025-09-29T00:00:00Z"},{"region":"fr-par","name":"1.33.10","label":"Kubernetes 1.33.10","available_cnis":["cilium","calico","kilo","none"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","DRAAdminAccess","DynamicResourceAllocation","PodLevelResources","CPUManagerPolicyAlphaOptions","ImageVolume"],"available_admission_plugins":["AlwaysPullImages","PodNodeSelector","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","cpuManagerPolicyOptions":"map[string]string","enableDebuggingHandlers":"bool","evictionHard":"map[string]string","evictionMinimumReclaim":"map[string]string","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxParallelImagePulls":"int32","maxPods":"uint16","registryBurst":"int32","registryPullQPS":"int32","serializeImagePulls":"bool"},"deprecated_at":"2026-09-04T00:00:00Z","end_of_life_at":"2026-11-04T00:00:00Z","released_at":"2025-09-04T00:00:00Z"},{"region":"fr-par","name":"1.32.13","label":"Kubernetes 1.32.13","available_cnis":["cilium","calico","kilo","none"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","InPlacePodVerticalScaling","SidecarContainers","DRAAdminAccess","DRAResourceClaimDeviceStatus","DynamicResourceAllocation","PodLevelResources","CPUManagerPolicyAlphaOptions","ImageVolume"],"available_admission_plugins":["AlwaysPullImages","PodNodeSelector","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","cpuManagerPolicyOptions":"map[string]string","enableDebuggingHandlers":"bool","evictionHard":"map[string]string","evictionMinimumReclaim":"map[string]string","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxParallelImagePulls":"int32","maxPods":"uint16","registryBurst":"int32","registryPullQPS":"int32","serializeImagePulls":"bool"},"deprecated_at":"2026-03-24T00:00:00Z","end_of_life_at":"2026-06-24T00:00:00Z","released_at":"2025-03-24T00:00:00Z"}]}'
+        headers:
+            Content-Length:
+                - "4355"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:01:53 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - d1c1763f-cada-4d72-a447-3a420d8f5812
+        status: 200 OK
+        code: 200
+        duration: 72.992741ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 120
+        host: api.scaleway.com
+        body: '{"name":"tf-vpc-eloquent-margulis","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"enable_routing":false}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 411
+        body: '{"id":"4c6f2f41-a3ed-438f-b4cf-63be705fee57","name":"tf-vpc-eloquent-margulis","tags":[],"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:01:53.908263Z","updated_at":"2026-04-14T16:01:53.908263Z","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","is_default":false,"private_network_count":0,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "411"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:01:53 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - 1d2d95be-eea4-4462-a1d3-e4fd5da72f36
+        status: 200 OK
+        code: 200
+        duration: 90.328009ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/4c6f2f41-a3ed-438f-b4cf-63be705fee57
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 411
+        body: '{"id":"4c6f2f41-a3ed-438f-b4cf-63be705fee57","name":"tf-vpc-eloquent-margulis","tags":[],"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:01:53.908263Z","updated_at":"2026-04-14T16:01:53.908263Z","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","is_default":false,"private_network_count":0,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "411"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:01:53 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - 5d0b5499-9bac-4e67-9d31-422ec7f3c120
+        status: 200 OK
+        code: 200
+        duration: 58.694464ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 208
+        host: api.scaleway.com
+        body: '{"name":"test-pool-validate-root-volume","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"subnets":null,"vpc_id":"4c6f2f41-a3ed-438f-b4cf-63be705fee57","default_route_propagation_enabled":false}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1076
+        body: '{"id":"59f194c7-197f-4ca6-84e5-f9c38afbfaed","name":"test-pool-validate-root-volume","tags":[],"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:01:54.065721Z","updated_at":"2026-04-14T16:01:54.065721Z","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnets":[{"id":"ce74d09e-a4e9-4b1c-aad0-caf264e1ef61","created_at":"2026-04-14T16:01:54.065721Z","updated_at":"2026-04-14T16:01:54.065721Z","subnet":"172.16.16.0/22","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"59f194c7-197f-4ca6-84e5-f9c38afbfaed","vpc_id":"4c6f2f41-a3ed-438f-b4cf-63be705fee57"},{"id":"9417c9dc-82cd-4bc2-bd08-bb051b54281b","created_at":"2026-04-14T16:01:54.065721Z","updated_at":"2026-04-14T16:01:54.065721Z","subnet":"fd63:256c:45f7:531d::/64","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"59f194c7-197f-4ca6-84e5-f9c38afbfaed","vpc_id":"4c6f2f41-a3ed-438f-b4cf-63be705fee57"}],"vpc_id":"4c6f2f41-a3ed-438f-b4cf-63be705fee57","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1076"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:01:54 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - 8e63cec9-ed93-4663-bd8b-9791f9c8822d
+        status: 200 OK
+        code: 200
+        duration: 641.210301ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/59f194c7-197f-4ca6-84e5-f9c38afbfaed
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1076
+        body: '{"id":"59f194c7-197f-4ca6-84e5-f9c38afbfaed","name":"test-pool-validate-root-volume","tags":[],"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:01:54.065721Z","updated_at":"2026-04-14T16:01:54.065721Z","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnets":[{"id":"ce74d09e-a4e9-4b1c-aad0-caf264e1ef61","created_at":"2026-04-14T16:01:54.065721Z","updated_at":"2026-04-14T16:01:54.065721Z","subnet":"172.16.16.0/22","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"59f194c7-197f-4ca6-84e5-f9c38afbfaed","vpc_id":"4c6f2f41-a3ed-438f-b4cf-63be705fee57"},{"id":"9417c9dc-82cd-4bc2-bd08-bb051b54281b","created_at":"2026-04-14T16:01:54.065721Z","updated_at":"2026-04-14T16:01:54.065721Z","subnet":"fd63:256c:45f7:531d::/64","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"59f194c7-197f-4ca6-84e5-f9c38afbfaed","vpc_id":"4c6f2f41-a3ed-438f-b4cf-63be705fee57"}],"vpc_id":"4c6f2f41-a3ed-438f-b4cf-63be705fee57","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1076"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:01:54 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - 883752bc-936d-4882-a55f-5259af16220f
+        status: 200 OK
+        code: 200
+        duration: 34.315661ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 721
+        host: api.scaleway.com
+        body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-pool-validate-root-volume","description":"","tags":["terraform-test","scaleway_k8s_pool","validate-root-volume"],"version":"1.35.3","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":[],"admission_plugins":[],"apiserver_cert_sans":[],"private_network_id":"59f194c7-197f-4ca6-84e5-f9c38afbfaed"}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1601
+        body: '{"region":"fr-par","id":"384a8300-efe2-4ea2-9078-2d89f5ad2383","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:01:55.214681Z","updated_at":"2026-04-14T16:01:55.214681Z","type":"kapsule","name":"test-pool-validate-root-volume","description":"","status":"creating","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","validate-root-volume"],"cluster_url":"https://384a8300-efe2-4ea2-9078-2d89f5ad2383.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.384a8300-efe2-4ea2-9078-2d89f5ad2383.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":0},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"59f194c7-197f-4ca6-84e5-f9c38afbfaed","commitment_ends_at":"2026-04-14T16:01:55.214686Z","acl_available":true,"iam_nodes_group_id":"","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1601"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:01:55 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - a398eddb-7ef0-46b2-9a01-cd296b2942f3
+        status: 200 OK
+        code: 200
+        duration: 586.870895ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/384a8300-efe2-4ea2-9078-2d89f5ad2383
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1601
+        body: '{"region":"fr-par","id":"384a8300-efe2-4ea2-9078-2d89f5ad2383","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:01:55.214681Z","updated_at":"2026-04-14T16:01:55.214681Z","type":"kapsule","name":"test-pool-validate-root-volume","description":"","status":"creating","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","validate-root-volume"],"cluster_url":"https://384a8300-efe2-4ea2-9078-2d89f5ad2383.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.384a8300-efe2-4ea2-9078-2d89f5ad2383.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":0},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"59f194c7-197f-4ca6-84e5-f9c38afbfaed","commitment_ends_at":"2026-04-14T16:01:55.214686Z","acl_available":true,"iam_nodes_group_id":"","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1601"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:01:55 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - f39e64bb-aeb1-48ca-be9e-f25f9cbdc7fd
+        status: 200 OK
+        code: 200
+        duration: 48.450571ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/384a8300-efe2-4ea2-9078-2d89f5ad2383
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1642
+        body: '{"region":"fr-par","id":"384a8300-efe2-4ea2-9078-2d89f5ad2383","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:01:55.214681Z","updated_at":"2026-04-14T16:01:56.146476Z","type":"kapsule","name":"test-pool-validate-root-volume","description":"","status":"pool_required","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","validate-root-volume"],"cluster_url":"https://384a8300-efe2-4ea2-9078-2d89f5ad2383.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.384a8300-efe2-4ea2-9078-2d89f5ad2383.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":0},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"59f194c7-197f-4ca6-84e5-f9c38afbfaed","commitment_ends_at":"2026-04-14T16:01:55.214686Z","acl_available":true,"iam_nodes_group_id":"1bb74d69-943b-44f2-b20b-dc114787fcea","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1642"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:02:00 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - 46f3eb88-64c1-4831-9ab5-522e717129b6
+        status: 200 OK
+        code: 200
+        duration: 45.516852ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_asc
+            page:
+                - "1"
+            status:
+                - unknown
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/384a8300-efe2-4ea2-9078-2d89f5ad2383/pools?order_by=created_at_asc&page=1&status=unknown
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 28
+        body: '{"total_count":0,"pools":[]}'
+        headers:
+            Content-Length:
+                - "28"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:02:00 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - c7146f68-f3e9-4da3-a09e-5854efdb81e9
+        status: 200 OK
+        code: 200
+        duration: 30.952376ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/384a8300-efe2-4ea2-9078-2d89f5ad2383
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1642
+        body: '{"region":"fr-par","id":"384a8300-efe2-4ea2-9078-2d89f5ad2383","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:01:55.214681Z","updated_at":"2026-04-14T16:01:56.146476Z","type":"kapsule","name":"test-pool-validate-root-volume","description":"","status":"pool_required","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","validate-root-volume"],"cluster_url":"https://384a8300-efe2-4ea2-9078-2d89f5ad2383.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.384a8300-efe2-4ea2-9078-2d89f5ad2383.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":0},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"59f194c7-197f-4ca6-84e5-f9c38afbfaed","commitment_ends_at":"2026-04-14T16:01:55.214686Z","acl_available":true,"iam_nodes_group_id":"1bb74d69-943b-44f2-b20b-dc114787fcea","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1642"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:02:00 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - b8f43720-d519-43e4-ba7d-5408a4100a3a
+        status: 200 OK
+        code: 200
+        duration: 26.53411ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/384a8300-efe2-4ea2-9078-2d89f5ad2383/kubeconfig
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1776
+        body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC12YWxpZGF0ZS1yb290LXZvbHVtZSIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVUpYZWtORFFWRkhaMEYzU1VKQlowbENRVVJCUzBKblozRm9hMnBQVUZGUlJFRnFRVlpOVWsxM1JWRlpSRlpSVVVSRmQzQnlaRmRLYkdOdE5Xd0taRWRXZWsxQ05GaEVWRWt5VFVSUmVFMTZSVEpOUkVVeFRsWnZXRVJVVFRKTlJGRjRUWHBGTWsxRVJURk9WbTkzUmxSRlZFMUNSVWRCTVZWRlFYaE5Td3BoTTFacFdsaEtkVnBZVW14amVrSmFUVUpOUjBKNWNVZFRUVFE1UVdkRlIwTkRjVWRUVFRRNVFYZEZTRUV3U1VGQ1JXTnRTa1k0VTNaS2IzVXhSSEJpQ25BeFJFcEVVa000YjJkNU56Wk9ORkpOYkZSNlkxZ3ZUMXBhVVM5UFNHMDNPRmM1ZVd0MGRDOVBaV0Z2YUhwMFJqVjFjekZVZG1SeVRpOWlOa051UW0wS1dVYzFiVkF5UjJwUmFrSkJUVUUwUjBFeFZXUkVkMFZDTDNkUlJVRjNTVU53UkVGUVFtZE9Wa2hTVFVKQlpqaEZRbFJCUkVGUlNDOU5RakJIUVRGVlpBcEVaMUZYUWtKU2NtVlRXbkJyY0ZGTVFXaHJObmROVlcxS1EwcHNjSE4xUWxoRVFVdENaMmR4YUd0cVQxQlJVVVJCWjA1SlFVUkNSa0ZwUlVFck4wUjZDa1JqVTBGWmFtZFdWVzUwYXlzMWRtMVRkemhxSzFNM2JuTkxOVlpaVjBOSlIyRlNZa0V2YzBOSlJrUkpOVFZNTlhkaU9XbDZVbGRWUWpkdFVsbExVRUVLWjB0eVJTdFpiR05yWjNGVFUxVlNabkJTYUdnS0xTMHRMUzFGVGtRZ1EwVlNWRWxHU1VOQlZFVXRMUzB0TFFvPQogICAgc2VydmVyOiBodHRwczovLzM4NGE4MzAwLWVmZTItNGVhMi05MDc4LTJkODlmNWFkMjM4My5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wtdmFsaWRhdGUtcm9vdC12b2x1bWUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC12YWxpZGF0ZS1yb290LXZvbHVtZSIKICAgIHVzZXI6IHRlc3QtcG9vbC12YWxpZGF0ZS1yb290LXZvbHVtZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC12YWxpZGF0ZS1yb290LXZvbHVtZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC12YWxpZGF0ZS1yb290LXZvbHVtZS1hZG1pbgogIHVzZXI6CiAgICB0b2tlbjogWEFPUGprT2luU2JqTTdGNjFjWTdJMFpvanNsa2dNUDdNdFFZZFQwMXhsN2dleEUzSXJDMkNRb3g="}'
+        headers:
+            Content-Length:
+                - "1776"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:02:00 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - 27460d84-0b6d-4991-9453-abf7fe45dfd1
+        status: 200 OK
+        code: 200
+        duration: 40.635888ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 41245
+        body: '{"servers": {"BASIC2-A16C-32G": {"alt_names": [], "arch": "arm64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 150.89, "hourly_price": 0.2067, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 503316480, "end_of_service": false}, "BASIC2-A16C-64G": {"alt_names": [], "arch": "arm64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 201.19, "hourly_price": 0.2756, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 503316480, "end_of_service": false}, "BASIC2-A2C-4G": {"alt_names": [], "arch": "arm64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 16.79, "hourly_price": 0.023, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 83886080, "end_of_service": false}, "BASIC2-A2C-8G": {"alt_names": [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 25.19, "hourly_price": 0.0345, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 83886080, "end_of_service": false}, "BASIC2-A4C-16G": {"alt_names": [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 50.3, "hourly_price": 0.0689, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 125829120, "end_of_service": false}, "BASIC2-A4C-8G": {"alt_names": [], "arch": "arm64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 37.74, "hourly_price": 0.0517, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 125829120, "end_of_service": false}, "BASIC2-A8C-16G": {"alt_names": [], "arch": "arm64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 75.48, "hourly_price": 0.1034, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 251658240, "end_of_service": false}, "BASIC2-A8C-32G": {"alt_names": [], "arch": "arm64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 100.59, "hourly_price": 0.1378, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 251658240, "end_of_service": false}, "BASIC3-X16C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 240.9, "hourly_price": 0.33, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]}, "block_bandwidth": 1048576000, "end_of_service": false}, "BASIC3-X16C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 321.2, "hourly_price": 0.44, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]}, "block_bandwidth": 1048576000, "end_of_service": false}, "BASIC3-X2C-4G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 26.791, "hourly_price": 0.0367, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth": 350000000, "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth": 350000000}]}, "block_bandwidth": 131072000, "end_of_service": false}, "BASIC3-X2C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 40.15, "hourly_price": 0.055, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth": 350000000, "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth": 350000000}]}, "block_bandwidth": 131072000, "end_of_service": false}, "BASIC3-X4C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 80.3, "hourly_price": 0.11, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth": 700000000, "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth": 700000000}]}, "block_bandwidth": 262144000, "end_of_service": false}, "BASIC3-X4C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 53.509, "hourly_price": 0.0733, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth": 700000000, "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth": 700000000}]}, "block_bandwidth": 262144000, "end_of_service": false}, "BASIC3-X8C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 120.45, "hourly_price": 0.165, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]}, "block_bandwidth": 524288000, "end_of_service": false}, "BASIC3-X8C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 160.6, "hourly_price": 0.22, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]}, "block_bandwidth": 524288000, "end_of_service": false}, "COMPUTE3-X16C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 320000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 341.786, "hourly_price": 0.4682, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 4000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 4000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "COMPUTE3-X2C-4G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 40000000000, "scratch_storage_max_volumes_count": 1, "monthly_price": 42.705, "hourly_price": 0.0585, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "COMPUTE3-X32C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 640000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 683.499, "hourly_price": 0.9363, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 8000000000, "sum_internet_bandwidth": 8000000000, "interfaces": [{"internal_bandwidth": 8000000000, "internet_bandwidth": 8000000000}]}, "block_bandwidth": 1000341504, "end_of_service": false}, "COMPUTE3-X48C-96G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 103079215104, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 960000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1019.81, "hourly_price": 1.397, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "COMPUTE3-X4C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 80000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 85.41, "hourly_price": 0.117, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "COMPUTE3-X64C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 1280000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1366.998, "hourly_price": 1.8726, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "COMPUTE3-X8C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 160000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 170.893, "hourly_price": 0.2341, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "COMPUTE3-X96C-192G": {"alt_names": [], "arch": "x86_64", "ncpus": 96, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 1280000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 2039.62, "hourly_price": 2.794, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "COPARM1-16C-64G": {"alt_names": [], "arch": "arm64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 252.14, "hourly_price": 0.3454, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 671088640, "end_of_service": false}, "COPARM1-2C-8G": {"alt_names": [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 31.1, "hourly_price": 0.0426, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 83886080, "end_of_service": false}, "COPARM1-32C-128G": {"alt_names": [], "arch": "arm64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 506.26, "hourly_price": 0.6935, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 1342177280, "end_of_service": false}, "COPARM1-4C-16G": {"alt_names": [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 62.56, "hourly_price": 0.0857, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 167772160, "end_of_service": false}, "COPARM1-8C-32G": {"alt_names": [], "arch": "arm64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 125.85, "hourly_price": 0.1724, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 335544320, "end_of_service": false}, "DEV1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 80000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 30.66, "hourly_price": 0.042, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 209715200, "end_of_service": false}, "DEV1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 3, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 40000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 14.454, "hourly_price": 0.0198, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 300000000, "sum_internet_bandwidth": 300000000, "interfaces": [{"internal_bandwidth": 300000000, "internet_bandwidth": 300000000}]}, "block_bandwidth": 157286400, "end_of_service": false}, "DEV1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 20000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 6.424, "hourly_price": 0.0088, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 104857600, "end_of_service": false}, "DEV1-XL": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 12884901888, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 120000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 46.5734, "hourly_price": 0.06378, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 262144000, "end_of_service": false}, "GP1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 554.07, "hourly_price": 0.759, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]}, "block_bandwidth": 1073741824, "end_of_service": false}, "GP1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 274.48, "hourly_price": 0.376, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "GP1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 300000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 136.51, "hourly_price": 0.187, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 524288000, "end_of_service": false}, "GP1-XL": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1197.93, "hourly_price": 1.641, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]}, "block_bandwidth": 2147483648, "end_of_service": false}, "GP1-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 150000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 66.43, "hourly_price": 0.091, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 314572800, "end_of_service": false}, "L4-1-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 51539607552, "gpu": 1, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 547.5, "hourly_price": 0.75, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 2500000000, "sum_internet_bandwidth": 2500000000, "interfaces": [{"internal_bandwidth": 2500000000, "internet_bandwidth": 2500000000}]}, "block_bandwidth": 1048576000, "end_of_service": false}, "L4-2-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 103079215104, "gpu": 2, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1095.0, "hourly_price": 1.5, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]}, "block_bandwidth": 1572864000, "end_of_service": false}, "L4-4-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 206158430208, "gpu": 4, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 2190.0, "hourly_price": 3.0, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]}, "block_bandwidth": 2621440000, "end_of_service": false}, "L4-8-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 412316860416, "gpu": 8, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 4380.0, "hourly_price": 6.0, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 20000000000, "sum_internet_bandwidth": 20000000000, "interfaces": [{"internal_bandwidth": 20000000000, "internet_bandwidth": 20000000000}]}, "block_bandwidth": 5242880000, "end_of_service": false}, "MEMORY3-X16C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 320000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 601.0, "hourly_price": 0.824, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 4000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 4000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "MEMORY3-X2C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 40000000000, "scratch_storage_max_volumes_count": 1, "monthly_price": 75.0, "hourly_price": 0.103, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "MEMORY3-X32C-256G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 640000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 1203.0, "hourly_price": 1.648, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 8000000000, "sum_internet_bandwidth": 8000000000, "interfaces": [{"internal_bandwidth": 8000000000, "internet_bandwidth": 8000000000}]}, "block_bandwidth": 1000341504, "end_of_service": false}, "MEMORY3-X48C-384G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 412316860416, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 960000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1804.0, "hourly_price": 2.472, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "MEMORY3-X4C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 80000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 150.0, "hourly_price": 0.206, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "MEMORY3-X8C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 160000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 300.0, "hourly_price": 0.412, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "PLAY2-MICRO": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 39.42, "hourly_price": 0.054, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 167772160, "end_of_service": false}, "PLAY2-NANO": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 19.71, "hourly_price": 0.027, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 83886080, "end_of_service": false}}}'
+        headers:
+            Content-Length:
+                - "41245"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:02:00 GMT
+            Link:
+                - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=3&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - a2af5b61-f92e-4e85-a50a-71b2a3bd51f9
+            X-Total-Count:
+                - "112"
+        status: 200 OK
+        code: 200
+        duration: 261.878633ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "2"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 40884
+        body: '{"servers": {"PLAY2-PICO": {"alt_names": [], "arch": "x86_64", "ncpus": 1, "ram": 2147483648, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 10.22, "hourly_price": 0.014, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]}, "block_bandwidth": 41943040, "end_of_service": false}, "POP2-16C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 430.7, "hourly_price": 0.59, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-16C-64G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1063.391, "hourly_price": 1.4567, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-2C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 53.66, "hourly_price": 0.0735, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-2C-8G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 133.079, "hourly_price": 0.1823, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-32C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 861.4, "hourly_price": 1.18, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-32C-128G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 2126.709, "hourly_price": 2.9133, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-48C-192G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1274.4, "hourly_price": 1.77, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-4C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 107.31, "hourly_price": 0.147, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-4C-16G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 265.501, "hourly_price": 0.3637, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-64C-256G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1715.5, "hourly_price": 2.35, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-8C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 211.7, "hourly_price": 0.29, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-8C-32G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 528.009, "hourly_price": 0.7233, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HC-16C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 310.69, "hourly_price": 0.4256, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-HC-2C-4G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 38.84, "hourly_price": 0.0532, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HC-32C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 621.38, "hourly_price": 0.8512, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HC-48C-96G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 103079215104, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 914.4, "hourly_price": 1.27, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HC-4C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 77.67, "hourly_price": 0.1064, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HC-64C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1242.75, "hourly_price": 1.7024, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HC-8C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 155.34, "hourly_price": 0.2128, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HM-16C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 601.52, "hourly_price": 0.824, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-HM-2C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 75.19, "hourly_price": 0.103, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HM-32C-256G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1203.04, "hourly_price": 1.648, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HM-48C-384G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 412316860416, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1778.4, "hourly_price": 2.47, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HM-4C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 150.38, "hourly_price": 0.206, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HM-64C-512G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 549755813888, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 2406.08, "hourly_price": 3.296, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HM-8C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 300.76, "hourly_price": 0.412, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HN-10": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 530.29, "hourly_price": 0.7264, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HN-3": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 186.49, "hourly_price": 0.2554, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HN-5": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 330.29, "hourly_price": 0.4524, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "PRO2-L": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 640.21, "hourly_price": 0.877, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6000000000, "sum_internet_bandwidth": 6000000000, "interfaces": [{"internal_bandwidth": 6000000000, "internet_bandwidth": 6000000000}]}, "block_bandwidth": 2097152000, "end_of_service": false}, "PRO2-M": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 319.74, "hourly_price": 0.438, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]}, "block_bandwidth": 1048576000, "end_of_service": false}, "PRO2-S": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 159.87, "hourly_price": 0.219, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]}, "block_bandwidth": 524288000, "end_of_service": false}, "PRO2-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 80.3, "hourly_price": 0.11, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth": 700000000, "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth": 700000000}]}, "block_bandwidth": 262144000, "end_of_service": false}, "PRO2-XXS": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 40.15, "hourly_price": 0.055, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth": 350000000, "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth": 350000000}]}, "block_bandwidth": 131072000, "end_of_service": false}, "RENDER-S": {"alt_names": [], "arch": "x86_64", "ncpus": 10, "ram": 45097156608, "gpu": 1, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "P100", "gpu_memory": 17179869184}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 400000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 891.33, "hourly_price": 1.221, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 2000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth": 2000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 2147483648, "end_of_service": false}, "STANDARD2-A16C-64G": {"alt_names": [], "arch": "arm64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 367.8324, "hourly_price": 0.5039, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "STANDARD2-A2C-8G": {"alt_names": [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 42.7525, "hourly_price": 0.0586, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "STANDARD2-A32C-128G": {"alt_names": [], "arch": "arm64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 735.7269, "hourly_price": 1.0078, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5033164800, "end_of_service": false}, "STANDARD2-A48C-192G": {"alt_names": [], "arch": "arm64", "ncpus": 48, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1103.5593, "hourly_price": 1.5117, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5033164800, "end_of_service": false}, "STANDARD2-A4C-16G": {"alt_names": [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 85.5049, "hourly_price": 0.1171, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "STANDARD2-A64C-256G": {"alt_names": [], "arch": "arm64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1470.366, "hourly_price": 2.0142, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5033164800, "end_of_service": false}, "STANDARD2-A8C-32G": {"alt_names": [], "arch": "arm64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 171.0098, "hourly_price": 0.2343, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "STANDARD3-X16C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 320000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 430.0, "hourly_price": 0.59, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 4000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 4000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "STANDARD3-X2C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 40000000000, "scratch_storage_max_volumes_count": 1, "monthly_price": 54.0, "hourly_price": 0.074, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "STANDARD3-X32C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 640000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 861.0, "hourly_price": 1.18, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 8000000000, "sum_internet_bandwidth": 8000000000, "interfaces": [{"internal_bandwidth": 8000000000, "internet_bandwidth": 8000000000}]}, "block_bandwidth": 1000341504, "end_of_service": false}, "STANDARD3-X48C-192G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 960000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1292.1, "hourly_price": 1.77, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "STANDARD3-X4C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 80000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 107.0, "hourly_price": 0.147, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "STANDARD3-X64C-256G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 1280000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1715.0, "hourly_price": 2.35, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "STANDARD3-X8C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 160000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 211.0, "hourly_price": 0.29, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}}}'
+        headers:
+            Content-Length:
+                - "40884"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:02:00 GMT
+            Link:
+                - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>; rel="previous",</products/servers?page=3&per_page=50&>; rel="next",</products/servers?page=3&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - b4c33253-1b32-4a63-97eb-d06194b86305
+            X-Total-Count:
+                - "112"
+        status: 200 OK
+        code: 200
+        duration: 51.711052ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "3"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 10027
+        body: '{"servers": {"STARDUST1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 1, "ram": 1073741824, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 10000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 0.1095, "hourly_price": 0.00015, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]}, "block_bandwidth": 52428800, "end_of_service": false}, "START1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 26.864, "hourly_price": 0.0368, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "START1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 100000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 14.162, "hourly_price": 0.0194, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 300000000, "sum_internet_bandwidth": 300000000, "interfaces": [{"internal_bandwidth": 300000000, "internet_bandwidth": 300000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "START1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 50000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 7.738, "hourly_price": 0.0106, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "START1-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 1, "ram": 1073741824, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 25000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 4.526, "hourly_price": 0.0062, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "VC1L": {"alt_names": ["X64-8GB"], "arch": "x86_64", "ncpus": 6, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 18.0164, "hourly_price": 0.02468, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "VC1M": {"alt_names": ["X64-4GB"], "arch": "x86_64", "ncpus": 4, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 100000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 11.3515, "hourly_price": 0.01555, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "VC1S": {"alt_names": ["X64-2GB"], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 50000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 6.2926, "hourly_price": 0.00862, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "X64-120GB": {"alt_names": [], "arch": "x86_64", "ncpus": 12, "ram": 128849018880, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 800000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 310.7902, "hourly_price": 0.42574, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 1000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "X64-15GB": {"alt_names": [], "arch": "x86_64", "ncpus": 6, "ram": 16106127360, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 44.0336, "hourly_price": 0.06032, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 250000000, "sum_internet_bandwidth": 250000000, "interfaces": [{"internal_bandwidth": 250000000, "internet_bandwidth": 250000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "X64-30GB": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 32212254720, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 400000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 86.9138, "hourly_price": 0.11906, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "X64-60GB": {"alt_names": [], "arch": "x86_64", "ncpus": 10, "ram": 64424509440, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 700000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 155.49, "hourly_price": 0.213, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 1000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 41943040, "end_of_service": true}}}'
+        headers:
+            Content-Length:
+                - "10027"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:02:00 GMT
+            Link:
+                - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=2&per_page=50&>; rel="previous",</products/servers?page=3&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - fe1313cd-f02a-4e50-a4d7-fc2f2036aa83
+            X-Total-Count:
+                - "112"
+        status: 200 OK
+        code: 200
+        duration: 74.634022ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/384a8300-efe2-4ea2-9078-2d89f5ad2383
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1642
+        body: '{"region":"fr-par","id":"384a8300-efe2-4ea2-9078-2d89f5ad2383","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:01:55.214681Z","updated_at":"2026-04-14T16:01:56.146476Z","type":"kapsule","name":"test-pool-validate-root-volume","description":"","status":"pool_required","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","validate-root-volume"],"cluster_url":"https://384a8300-efe2-4ea2-9078-2d89f5ad2383.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.384a8300-efe2-4ea2-9078-2d89f5ad2383.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":0},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"59f194c7-197f-4ca6-84e5-f9c38afbfaed","commitment_ends_at":"2026-04-14T16:01:55.214686Z","acl_available":true,"iam_nodes_group_id":"1bb74d69-943b-44f2-b20b-dc114787fcea","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1642"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:02:00 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - 1355e045-602b-4bda-b714-4a0ec0c088d4
+        status: 200 OK
+        code: 200
+        duration: 34.290874ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 426
+        host: api.scaleway.com
+        body: '{"name":"test-pool-validate-root-volume","node_type":"PRO2_XXS","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","validate-root-volume"],"kubelet_args":{},"zone":"fr-par-1","root_volume_type":"default_volume_type","root_volume_size":20000000000,"public_ip_disabled":false,"labels":null,"taints":null,"startup_taints":null}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/384a8300-efe2-4ea2-9078-2d89f5ad2383/pools
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 783
+        body: '{"region":"fr-par","id":"67f68cb0-03f7-4318-9a03-16764323873a","cluster_id":"384a8300-efe2-4ea2-9078-2d89f5ad2383","created_at":"2026-04-14T16:02:00.986391Z","updated_at":"2026-04-14T16:02:00.986391Z","name":"test-pool-validate-root-volume","status":"scaling","version":"1.35.3","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","validate-root-volume"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{},"taints":[],"startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "783"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:02:01 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - efaac614-4696-4619-92a6-7ece61eb52dc
+        status: 200 OK
+        code: 200
+        duration: 158.332103ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/67f68cb0-03f7-4318-9a03-16764323873a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 783
+        body: '{"region":"fr-par","id":"67f68cb0-03f7-4318-9a03-16764323873a","cluster_id":"384a8300-efe2-4ea2-9078-2d89f5ad2383","created_at":"2026-04-14T16:02:00.986391Z","updated_at":"2026-04-14T16:02:00.986391Z","name":"test-pool-validate-root-volume","status":"scaling","version":"1.35.3","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","validate-root-volume"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{},"taints":[],"startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "783"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:02:01 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - dbf1ab25-f8ea-4b4d-b76f-08c8e4635f5f
+        status: 200 OK
+        code: 200
+        duration: 23.994993ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/67f68cb0-03f7-4318-9a03-16764323873a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 781
+        body: '{"region":"fr-par","id":"67f68cb0-03f7-4318-9a03-16764323873a","cluster_id":"384a8300-efe2-4ea2-9078-2d89f5ad2383","created_at":"2026-04-14T16:02:00.986391Z","updated_at":"2026-04-14T16:04:58.020478Z","name":"test-pool-validate-root-volume","status":"ready","version":"1.35.3","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","validate-root-volume"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{},"taints":[],"startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "781"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - c4fbe03c-7ee8-41d0-b00f-881c76c3e688
+        status: 200 OK
+        code: 200
+        duration: 30.64546ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/384a8300-efe2-4ea2-9078-2d89f5ad2383
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1634
+        body: '{"region":"fr-par","id":"384a8300-efe2-4ea2-9078-2d89f5ad2383","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:01:55.214681Z","updated_at":"2026-04-14T16:03:46.070598Z","type":"kapsule","name":"test-pool-validate-root-volume","description":"","status":"ready","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","validate-root-volume"],"cluster_url":"https://384a8300-efe2-4ea2-9078-2d89f5ad2383.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.384a8300-efe2-4ea2-9078-2d89f5ad2383.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":0},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"59f194c7-197f-4ca6-84e5-f9c38afbfaed","commitment_ends_at":"2026-04-14T16:01:55.214686Z","acl_available":true,"iam_nodes_group_id":"1bb74d69-943b-44f2-b20b-dc114787fcea","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1634"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - a0e2adb4-d0fa-48ae-a136-e8d65a77d269
+        status: 200 OK
+        code: 200
+        duration: 22.94926ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/67f68cb0-03f7-4318-9a03-16764323873a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 781
+        body: '{"region":"fr-par","id":"67f68cb0-03f7-4318-9a03-16764323873a","cluster_id":"384a8300-efe2-4ea2-9078-2d89f5ad2383","created_at":"2026-04-14T16:02:00.986391Z","updated_at":"2026-04-14T16:04:58.020478Z","name":"test-pool-validate-root-volume","status":"ready","version":"1.35.3","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","validate-root-volume"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{},"taints":[],"startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "781"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - 40b71f88-5ea5-48b6-b3b8-862faa14fe10
+        status: 200 OK
+        code: 200
+        duration: 19.206246ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_asc
+            page:
+                - "1"
+            pool_id:
+                - 67f68cb0-03f7-4318-9a03-16764323873a
+            status:
+                - unknown
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/384a8300-efe2-4ea2-9078-2d89f5ad2383/nodes?order_by=created_at_asc&page=1&pool_id=67f68cb0-03f7-4318-9a03-16764323873a&status=unknown
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 604
+        body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"079354f4-804c-4ac3-9e26-9c05bfb45335","cluster_id":"384a8300-efe2-4ea2-9078-2d89f5ad2383","created_at":"2026-04-14T16:03:52.717593Z","updated_at":"2026-04-14T16:04:58.008311Z","pool_id":"67f68cb0-03f7-4318-9a03-16764323873a","status":"ready","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"name":"scw-test-pool-validat-test-pool-validat-079354","public_ip_v4":"212.47.254.177","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/011d187e-15fe-4df9-bead-febdb7a0fd20","error_message":""}]}'
+        headers:
+            Content-Length:
+                - "604"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - 198bf634-1f91-403f-b966-ef0600279178
+        status: 200 OK
+        code: 200
+        duration: 37.211476ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/384a8300-efe2-4ea2-9078-2d89f5ad2383
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1634
+        body: '{"region":"fr-par","id":"384a8300-efe2-4ea2-9078-2d89f5ad2383","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:01:55.214681Z","updated_at":"2026-04-14T16:03:46.070598Z","type":"kapsule","name":"test-pool-validate-root-volume","description":"","status":"ready","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","validate-root-volume"],"cluster_url":"https://384a8300-efe2-4ea2-9078-2d89f5ad2383.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.384a8300-efe2-4ea2-9078-2d89f5ad2383.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":0},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"59f194c7-197f-4ca6-84e5-f9c38afbfaed","commitment_ends_at":"2026-04-14T16:01:55.214686Z","acl_available":true,"iam_nodes_group_id":"1bb74d69-943b-44f2-b20b-dc114787fcea","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1634"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - e5c1ff9b-e3dc-4d70-9c64-3aa52aa8e6b3
+        status: 200 OK
+        code: 200
+        duration: 26.558172ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_desc
+            project_id:
+                - fa1e3217-dc80-42ac-85c3-3f034b78b552
+            resource_name:
+                - scw-test-pool-validat-test-pool-validat-079354
+            resource_type:
+                - unknown_type
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=fa1e3217-dc80-42ac-85c3-3f034b78b552&resource_name=scw-test-pool-validat-test-pool-validat-079354&resource_type=unknown_type
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1092
+        body: '{"total_count":2,"ips":[{"id":"4a7b0a65-b64a-4153-8c40-2b272d27848e","address":"fd63:256c:45f7:531d:ff86:f246:b0d2:7029/64","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","is_ipv6":true,"created_at":"2026-04-14T16:03:55.261366Z","updated_at":"2026-04-14T16:03:55.261366Z","source":{"subnet_id":"9417c9dc-82cd-4bc2-bd08-bb051b54281b"},"resource":{"type":"instance_private_nic","id":"5df56e4d-0ed3-4270-b00d-58f2b1679072","mac_address":"02:00:00:18:C1:84","name":"scw-test-pool-validat-test-pool-validat-079354"},"tags":[],"reverses":[],"region":"fr-par","zone":null},{"id":"01db5f80-7095-48de-b30b-5791574628d5","address":"172.16.16.3/22","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","is_ipv6":false,"created_at":"2026-04-14T16:03:55.165436Z","updated_at":"2026-04-14T16:03:55.165436Z","source":{"subnet_id":"ce74d09e-a4e9-4b1c-aad0-caf264e1ef61"},"resource":{"type":"instance_private_nic","id":"5df56e4d-0ed3-4270-b00d-58f2b1679072","mac_address":"02:00:00:18:C1:84","name":"scw-test-pool-validat-test-pool-validat-079354"},"tags":[],"reverses":[],"region":"fr-par","zone":null}]}'
+        headers:
+            Content-Length:
+                - "1092"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:02 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - d5737c02-67df-4f35-8012-66c32e86d136
+        status: 200 OK
+        code: 200
+        duration: 57.77416ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/384a8300-efe2-4ea2-9078-2d89f5ad2383
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1634
+        body: '{"region":"fr-par","id":"384a8300-efe2-4ea2-9078-2d89f5ad2383","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:01:55.214681Z","updated_at":"2026-04-14T16:03:46.070598Z","type":"kapsule","name":"test-pool-validate-root-volume","description":"","status":"ready","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","validate-root-volume"],"cluster_url":"https://384a8300-efe2-4ea2-9078-2d89f5ad2383.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.384a8300-efe2-4ea2-9078-2d89f5ad2383.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":0},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"59f194c7-197f-4ca6-84e5-f9c38afbfaed","commitment_ends_at":"2026-04-14T16:01:55.214686Z","acl_available":true,"iam_nodes_group_id":"1bb74d69-943b-44f2-b20b-dc114787fcea","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1634"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - 661c20fe-70b1-4e30-9115-c7328c25e387
+        status: 200 OK
+        code: 200
+        duration: 21.376357ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/67f68cb0-03f7-4318-9a03-16764323873a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 781
+        body: '{"region":"fr-par","id":"67f68cb0-03f7-4318-9a03-16764323873a","cluster_id":"384a8300-efe2-4ea2-9078-2d89f5ad2383","created_at":"2026-04-14T16:02:00.986391Z","updated_at":"2026-04-14T16:04:58.020478Z","name":"test-pool-validate-root-volume","status":"ready","version":"1.35.3","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","validate-root-volume"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{},"taints":[],"startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "781"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - 6485e7b1-c3c0-4535-b2c8-ec83f31d7560
+        status: 200 OK
+        code: 200
+        duration: 20.448592ms
+    - id: 25
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/4c6f2f41-a3ed-438f-b4cf-63be705fee57
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 411
+        body: '{"id":"4c6f2f41-a3ed-438f-b4cf-63be705fee57","name":"tf-vpc-eloquent-margulis","tags":[],"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:01:53.908263Z","updated_at":"2026-04-14T16:01:53.908263Z","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","is_default":false,"private_network_count":1,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "411"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - 8ef6b4e6-20eb-41d9-8065-9404b14a28a4
+        status: 200 OK
+        code: 200
+        duration: 24.689776ms
+    - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/59f194c7-197f-4ca6-84e5-f9c38afbfaed
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1076
+        body: '{"id":"59f194c7-197f-4ca6-84e5-f9c38afbfaed","name":"test-pool-validate-root-volume","tags":[],"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:01:54.065721Z","updated_at":"2026-04-14T16:01:54.065721Z","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnets":[{"id":"ce74d09e-a4e9-4b1c-aad0-caf264e1ef61","created_at":"2026-04-14T16:01:54.065721Z","updated_at":"2026-04-14T16:01:54.065721Z","subnet":"172.16.16.0/22","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"59f194c7-197f-4ca6-84e5-f9c38afbfaed","vpc_id":"4c6f2f41-a3ed-438f-b4cf-63be705fee57"},{"id":"9417c9dc-82cd-4bc2-bd08-bb051b54281b","created_at":"2026-04-14T16:01:54.065721Z","updated_at":"2026-04-14T16:01:54.065721Z","subnet":"fd63:256c:45f7:531d::/64","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"59f194c7-197f-4ca6-84e5-f9c38afbfaed","vpc_id":"4c6f2f41-a3ed-438f-b4cf-63be705fee57"}],"vpc_id":"4c6f2f41-a3ed-438f-b4cf-63be705fee57","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1076"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - e83930aa-6323-449c-afa5-c248d11787bf
+        status: 200 OK
+        code: 200
+        duration: 26.87185ms
+    - id: 27
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/384a8300-efe2-4ea2-9078-2d89f5ad2383
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1634
+        body: '{"region":"fr-par","id":"384a8300-efe2-4ea2-9078-2d89f5ad2383","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:01:55.214681Z","updated_at":"2026-04-14T16:03:46.070598Z","type":"kapsule","name":"test-pool-validate-root-volume","description":"","status":"ready","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","validate-root-volume"],"cluster_url":"https://384a8300-efe2-4ea2-9078-2d89f5ad2383.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.384a8300-efe2-4ea2-9078-2d89f5ad2383.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":0},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"59f194c7-197f-4ca6-84e5-f9c38afbfaed","commitment_ends_at":"2026-04-14T16:01:55.214686Z","acl_available":true,"iam_nodes_group_id":"1bb74d69-943b-44f2-b20b-dc114787fcea","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1634"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - 47833a27-796d-4a49-add8-d26017e9cdf0
+        status: 200 OK
+        code: 200
+        duration: 32.686489ms
+    - id: 28
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/384a8300-efe2-4ea2-9078-2d89f5ad2383/kubeconfig
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1776
+        body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC12YWxpZGF0ZS1yb290LXZvbHVtZSIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVUpYZWtORFFWRkhaMEYzU1VKQlowbENRVVJCUzBKblozRm9hMnBQVUZGUlJFRnFRVlpOVWsxM1JWRlpSRlpSVVVSRmQzQnlaRmRLYkdOdE5Xd0taRWRXZWsxQ05GaEVWRWt5VFVSUmVFMTZSVEpOUkVVeFRsWnZXRVJVVFRKTlJGRjRUWHBGTWsxRVJURk9WbTkzUmxSRlZFMUNSVWRCTVZWRlFYaE5Td3BoTTFacFdsaEtkVnBZVW14amVrSmFUVUpOUjBKNWNVZFRUVFE1UVdkRlIwTkRjVWRUVFRRNVFYZEZTRUV3U1VGQ1JXTnRTa1k0VTNaS2IzVXhSSEJpQ25BeFJFcEVVa000YjJkNU56Wk9ORkpOYkZSNlkxZ3ZUMXBhVVM5UFNHMDNPRmM1ZVd0MGRDOVBaV0Z2YUhwMFJqVjFjekZVZG1SeVRpOWlOa051UW0wS1dVYzFiVkF5UjJwUmFrSkJUVUUwUjBFeFZXUkVkMFZDTDNkUlJVRjNTVU53UkVGUVFtZE9Wa2hTVFVKQlpqaEZRbFJCUkVGUlNDOU5RakJIUVRGVlpBcEVaMUZYUWtKU2NtVlRXbkJyY0ZGTVFXaHJObmROVlcxS1EwcHNjSE4xUWxoRVFVdENaMmR4YUd0cVQxQlJVVVJCWjA1SlFVUkNSa0ZwUlVFck4wUjZDa1JqVTBGWmFtZFdWVzUwYXlzMWRtMVRkemhxSzFNM2JuTkxOVlpaVjBOSlIyRlNZa0V2YzBOSlJrUkpOVFZNTlhkaU9XbDZVbGRWUWpkdFVsbExVRUVLWjB0eVJTdFpiR05yWjNGVFUxVlNabkJTYUdnS0xTMHRMUzFGVGtRZ1EwVlNWRWxHU1VOQlZFVXRMUzB0TFFvPQogICAgc2VydmVyOiBodHRwczovLzM4NGE4MzAwLWVmZTItNGVhMi05MDc4LTJkODlmNWFkMjM4My5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wtdmFsaWRhdGUtcm9vdC12b2x1bWUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC12YWxpZGF0ZS1yb290LXZvbHVtZSIKICAgIHVzZXI6IHRlc3QtcG9vbC12YWxpZGF0ZS1yb290LXZvbHVtZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC12YWxpZGF0ZS1yb290LXZvbHVtZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC12YWxpZGF0ZS1yb290LXZvbHVtZS1hZG1pbgogIHVzZXI6CiAgICB0b2tlbjogWEFPUGprT2luU2JqTTdGNjFjWTdJMFpvanNsa2dNUDdNdFFZZFQwMXhsN2dleEUzSXJDMkNRb3g="}'
+        headers:
+            Content-Length:
+                - "1776"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - fa4d6545-611b-4449-90d7-bcb7c9095382
+        status: 200 OK
+        code: 200
+        duration: 50.559682ms
+    - id: 29
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/67f68cb0-03f7-4318-9a03-16764323873a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 781
+        body: '{"region":"fr-par","id":"67f68cb0-03f7-4318-9a03-16764323873a","cluster_id":"384a8300-efe2-4ea2-9078-2d89f5ad2383","created_at":"2026-04-14T16:02:00.986391Z","updated_at":"2026-04-14T16:04:58.020478Z","name":"test-pool-validate-root-volume","status":"ready","version":"1.35.3","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","validate-root-volume"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{},"taints":[],"startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "781"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - 46b715a9-daa9-4525-bc2c-7b2deb003ff3
+        status: 200 OK
+        code: 200
+        duration: 24.479824ms
+    - id: 30
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_asc
+            page:
+                - "1"
+            pool_id:
+                - 67f68cb0-03f7-4318-9a03-16764323873a
+            status:
+                - unknown
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/384a8300-efe2-4ea2-9078-2d89f5ad2383/nodes?order_by=created_at_asc&page=1&pool_id=67f68cb0-03f7-4318-9a03-16764323873a&status=unknown
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 604
+        body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"079354f4-804c-4ac3-9e26-9c05bfb45335","cluster_id":"384a8300-efe2-4ea2-9078-2d89f5ad2383","created_at":"2026-04-14T16:03:52.717593Z","updated_at":"2026-04-14T16:04:58.008311Z","pool_id":"67f68cb0-03f7-4318-9a03-16764323873a","status":"ready","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"name":"scw-test-pool-validat-test-pool-validat-079354","public_ip_v4":"212.47.254.177","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/011d187e-15fe-4df9-bead-febdb7a0fd20","error_message":""}]}'
+        headers:
+            Content-Length:
+                - "604"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - 28f2b72a-12ac-4b60-a0be-9e5acfe4edba
+        status: 200 OK
+        code: 200
+        duration: 43.437014ms
+    - id: 31
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/384a8300-efe2-4ea2-9078-2d89f5ad2383
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1634
+        body: '{"region":"fr-par","id":"384a8300-efe2-4ea2-9078-2d89f5ad2383","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:01:55.214681Z","updated_at":"2026-04-14T16:03:46.070598Z","type":"kapsule","name":"test-pool-validate-root-volume","description":"","status":"ready","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","validate-root-volume"],"cluster_url":"https://384a8300-efe2-4ea2-9078-2d89f5ad2383.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.384a8300-efe2-4ea2-9078-2d89f5ad2383.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":0},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"59f194c7-197f-4ca6-84e5-f9c38afbfaed","commitment_ends_at":"2026-04-14T16:01:55.214686Z","acl_available":true,"iam_nodes_group_id":"1bb74d69-943b-44f2-b20b-dc114787fcea","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1634"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - 17800c5f-68c4-40a9-8593-48a92ba65059
+        status: 200 OK
+        code: 200
+        duration: 28.215293ms
+    - id: 32
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_desc
+            project_id:
+                - fa1e3217-dc80-42ac-85c3-3f034b78b552
+            resource_name:
+                - scw-test-pool-validat-test-pool-validat-079354
+            resource_type:
+                - unknown_type
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=fa1e3217-dc80-42ac-85c3-3f034b78b552&resource_name=scw-test-pool-validat-test-pool-validat-079354&resource_type=unknown_type
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1092
+        body: '{"total_count":2,"ips":[{"id":"4a7b0a65-b64a-4153-8c40-2b272d27848e","address":"fd63:256c:45f7:531d:ff86:f246:b0d2:7029/64","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","is_ipv6":true,"created_at":"2026-04-14T16:03:55.261366Z","updated_at":"2026-04-14T16:03:55.261366Z","source":{"subnet_id":"9417c9dc-82cd-4bc2-bd08-bb051b54281b"},"resource":{"type":"instance_private_nic","id":"5df56e4d-0ed3-4270-b00d-58f2b1679072","mac_address":"02:00:00:18:C1:84","name":"scw-test-pool-validat-test-pool-validat-079354"},"tags":[],"reverses":[],"region":"fr-par","zone":null},{"id":"01db5f80-7095-48de-b30b-5791574628d5","address":"172.16.16.3/22","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","is_ipv6":false,"created_at":"2026-04-14T16:03:55.165436Z","updated_at":"2026-04-14T16:03:55.165436Z","source":{"subnet_id":"ce74d09e-a4e9-4b1c-aad0-caf264e1ef61"},"resource":{"type":"instance_private_nic","id":"5df56e4d-0ed3-4270-b00d-58f2b1679072","mac_address":"02:00:00:18:C1:84","name":"scw-test-pool-validat-test-pool-validat-079354"},"tags":[],"reverses":[],"region":"fr-par","zone":null}]}'
+        headers:
+            Content-Length:
+                - "1092"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - 29dbdf52-6551-446f-b8f0-4a77227165d0
+        status: 200 OK
+        code: 200
+        duration: 27.860409ms
+    - id: 33
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/4c6f2f41-a3ed-438f-b4cf-63be705fee57
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 411
+        body: '{"id":"4c6f2f41-a3ed-438f-b4cf-63be705fee57","name":"tf-vpc-eloquent-margulis","tags":[],"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:01:53.908263Z","updated_at":"2026-04-14T16:01:53.908263Z","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","is_default":false,"private_network_count":1,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "411"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - b1d0c389-7702-4b85-ae54-0ad2b2c150b7
+        status: 200 OK
+        code: 200
+        duration: 24.981712ms
+    - id: 34
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/59f194c7-197f-4ca6-84e5-f9c38afbfaed
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1076
+        body: '{"id":"59f194c7-197f-4ca6-84e5-f9c38afbfaed","name":"test-pool-validate-root-volume","tags":[],"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:01:54.065721Z","updated_at":"2026-04-14T16:01:54.065721Z","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnets":[{"id":"ce74d09e-a4e9-4b1c-aad0-caf264e1ef61","created_at":"2026-04-14T16:01:54.065721Z","updated_at":"2026-04-14T16:01:54.065721Z","subnet":"172.16.16.0/22","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"59f194c7-197f-4ca6-84e5-f9c38afbfaed","vpc_id":"4c6f2f41-a3ed-438f-b4cf-63be705fee57"},{"id":"9417c9dc-82cd-4bc2-bd08-bb051b54281b","created_at":"2026-04-14T16:01:54.065721Z","updated_at":"2026-04-14T16:01:54.065721Z","subnet":"fd63:256c:45f7:531d::/64","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"59f194c7-197f-4ca6-84e5-f9c38afbfaed","vpc_id":"4c6f2f41-a3ed-438f-b4cf-63be705fee57"}],"vpc_id":"4c6f2f41-a3ed-438f-b4cf-63be705fee57","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1076"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:04 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - 800bf6ed-56f8-414a-822e-1fd2ce8e815f
+        status: 200 OK
+        code: 200
+        duration: 24.975171ms
+    - id: 35
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/384a8300-efe2-4ea2-9078-2d89f5ad2383
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1634
+        body: '{"region":"fr-par","id":"384a8300-efe2-4ea2-9078-2d89f5ad2383","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:01:55.214681Z","updated_at":"2026-04-14T16:03:46.070598Z","type":"kapsule","name":"test-pool-validate-root-volume","description":"","status":"ready","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","validate-root-volume"],"cluster_url":"https://384a8300-efe2-4ea2-9078-2d89f5ad2383.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.384a8300-efe2-4ea2-9078-2d89f5ad2383.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":0},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"59f194c7-197f-4ca6-84e5-f9c38afbfaed","commitment_ends_at":"2026-04-14T16:01:55.214686Z","acl_available":true,"iam_nodes_group_id":"1bb74d69-943b-44f2-b20b-dc114787fcea","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1634"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:04 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - 0826d6ae-313f-4165-8727-127645e80135
+        status: 200 OK
+        code: 200
+        duration: 34.505183ms
+    - id: 36
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/384a8300-efe2-4ea2-9078-2d89f5ad2383/kubeconfig
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1776
+        body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC12YWxpZGF0ZS1yb290LXZvbHVtZSIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVUpYZWtORFFWRkhaMEYzU1VKQlowbENRVVJCUzBKblozRm9hMnBQVUZGUlJFRnFRVlpOVWsxM1JWRlpSRlpSVVVSRmQzQnlaRmRLYkdOdE5Xd0taRWRXZWsxQ05GaEVWRWt5VFVSUmVFMTZSVEpOUkVVeFRsWnZXRVJVVFRKTlJGRjRUWHBGTWsxRVJURk9WbTkzUmxSRlZFMUNSVWRCTVZWRlFYaE5Td3BoTTFacFdsaEtkVnBZVW14amVrSmFUVUpOUjBKNWNVZFRUVFE1UVdkRlIwTkRjVWRUVFRRNVFYZEZTRUV3U1VGQ1JXTnRTa1k0VTNaS2IzVXhSSEJpQ25BeFJFcEVVa000YjJkNU56Wk9ORkpOYkZSNlkxZ3ZUMXBhVVM5UFNHMDNPRmM1ZVd0MGRDOVBaV0Z2YUhwMFJqVjFjekZVZG1SeVRpOWlOa051UW0wS1dVYzFiVkF5UjJwUmFrSkJUVUUwUjBFeFZXUkVkMFZDTDNkUlJVRjNTVU53UkVGUVFtZE9Wa2hTVFVKQlpqaEZRbFJCUkVGUlNDOU5RakJIUVRGVlpBcEVaMUZYUWtKU2NtVlRXbkJyY0ZGTVFXaHJObmROVlcxS1EwcHNjSE4xUWxoRVFVdENaMmR4YUd0cVQxQlJVVVJCWjA1SlFVUkNSa0ZwUlVFck4wUjZDa1JqVTBGWmFtZFdWVzUwYXlzMWRtMVRkemhxSzFNM2JuTkxOVlpaVjBOSlIyRlNZa0V2YzBOSlJrUkpOVFZNTlhkaU9XbDZVbGRWUWpkdFVsbExVRUVLWjB0eVJTdFpiR05yWjNGVFUxVlNabkJTYUdnS0xTMHRMUzFGVGtRZ1EwVlNWRWxHU1VOQlZFVXRMUzB0TFFvPQogICAgc2VydmVyOiBodHRwczovLzM4NGE4MzAwLWVmZTItNGVhMi05MDc4LTJkODlmNWFkMjM4My5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wtdmFsaWRhdGUtcm9vdC12b2x1bWUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC12YWxpZGF0ZS1yb290LXZvbHVtZSIKICAgIHVzZXI6IHRlc3QtcG9vbC12YWxpZGF0ZS1yb290LXZvbHVtZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC12YWxpZGF0ZS1yb290LXZvbHVtZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC12YWxpZGF0ZS1yb290LXZvbHVtZS1hZG1pbgogIHVzZXI6CiAgICB0b2tlbjogWEFPUGprT2luU2JqTTdGNjFjWTdJMFpvanNsa2dNUDdNdFFZZFQwMXhsN2dleEUzSXJDMkNRb3g="}'
+        headers:
+            Content-Length:
+                - "1776"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:04 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - d83744a8-be56-4192-89ec-fe24e0d41a3b
+        status: 200 OK
+        code: 200
+        duration: 53.596144ms
+    - id: 37
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/67f68cb0-03f7-4318-9a03-16764323873a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 781
+        body: '{"region":"fr-par","id":"67f68cb0-03f7-4318-9a03-16764323873a","cluster_id":"384a8300-efe2-4ea2-9078-2d89f5ad2383","created_at":"2026-04-14T16:02:00.986391Z","updated_at":"2026-04-14T16:04:58.020478Z","name":"test-pool-validate-root-volume","status":"ready","version":"1.35.3","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","validate-root-volume"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{},"taints":[],"startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "781"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:04 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - e1b1e4db-0364-424a-b4e1-d9875d459439
+        status: 200 OK
+        code: 200
+        duration: 23.749869ms
+    - id: 38
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_asc
+            page:
+                - "1"
+            pool_id:
+                - 67f68cb0-03f7-4318-9a03-16764323873a
+            status:
+                - unknown
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/384a8300-efe2-4ea2-9078-2d89f5ad2383/nodes?order_by=created_at_asc&page=1&pool_id=67f68cb0-03f7-4318-9a03-16764323873a&status=unknown
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 604
+        body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"079354f4-804c-4ac3-9e26-9c05bfb45335","cluster_id":"384a8300-efe2-4ea2-9078-2d89f5ad2383","created_at":"2026-04-14T16:03:52.717593Z","updated_at":"2026-04-14T16:04:58.008311Z","pool_id":"67f68cb0-03f7-4318-9a03-16764323873a","status":"ready","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"name":"scw-test-pool-validat-test-pool-validat-079354","public_ip_v4":"212.47.254.177","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/011d187e-15fe-4df9-bead-febdb7a0fd20","error_message":""}]}'
+        headers:
+            Content-Length:
+                - "604"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:04 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - ca61b566-425c-4d8f-bf26-73c801338d75
+        status: 200 OK
+        code: 200
+        duration: 45.275765ms
+    - id: 39
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/384a8300-efe2-4ea2-9078-2d89f5ad2383
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1634
+        body: '{"region":"fr-par","id":"384a8300-efe2-4ea2-9078-2d89f5ad2383","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:01:55.214681Z","updated_at":"2026-04-14T16:03:46.070598Z","type":"kapsule","name":"test-pool-validate-root-volume","description":"","status":"ready","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","validate-root-volume"],"cluster_url":"https://384a8300-efe2-4ea2-9078-2d89f5ad2383.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.384a8300-efe2-4ea2-9078-2d89f5ad2383.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":0},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"59f194c7-197f-4ca6-84e5-f9c38afbfaed","commitment_ends_at":"2026-04-14T16:01:55.214686Z","acl_available":true,"iam_nodes_group_id":"1bb74d69-943b-44f2-b20b-dc114787fcea","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1634"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:04 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - a2ec1785-2d06-4255-88dc-17bbc5d00927
+        status: 200 OK
+        code: 200
+        duration: 19.131407ms
+    - id: 40
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_desc
+            project_id:
+                - fa1e3217-dc80-42ac-85c3-3f034b78b552
+            resource_name:
+                - scw-test-pool-validat-test-pool-validat-079354
+            resource_type:
+                - unknown_type
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=fa1e3217-dc80-42ac-85c3-3f034b78b552&resource_name=scw-test-pool-validat-test-pool-validat-079354&resource_type=unknown_type
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1092
+        body: '{"total_count":2,"ips":[{"id":"4a7b0a65-b64a-4153-8c40-2b272d27848e","address":"fd63:256c:45f7:531d:ff86:f246:b0d2:7029/64","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","is_ipv6":true,"created_at":"2026-04-14T16:03:55.261366Z","updated_at":"2026-04-14T16:03:55.261366Z","source":{"subnet_id":"9417c9dc-82cd-4bc2-bd08-bb051b54281b"},"resource":{"type":"instance_private_nic","id":"5df56e4d-0ed3-4270-b00d-58f2b1679072","mac_address":"02:00:00:18:C1:84","name":"scw-test-pool-validat-test-pool-validat-079354"},"tags":[],"reverses":[],"region":"fr-par","zone":null},{"id":"01db5f80-7095-48de-b30b-5791574628d5","address":"172.16.16.3/22","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","is_ipv6":false,"created_at":"2026-04-14T16:03:55.165436Z","updated_at":"2026-04-14T16:03:55.165436Z","source":{"subnet_id":"ce74d09e-a4e9-4b1c-aad0-caf264e1ef61"},"resource":{"type":"instance_private_nic","id":"5df56e4d-0ed3-4270-b00d-58f2b1679072","mac_address":"02:00:00:18:C1:84","name":"scw-test-pool-validat-test-pool-validat-079354"},"tags":[],"reverses":[],"region":"fr-par","zone":null}]}'
+        headers:
+            Content-Length:
+                - "1092"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:04 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - ac6c08d3-d78c-4a07-99ba-1c31f2701632
+        status: 200 OK
+        code: 200
+        duration: 60.377702ms
+    - id: 41
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 41245
+        body: '{"servers": {"BASIC2-A16C-32G": {"alt_names": [], "arch": "arm64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 150.89, "hourly_price": 0.2067, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 503316480, "end_of_service": false}, "BASIC2-A16C-64G": {"alt_names": [], "arch": "arm64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 201.19, "hourly_price": 0.2756, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 503316480, "end_of_service": false}, "BASIC2-A2C-4G": {"alt_names": [], "arch": "arm64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 16.79, "hourly_price": 0.023, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 83886080, "end_of_service": false}, "BASIC2-A2C-8G": {"alt_names": [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 25.19, "hourly_price": 0.0345, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 83886080, "end_of_service": false}, "BASIC2-A4C-16G": {"alt_names": [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 50.3, "hourly_price": 0.0689, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 125829120, "end_of_service": false}, "BASIC2-A4C-8G": {"alt_names": [], "arch": "arm64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 37.74, "hourly_price": 0.0517, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 125829120, "end_of_service": false}, "BASIC2-A8C-16G": {"alt_names": [], "arch": "arm64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 75.48, "hourly_price": 0.1034, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 251658240, "end_of_service": false}, "BASIC2-A8C-32G": {"alt_names": [], "arch": "arm64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 100.59, "hourly_price": 0.1378, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 251658240, "end_of_service": false}, "BASIC3-X16C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 240.9, "hourly_price": 0.33, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]}, "block_bandwidth": 1048576000, "end_of_service": false}, "BASIC3-X16C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 321.2, "hourly_price": 0.44, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]}, "block_bandwidth": 1048576000, "end_of_service": false}, "BASIC3-X2C-4G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 26.791, "hourly_price": 0.0367, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth": 350000000, "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth": 350000000}]}, "block_bandwidth": 131072000, "end_of_service": false}, "BASIC3-X2C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 40.15, "hourly_price": 0.055, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth": 350000000, "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth": 350000000}]}, "block_bandwidth": 131072000, "end_of_service": false}, "BASIC3-X4C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 80.3, "hourly_price": 0.11, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth": 700000000, "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth": 700000000}]}, "block_bandwidth": 262144000, "end_of_service": false}, "BASIC3-X4C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 53.509, "hourly_price": 0.0733, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth": 700000000, "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth": 700000000}]}, "block_bandwidth": 262144000, "end_of_service": false}, "BASIC3-X8C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 120.45, "hourly_price": 0.165, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]}, "block_bandwidth": 524288000, "end_of_service": false}, "BASIC3-X8C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 160.6, "hourly_price": 0.22, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]}, "block_bandwidth": 524288000, "end_of_service": false}, "COMPUTE3-X16C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 320000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 341.786, "hourly_price": 0.4682, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 4000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 4000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "COMPUTE3-X2C-4G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 40000000000, "scratch_storage_max_volumes_count": 1, "monthly_price": 42.705, "hourly_price": 0.0585, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "COMPUTE3-X32C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 640000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 683.499, "hourly_price": 0.9363, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 8000000000, "sum_internet_bandwidth": 8000000000, "interfaces": [{"internal_bandwidth": 8000000000, "internet_bandwidth": 8000000000}]}, "block_bandwidth": 1000341504, "end_of_service": false}, "COMPUTE3-X48C-96G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 103079215104, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 960000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1019.81, "hourly_price": 1.397, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "COMPUTE3-X4C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 80000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 85.41, "hourly_price": 0.117, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "COMPUTE3-X64C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 1280000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1366.998, "hourly_price": 1.8726, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "COMPUTE3-X8C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 160000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 170.893, "hourly_price": 0.2341, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "COMPUTE3-X96C-192G": {"alt_names": [], "arch": "x86_64", "ncpus": 96, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 1280000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 2039.62, "hourly_price": 2.794, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "COPARM1-16C-64G": {"alt_names": [], "arch": "arm64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 252.14, "hourly_price": 0.3454, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 671088640, "end_of_service": false}, "COPARM1-2C-8G": {"alt_names": [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 31.1, "hourly_price": 0.0426, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 83886080, "end_of_service": false}, "COPARM1-32C-128G": {"alt_names": [], "arch": "arm64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 506.26, "hourly_price": 0.6935, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 1342177280, "end_of_service": false}, "COPARM1-4C-16G": {"alt_names": [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 62.56, "hourly_price": 0.0857, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 167772160, "end_of_service": false}, "COPARM1-8C-32G": {"alt_names": [], "arch": "arm64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 125.85, "hourly_price": 0.1724, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 335544320, "end_of_service": false}, "DEV1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 80000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 30.66, "hourly_price": 0.042, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 209715200, "end_of_service": false}, "DEV1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 3, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 40000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 14.454, "hourly_price": 0.0198, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 300000000, "sum_internet_bandwidth": 300000000, "interfaces": [{"internal_bandwidth": 300000000, "internet_bandwidth": 300000000}]}, "block_bandwidth": 157286400, "end_of_service": false}, "DEV1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 20000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 6.424, "hourly_price": 0.0088, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 104857600, "end_of_service": false}, "DEV1-XL": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 12884901888, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 120000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 46.5734, "hourly_price": 0.06378, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 262144000, "end_of_service": false}, "GP1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 554.07, "hourly_price": 0.759, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]}, "block_bandwidth": 1073741824, "end_of_service": false}, "GP1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 274.48, "hourly_price": 0.376, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "GP1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 300000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 136.51, "hourly_price": 0.187, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 524288000, "end_of_service": false}, "GP1-XL": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1197.93, "hourly_price": 1.641, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]}, "block_bandwidth": 2147483648, "end_of_service": false}, "GP1-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 150000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 66.43, "hourly_price": 0.091, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 314572800, "end_of_service": false}, "L4-1-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 51539607552, "gpu": 1, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 547.5, "hourly_price": 0.75, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 2500000000, "sum_internet_bandwidth": 2500000000, "interfaces": [{"internal_bandwidth": 2500000000, "internet_bandwidth": 2500000000}]}, "block_bandwidth": 1048576000, "end_of_service": false}, "L4-2-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 103079215104, "gpu": 2, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1095.0, "hourly_price": 1.5, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]}, "block_bandwidth": 1572864000, "end_of_service": false}, "L4-4-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 206158430208, "gpu": 4, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 2190.0, "hourly_price": 3.0, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]}, "block_bandwidth": 2621440000, "end_of_service": false}, "L4-8-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 412316860416, "gpu": 8, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 4380.0, "hourly_price": 6.0, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 20000000000, "sum_internet_bandwidth": 20000000000, "interfaces": [{"internal_bandwidth": 20000000000, "internet_bandwidth": 20000000000}]}, "block_bandwidth": 5242880000, "end_of_service": false}, "MEMORY3-X16C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 320000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 601.0, "hourly_price": 0.824, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 4000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 4000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "MEMORY3-X2C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 40000000000, "scratch_storage_max_volumes_count": 1, "monthly_price": 75.0, "hourly_price": 0.103, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "MEMORY3-X32C-256G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 640000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 1203.0, "hourly_price": 1.648, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 8000000000, "sum_internet_bandwidth": 8000000000, "interfaces": [{"internal_bandwidth": 8000000000, "internet_bandwidth": 8000000000}]}, "block_bandwidth": 1000341504, "end_of_service": false}, "MEMORY3-X48C-384G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 412316860416, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 960000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1804.0, "hourly_price": 2.472, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "MEMORY3-X4C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 80000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 150.0, "hourly_price": 0.206, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "MEMORY3-X8C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 160000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 300.0, "hourly_price": 0.412, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "PLAY2-MICRO": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 39.42, "hourly_price": 0.054, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 167772160, "end_of_service": false}, "PLAY2-NANO": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 19.71, "hourly_price": 0.027, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 83886080, "end_of_service": false}}}'
+        headers:
+            Content-Length:
+                - "41245"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:04 GMT
+            Link:
+                - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=3&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - de916c8c-1973-426e-875d-902147c85ceb
+            X-Total-Count:
+                - "112"
+        status: 200 OK
+        code: 200
+        duration: 42.561416ms
+    - id: 42
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "2"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 40884
+        body: '{"servers": {"PLAY2-PICO": {"alt_names": [], "arch": "x86_64", "ncpus": 1, "ram": 2147483648, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 10.22, "hourly_price": 0.014, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]}, "block_bandwidth": 41943040, "end_of_service": false}, "POP2-16C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 430.7, "hourly_price": 0.59, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-16C-64G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1063.391, "hourly_price": 1.4567, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-2C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 53.66, "hourly_price": 0.0735, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-2C-8G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 133.079, "hourly_price": 0.1823, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-32C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 861.4, "hourly_price": 1.18, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-32C-128G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 2126.709, "hourly_price": 2.9133, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-48C-192G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1274.4, "hourly_price": 1.77, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-4C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 107.31, "hourly_price": 0.147, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-4C-16G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 265.501, "hourly_price": 0.3637, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-64C-256G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1715.5, "hourly_price": 2.35, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-8C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 211.7, "hourly_price": 0.29, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-8C-32G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 528.009, "hourly_price": 0.7233, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HC-16C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 310.69, "hourly_price": 0.4256, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-HC-2C-4G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 38.84, "hourly_price": 0.0532, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HC-32C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 621.38, "hourly_price": 0.8512, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HC-48C-96G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 103079215104, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 914.4, "hourly_price": 1.27, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HC-4C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 77.67, "hourly_price": 0.1064, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HC-64C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1242.75, "hourly_price": 1.7024, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HC-8C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 155.34, "hourly_price": 0.2128, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HM-16C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 601.52, "hourly_price": 0.824, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-HM-2C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 75.19, "hourly_price": 0.103, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HM-32C-256G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1203.04, "hourly_price": 1.648, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HM-48C-384G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 412316860416, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1778.4, "hourly_price": 2.47, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HM-4C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 150.38, "hourly_price": 0.206, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HM-64C-512G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 549755813888, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 2406.08, "hourly_price": 3.296, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HM-8C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 300.76, "hourly_price": 0.412, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HN-10": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 530.29, "hourly_price": 0.7264, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HN-3": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 186.49, "hourly_price": 0.2554, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HN-5": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 330.29, "hourly_price": 0.4524, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "PRO2-L": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 640.21, "hourly_price": 0.877, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6000000000, "sum_internet_bandwidth": 6000000000, "interfaces": [{"internal_bandwidth": 6000000000, "internet_bandwidth": 6000000000}]}, "block_bandwidth": 2097152000, "end_of_service": false}, "PRO2-M": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 319.74, "hourly_price": 0.438, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]}, "block_bandwidth": 1048576000, "end_of_service": false}, "PRO2-S": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 159.87, "hourly_price": 0.219, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]}, "block_bandwidth": 524288000, "end_of_service": false}, "PRO2-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 80.3, "hourly_price": 0.11, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth": 700000000, "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth": 700000000}]}, "block_bandwidth": 262144000, "end_of_service": false}, "PRO2-XXS": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 40.15, "hourly_price": 0.055, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth": 350000000, "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth": 350000000}]}, "block_bandwidth": 131072000, "end_of_service": false}, "RENDER-S": {"alt_names": [], "arch": "x86_64", "ncpus": 10, "ram": 45097156608, "gpu": 1, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "P100", "gpu_memory": 17179869184}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 400000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 891.33, "hourly_price": 1.221, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 2000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth": 2000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 2147483648, "end_of_service": false}, "STANDARD2-A16C-64G": {"alt_names": [], "arch": "arm64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 367.8324, "hourly_price": 0.5039, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "STANDARD2-A2C-8G": {"alt_names": [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 42.7525, "hourly_price": 0.0586, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "STANDARD2-A32C-128G": {"alt_names": [], "arch": "arm64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 735.7269, "hourly_price": 1.0078, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5033164800, "end_of_service": false}, "STANDARD2-A48C-192G": {"alt_names": [], "arch": "arm64", "ncpus": 48, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1103.5593, "hourly_price": 1.5117, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5033164800, "end_of_service": false}, "STANDARD2-A4C-16G": {"alt_names": [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 85.5049, "hourly_price": 0.1171, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "STANDARD2-A64C-256G": {"alt_names": [], "arch": "arm64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1470.366, "hourly_price": 2.0142, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5033164800, "end_of_service": false}, "STANDARD2-A8C-32G": {"alt_names": [], "arch": "arm64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 171.0098, "hourly_price": 0.2343, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "STANDARD3-X16C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 320000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 430.0, "hourly_price": 0.59, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 4000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 4000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "STANDARD3-X2C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 40000000000, "scratch_storage_max_volumes_count": 1, "monthly_price": 54.0, "hourly_price": 0.074, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "STANDARD3-X32C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 640000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 861.0, "hourly_price": 1.18, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 8000000000, "sum_internet_bandwidth": 8000000000, "interfaces": [{"internal_bandwidth": 8000000000, "internet_bandwidth": 8000000000}]}, "block_bandwidth": 1000341504, "end_of_service": false}, "STANDARD3-X48C-192G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 960000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1292.1, "hourly_price": 1.77, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "STANDARD3-X4C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 80000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 107.0, "hourly_price": 0.147, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "STANDARD3-X64C-256G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 1280000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1715.0, "hourly_price": 2.35, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "STANDARD3-X8C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 160000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 211.0, "hourly_price": 0.29, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}}}'
+        headers:
+            Content-Length:
+                - "40884"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:04 GMT
+            Link:
+                - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>; rel="previous",</products/servers?page=3&per_page=50&>; rel="next",</products/servers?page=3&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - 41f29626-c0bf-4bc2-8dd7-89cb34db75d2
+            X-Total-Count:
+                - "112"
+        status: 200 OK
+        code: 200
+        duration: 41.788089ms
+    - id: 43
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "3"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 10027
+        body: '{"servers": {"STARDUST1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 1, "ram": 1073741824, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 10000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 0.1095, "hourly_price": 0.00015, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]}, "block_bandwidth": 52428800, "end_of_service": false}, "START1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 26.864, "hourly_price": 0.0368, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "START1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 100000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 14.162, "hourly_price": 0.0194, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 300000000, "sum_internet_bandwidth": 300000000, "interfaces": [{"internal_bandwidth": 300000000, "internet_bandwidth": 300000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "START1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 50000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 7.738, "hourly_price": 0.0106, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "START1-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 1, "ram": 1073741824, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 25000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 4.526, "hourly_price": 0.0062, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "VC1L": {"alt_names": ["X64-8GB"], "arch": "x86_64", "ncpus": 6, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 18.0164, "hourly_price": 0.02468, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "VC1M": {"alt_names": ["X64-4GB"], "arch": "x86_64", "ncpus": 4, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 100000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 11.3515, "hourly_price": 0.01555, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "VC1S": {"alt_names": ["X64-2GB"], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 50000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 6.2926, "hourly_price": 0.00862, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "X64-120GB": {"alt_names": [], "arch": "x86_64", "ncpus": 12, "ram": 128849018880, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 800000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 310.7902, "hourly_price": 0.42574, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 1000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "X64-15GB": {"alt_names": [], "arch": "x86_64", "ncpus": 6, "ram": 16106127360, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 44.0336, "hourly_price": 0.06032, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 250000000, "sum_internet_bandwidth": 250000000, "interfaces": [{"internal_bandwidth": 250000000, "internet_bandwidth": 250000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "X64-30GB": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 32212254720, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 400000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 86.9138, "hourly_price": 0.11906, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "X64-60GB": {"alt_names": [], "arch": "x86_64", "ncpus": 10, "ram": 64424509440, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 700000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 155.49, "hourly_price": 0.213, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 1000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 41943040, "end_of_service": true}}}'
+        headers:
+            Content-Length:
+                - "10027"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:04 GMT
+            Link:
+                - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=2&per_page=50&>; rel="previous",</products/servers?page=3&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - 17a1fd7b-924c-4024-b8f3-f170a56ef581
+            X-Total-Count:
+                - "112"
+        status: 200 OK
+        code: 200
+        duration: 50.962496ms
+    - id: 44
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/4c6f2f41-a3ed-438f-b4cf-63be705fee57
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 411
+        body: '{"id":"4c6f2f41-a3ed-438f-b4cf-63be705fee57","name":"tf-vpc-eloquent-margulis","tags":[],"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:01:53.908263Z","updated_at":"2026-04-14T16:01:53.908263Z","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","is_default":false,"private_network_count":1,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "411"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:04 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - ddc1babb-6aec-44ef-96c5-2abb7a23bc0c
+        status: 200 OK
+        code: 200
+        duration: 21.486534ms
+    - id: 45
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/59f194c7-197f-4ca6-84e5-f9c38afbfaed
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1076
+        body: '{"id":"59f194c7-197f-4ca6-84e5-f9c38afbfaed","name":"test-pool-validate-root-volume","tags":[],"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:01:54.065721Z","updated_at":"2026-04-14T16:01:54.065721Z","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnets":[{"id":"ce74d09e-a4e9-4b1c-aad0-caf264e1ef61","created_at":"2026-04-14T16:01:54.065721Z","updated_at":"2026-04-14T16:01:54.065721Z","subnet":"172.16.16.0/22","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"59f194c7-197f-4ca6-84e5-f9c38afbfaed","vpc_id":"4c6f2f41-a3ed-438f-b4cf-63be705fee57"},{"id":"9417c9dc-82cd-4bc2-bd08-bb051b54281b","created_at":"2026-04-14T16:01:54.065721Z","updated_at":"2026-04-14T16:01:54.065721Z","subnet":"fd63:256c:45f7:531d::/64","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"59f194c7-197f-4ca6-84e5-f9c38afbfaed","vpc_id":"4c6f2f41-a3ed-438f-b4cf-63be705fee57"}],"vpc_id":"4c6f2f41-a3ed-438f-b4cf-63be705fee57","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1076"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:04 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - 8f3d69c7-a16e-4114-8f0a-ad9e77f03814
+        status: 200 OK
+        code: 200
+        duration: 31.264088ms
+    - id: 46
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/384a8300-efe2-4ea2-9078-2d89f5ad2383
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1634
+        body: '{"region":"fr-par","id":"384a8300-efe2-4ea2-9078-2d89f5ad2383","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:01:55.214681Z","updated_at":"2026-04-14T16:03:46.070598Z","type":"kapsule","name":"test-pool-validate-root-volume","description":"","status":"ready","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","validate-root-volume"],"cluster_url":"https://384a8300-efe2-4ea2-9078-2d89f5ad2383.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.384a8300-efe2-4ea2-9078-2d89f5ad2383.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":0},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"59f194c7-197f-4ca6-84e5-f9c38afbfaed","commitment_ends_at":"2026-04-14T16:01:55.214686Z","acl_available":true,"iam_nodes_group_id":"1bb74d69-943b-44f2-b20b-dc114787fcea","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1634"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:04 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - 62a4642f-ca03-42af-9552-01f42973983b
+        status: 200 OK
+        code: 200
+        duration: 26.13432ms
+    - id: 47
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/384a8300-efe2-4ea2-9078-2d89f5ad2383/kubeconfig
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1776
+        body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC12YWxpZGF0ZS1yb290LXZvbHVtZSIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVUpYZWtORFFWRkhaMEYzU1VKQlowbENRVVJCUzBKblozRm9hMnBQVUZGUlJFRnFRVlpOVWsxM1JWRlpSRlpSVVVSRmQzQnlaRmRLYkdOdE5Xd0taRWRXZWsxQ05GaEVWRWt5VFVSUmVFMTZSVEpOUkVVeFRsWnZXRVJVVFRKTlJGRjRUWHBGTWsxRVJURk9WbTkzUmxSRlZFMUNSVWRCTVZWRlFYaE5Td3BoTTFacFdsaEtkVnBZVW14amVrSmFUVUpOUjBKNWNVZFRUVFE1UVdkRlIwTkRjVWRUVFRRNVFYZEZTRUV3U1VGQ1JXTnRTa1k0VTNaS2IzVXhSSEJpQ25BeFJFcEVVa000YjJkNU56Wk9ORkpOYkZSNlkxZ3ZUMXBhVVM5UFNHMDNPRmM1ZVd0MGRDOVBaV0Z2YUhwMFJqVjFjekZVZG1SeVRpOWlOa051UW0wS1dVYzFiVkF5UjJwUmFrSkJUVUUwUjBFeFZXUkVkMFZDTDNkUlJVRjNTVU53UkVGUVFtZE9Wa2hTVFVKQlpqaEZRbFJCUkVGUlNDOU5RakJIUVRGVlpBcEVaMUZYUWtKU2NtVlRXbkJyY0ZGTVFXaHJObmROVlcxS1EwcHNjSE4xUWxoRVFVdENaMmR4YUd0cVQxQlJVVVJCWjA1SlFVUkNSa0ZwUlVFck4wUjZDa1JqVTBGWmFtZFdWVzUwYXlzMWRtMVRkemhxSzFNM2JuTkxOVlpaVjBOSlIyRlNZa0V2YzBOSlJrUkpOVFZNTlhkaU9XbDZVbGRWUWpkdFVsbExVRUVLWjB0eVJTdFpiR05yWjNGVFUxVlNabkJTYUdnS0xTMHRMUzFGVGtRZ1EwVlNWRWxHU1VOQlZFVXRMUzB0TFFvPQogICAgc2VydmVyOiBodHRwczovLzM4NGE4MzAwLWVmZTItNGVhMi05MDc4LTJkODlmNWFkMjM4My5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wtdmFsaWRhdGUtcm9vdC12b2x1bWUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC12YWxpZGF0ZS1yb290LXZvbHVtZSIKICAgIHVzZXI6IHRlc3QtcG9vbC12YWxpZGF0ZS1yb290LXZvbHVtZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC12YWxpZGF0ZS1yb290LXZvbHVtZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC12YWxpZGF0ZS1yb290LXZvbHVtZS1hZG1pbgogIHVzZXI6CiAgICB0b2tlbjogWEFPUGprT2luU2JqTTdGNjFjWTdJMFpvanNsa2dNUDdNdFFZZFQwMXhsN2dleEUzSXJDMkNRb3g="}'
+        headers:
+            Content-Length:
+                - "1776"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:04 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - 77c18198-a648-4ef7-b2bb-fe16b805fe1a
+        status: 200 OK
+        code: 200
+        duration: 53.399104ms
+    - id: 48
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/67f68cb0-03f7-4318-9a03-16764323873a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 781
+        body: '{"region":"fr-par","id":"67f68cb0-03f7-4318-9a03-16764323873a","cluster_id":"384a8300-efe2-4ea2-9078-2d89f5ad2383","created_at":"2026-04-14T16:02:00.986391Z","updated_at":"2026-04-14T16:04:58.020478Z","name":"test-pool-validate-root-volume","status":"ready","version":"1.35.3","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","validate-root-volume"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{},"taints":[],"startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "781"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - 7fbe9f6e-dab1-44a2-b78f-f6a8aaf98a78
+        status: 200 OK
+        code: 200
+        duration: 18.953975ms
+    - id: 49
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_asc
+            page:
+                - "1"
+            pool_id:
+                - 67f68cb0-03f7-4318-9a03-16764323873a
+            status:
+                - unknown
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/384a8300-efe2-4ea2-9078-2d89f5ad2383/nodes?order_by=created_at_asc&page=1&pool_id=67f68cb0-03f7-4318-9a03-16764323873a&status=unknown
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 604
+        body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"079354f4-804c-4ac3-9e26-9c05bfb45335","cluster_id":"384a8300-efe2-4ea2-9078-2d89f5ad2383","created_at":"2026-04-14T16:03:52.717593Z","updated_at":"2026-04-14T16:04:58.008311Z","pool_id":"67f68cb0-03f7-4318-9a03-16764323873a","status":"ready","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"name":"scw-test-pool-validat-test-pool-validat-079354","public_ip_v4":"212.47.254.177","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/011d187e-15fe-4df9-bead-febdb7a0fd20","error_message":""}]}'
+        headers:
+            Content-Length:
+                - "604"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - 24e8bd50-ca4d-45c1-b2e3-61316961af4d
+        status: 200 OK
+        code: 200
+        duration: 24.614447ms
+    - id: 50
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/384a8300-efe2-4ea2-9078-2d89f5ad2383
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1634
+        body: '{"region":"fr-par","id":"384a8300-efe2-4ea2-9078-2d89f5ad2383","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:01:55.214681Z","updated_at":"2026-04-14T16:03:46.070598Z","type":"kapsule","name":"test-pool-validate-root-volume","description":"","status":"ready","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","validate-root-volume"],"cluster_url":"https://384a8300-efe2-4ea2-9078-2d89f5ad2383.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.384a8300-efe2-4ea2-9078-2d89f5ad2383.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":0},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"59f194c7-197f-4ca6-84e5-f9c38afbfaed","commitment_ends_at":"2026-04-14T16:01:55.214686Z","acl_available":true,"iam_nodes_group_id":"1bb74d69-943b-44f2-b20b-dc114787fcea","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1634"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - 51d30507-14eb-4ef9-be65-abce71f9582f
+        status: 200 OK
+        code: 200
+        duration: 24.397841ms
+    - id: 51
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_desc
+            project_id:
+                - fa1e3217-dc80-42ac-85c3-3f034b78b552
+            resource_name:
+                - scw-test-pool-validat-test-pool-validat-079354
+            resource_type:
+                - unknown_type
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=fa1e3217-dc80-42ac-85c3-3f034b78b552&resource_name=scw-test-pool-validat-test-pool-validat-079354&resource_type=unknown_type
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1092
+        body: '{"total_count":2,"ips":[{"id":"4a7b0a65-b64a-4153-8c40-2b272d27848e","address":"fd63:256c:45f7:531d:ff86:f246:b0d2:7029/64","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","is_ipv6":true,"created_at":"2026-04-14T16:03:55.261366Z","updated_at":"2026-04-14T16:03:55.261366Z","source":{"subnet_id":"9417c9dc-82cd-4bc2-bd08-bb051b54281b"},"resource":{"type":"instance_private_nic","id":"5df56e4d-0ed3-4270-b00d-58f2b1679072","mac_address":"02:00:00:18:C1:84","name":"scw-test-pool-validat-test-pool-validat-079354"},"tags":[],"reverses":[],"region":"fr-par","zone":null},{"id":"01db5f80-7095-48de-b30b-5791574628d5","address":"172.16.16.3/22","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","is_ipv6":false,"created_at":"2026-04-14T16:03:55.165436Z","updated_at":"2026-04-14T16:03:55.165436Z","source":{"subnet_id":"ce74d09e-a4e9-4b1c-aad0-caf264e1ef61"},"resource":{"type":"instance_private_nic","id":"5df56e4d-0ed3-4270-b00d-58f2b1679072","mac_address":"02:00:00:18:C1:84","name":"scw-test-pool-validat-test-pool-validat-079354"},"tags":[],"reverses":[],"region":"fr-par","zone":null}]}'
+        headers:
+            Content-Length:
+                - "1092"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - 4f033d93-542b-4e91-9ae2-c6248228bc0c
+        status: 200 OK
+        code: 200
+        duration: 33.58958ms
+    - id: 52
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 41245
+        body: '{"servers": {"BASIC2-A16C-32G": {"alt_names": [], "arch": "arm64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 150.89, "hourly_price": 0.2067, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 503316480, "end_of_service": false}, "BASIC2-A16C-64G": {"alt_names": [], "arch": "arm64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 201.19, "hourly_price": 0.2756, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 503316480, "end_of_service": false}, "BASIC2-A2C-4G": {"alt_names": [], "arch": "arm64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 16.79, "hourly_price": 0.023, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 83886080, "end_of_service": false}, "BASIC2-A2C-8G": {"alt_names": [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 25.19, "hourly_price": 0.0345, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 83886080, "end_of_service": false}, "BASIC2-A4C-16G": {"alt_names": [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 50.3, "hourly_price": 0.0689, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 125829120, "end_of_service": false}, "BASIC2-A4C-8G": {"alt_names": [], "arch": "arm64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 37.74, "hourly_price": 0.0517, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 125829120, "end_of_service": false}, "BASIC2-A8C-16G": {"alt_names": [], "arch": "arm64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 75.48, "hourly_price": 0.1034, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 251658240, "end_of_service": false}, "BASIC2-A8C-32G": {"alt_names": [], "arch": "arm64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 100.59, "hourly_price": 0.1378, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 251658240, "end_of_service": false}, "BASIC3-X16C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 240.9, "hourly_price": 0.33, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]}, "block_bandwidth": 1048576000, "end_of_service": false}, "BASIC3-X16C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 321.2, "hourly_price": 0.44, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]}, "block_bandwidth": 1048576000, "end_of_service": false}, "BASIC3-X2C-4G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 26.791, "hourly_price": 0.0367, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth": 350000000, "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth": 350000000}]}, "block_bandwidth": 131072000, "end_of_service": false}, "BASIC3-X2C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 40.15, "hourly_price": 0.055, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth": 350000000, "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth": 350000000}]}, "block_bandwidth": 131072000, "end_of_service": false}, "BASIC3-X4C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 80.3, "hourly_price": 0.11, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth": 700000000, "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth": 700000000}]}, "block_bandwidth": 262144000, "end_of_service": false}, "BASIC3-X4C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 53.509, "hourly_price": 0.0733, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth": 700000000, "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth": 700000000}]}, "block_bandwidth": 262144000, "end_of_service": false}, "BASIC3-X8C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 120.45, "hourly_price": 0.165, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]}, "block_bandwidth": 524288000, "end_of_service": false}, "BASIC3-X8C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 160.6, "hourly_price": 0.22, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]}, "block_bandwidth": 524288000, "end_of_service": false}, "COMPUTE3-X16C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 320000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 341.786, "hourly_price": 0.4682, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 4000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 4000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "COMPUTE3-X2C-4G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 40000000000, "scratch_storage_max_volumes_count": 1, "monthly_price": 42.705, "hourly_price": 0.0585, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "COMPUTE3-X32C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 640000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 683.499, "hourly_price": 0.9363, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 8000000000, "sum_internet_bandwidth": 8000000000, "interfaces": [{"internal_bandwidth": 8000000000, "internet_bandwidth": 8000000000}]}, "block_bandwidth": 1000341504, "end_of_service": false}, "COMPUTE3-X48C-96G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 103079215104, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 960000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1019.81, "hourly_price": 1.397, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "COMPUTE3-X4C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 80000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 85.41, "hourly_price": 0.117, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "COMPUTE3-X64C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 1280000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1366.998, "hourly_price": 1.8726, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "COMPUTE3-X8C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 160000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 170.893, "hourly_price": 0.2341, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "COMPUTE3-X96C-192G": {"alt_names": [], "arch": "x86_64", "ncpus": 96, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 1280000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 2039.62, "hourly_price": 2.794, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "COPARM1-16C-64G": {"alt_names": [], "arch": "arm64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 252.14, "hourly_price": 0.3454, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 671088640, "end_of_service": false}, "COPARM1-2C-8G": {"alt_names": [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 31.1, "hourly_price": 0.0426, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 83886080, "end_of_service": false}, "COPARM1-32C-128G": {"alt_names": [], "arch": "arm64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 506.26, "hourly_price": 0.6935, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 1342177280, "end_of_service": false}, "COPARM1-4C-16G": {"alt_names": [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 62.56, "hourly_price": 0.0857, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 167772160, "end_of_service": false}, "COPARM1-8C-32G": {"alt_names": [], "arch": "arm64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 125.85, "hourly_price": 0.1724, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 335544320, "end_of_service": false}, "DEV1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 80000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 30.66, "hourly_price": 0.042, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 209715200, "end_of_service": false}, "DEV1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 3, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 40000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 14.454, "hourly_price": 0.0198, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 300000000, "sum_internet_bandwidth": 300000000, "interfaces": [{"internal_bandwidth": 300000000, "internet_bandwidth": 300000000}]}, "block_bandwidth": 157286400, "end_of_service": false}, "DEV1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 20000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 6.424, "hourly_price": 0.0088, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 104857600, "end_of_service": false}, "DEV1-XL": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 12884901888, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 120000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 46.5734, "hourly_price": 0.06378, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 262144000, "end_of_service": false}, "GP1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 554.07, "hourly_price": 0.759, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]}, "block_bandwidth": 1073741824, "end_of_service": false}, "GP1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 274.48, "hourly_price": 0.376, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "GP1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 300000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 136.51, "hourly_price": 0.187, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 524288000, "end_of_service": false}, "GP1-XL": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1197.93, "hourly_price": 1.641, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]}, "block_bandwidth": 2147483648, "end_of_service": false}, "GP1-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 150000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 66.43, "hourly_price": 0.091, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 314572800, "end_of_service": false}, "L4-1-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 51539607552, "gpu": 1, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 547.5, "hourly_price": 0.75, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 2500000000, "sum_internet_bandwidth": 2500000000, "interfaces": [{"internal_bandwidth": 2500000000, "internet_bandwidth": 2500000000}]}, "block_bandwidth": 1048576000, "end_of_service": false}, "L4-2-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 103079215104, "gpu": 2, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1095.0, "hourly_price": 1.5, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]}, "block_bandwidth": 1572864000, "end_of_service": false}, "L4-4-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 206158430208, "gpu": 4, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 2190.0, "hourly_price": 3.0, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]}, "block_bandwidth": 2621440000, "end_of_service": false}, "L4-8-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 412316860416, "gpu": 8, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 4380.0, "hourly_price": 6.0, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 20000000000, "sum_internet_bandwidth": 20000000000, "interfaces": [{"internal_bandwidth": 20000000000, "internet_bandwidth": 20000000000}]}, "block_bandwidth": 5242880000, "end_of_service": false}, "MEMORY3-X16C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 320000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 601.0, "hourly_price": 0.824, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 4000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 4000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "MEMORY3-X2C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 40000000000, "scratch_storage_max_volumes_count": 1, "monthly_price": 75.0, "hourly_price": 0.103, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "MEMORY3-X32C-256G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 640000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 1203.0, "hourly_price": 1.648, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 8000000000, "sum_internet_bandwidth": 8000000000, "interfaces": [{"internal_bandwidth": 8000000000, "internet_bandwidth": 8000000000}]}, "block_bandwidth": 1000341504, "end_of_service": false}, "MEMORY3-X48C-384G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 412316860416, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 960000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1804.0, "hourly_price": 2.472, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "MEMORY3-X4C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 80000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 150.0, "hourly_price": 0.206, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "MEMORY3-X8C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 160000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 300.0, "hourly_price": 0.412, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "PLAY2-MICRO": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 39.42, "hourly_price": 0.054, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 167772160, "end_of_service": false}, "PLAY2-NANO": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 19.71, "hourly_price": 0.027, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 83886080, "end_of_service": false}}}'
+        headers:
+            Content-Length:
+                - "41245"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:05 GMT
+            Link:
+                - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=3&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - 0cd3785b-bf1c-48ea-9280-3b5c3c08750d
+            X-Total-Count:
+                - "112"
+        status: 200 OK
+        code: 200
+        duration: 39.870291ms
+    - id: 53
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "2"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 40884
+        body: '{"servers": {"PLAY2-PICO": {"alt_names": [], "arch": "x86_64", "ncpus": 1, "ram": 2147483648, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 10.22, "hourly_price": 0.014, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]}, "block_bandwidth": 41943040, "end_of_service": false}, "POP2-16C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 430.7, "hourly_price": 0.59, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-16C-64G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1063.391, "hourly_price": 1.4567, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-2C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 53.66, "hourly_price": 0.0735, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-2C-8G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 133.079, "hourly_price": 0.1823, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-32C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 861.4, "hourly_price": 1.18, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-32C-128G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 2126.709, "hourly_price": 2.9133, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-48C-192G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1274.4, "hourly_price": 1.77, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-4C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 107.31, "hourly_price": 0.147, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-4C-16G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 265.501, "hourly_price": 0.3637, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-64C-256G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1715.5, "hourly_price": 2.35, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-8C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 211.7, "hourly_price": 0.29, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-8C-32G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 528.009, "hourly_price": 0.7233, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HC-16C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 310.69, "hourly_price": 0.4256, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-HC-2C-4G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 38.84, "hourly_price": 0.0532, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HC-32C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 621.38, "hourly_price": 0.8512, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HC-48C-96G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 103079215104, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 914.4, "hourly_price": 1.27, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HC-4C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 77.67, "hourly_price": 0.1064, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HC-64C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1242.75, "hourly_price": 1.7024, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HC-8C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 155.34, "hourly_price": 0.2128, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HM-16C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 601.52, "hourly_price": 0.824, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-HM-2C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 75.19, "hourly_price": 0.103, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HM-32C-256G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1203.04, "hourly_price": 1.648, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HM-48C-384G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 412316860416, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1778.4, "hourly_price": 2.47, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HM-4C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 150.38, "hourly_price": 0.206, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HM-64C-512G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 549755813888, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 2406.08, "hourly_price": 3.296, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HM-8C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 300.76, "hourly_price": 0.412, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HN-10": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 530.29, "hourly_price": 0.7264, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HN-3": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 186.49, "hourly_price": 0.2554, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HN-5": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 330.29, "hourly_price": 0.4524, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "PRO2-L": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 640.21, "hourly_price": 0.877, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6000000000, "sum_internet_bandwidth": 6000000000, "interfaces": [{"internal_bandwidth": 6000000000, "internet_bandwidth": 6000000000}]}, "block_bandwidth": 2097152000, "end_of_service": false}, "PRO2-M": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 319.74, "hourly_price": 0.438, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]}, "block_bandwidth": 1048576000, "end_of_service": false}, "PRO2-S": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 159.87, "hourly_price": 0.219, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]}, "block_bandwidth": 524288000, "end_of_service": false}, "PRO2-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 80.3, "hourly_price": 0.11, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth": 700000000, "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth": 700000000}]}, "block_bandwidth": 262144000, "end_of_service": false}, "PRO2-XXS": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 40.15, "hourly_price": 0.055, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth": 350000000, "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth": 350000000}]}, "block_bandwidth": 131072000, "end_of_service": false}, "RENDER-S": {"alt_names": [], "arch": "x86_64", "ncpus": 10, "ram": 45097156608, "gpu": 1, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "P100", "gpu_memory": 17179869184}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 400000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 891.33, "hourly_price": 1.221, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 2000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth": 2000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 2147483648, "end_of_service": false}, "STANDARD2-A16C-64G": {"alt_names": [], "arch": "arm64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 367.8324, "hourly_price": 0.5039, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "STANDARD2-A2C-8G": {"alt_names": [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 42.7525, "hourly_price": 0.0586, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "STANDARD2-A32C-128G": {"alt_names": [], "arch": "arm64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 735.7269, "hourly_price": 1.0078, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5033164800, "end_of_service": false}, "STANDARD2-A48C-192G": {"alt_names": [], "arch": "arm64", "ncpus": 48, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1103.5593, "hourly_price": 1.5117, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5033164800, "end_of_service": false}, "STANDARD2-A4C-16G": {"alt_names": [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 85.5049, "hourly_price": 0.1171, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "STANDARD2-A64C-256G": {"alt_names": [], "arch": "arm64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1470.366, "hourly_price": 2.0142, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5033164800, "end_of_service": false}, "STANDARD2-A8C-32G": {"alt_names": [], "arch": "arm64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 171.0098, "hourly_price": 0.2343, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "STANDARD3-X16C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 320000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 430.0, "hourly_price": 0.59, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 4000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 4000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "STANDARD3-X2C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 40000000000, "scratch_storage_max_volumes_count": 1, "monthly_price": 54.0, "hourly_price": 0.074, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "STANDARD3-X32C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 640000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 861.0, "hourly_price": 1.18, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 8000000000, "sum_internet_bandwidth": 8000000000, "interfaces": [{"internal_bandwidth": 8000000000, "internet_bandwidth": 8000000000}]}, "block_bandwidth": 1000341504, "end_of_service": false}, "STANDARD3-X48C-192G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 960000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1292.1, "hourly_price": 1.77, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "STANDARD3-X4C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 80000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 107.0, "hourly_price": 0.147, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "STANDARD3-X64C-256G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 1280000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1715.0, "hourly_price": 2.35, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "STANDARD3-X8C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 160000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 211.0, "hourly_price": 0.29, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}}}'
+        headers:
+            Content-Length:
+                - "40884"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:05 GMT
+            Link:
+                - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>; rel="previous",</products/servers?page=3&per_page=50&>; rel="next",</products/servers?page=3&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - e31365c9-72d7-4d1d-b32a-782890b61310
+            X-Total-Count:
+                - "112"
+        status: 200 OK
+        code: 200
+        duration: 41.14183ms
+    - id: 54
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "3"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 10027
+        body: '{"servers": {"STARDUST1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 1, "ram": 1073741824, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 10000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 0.1095, "hourly_price": 0.00015, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]}, "block_bandwidth": 52428800, "end_of_service": false}, "START1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 26.864, "hourly_price": 0.0368, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "START1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 100000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 14.162, "hourly_price": 0.0194, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 300000000, "sum_internet_bandwidth": 300000000, "interfaces": [{"internal_bandwidth": 300000000, "internet_bandwidth": 300000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "START1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 50000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 7.738, "hourly_price": 0.0106, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "START1-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 1, "ram": 1073741824, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 25000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 4.526, "hourly_price": 0.0062, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "VC1L": {"alt_names": ["X64-8GB"], "arch": "x86_64", "ncpus": 6, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 18.0164, "hourly_price": 0.02468, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "VC1M": {"alt_names": ["X64-4GB"], "arch": "x86_64", "ncpus": 4, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 100000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 11.3515, "hourly_price": 0.01555, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "VC1S": {"alt_names": ["X64-2GB"], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 50000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 6.2926, "hourly_price": 0.00862, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "X64-120GB": {"alt_names": [], "arch": "x86_64", "ncpus": 12, "ram": 128849018880, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 800000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 310.7902, "hourly_price": 0.42574, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 1000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "X64-15GB": {"alt_names": [], "arch": "x86_64", "ncpus": 6, "ram": 16106127360, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 44.0336, "hourly_price": 0.06032, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 250000000, "sum_internet_bandwidth": 250000000, "interfaces": [{"internal_bandwidth": 250000000, "internet_bandwidth": 250000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "X64-30GB": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 32212254720, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 400000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 86.9138, "hourly_price": 0.11906, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "X64-60GB": {"alt_names": [], "arch": "x86_64", "ncpus": 10, "ram": 64424509440, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 700000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 155.49, "hourly_price": 0.213, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 1000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 41943040, "end_of_service": true}}}'
+        headers:
+            Content-Length:
+                - "10027"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:05 GMT
+            Link:
+                - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=2&per_page=50&>; rel="previous",</products/servers?page=3&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - 3e482baa-58cb-4752-9f09-f7f89a9e0a90
+            X-Total-Count:
+                - "112"
+        status: 200 OK
+        code: 200
+        duration: 38.523932ms
+    - id: 55
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/4c6f2f41-a3ed-438f-b4cf-63be705fee57
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 411
+        body: '{"id":"4c6f2f41-a3ed-438f-b4cf-63be705fee57","name":"tf-vpc-eloquent-margulis","tags":[],"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:01:53.908263Z","updated_at":"2026-04-14T16:01:53.908263Z","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","is_default":false,"private_network_count":1,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "411"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - c245b29f-545a-462c-8977-844ae01d610d
+        status: 200 OK
+        code: 200
+        duration: 21.727634ms
+    - id: 56
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/59f194c7-197f-4ca6-84e5-f9c38afbfaed
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1076
+        body: '{"id":"59f194c7-197f-4ca6-84e5-f9c38afbfaed","name":"test-pool-validate-root-volume","tags":[],"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:01:54.065721Z","updated_at":"2026-04-14T16:01:54.065721Z","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnets":[{"id":"ce74d09e-a4e9-4b1c-aad0-caf264e1ef61","created_at":"2026-04-14T16:01:54.065721Z","updated_at":"2026-04-14T16:01:54.065721Z","subnet":"172.16.16.0/22","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"59f194c7-197f-4ca6-84e5-f9c38afbfaed","vpc_id":"4c6f2f41-a3ed-438f-b4cf-63be705fee57"},{"id":"9417c9dc-82cd-4bc2-bd08-bb051b54281b","created_at":"2026-04-14T16:01:54.065721Z","updated_at":"2026-04-14T16:01:54.065721Z","subnet":"fd63:256c:45f7:531d::/64","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"59f194c7-197f-4ca6-84e5-f9c38afbfaed","vpc_id":"4c6f2f41-a3ed-438f-b4cf-63be705fee57"}],"vpc_id":"4c6f2f41-a3ed-438f-b4cf-63be705fee57","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1076"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - 4b2b794c-e950-446d-818d-983b412af930
+        status: 200 OK
+        code: 200
+        duration: 27.783346ms
+    - id: 57
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/384a8300-efe2-4ea2-9078-2d89f5ad2383
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1634
+        body: '{"region":"fr-par","id":"384a8300-efe2-4ea2-9078-2d89f5ad2383","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:01:55.214681Z","updated_at":"2026-04-14T16:03:46.070598Z","type":"kapsule","name":"test-pool-validate-root-volume","description":"","status":"ready","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","validate-root-volume"],"cluster_url":"https://384a8300-efe2-4ea2-9078-2d89f5ad2383.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.384a8300-efe2-4ea2-9078-2d89f5ad2383.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":0},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"59f194c7-197f-4ca6-84e5-f9c38afbfaed","commitment_ends_at":"2026-04-14T16:01:55.214686Z","acl_available":true,"iam_nodes_group_id":"1bb74d69-943b-44f2-b20b-dc114787fcea","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1634"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - b202ef76-d6e0-4c8c-ae59-94d81ceda6c7
+        status: 200 OK
+        code: 200
+        duration: 49.606068ms
+    - id: 58
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/384a8300-efe2-4ea2-9078-2d89f5ad2383/kubeconfig
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1776
+        body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC12YWxpZGF0ZS1yb290LXZvbHVtZSIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVUpYZWtORFFWRkhaMEYzU1VKQlowbENRVVJCUzBKblozRm9hMnBQVUZGUlJFRnFRVlpOVWsxM1JWRlpSRlpSVVVSRmQzQnlaRmRLYkdOdE5Xd0taRWRXZWsxQ05GaEVWRWt5VFVSUmVFMTZSVEpOUkVVeFRsWnZXRVJVVFRKTlJGRjRUWHBGTWsxRVJURk9WbTkzUmxSRlZFMUNSVWRCTVZWRlFYaE5Td3BoTTFacFdsaEtkVnBZVW14amVrSmFUVUpOUjBKNWNVZFRUVFE1UVdkRlIwTkRjVWRUVFRRNVFYZEZTRUV3U1VGQ1JXTnRTa1k0VTNaS2IzVXhSSEJpQ25BeFJFcEVVa000YjJkNU56Wk9ORkpOYkZSNlkxZ3ZUMXBhVVM5UFNHMDNPRmM1ZVd0MGRDOVBaV0Z2YUhwMFJqVjFjekZVZG1SeVRpOWlOa051UW0wS1dVYzFiVkF5UjJwUmFrSkJUVUUwUjBFeFZXUkVkMFZDTDNkUlJVRjNTVU53UkVGUVFtZE9Wa2hTVFVKQlpqaEZRbFJCUkVGUlNDOU5RakJIUVRGVlpBcEVaMUZYUWtKU2NtVlRXbkJyY0ZGTVFXaHJObmROVlcxS1EwcHNjSE4xUWxoRVFVdENaMmR4YUd0cVQxQlJVVVJCWjA1SlFVUkNSa0ZwUlVFck4wUjZDa1JqVTBGWmFtZFdWVzUwYXlzMWRtMVRkemhxSzFNM2JuTkxOVlpaVjBOSlIyRlNZa0V2YzBOSlJrUkpOVFZNTlhkaU9XbDZVbGRWUWpkdFVsbExVRUVLWjB0eVJTdFpiR05yWjNGVFUxVlNabkJTYUdnS0xTMHRMUzFGVGtRZ1EwVlNWRWxHU1VOQlZFVXRMUzB0TFFvPQogICAgc2VydmVyOiBodHRwczovLzM4NGE4MzAwLWVmZTItNGVhMi05MDc4LTJkODlmNWFkMjM4My5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wtdmFsaWRhdGUtcm9vdC12b2x1bWUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC12YWxpZGF0ZS1yb290LXZvbHVtZSIKICAgIHVzZXI6IHRlc3QtcG9vbC12YWxpZGF0ZS1yb290LXZvbHVtZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC12YWxpZGF0ZS1yb290LXZvbHVtZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC12YWxpZGF0ZS1yb290LXZvbHVtZS1hZG1pbgogIHVzZXI6CiAgICB0b2tlbjogWEFPUGprT2luU2JqTTdGNjFjWTdJMFpvanNsa2dNUDdNdFFZZFQwMXhsN2dleEUzSXJDMkNRb3g="}'
+        headers:
+            Content-Length:
+                - "1776"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - dac61f1c-f0dd-407b-9ed7-ad7712dd3ed2
+        status: 200 OK
+        code: 200
+        duration: 31.006006ms
+    - id: 59
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/67f68cb0-03f7-4318-9a03-16764323873a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 781
+        body: '{"region":"fr-par","id":"67f68cb0-03f7-4318-9a03-16764323873a","cluster_id":"384a8300-efe2-4ea2-9078-2d89f5ad2383","created_at":"2026-04-14T16:02:00.986391Z","updated_at":"2026-04-14T16:04:58.020478Z","name":"test-pool-validate-root-volume","status":"ready","version":"1.35.3","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","validate-root-volume"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{},"taints":[],"startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "781"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - 8f4d3792-d1d3-468a-a34f-c5e70afb0f58
+        status: 200 OK
+        code: 200
+        duration: 20.508343ms
+    - id: 60
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_asc
+            page:
+                - "1"
+            pool_id:
+                - 67f68cb0-03f7-4318-9a03-16764323873a
+            status:
+                - unknown
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/384a8300-efe2-4ea2-9078-2d89f5ad2383/nodes?order_by=created_at_asc&page=1&pool_id=67f68cb0-03f7-4318-9a03-16764323873a&status=unknown
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 604
+        body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"079354f4-804c-4ac3-9e26-9c05bfb45335","cluster_id":"384a8300-efe2-4ea2-9078-2d89f5ad2383","created_at":"2026-04-14T16:03:52.717593Z","updated_at":"2026-04-14T16:04:58.008311Z","pool_id":"67f68cb0-03f7-4318-9a03-16764323873a","status":"ready","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"name":"scw-test-pool-validat-test-pool-validat-079354","public_ip_v4":"212.47.254.177","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/011d187e-15fe-4df9-bead-febdb7a0fd20","error_message":""}]}'
+        headers:
+            Content-Length:
+                - "604"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - ce3c6824-f3e5-486b-8fd7-d91acb1f1b8d
+        status: 200 OK
+        code: 200
+        duration: 23.355711ms
+    - id: 61
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/384a8300-efe2-4ea2-9078-2d89f5ad2383
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1634
+        body: '{"region":"fr-par","id":"384a8300-efe2-4ea2-9078-2d89f5ad2383","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:01:55.214681Z","updated_at":"2026-04-14T16:03:46.070598Z","type":"kapsule","name":"test-pool-validate-root-volume","description":"","status":"ready","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","validate-root-volume"],"cluster_url":"https://384a8300-efe2-4ea2-9078-2d89f5ad2383.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.384a8300-efe2-4ea2-9078-2d89f5ad2383.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":0},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"59f194c7-197f-4ca6-84e5-f9c38afbfaed","commitment_ends_at":"2026-04-14T16:01:55.214686Z","acl_available":true,"iam_nodes_group_id":"1bb74d69-943b-44f2-b20b-dc114787fcea","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1634"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - f720ffc0-ed14-4f16-935f-7fd9062bd142
+        status: 200 OK
+        code: 200
+        duration: 25.800536ms
+    - id: 62
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_desc
+            project_id:
+                - fa1e3217-dc80-42ac-85c3-3f034b78b552
+            resource_name:
+                - scw-test-pool-validat-test-pool-validat-079354
+            resource_type:
+                - unknown_type
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=fa1e3217-dc80-42ac-85c3-3f034b78b552&resource_name=scw-test-pool-validat-test-pool-validat-079354&resource_type=unknown_type
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1092
+        body: '{"total_count":2,"ips":[{"id":"4a7b0a65-b64a-4153-8c40-2b272d27848e","address":"fd63:256c:45f7:531d:ff86:f246:b0d2:7029/64","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","is_ipv6":true,"created_at":"2026-04-14T16:03:55.261366Z","updated_at":"2026-04-14T16:03:55.261366Z","source":{"subnet_id":"9417c9dc-82cd-4bc2-bd08-bb051b54281b"},"resource":{"type":"instance_private_nic","id":"5df56e4d-0ed3-4270-b00d-58f2b1679072","mac_address":"02:00:00:18:C1:84","name":"scw-test-pool-validat-test-pool-validat-079354"},"tags":[],"reverses":[],"region":"fr-par","zone":null},{"id":"01db5f80-7095-48de-b30b-5791574628d5","address":"172.16.16.3/22","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","is_ipv6":false,"created_at":"2026-04-14T16:03:55.165436Z","updated_at":"2026-04-14T16:03:55.165436Z","source":{"subnet_id":"ce74d09e-a4e9-4b1c-aad0-caf264e1ef61"},"resource":{"type":"instance_private_nic","id":"5df56e4d-0ed3-4270-b00d-58f2b1679072","mac_address":"02:00:00:18:C1:84","name":"scw-test-pool-validat-test-pool-validat-079354"},"tags":[],"reverses":[],"region":"fr-par","zone":null}]}'
+        headers:
+            Content-Length:
+                - "1092"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - 39c99fda-f8a8-476e-8b6b-c04d2ad11383
+        status: 200 OK
+        code: 200
+        duration: 31.39863ms
+    - id: 63
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 41245
+        body: '{"servers": {"BASIC2-A16C-32G": {"alt_names": [], "arch": "arm64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 150.89, "hourly_price": 0.2067, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 503316480, "end_of_service": false}, "BASIC2-A16C-64G": {"alt_names": [], "arch": "arm64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 201.19, "hourly_price": 0.2756, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 503316480, "end_of_service": false}, "BASIC2-A2C-4G": {"alt_names": [], "arch": "arm64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 16.79, "hourly_price": 0.023, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 83886080, "end_of_service": false}, "BASIC2-A2C-8G": {"alt_names": [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 25.19, "hourly_price": 0.0345, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 83886080, "end_of_service": false}, "BASIC2-A4C-16G": {"alt_names": [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 50.3, "hourly_price": 0.0689, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 125829120, "end_of_service": false}, "BASIC2-A4C-8G": {"alt_names": [], "arch": "arm64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 37.74, "hourly_price": 0.0517, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 125829120, "end_of_service": false}, "BASIC2-A8C-16G": {"alt_names": [], "arch": "arm64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 75.48, "hourly_price": 0.1034, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 251658240, "end_of_service": false}, "BASIC2-A8C-32G": {"alt_names": [], "arch": "arm64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 100.59, "hourly_price": 0.1378, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 251658240, "end_of_service": false}, "BASIC3-X16C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 240.9, "hourly_price": 0.33, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]}, "block_bandwidth": 1048576000, "end_of_service": false}, "BASIC3-X16C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 321.2, "hourly_price": 0.44, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]}, "block_bandwidth": 1048576000, "end_of_service": false}, "BASIC3-X2C-4G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 26.791, "hourly_price": 0.0367, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth": 350000000, "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth": 350000000}]}, "block_bandwidth": 131072000, "end_of_service": false}, "BASIC3-X2C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 40.15, "hourly_price": 0.055, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth": 350000000, "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth": 350000000}]}, "block_bandwidth": 131072000, "end_of_service": false}, "BASIC3-X4C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 80.3, "hourly_price": 0.11, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth": 700000000, "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth": 700000000}]}, "block_bandwidth": 262144000, "end_of_service": false}, "BASIC3-X4C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 53.509, "hourly_price": 0.0733, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth": 700000000, "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth": 700000000}]}, "block_bandwidth": 262144000, "end_of_service": false}, "BASIC3-X8C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 120.45, "hourly_price": 0.165, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]}, "block_bandwidth": 524288000, "end_of_service": false}, "BASIC3-X8C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 160.6, "hourly_price": 0.22, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]}, "block_bandwidth": 524288000, "end_of_service": false}, "COMPUTE3-X16C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 320000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 341.786, "hourly_price": 0.4682, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 4000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 4000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "COMPUTE3-X2C-4G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 40000000000, "scratch_storage_max_volumes_count": 1, "monthly_price": 42.705, "hourly_price": 0.0585, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "COMPUTE3-X32C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 640000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 683.499, "hourly_price": 0.9363, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 8000000000, "sum_internet_bandwidth": 8000000000, "interfaces": [{"internal_bandwidth": 8000000000, "internet_bandwidth": 8000000000}]}, "block_bandwidth": 1000341504, "end_of_service": false}, "COMPUTE3-X48C-96G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 103079215104, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 960000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1019.81, "hourly_price": 1.397, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "COMPUTE3-X4C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 80000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 85.41, "hourly_price": 0.117, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "COMPUTE3-X64C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 1280000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1366.998, "hourly_price": 1.8726, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "COMPUTE3-X8C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 160000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 170.893, "hourly_price": 0.2341, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "COMPUTE3-X96C-192G": {"alt_names": [], "arch": "x86_64", "ncpus": 96, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 1280000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 2039.62, "hourly_price": 2.794, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "COPARM1-16C-64G": {"alt_names": [], "arch": "arm64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 252.14, "hourly_price": 0.3454, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 671088640, "end_of_service": false}, "COPARM1-2C-8G": {"alt_names": [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 31.1, "hourly_price": 0.0426, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 83886080, "end_of_service": false}, "COPARM1-32C-128G": {"alt_names": [], "arch": "arm64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 506.26, "hourly_price": 0.6935, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 1342177280, "end_of_service": false}, "COPARM1-4C-16G": {"alt_names": [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 62.56, "hourly_price": 0.0857, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 167772160, "end_of_service": false}, "COPARM1-8C-32G": {"alt_names": [], "arch": "arm64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 125.85, "hourly_price": 0.1724, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 335544320, "end_of_service": false}, "DEV1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 80000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 30.66, "hourly_price": 0.042, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 209715200, "end_of_service": false}, "DEV1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 3, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 40000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 14.454, "hourly_price": 0.0198, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 300000000, "sum_internet_bandwidth": 300000000, "interfaces": [{"internal_bandwidth": 300000000, "internet_bandwidth": 300000000}]}, "block_bandwidth": 157286400, "end_of_service": false}, "DEV1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 20000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 6.424, "hourly_price": 0.0088, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 104857600, "end_of_service": false}, "DEV1-XL": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 12884901888, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 120000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 46.5734, "hourly_price": 0.06378, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 262144000, "end_of_service": false}, "GP1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 554.07, "hourly_price": 0.759, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]}, "block_bandwidth": 1073741824, "end_of_service": false}, "GP1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 274.48, "hourly_price": 0.376, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "GP1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 300000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 136.51, "hourly_price": 0.187, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 524288000, "end_of_service": false}, "GP1-XL": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1197.93, "hourly_price": 1.641, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]}, "block_bandwidth": 2147483648, "end_of_service": false}, "GP1-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 150000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 66.43, "hourly_price": 0.091, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 314572800, "end_of_service": false}, "L4-1-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 51539607552, "gpu": 1, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 547.5, "hourly_price": 0.75, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 2500000000, "sum_internet_bandwidth": 2500000000, "interfaces": [{"internal_bandwidth": 2500000000, "internet_bandwidth": 2500000000}]}, "block_bandwidth": 1048576000, "end_of_service": false}, "L4-2-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 103079215104, "gpu": 2, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1095.0, "hourly_price": 1.5, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]}, "block_bandwidth": 1572864000, "end_of_service": false}, "L4-4-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 206158430208, "gpu": 4, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 2190.0, "hourly_price": 3.0, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]}, "block_bandwidth": 2621440000, "end_of_service": false}, "L4-8-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 412316860416, "gpu": 8, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 4380.0, "hourly_price": 6.0, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 20000000000, "sum_internet_bandwidth": 20000000000, "interfaces": [{"internal_bandwidth": 20000000000, "internet_bandwidth": 20000000000}]}, "block_bandwidth": 5242880000, "end_of_service": false}, "MEMORY3-X16C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 320000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 601.0, "hourly_price": 0.824, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 4000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 4000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "MEMORY3-X2C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 40000000000, "scratch_storage_max_volumes_count": 1, "monthly_price": 75.0, "hourly_price": 0.103, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "MEMORY3-X32C-256G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 640000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 1203.0, "hourly_price": 1.648, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 8000000000, "sum_internet_bandwidth": 8000000000, "interfaces": [{"internal_bandwidth": 8000000000, "internet_bandwidth": 8000000000}]}, "block_bandwidth": 1000341504, "end_of_service": false}, "MEMORY3-X48C-384G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 412316860416, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 960000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1804.0, "hourly_price": 2.472, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "MEMORY3-X4C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 80000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 150.0, "hourly_price": 0.206, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "MEMORY3-X8C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 160000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 300.0, "hourly_price": 0.412, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "PLAY2-MICRO": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 39.42, "hourly_price": 0.054, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 167772160, "end_of_service": false}, "PLAY2-NANO": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 19.71, "hourly_price": 0.027, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 83886080, "end_of_service": false}}}'
+        headers:
+            Content-Length:
+                - "41245"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:06 GMT
+            Link:
+                - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=3&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - 046a5cbb-ec86-4ec2-a755-728b9bf9bfc1
+            X-Total-Count:
+                - "112"
+        status: 200 OK
+        code: 200
+        duration: 50.879311ms
+    - id: 64
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "2"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 40884
+        body: '{"servers": {"PLAY2-PICO": {"alt_names": [], "arch": "x86_64", "ncpus": 1, "ram": 2147483648, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 10.22, "hourly_price": 0.014, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]}, "block_bandwidth": 41943040, "end_of_service": false}, "POP2-16C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 430.7, "hourly_price": 0.59, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-16C-64G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1063.391, "hourly_price": 1.4567, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-2C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 53.66, "hourly_price": 0.0735, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-2C-8G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 133.079, "hourly_price": 0.1823, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-32C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 861.4, "hourly_price": 1.18, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-32C-128G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 2126.709, "hourly_price": 2.9133, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-48C-192G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1274.4, "hourly_price": 1.77, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-4C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 107.31, "hourly_price": 0.147, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-4C-16G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 265.501, "hourly_price": 0.3637, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-64C-256G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1715.5, "hourly_price": 2.35, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-8C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 211.7, "hourly_price": 0.29, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-8C-32G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 528.009, "hourly_price": 0.7233, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HC-16C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 310.69, "hourly_price": 0.4256, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-HC-2C-4G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 38.84, "hourly_price": 0.0532, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HC-32C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 621.38, "hourly_price": 0.8512, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HC-48C-96G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 103079215104, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 914.4, "hourly_price": 1.27, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HC-4C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 77.67, "hourly_price": 0.1064, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HC-64C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1242.75, "hourly_price": 1.7024, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HC-8C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 155.34, "hourly_price": 0.2128, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HM-16C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 601.52, "hourly_price": 0.824, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-HM-2C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 75.19, "hourly_price": 0.103, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HM-32C-256G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1203.04, "hourly_price": 1.648, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HM-48C-384G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 412316860416, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1778.4, "hourly_price": 2.47, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HM-4C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 150.38, "hourly_price": 0.206, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HM-64C-512G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 549755813888, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 2406.08, "hourly_price": 3.296, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HM-8C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 300.76, "hourly_price": 0.412, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HN-10": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 530.29, "hourly_price": 0.7264, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HN-3": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 186.49, "hourly_price": 0.2554, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HN-5": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 330.29, "hourly_price": 0.4524, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "PRO2-L": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 640.21, "hourly_price": 0.877, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6000000000, "sum_internet_bandwidth": 6000000000, "interfaces": [{"internal_bandwidth": 6000000000, "internet_bandwidth": 6000000000}]}, "block_bandwidth": 2097152000, "end_of_service": false}, "PRO2-M": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 319.74, "hourly_price": 0.438, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]}, "block_bandwidth": 1048576000, "end_of_service": false}, "PRO2-S": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 159.87, "hourly_price": 0.219, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]}, "block_bandwidth": 524288000, "end_of_service": false}, "PRO2-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 80.3, "hourly_price": 0.11, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth": 700000000, "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth": 700000000}]}, "block_bandwidth": 262144000, "end_of_service": false}, "PRO2-XXS": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 40.15, "hourly_price": 0.055, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth": 350000000, "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth": 350000000}]}, "block_bandwidth": 131072000, "end_of_service": false}, "RENDER-S": {"alt_names": [], "arch": "x86_64", "ncpus": 10, "ram": 45097156608, "gpu": 1, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "P100", "gpu_memory": 17179869184}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 400000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 891.33, "hourly_price": 1.221, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 2000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth": 2000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 2147483648, "end_of_service": false}, "STANDARD2-A16C-64G": {"alt_names": [], "arch": "arm64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 367.8324, "hourly_price": 0.5039, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "STANDARD2-A2C-8G": {"alt_names": [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 42.7525, "hourly_price": 0.0586, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "STANDARD2-A32C-128G": {"alt_names": [], "arch": "arm64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 735.7269, "hourly_price": 1.0078, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5033164800, "end_of_service": false}, "STANDARD2-A48C-192G": {"alt_names": [], "arch": "arm64", "ncpus": 48, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1103.5593, "hourly_price": 1.5117, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5033164800, "end_of_service": false}, "STANDARD2-A4C-16G": {"alt_names": [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 85.5049, "hourly_price": 0.1171, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "STANDARD2-A64C-256G": {"alt_names": [], "arch": "arm64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1470.366, "hourly_price": 2.0142, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5033164800, "end_of_service": false}, "STANDARD2-A8C-32G": {"alt_names": [], "arch": "arm64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 171.0098, "hourly_price": 0.2343, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "STANDARD3-X16C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 320000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 430.0, "hourly_price": 0.59, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 4000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 4000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "STANDARD3-X2C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 40000000000, "scratch_storage_max_volumes_count": 1, "monthly_price": 54.0, "hourly_price": 0.074, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "STANDARD3-X32C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 640000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 861.0, "hourly_price": 1.18, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 8000000000, "sum_internet_bandwidth": 8000000000, "interfaces": [{"internal_bandwidth": 8000000000, "internet_bandwidth": 8000000000}]}, "block_bandwidth": 1000341504, "end_of_service": false}, "STANDARD3-X48C-192G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 960000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1292.1, "hourly_price": 1.77, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "STANDARD3-X4C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 80000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 107.0, "hourly_price": 0.147, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "STANDARD3-X64C-256G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 1280000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1715.0, "hourly_price": 2.35, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "STANDARD3-X8C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 160000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 211.0, "hourly_price": 0.29, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}}}'
+        headers:
+            Content-Length:
+                - "40884"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:06 GMT
+            Link:
+                - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>; rel="previous",</products/servers?page=3&per_page=50&>; rel="next",</products/servers?page=3&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - ad7b5943-951b-4b1c-b665-7811e2f6849d
+            X-Total-Count:
+                - "112"
+        status: 200 OK
+        code: 200
+        duration: 34.915771ms
+    - id: 65
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "3"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 10027
+        body: '{"servers": {"STARDUST1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 1, "ram": 1073741824, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 10000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 0.1095, "hourly_price": 0.00015, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]}, "block_bandwidth": 52428800, "end_of_service": false}, "START1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 26.864, "hourly_price": 0.0368, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "START1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 100000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 14.162, "hourly_price": 0.0194, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 300000000, "sum_internet_bandwidth": 300000000, "interfaces": [{"internal_bandwidth": 300000000, "internet_bandwidth": 300000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "START1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 50000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 7.738, "hourly_price": 0.0106, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "START1-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 1, "ram": 1073741824, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 25000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 4.526, "hourly_price": 0.0062, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "VC1L": {"alt_names": ["X64-8GB"], "arch": "x86_64", "ncpus": 6, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 18.0164, "hourly_price": 0.02468, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "VC1M": {"alt_names": ["X64-4GB"], "arch": "x86_64", "ncpus": 4, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 100000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 11.3515, "hourly_price": 0.01555, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "VC1S": {"alt_names": ["X64-2GB"], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 50000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 6.2926, "hourly_price": 0.00862, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "X64-120GB": {"alt_names": [], "arch": "x86_64", "ncpus": 12, "ram": 128849018880, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 800000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 310.7902, "hourly_price": 0.42574, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 1000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "X64-15GB": {"alt_names": [], "arch": "x86_64", "ncpus": 6, "ram": 16106127360, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 44.0336, "hourly_price": 0.06032, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 250000000, "sum_internet_bandwidth": 250000000, "interfaces": [{"internal_bandwidth": 250000000, "internet_bandwidth": 250000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "X64-30GB": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 32212254720, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 400000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 86.9138, "hourly_price": 0.11906, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "X64-60GB": {"alt_names": [], "arch": "x86_64", "ncpus": 10, "ram": 64424509440, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 700000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 155.49, "hourly_price": 0.213, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 1000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 41943040, "end_of_service": true}}}'
+        headers:
+            Content-Length:
+                - "10027"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:06 GMT
+            Link:
+                - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=2&per_page=50&>; rel="previous",</products/servers?page=3&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - 500dabbc-9d7a-4337-98f4-e982af7c8041
+            X-Total-Count:
+                - "112"
+        status: 200 OK
+        code: 200
+        duration: 41.524407ms
+    - id: 66
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/67f68cb0-03f7-4318-9a03-16764323873a
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 784
+        body: '{"region":"fr-par","id":"67f68cb0-03f7-4318-9a03-16764323873a","cluster_id":"384a8300-efe2-4ea2-9078-2d89f5ad2383","created_at":"2026-04-14T16:02:00.986391Z","updated_at":"2026-04-14T16:05:06.487667Z","name":"test-pool-validate-root-volume","status":"deleting","version":"1.35.3","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","validate-root-volume"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{},"taints":[],"startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "784"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:06 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - c5c20986-723d-4357-8213-b59f94e32661
+        status: 200 OK
+        code: 200
+        duration: 78.68539ms
+    - id: 67
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/67f68cb0-03f7-4318-9a03-16764323873a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 784
+        body: '{"region":"fr-par","id":"67f68cb0-03f7-4318-9a03-16764323873a","cluster_id":"384a8300-efe2-4ea2-9078-2d89f5ad2383","created_at":"2026-04-14T16:02:00.986391Z","updated_at":"2026-04-14T16:05:06.487667Z","name":"test-pool-validate-root-volume","status":"deleting","version":"1.35.3","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","validate-root-volume"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{},"taints":[],"startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "784"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:06 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - 09096b73-7a12-4c34-90c4-bb3380a8ab4a
+        status: 200 OK
+        code: 200
+        duration: 24.021577ms
+    - id: 68
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/67f68cb0-03f7-4318-9a03-16764323873a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 125
+        body: '{"message":"resource is not found","resource":"pool","resource_id":"67f68cb0-03f7-4318-9a03-16764323873a","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "125"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:07:07 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - b7743b7c-c3d5-49fc-a073-b57d40ceb421
+        status: 404 Not Found
+        code: 404
+        duration: 31.048054ms
+    - id: 69
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            with_additional_resources:
+                - "false"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/384a8300-efe2-4ea2-9078-2d89f5ad2383?with_additional_resources=false
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1637
+        body: '{"region":"fr-par","id":"384a8300-efe2-4ea2-9078-2d89f5ad2383","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:01:55.214681Z","updated_at":"2026-04-14T16:07:07.192035Z","type":"kapsule","name":"test-pool-validate-root-volume","description":"","status":"deleting","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","validate-root-volume"],"cluster_url":"https://384a8300-efe2-4ea2-9078-2d89f5ad2383.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.384a8300-efe2-4ea2-9078-2d89f5ad2383.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":0},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"59f194c7-197f-4ca6-84e5-f9c38afbfaed","commitment_ends_at":"2026-04-14T16:01:55.214686Z","acl_available":true,"iam_nodes_group_id":"1bb74d69-943b-44f2-b20b-dc114787fcea","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1637"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:07:07 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - 1ab9230f-59d4-454f-a840-fd31abace1e4
+        status: 200 OK
+        code: 200
+        duration: 160.020299ms
+    - id: 70
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/384a8300-efe2-4ea2-9078-2d89f5ad2383
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1637
+        body: '{"region":"fr-par","id":"384a8300-efe2-4ea2-9078-2d89f5ad2383","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:01:55.214681Z","updated_at":"2026-04-14T16:07:07.192035Z","type":"kapsule","name":"test-pool-validate-root-volume","description":"","status":"deleting","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","validate-root-volume"],"cluster_url":"https://384a8300-efe2-4ea2-9078-2d89f5ad2383.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.384a8300-efe2-4ea2-9078-2d89f5ad2383.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":0},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"59f194c7-197f-4ca6-84e5-f9c38afbfaed","commitment_ends_at":"2026-04-14T16:01:55.214686Z","acl_available":true,"iam_nodes_group_id":"1bb74d69-943b-44f2-b20b-dc114787fcea","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1637"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:07:07 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - af07b2e1-4868-482b-80e9-c326100cf83d
+        status: 200 OK
+        code: 200
+        duration: 38.703077ms
+    - id: 71
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/384a8300-efe2-4ea2-9078-2d89f5ad2383
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 128
+        body: '{"message":"resource is not found","resource":"cluster","resource_id":"384a8300-efe2-4ea2-9078-2d89f5ad2383","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "128"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:07:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - 3e0cf466-04bc-42ce-97af-56621c517203
+        status: 404 Not Found
+        code: 404
+        duration: 25.367281ms
+    - id: 72
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/59f194c7-197f-4ca6-84e5-f9c38afbfaed
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:07:24 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - 6bba3adf-45b8-400f-b8b8-d5f6fd71cbca
+        status: 204 No Content
+        code: 204
+        duration: 1.610422993s
+    - id: 73
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/4c6f2f41-a3ed-438f-b4cf-63be705fee57
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:07:24 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - db980e0c-f6b9-49b7-921b-530641eb2966
+        status: 204 No Content
+        code: 204
+        duration: 418.606284ms
+    - id: 74
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/67f68cb0-03f7-4318-9a03-16764323873a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 125
+        body: '{"message":"resource is not found","resource":"pool","resource_id":"67f68cb0-03f7-4318-9a03-16764323873a","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "125"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:07:24 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - 664f8f1a-7b5d-4d6b-80ff-863fe47af058
+        status: 404 Not Found
+        code: 404
+        duration: 23.821537ms
+    - id: 75
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/384a8300-efe2-4ea2-9078-2d89f5ad2383
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 128
+        body: '{"message":"resource is not found","resource":"cluster","resource_id":"384a8300-efe2-4ea2-9078-2d89f5ad2383","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "128"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:07:24 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - 15a26f7d-40d2-4515-8e17-66f7964bbe60
+        status: 404 Not Found
+        code: 404
+        duration: 25.265911ms
+    - id: 76
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/59f194c7-197f-4ca6-84e5-f9c38afbfaed
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 136
+        body: '{"message":"resource is not found","resource":"private_network","resource_id":"59f194c7-197f-4ca6-84e5-f9c38afbfaed","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "136"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:07:24 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge03)
+            X-Request-Id:
+                - 7ac06b12-e638-42c6-9277-916e634c238a
+        status: 404 Not Found
+        code: 404
+        duration: 23.626521ms

--- a/internal/services/k8s/testdata/pool-validate-size-dedicated.cassette.yaml
+++ b/internal/services/k8s/testdata/pool-validate-size-dedicated.cassette.yaml
@@ -1,0 +1,1681 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/versions
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 4355
+        body: '{"versions":[{"region":"fr-par","name":"1.35.3","label":"Kubernetes 1.35.3","available_cnis":["cilium","cilium_native","calico","kilo","none"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","CPUManagerPolicyAlphaOptions","ImageVolume","MutatingAdmissionPolicy"],"available_admission_plugins":["AlwaysPullImages","PodNodeSelector","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","cpuManagerPolicyOptions":"map[string]string","enableDebuggingHandlers":"bool","evictionHard":"map[string]string","evictionMinimumReclaim":"map[string]string","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxParallelImagePulls":"int32","maxPods":"uint16","registryBurst":"int32","registryPullQPS":"int32","serializeImagePulls":"bool"},"deprecated_at":"2027-01-19T00:00:00Z","end_of_life_at":"2027-03-19T00:00:00Z","released_at":"2026-01-19T00:00:00Z"},{"region":"fr-par","name":"1.34.6","label":"Kubernetes 1.34.6","available_cnis":["cilium","cilium_native","calico","kilo","none"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","CPUManagerPolicyAlphaOptions","ImageVolume","MutatingAdmissionPolicy"],"available_admission_plugins":["AlwaysPullImages","PodNodeSelector","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","cpuManagerPolicyOptions":"map[string]string","enableDebuggingHandlers":"bool","evictionHard":"map[string]string","evictionMinimumReclaim":"map[string]string","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxParallelImagePulls":"int32","maxPods":"uint16","registryBurst":"int32","registryPullQPS":"int32","serializeImagePulls":"bool"},"deprecated_at":"2026-09-29T00:00:00Z","end_of_life_at":"2026-11-29T00:00:00Z","released_at":"2025-09-29T00:00:00Z"},{"region":"fr-par","name":"1.33.10","label":"Kubernetes 1.33.10","available_cnis":["cilium","calico","kilo","none"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","DRAAdminAccess","DynamicResourceAllocation","PodLevelResources","CPUManagerPolicyAlphaOptions","ImageVolume"],"available_admission_plugins":["AlwaysPullImages","PodNodeSelector","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","cpuManagerPolicyOptions":"map[string]string","enableDebuggingHandlers":"bool","evictionHard":"map[string]string","evictionMinimumReclaim":"map[string]string","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxParallelImagePulls":"int32","maxPods":"uint16","registryBurst":"int32","registryPullQPS":"int32","serializeImagePulls":"bool"},"deprecated_at":"2026-09-04T00:00:00Z","end_of_life_at":"2026-11-04T00:00:00Z","released_at":"2025-09-04T00:00:00Z"},{"region":"fr-par","name":"1.32.13","label":"Kubernetes 1.32.13","available_cnis":["cilium","calico","kilo","none"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","InPlacePodVerticalScaling","SidecarContainers","DRAAdminAccess","DRAResourceClaimDeviceStatus","DynamicResourceAllocation","PodLevelResources","CPUManagerPolicyAlphaOptions","ImageVolume"],"available_admission_plugins":["AlwaysPullImages","PodNodeSelector","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","cpuManagerPolicyOptions":"map[string]string","enableDebuggingHandlers":"bool","evictionHard":"map[string]string","evictionMinimumReclaim":"map[string]string","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxParallelImagePulls":"int32","maxPods":"uint16","registryBurst":"int32","registryPullQPS":"int32","serializeImagePulls":"bool"},"deprecated_at":"2026-03-24T00:00:00Z","end_of_life_at":"2026-06-24T00:00:00Z","released_at":"2025-03-24T00:00:00Z"}]}'
+        headers:
+            Content-Length:
+                - "4355"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:02:04 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - ff608135-f806-428b-94ad-e4426198562c
+        status: 200 OK
+        code: 200
+        duration: 58.570772ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 124
+        host: api.scaleway.com
+        body: '{"name":"tf-vpc-flamboyant-archimedes","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"enable_routing":false}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 415
+        body: '{"id":"6529612e-91e2-4668-b4cb-3425c9cbc505","name":"tf-vpc-flamboyant-archimedes","tags":[],"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:02:04.566296Z","updated_at":"2026-04-14T16:02:04.566296Z","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","is_default":false,"private_network_count":0,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "415"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:02:04 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - 506678f3-2257-45c4-8635-c7ed46ade661
+        status: 200 OK
+        code: 200
+        duration: 62.845689ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/6529612e-91e2-4668-b4cb-3425c9cbc505
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 415
+        body: '{"id":"6529612e-91e2-4668-b4cb-3425c9cbc505","name":"tf-vpc-flamboyant-archimedes","tags":[],"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:02:04.566296Z","updated_at":"2026-04-14T16:02:04.566296Z","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","is_default":false,"private_network_count":0,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "415"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:02:04 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - 686a480e-5fcb-40bf-86b8-dd083f8461f0
+        status: 200 OK
+        code: 200
+        duration: 54.674497ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 206
+        host: api.scaleway.com
+        body: '{"name":"test-pool-validate-size-dedi","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"subnets":null,"vpc_id":"6529612e-91e2-4668-b4cb-3425c9cbc505","default_route_propagation_enabled":false}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1073
+        body: '{"id":"2d8463c9-1f6a-46c3-b7c5-12918cf80a3e","name":"test-pool-validate-size-dedi","tags":[],"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:02:04.695148Z","updated_at":"2026-04-14T16:02:04.695148Z","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnets":[{"id":"f4730d51-9d91-4769-963e-fa31668f6722","created_at":"2026-04-14T16:02:04.695148Z","updated_at":"2026-04-14T16:02:04.695148Z","subnet":"172.16.8.0/22","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"2d8463c9-1f6a-46c3-b7c5-12918cf80a3e","vpc_id":"6529612e-91e2-4668-b4cb-3425c9cbc505"},{"id":"af4a68ee-46ab-4424-9334-fe24f2a4e30a","created_at":"2026-04-14T16:02:04.695148Z","updated_at":"2026-04-14T16:02:04.695148Z","subnet":"fd63:256c:45f7:844f::/64","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"2d8463c9-1f6a-46c3-b7c5-12918cf80a3e","vpc_id":"6529612e-91e2-4668-b4cb-3425c9cbc505"}],"vpc_id":"6529612e-91e2-4668-b4cb-3425c9cbc505","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1073"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:02:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - 1a126fdc-a098-4658-8cfb-28c254587c8c
+        status: 200 OK
+        code: 200
+        duration: 630.812312ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/2d8463c9-1f6a-46c3-b7c5-12918cf80a3e
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1073
+        body: '{"id":"2d8463c9-1f6a-46c3-b7c5-12918cf80a3e","name":"test-pool-validate-size-dedi","tags":[],"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:02:04.695148Z","updated_at":"2026-04-14T16:02:04.695148Z","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnets":[{"id":"f4730d51-9d91-4769-963e-fa31668f6722","created_at":"2026-04-14T16:02:04.695148Z","updated_at":"2026-04-14T16:02:04.695148Z","subnet":"172.16.8.0/22","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"2d8463c9-1f6a-46c3-b7c5-12918cf80a3e","vpc_id":"6529612e-91e2-4668-b4cb-3425c9cbc505"},{"id":"af4a68ee-46ab-4424-9334-fe24f2a4e30a","created_at":"2026-04-14T16:02:04.695148Z","updated_at":"2026-04-14T16:02:04.695148Z","subnet":"fd63:256c:45f7:844f::/64","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"2d8463c9-1f6a-46c3-b7c5-12918cf80a3e","vpc_id":"6529612e-91e2-4668-b4cb-3425c9cbc505"}],"vpc_id":"6529612e-91e2-4668-b4cb-3425c9cbc505","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1073"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:02:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - 4307b243-8e97-4289-906e-5840a7b78adf
+        status: 200 OK
+        code: 200
+        duration: 45.004821ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 736
+        host: api.scaleway.com
+        body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"kapsule-dedicated-4","name":"test-pool-validate-size-dedi","description":"","tags":["terraform-test","scaleway_k8s_pool","validate-size-dedi"],"version":"1.35.3","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":[],"admission_plugins":[],"apiserver_cert_sans":[],"private_network_id":"2d8463c9-1f6a-46c3-b7c5-12918cf80a3e"}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1609
+        body: '{"region":"fr-par","id":"1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:02:05.628299Z","updated_at":"2026-04-14T16:02:05.628299Z","type":"kapsule-dedicated-4","name":"test-pool-validate-size-dedi","description":"","status":"creating","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","validate-size-dedi"],"cluster_url":"https://1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":0},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"2d8463c9-1f6a-46c3-b7c5-12918cf80a3e","commitment_ends_at":"2026-05-14T16:02:05.628306Z","acl_available":true,"iam_nodes_group_id":"","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1609"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:02:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - eba82d3e-9161-4425-b37e-f2451a519d49
+        status: 200 OK
+        code: 200
+        duration: 334.173093ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1609
+        body: '{"region":"fr-par","id":"1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:02:05.628299Z","updated_at":"2026-04-14T16:02:05.628299Z","type":"kapsule-dedicated-4","name":"test-pool-validate-size-dedi","description":"","status":"creating","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","validate-size-dedi"],"cluster_url":"https://1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":0},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"2d8463c9-1f6a-46c3-b7c5-12918cf80a3e","commitment_ends_at":"2026-05-14T16:02:05.628306Z","acl_available":true,"iam_nodes_group_id":"","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1609"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:02:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - d2e2b819-9a15-4df9-9347-0b192829553d
+        status: 200 OK
+        code: 200
+        duration: 47.537746ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1642
+        body: '{"region":"fr-par","id":"1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:02:05.628299Z","updated_at":"2026-04-14T16:03:54.257711Z","type":"kapsule-dedicated-4","name":"test-pool-validate-size-dedi","description":"","status":"ready","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","validate-size-dedi"],"cluster_url":"https://1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":0},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"2d8463c9-1f6a-46c3-b7c5-12918cf80a3e","commitment_ends_at":"2026-05-14T16:02:05.628306Z","acl_available":true,"iam_nodes_group_id":"7ce2e2eb-69ce-4e3c-a744-d42d2f1ddf21","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1642"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:03:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - ecf5e66b-73fd-4c8d-a175-1cff04552bc0
+        status: 200 OK
+        code: 200
+        duration: 38.040015ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_asc
+            page:
+                - "1"
+            status:
+                - unknown
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8/pools?order_by=created_at_asc&page=1&status=unknown
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 28
+        body: '{"total_count":0,"pools":[]}'
+        headers:
+            Content-Length:
+                - "28"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:03:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - 4b05a2e9-9e85-4cd9-adca-f094f7c5c44f
+        status: 200 OK
+        code: 200
+        duration: 41.505022ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1642
+        body: '{"region":"fr-par","id":"1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:02:05.628299Z","updated_at":"2026-04-14T16:03:54.257711Z","type":"kapsule-dedicated-4","name":"test-pool-validate-size-dedi","description":"","status":"ready","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","validate-size-dedi"],"cluster_url":"https://1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":0},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"2d8463c9-1f6a-46c3-b7c5-12918cf80a3e","commitment_ends_at":"2026-05-14T16:02:05.628306Z","acl_available":true,"iam_nodes_group_id":"7ce2e2eb-69ce-4e3c-a744-d42d2f1ddf21","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1642"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:03:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - e4990c6d-a681-46ce-b9a6-18c29d8044bb
+        status: 200 OK
+        code: 200
+        duration: 24.198406ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8/kubeconfig
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1764
+        body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC12YWxpZGF0ZS1zaXplLWRlZGkiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VKWVJFTkRRVkZIWjBGM1NVSkJaMGxDUVVSQlMwSm5aM0ZvYTJwUFVGRlJSRUZxUVZaTlVrMTNSVkZaUkZaUlVVUkZkM0J5WkZkS2JHTnROV3dLWkVkV2VrMUNORmhFVkVreVRVUlJlRTE2UlRKTlJFbDRUVVp2V0VSVVRUSk5SRkY0VFhwRk1rMUVTWGhOUm05M1JsUkZWRTFDUlVkQk1WVkZRWGhOU3dwaE0xWnBXbGhLZFZwWVVteGpla0phVFVKTlIwSjVjVWRUVFRRNVFXZEZSME5EY1VkVFRUUTVRWGRGU0VFd1NVRkNSMHMwV1ZablVXNTBlVE5pYm05UkNrMUtMMFpCZGpWVGVtUnNObm93UVhZNVRDdG5ibE16ZVRoc05sRmxiRzF6UWxka05UQXZVakIyUTNGVmMzVnFNMlY1WWtGNmJWZHhhRWRNV2t0SmNuSUtOWFZ2VnpWWU1tcFJha0pCVFVFMFIwRXhWV1JFZDBWQ0wzZFJSVUYzU1VOd1JFRlFRbWRPVmtoU1RVSkJaamhGUWxSQlJFRlJTQzlOUWpCSFFURlZaQXBFWjFGWFFrSlRha2xFWWl0TFFXYzFiWFozYkZKeFkycFlObUY1VDFGcVNYZEVRVXRDWjJkeGFHdHFUMUJSVVVSQlowNUtRVVJDUjBGcFJVRnVhMVJVQ25Ka1JHdFNlVXR3VUdGS1RXMUdlRVpyZG14RFZ6Rk1TME5PTmtGaVozbDVjamg1WWpoemEwTkpVVVJYVkZWS1JqSkhkWHBDZG5OQ2NWQkVUV2xDV2pJS2RrZElLeTluT1ZoTFducHRXWE5xSzNaU1pGZDVVVDA5Q2kwdExTMHRSVTVFSUVORlVsUkpSa2xEUVZSRkxTMHRMUzBLCiAgICBzZXJ2ZXI6IGh0dHBzOi8vMWJiMzRiZmItNzFlNy00OWY4LWJkYjAtYTcwNWMyMGVmOGE4LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC12YWxpZGF0ZS1zaXplLWRlZGkKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC12YWxpZGF0ZS1zaXplLWRlZGkiCiAgICB1c2VyOiB0ZXN0LXBvb2wtdmFsaWRhdGUtc2l6ZS1kZWRpLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXZhbGlkYXRlLXNpemUtZGVkaQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC12YWxpZGF0ZS1zaXplLWRlZGktYWRtaW4KICB1c2VyOgogICAgdG9rZW46IGh4T2hOcncxbGxGdlRDVDNhNlcydW9qTHY1OERPcUVDV281SGx1ZU44MG5pNmNsQmNjVjRMenZn"}'
+        headers:
+            Content-Length:
+                - "1764"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:03:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - c9379b73-039d-4d2a-9491-2831808a0de9
+        status: 200 OK
+        code: 200
+        duration: 54.106474ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 41245
+        body: '{"servers": {"BASIC2-A16C-32G": {"alt_names": [], "arch": "arm64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 150.89, "hourly_price": 0.2067, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 503316480, "end_of_service": false}, "BASIC2-A16C-64G": {"alt_names": [], "arch": "arm64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 201.19, "hourly_price": 0.2756, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 503316480, "end_of_service": false}, "BASIC2-A2C-4G": {"alt_names": [], "arch": "arm64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 16.79, "hourly_price": 0.023, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 83886080, "end_of_service": false}, "BASIC2-A2C-8G": {"alt_names": [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 25.19, "hourly_price": 0.0345, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 83886080, "end_of_service": false}, "BASIC2-A4C-16G": {"alt_names": [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 50.3, "hourly_price": 0.0689, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 125829120, "end_of_service": false}, "BASIC2-A4C-8G": {"alt_names": [], "arch": "arm64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 37.74, "hourly_price": 0.0517, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 125829120, "end_of_service": false}, "BASIC2-A8C-16G": {"alt_names": [], "arch": "arm64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 75.48, "hourly_price": 0.1034, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 251658240, "end_of_service": false}, "BASIC2-A8C-32G": {"alt_names": [], "arch": "arm64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 100.59, "hourly_price": 0.1378, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 251658240, "end_of_service": false}, "BASIC3-X16C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 240.9, "hourly_price": 0.33, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]}, "block_bandwidth": 1048576000, "end_of_service": false}, "BASIC3-X16C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 321.2, "hourly_price": 0.44, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]}, "block_bandwidth": 1048576000, "end_of_service": false}, "BASIC3-X2C-4G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 26.791, "hourly_price": 0.0367, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth": 350000000, "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth": 350000000}]}, "block_bandwidth": 131072000, "end_of_service": false}, "BASIC3-X2C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 40.15, "hourly_price": 0.055, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth": 350000000, "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth": 350000000}]}, "block_bandwidth": 131072000, "end_of_service": false}, "BASIC3-X4C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 80.3, "hourly_price": 0.11, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth": 700000000, "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth": 700000000}]}, "block_bandwidth": 262144000, "end_of_service": false}, "BASIC3-X4C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 53.509, "hourly_price": 0.0733, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth": 700000000, "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth": 700000000}]}, "block_bandwidth": 262144000, "end_of_service": false}, "BASIC3-X8C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 120.45, "hourly_price": 0.165, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]}, "block_bandwidth": 524288000, "end_of_service": false}, "BASIC3-X8C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 160.6, "hourly_price": 0.22, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]}, "block_bandwidth": 524288000, "end_of_service": false}, "COMPUTE3-X16C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 320000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 341.786, "hourly_price": 0.4682, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 4000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 4000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "COMPUTE3-X2C-4G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 40000000000, "scratch_storage_max_volumes_count": 1, "monthly_price": 42.705, "hourly_price": 0.0585, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "COMPUTE3-X32C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 640000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 683.499, "hourly_price": 0.9363, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 8000000000, "sum_internet_bandwidth": 8000000000, "interfaces": [{"internal_bandwidth": 8000000000, "internet_bandwidth": 8000000000}]}, "block_bandwidth": 1000341504, "end_of_service": false}, "COMPUTE3-X48C-96G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 103079215104, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 960000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1019.81, "hourly_price": 1.397, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "COMPUTE3-X4C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 80000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 85.41, "hourly_price": 0.117, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "COMPUTE3-X64C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 1280000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1366.998, "hourly_price": 1.8726, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "COMPUTE3-X8C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 160000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 170.893, "hourly_price": 0.2341, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "COMPUTE3-X96C-192G": {"alt_names": [], "arch": "x86_64", "ncpus": 96, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 1280000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 2039.62, "hourly_price": 2.794, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "COPARM1-16C-64G": {"alt_names": [], "arch": "arm64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 252.14, "hourly_price": 0.3454, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 671088640, "end_of_service": false}, "COPARM1-2C-8G": {"alt_names": [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 31.1, "hourly_price": 0.0426, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 83886080, "end_of_service": false}, "COPARM1-32C-128G": {"alt_names": [], "arch": "arm64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 506.26, "hourly_price": 0.6935, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 1342177280, "end_of_service": false}, "COPARM1-4C-16G": {"alt_names": [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 62.56, "hourly_price": 0.0857, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 167772160, "end_of_service": false}, "COPARM1-8C-32G": {"alt_names": [], "arch": "arm64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 125.85, "hourly_price": 0.1724, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 335544320, "end_of_service": false}, "DEV1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 80000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 30.66, "hourly_price": 0.042, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 209715200, "end_of_service": false}, "DEV1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 3, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 40000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 14.454, "hourly_price": 0.0198, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 300000000, "sum_internet_bandwidth": 300000000, "interfaces": [{"internal_bandwidth": 300000000, "internet_bandwidth": 300000000}]}, "block_bandwidth": 157286400, "end_of_service": false}, "DEV1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 20000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 6.424, "hourly_price": 0.0088, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 104857600, "end_of_service": false}, "DEV1-XL": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 12884901888, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 120000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 46.5734, "hourly_price": 0.06378, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 262144000, "end_of_service": false}, "GP1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 554.07, "hourly_price": 0.759, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]}, "block_bandwidth": 1073741824, "end_of_service": false}, "GP1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 274.48, "hourly_price": 0.376, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "GP1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 300000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 136.51, "hourly_price": 0.187, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 524288000, "end_of_service": false}, "GP1-XL": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1197.93, "hourly_price": 1.641, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]}, "block_bandwidth": 2147483648, "end_of_service": false}, "GP1-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 150000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 66.43, "hourly_price": 0.091, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 314572800, "end_of_service": false}, "L4-1-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 51539607552, "gpu": 1, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 547.5, "hourly_price": 0.75, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 2500000000, "sum_internet_bandwidth": 2500000000, "interfaces": [{"internal_bandwidth": 2500000000, "internet_bandwidth": 2500000000}]}, "block_bandwidth": 1048576000, "end_of_service": false}, "L4-2-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 103079215104, "gpu": 2, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1095.0, "hourly_price": 1.5, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]}, "block_bandwidth": 1572864000, "end_of_service": false}, "L4-4-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 206158430208, "gpu": 4, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 2190.0, "hourly_price": 3.0, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]}, "block_bandwidth": 2621440000, "end_of_service": false}, "L4-8-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 412316860416, "gpu": 8, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 4380.0, "hourly_price": 6.0, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 20000000000, "sum_internet_bandwidth": 20000000000, "interfaces": [{"internal_bandwidth": 20000000000, "internet_bandwidth": 20000000000}]}, "block_bandwidth": 5242880000, "end_of_service": false}, "MEMORY3-X16C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 320000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 601.0, "hourly_price": 0.824, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 4000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 4000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "MEMORY3-X2C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 40000000000, "scratch_storage_max_volumes_count": 1, "monthly_price": 75.0, "hourly_price": 0.103, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "MEMORY3-X32C-256G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 640000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 1203.0, "hourly_price": 1.648, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 8000000000, "sum_internet_bandwidth": 8000000000, "interfaces": [{"internal_bandwidth": 8000000000, "internet_bandwidth": 8000000000}]}, "block_bandwidth": 1000341504, "end_of_service": false}, "MEMORY3-X48C-384G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 412316860416, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 960000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1804.0, "hourly_price": 2.472, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "MEMORY3-X4C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 80000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 150.0, "hourly_price": 0.206, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "MEMORY3-X8C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 160000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 300.0, "hourly_price": 0.412, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "PLAY2-MICRO": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 39.42, "hourly_price": 0.054, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 167772160, "end_of_service": false}, "PLAY2-NANO": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 19.71, "hourly_price": 0.027, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 83886080, "end_of_service": false}}}'
+        headers:
+            Content-Length:
+                - "41245"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:03:57 GMT
+            Link:
+                - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=3&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - 647ace9d-04a6-4dbe-af95-897a4f047a5c
+            X-Total-Count:
+                - "112"
+        status: 200 OK
+        code: 200
+        duration: 42.255341ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "2"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 40884
+        body: '{"servers": {"PLAY2-PICO": {"alt_names": [], "arch": "x86_64", "ncpus": 1, "ram": 2147483648, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 10.22, "hourly_price": 0.014, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]}, "block_bandwidth": 41943040, "end_of_service": false}, "POP2-16C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 430.7, "hourly_price": 0.59, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-16C-64G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1063.391, "hourly_price": 1.4567, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-2C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 53.66, "hourly_price": 0.0735, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-2C-8G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 133.079, "hourly_price": 0.1823, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-32C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 861.4, "hourly_price": 1.18, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-32C-128G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 2126.709, "hourly_price": 2.9133, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-48C-192G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1274.4, "hourly_price": 1.77, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-4C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 107.31, "hourly_price": 0.147, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-4C-16G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 265.501, "hourly_price": 0.3637, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-64C-256G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1715.5, "hourly_price": 2.35, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-8C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 211.7, "hourly_price": 0.29, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-8C-32G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 528.009, "hourly_price": 0.7233, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HC-16C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 310.69, "hourly_price": 0.4256, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-HC-2C-4G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 38.84, "hourly_price": 0.0532, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HC-32C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 621.38, "hourly_price": 0.8512, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HC-48C-96G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 103079215104, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 914.4, "hourly_price": 1.27, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HC-4C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 77.67, "hourly_price": 0.1064, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HC-64C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1242.75, "hourly_price": 1.7024, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HC-8C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 155.34, "hourly_price": 0.2128, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HM-16C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 601.52, "hourly_price": 0.824, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-HM-2C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 75.19, "hourly_price": 0.103, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HM-32C-256G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1203.04, "hourly_price": 1.648, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HM-48C-384G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 412316860416, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1778.4, "hourly_price": 2.47, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HM-4C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 150.38, "hourly_price": 0.206, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HM-64C-512G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 549755813888, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 2406.08, "hourly_price": 3.296, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HM-8C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 300.76, "hourly_price": 0.412, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HN-10": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 530.29, "hourly_price": 0.7264, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HN-3": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 186.49, "hourly_price": 0.2554, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HN-5": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 330.29, "hourly_price": 0.4524, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "PRO2-L": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 640.21, "hourly_price": 0.877, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6000000000, "sum_internet_bandwidth": 6000000000, "interfaces": [{"internal_bandwidth": 6000000000, "internet_bandwidth": 6000000000}]}, "block_bandwidth": 2097152000, "end_of_service": false}, "PRO2-M": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 319.74, "hourly_price": 0.438, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]}, "block_bandwidth": 1048576000, "end_of_service": false}, "PRO2-S": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 159.87, "hourly_price": 0.219, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]}, "block_bandwidth": 524288000, "end_of_service": false}, "PRO2-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 80.3, "hourly_price": 0.11, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth": 700000000, "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth": 700000000}]}, "block_bandwidth": 262144000, "end_of_service": false}, "PRO2-XXS": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 40.15, "hourly_price": 0.055, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth": 350000000, "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth": 350000000}]}, "block_bandwidth": 131072000, "end_of_service": false}, "RENDER-S": {"alt_names": [], "arch": "x86_64", "ncpus": 10, "ram": 45097156608, "gpu": 1, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "P100", "gpu_memory": 17179869184}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 400000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 891.33, "hourly_price": 1.221, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 2000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth": 2000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 2147483648, "end_of_service": false}, "STANDARD2-A16C-64G": {"alt_names": [], "arch": "arm64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 367.8324, "hourly_price": 0.5039, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "STANDARD2-A2C-8G": {"alt_names": [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 42.7525, "hourly_price": 0.0586, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "STANDARD2-A32C-128G": {"alt_names": [], "arch": "arm64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 735.7269, "hourly_price": 1.0078, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5033164800, "end_of_service": false}, "STANDARD2-A48C-192G": {"alt_names": [], "arch": "arm64", "ncpus": 48, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1103.5593, "hourly_price": 1.5117, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5033164800, "end_of_service": false}, "STANDARD2-A4C-16G": {"alt_names": [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 85.5049, "hourly_price": 0.1171, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "STANDARD2-A64C-256G": {"alt_names": [], "arch": "arm64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1470.366, "hourly_price": 2.0142, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5033164800, "end_of_service": false}, "STANDARD2-A8C-32G": {"alt_names": [], "arch": "arm64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 171.0098, "hourly_price": 0.2343, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "STANDARD3-X16C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 320000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 430.0, "hourly_price": 0.59, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 4000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 4000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "STANDARD3-X2C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 40000000000, "scratch_storage_max_volumes_count": 1, "monthly_price": 54.0, "hourly_price": 0.074, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "STANDARD3-X32C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 640000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 861.0, "hourly_price": 1.18, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 8000000000, "sum_internet_bandwidth": 8000000000, "interfaces": [{"internal_bandwidth": 8000000000, "internet_bandwidth": 8000000000}]}, "block_bandwidth": 1000341504, "end_of_service": false}, "STANDARD3-X48C-192G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 960000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1292.1, "hourly_price": 1.77, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "STANDARD3-X4C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 80000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 107.0, "hourly_price": 0.147, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "STANDARD3-X64C-256G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 1280000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1715.0, "hourly_price": 2.35, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "STANDARD3-X8C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 160000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 211.0, "hourly_price": 0.29, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}}}'
+        headers:
+            Content-Length:
+                - "40884"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:03:57 GMT
+            Link:
+                - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>; rel="previous",</products/servers?page=3&per_page=50&>; rel="next",</products/servers?page=3&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - cbee6a62-fe5c-4ba1-b798-0e3a77db07d1
+            X-Total-Count:
+                - "112"
+        status: 200 OK
+        code: 200
+        duration: 46.657617ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "3"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 10027
+        body: '{"servers": {"STARDUST1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 1, "ram": 1073741824, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 10000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 0.1095, "hourly_price": 0.00015, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]}, "block_bandwidth": 52428800, "end_of_service": false}, "START1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 26.864, "hourly_price": 0.0368, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "START1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 100000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 14.162, "hourly_price": 0.0194, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 300000000, "sum_internet_bandwidth": 300000000, "interfaces": [{"internal_bandwidth": 300000000, "internet_bandwidth": 300000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "START1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 50000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 7.738, "hourly_price": 0.0106, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "START1-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 1, "ram": 1073741824, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 25000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 4.526, "hourly_price": 0.0062, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "VC1L": {"alt_names": ["X64-8GB"], "arch": "x86_64", "ncpus": 6, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 18.0164, "hourly_price": 0.02468, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "VC1M": {"alt_names": ["X64-4GB"], "arch": "x86_64", "ncpus": 4, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 100000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 11.3515, "hourly_price": 0.01555, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "VC1S": {"alt_names": ["X64-2GB"], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 50000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 6.2926, "hourly_price": 0.00862, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "X64-120GB": {"alt_names": [], "arch": "x86_64", "ncpus": 12, "ram": 128849018880, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 800000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 310.7902, "hourly_price": 0.42574, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 1000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "X64-15GB": {"alt_names": [], "arch": "x86_64", "ncpus": 6, "ram": 16106127360, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 44.0336, "hourly_price": 0.06032, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 250000000, "sum_internet_bandwidth": 250000000, "interfaces": [{"internal_bandwidth": 250000000, "internet_bandwidth": 250000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "X64-30GB": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 32212254720, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 400000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 86.9138, "hourly_price": 0.11906, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "X64-60GB": {"alt_names": [], "arch": "x86_64", "ncpus": 10, "ram": 64424509440, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 700000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 155.49, "hourly_price": 0.213, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 1000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 41943040, "end_of_service": true}}}'
+        headers:
+            Content-Length:
+                - "10027"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:03:57 GMT
+            Link:
+                - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=2&per_page=50&>; rel="previous",</products/servers?page=3&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - fe8d22ac-4d65-4e9f-a5c9-37b905fb512b
+            X-Total-Count:
+                - "112"
+        status: 200 OK
+        code: 200
+        duration: 44.958537ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1642
+        body: '{"region":"fr-par","id":"1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:02:05.628299Z","updated_at":"2026-04-14T16:03:54.257711Z","type":"kapsule-dedicated-4","name":"test-pool-validate-size-dedi","description":"","status":"ready","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","validate-size-dedi"],"cluster_url":"https://1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":0},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"2d8463c9-1f6a-46c3-b7c5-12918cf80a3e","commitment_ends_at":"2026-05-14T16:02:05.628306Z","acl_available":true,"iam_nodes_group_id":"7ce2e2eb-69ce-4e3c-a744-d42d2f1ddf21","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1642"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:03:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - d7fc1d0e-a2af-4fab-a6e2-cff9154ec978
+        status: 200 OK
+        code: 200
+        duration: 26.649709ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/6529612e-91e2-4668-b4cb-3425c9cbc505
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 415
+        body: '{"id":"6529612e-91e2-4668-b4cb-3425c9cbc505","name":"tf-vpc-flamboyant-archimedes","tags":[],"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:02:04.566296Z","updated_at":"2026-04-14T16:02:04.566296Z","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","is_default":false,"private_network_count":1,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "415"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:03:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - 8c494f52-c3ef-4b0a-b11c-669728f2a23f
+        status: 200 OK
+        code: 200
+        duration: 28.564554ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/2d8463c9-1f6a-46c3-b7c5-12918cf80a3e
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1073
+        body: '{"id":"2d8463c9-1f6a-46c3-b7c5-12918cf80a3e","name":"test-pool-validate-size-dedi","tags":[],"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:02:04.695148Z","updated_at":"2026-04-14T16:02:04.695148Z","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnets":[{"id":"f4730d51-9d91-4769-963e-fa31668f6722","created_at":"2026-04-14T16:02:04.695148Z","updated_at":"2026-04-14T16:02:04.695148Z","subnet":"172.16.8.0/22","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"2d8463c9-1f6a-46c3-b7c5-12918cf80a3e","vpc_id":"6529612e-91e2-4668-b4cb-3425c9cbc505"},{"id":"af4a68ee-46ab-4424-9334-fe24f2a4e30a","created_at":"2026-04-14T16:02:04.695148Z","updated_at":"2026-04-14T16:02:04.695148Z","subnet":"fd63:256c:45f7:844f::/64","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"2d8463c9-1f6a-46c3-b7c5-12918cf80a3e","vpc_id":"6529612e-91e2-4668-b4cb-3425c9cbc505"}],"vpc_id":"6529612e-91e2-4668-b4cb-3425c9cbc505","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1073"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:03:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - ca449844-2636-41b3-b9da-5bcdb03304ac
+        status: 200 OK
+        code: 200
+        duration: 52.49632ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1642
+        body: '{"region":"fr-par","id":"1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:02:05.628299Z","updated_at":"2026-04-14T16:03:54.257711Z","type":"kapsule-dedicated-4","name":"test-pool-validate-size-dedi","description":"","status":"ready","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","validate-size-dedi"],"cluster_url":"https://1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":0},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"2d8463c9-1f6a-46c3-b7c5-12918cf80a3e","commitment_ends_at":"2026-05-14T16:02:05.628306Z","acl_available":true,"iam_nodes_group_id":"7ce2e2eb-69ce-4e3c-a744-d42d2f1ddf21","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1642"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:03:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - 1846125c-648e-4b4a-8940-c4b8d03a0432
+        status: 200 OK
+        code: 200
+        duration: 25.029818ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8/kubeconfig
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1764
+        body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC12YWxpZGF0ZS1zaXplLWRlZGkiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VKWVJFTkRRVkZIWjBGM1NVSkJaMGxDUVVSQlMwSm5aM0ZvYTJwUFVGRlJSRUZxUVZaTlVrMTNSVkZaUkZaUlVVUkZkM0J5WkZkS2JHTnROV3dLWkVkV2VrMUNORmhFVkVreVRVUlJlRTE2UlRKTlJFbDRUVVp2V0VSVVRUSk5SRkY0VFhwRk1rMUVTWGhOUm05M1JsUkZWRTFDUlVkQk1WVkZRWGhOU3dwaE0xWnBXbGhLZFZwWVVteGpla0phVFVKTlIwSjVjVWRUVFRRNVFXZEZSME5EY1VkVFRUUTVRWGRGU0VFd1NVRkNSMHMwV1ZablVXNTBlVE5pYm05UkNrMUtMMFpCZGpWVGVtUnNObm93UVhZNVRDdG5ibE16ZVRoc05sRmxiRzF6UWxka05UQXZVakIyUTNGVmMzVnFNMlY1WWtGNmJWZHhhRWRNV2t0SmNuSUtOWFZ2VnpWWU1tcFJha0pCVFVFMFIwRXhWV1JFZDBWQ0wzZFJSVUYzU1VOd1JFRlFRbWRPVmtoU1RVSkJaamhGUWxSQlJFRlJTQzlOUWpCSFFURlZaQXBFWjFGWFFrSlRha2xFWWl0TFFXYzFiWFozYkZKeFkycFlObUY1VDFGcVNYZEVRVXRDWjJkeGFHdHFUMUJSVVVSQlowNUtRVVJDUjBGcFJVRnVhMVJVQ25Ka1JHdFNlVXR3VUdGS1RXMUdlRVpyZG14RFZ6Rk1TME5PTmtGaVozbDVjamg1WWpoemEwTkpVVVJYVkZWS1JqSkhkWHBDZG5OQ2NWQkVUV2xDV2pJS2RrZElLeTluT1ZoTFducHRXWE5xSzNaU1pGZDVVVDA5Q2kwdExTMHRSVTVFSUVORlVsUkpSa2xEUVZSRkxTMHRMUzBLCiAgICBzZXJ2ZXI6IGh0dHBzOi8vMWJiMzRiZmItNzFlNy00OWY4LWJkYjAtYTcwNWMyMGVmOGE4LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC12YWxpZGF0ZS1zaXplLWRlZGkKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC12YWxpZGF0ZS1zaXplLWRlZGkiCiAgICB1c2VyOiB0ZXN0LXBvb2wtdmFsaWRhdGUtc2l6ZS1kZWRpLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXZhbGlkYXRlLXNpemUtZGVkaQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC12YWxpZGF0ZS1zaXplLWRlZGktYWRtaW4KICB1c2VyOgogICAgdG9rZW46IGh4T2hOcncxbGxGdlRDVDNhNlcydW9qTHY1OERPcUVDV281SGx1ZU44MG5pNmNsQmNjVjRMenZn"}'
+        headers:
+            Content-Length:
+                - "1764"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:03:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - 48b10f1c-bb43-4d7d-9d36-a68333199f80
+        status: 200 OK
+        code: 200
+        duration: 44.449029ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 41245
+        body: '{"servers": {"BASIC2-A16C-32G": {"alt_names": [], "arch": "arm64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 150.89, "hourly_price": 0.2067, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 503316480, "end_of_service": false}, "BASIC2-A16C-64G": {"alt_names": [], "arch": "arm64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 201.19, "hourly_price": 0.2756, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 503316480, "end_of_service": false}, "BASIC2-A2C-4G": {"alt_names": [], "arch": "arm64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 16.79, "hourly_price": 0.023, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 83886080, "end_of_service": false}, "BASIC2-A2C-8G": {"alt_names": [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 25.19, "hourly_price": 0.0345, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 83886080, "end_of_service": false}, "BASIC2-A4C-16G": {"alt_names": [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 50.3, "hourly_price": 0.0689, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 125829120, "end_of_service": false}, "BASIC2-A4C-8G": {"alt_names": [], "arch": "arm64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 37.74, "hourly_price": 0.0517, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 125829120, "end_of_service": false}, "BASIC2-A8C-16G": {"alt_names": [], "arch": "arm64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 75.48, "hourly_price": 0.1034, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 251658240, "end_of_service": false}, "BASIC2-A8C-32G": {"alt_names": [], "arch": "arm64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 100.59, "hourly_price": 0.1378, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 251658240, "end_of_service": false}, "BASIC3-X16C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 240.9, "hourly_price": 0.33, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]}, "block_bandwidth": 1048576000, "end_of_service": false}, "BASIC3-X16C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 321.2, "hourly_price": 0.44, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]}, "block_bandwidth": 1048576000, "end_of_service": false}, "BASIC3-X2C-4G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 26.791, "hourly_price": 0.0367, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth": 350000000, "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth": 350000000}]}, "block_bandwidth": 131072000, "end_of_service": false}, "BASIC3-X2C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 40.15, "hourly_price": 0.055, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth": 350000000, "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth": 350000000}]}, "block_bandwidth": 131072000, "end_of_service": false}, "BASIC3-X4C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 80.3, "hourly_price": 0.11, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth": 700000000, "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth": 700000000}]}, "block_bandwidth": 262144000, "end_of_service": false}, "BASIC3-X4C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 53.509, "hourly_price": 0.0733, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth": 700000000, "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth": 700000000}]}, "block_bandwidth": 262144000, "end_of_service": false}, "BASIC3-X8C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 120.45, "hourly_price": 0.165, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]}, "block_bandwidth": 524288000, "end_of_service": false}, "BASIC3-X8C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 160.6, "hourly_price": 0.22, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]}, "block_bandwidth": 524288000, "end_of_service": false}, "COMPUTE3-X16C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 320000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 341.786, "hourly_price": 0.4682, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 4000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 4000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "COMPUTE3-X2C-4G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 40000000000, "scratch_storage_max_volumes_count": 1, "monthly_price": 42.705, "hourly_price": 0.0585, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "COMPUTE3-X32C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 640000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 683.499, "hourly_price": 0.9363, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 8000000000, "sum_internet_bandwidth": 8000000000, "interfaces": [{"internal_bandwidth": 8000000000, "internet_bandwidth": 8000000000}]}, "block_bandwidth": 1000341504, "end_of_service": false}, "COMPUTE3-X48C-96G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 103079215104, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 960000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1019.81, "hourly_price": 1.397, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "COMPUTE3-X4C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 80000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 85.41, "hourly_price": 0.117, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "COMPUTE3-X64C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 1280000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1366.998, "hourly_price": 1.8726, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "COMPUTE3-X8C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 160000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 170.893, "hourly_price": 0.2341, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "COMPUTE3-X96C-192G": {"alt_names": [], "arch": "x86_64", "ncpus": 96, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 1280000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 2039.62, "hourly_price": 2.794, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "COPARM1-16C-64G": {"alt_names": [], "arch": "arm64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 252.14, "hourly_price": 0.3454, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 671088640, "end_of_service": false}, "COPARM1-2C-8G": {"alt_names": [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 31.1, "hourly_price": 0.0426, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 83886080, "end_of_service": false}, "COPARM1-32C-128G": {"alt_names": [], "arch": "arm64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 506.26, "hourly_price": 0.6935, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 1342177280, "end_of_service": false}, "COPARM1-4C-16G": {"alt_names": [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 62.56, "hourly_price": 0.0857, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 167772160, "end_of_service": false}, "COPARM1-8C-32G": {"alt_names": [], "arch": "arm64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 125.85, "hourly_price": 0.1724, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 335544320, "end_of_service": false}, "DEV1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 80000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 30.66, "hourly_price": 0.042, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 209715200, "end_of_service": false}, "DEV1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 3, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 40000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 14.454, "hourly_price": 0.0198, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 300000000, "sum_internet_bandwidth": 300000000, "interfaces": [{"internal_bandwidth": 300000000, "internet_bandwidth": 300000000}]}, "block_bandwidth": 157286400, "end_of_service": false}, "DEV1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 20000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 6.424, "hourly_price": 0.0088, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 104857600, "end_of_service": false}, "DEV1-XL": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 12884901888, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 120000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 46.5734, "hourly_price": 0.06378, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 262144000, "end_of_service": false}, "GP1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 554.07, "hourly_price": 0.759, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]}, "block_bandwidth": 1073741824, "end_of_service": false}, "GP1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 274.48, "hourly_price": 0.376, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "GP1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 300000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 136.51, "hourly_price": 0.187, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 524288000, "end_of_service": false}, "GP1-XL": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1197.93, "hourly_price": 1.641, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]}, "block_bandwidth": 2147483648, "end_of_service": false}, "GP1-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 150000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 66.43, "hourly_price": 0.091, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 314572800, "end_of_service": false}, "L4-1-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 51539607552, "gpu": 1, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 547.5, "hourly_price": 0.75, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 2500000000, "sum_internet_bandwidth": 2500000000, "interfaces": [{"internal_bandwidth": 2500000000, "internet_bandwidth": 2500000000}]}, "block_bandwidth": 1048576000, "end_of_service": false}, "L4-2-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 103079215104, "gpu": 2, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1095.0, "hourly_price": 1.5, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]}, "block_bandwidth": 1572864000, "end_of_service": false}, "L4-4-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 206158430208, "gpu": 4, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 2190.0, "hourly_price": 3.0, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]}, "block_bandwidth": 2621440000, "end_of_service": false}, "L4-8-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 412316860416, "gpu": 8, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 4380.0, "hourly_price": 6.0, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 20000000000, "sum_internet_bandwidth": 20000000000, "interfaces": [{"internal_bandwidth": 20000000000, "internet_bandwidth": 20000000000}]}, "block_bandwidth": 5242880000, "end_of_service": false}, "MEMORY3-X16C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 320000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 601.0, "hourly_price": 0.824, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 4000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 4000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "MEMORY3-X2C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 40000000000, "scratch_storage_max_volumes_count": 1, "monthly_price": 75.0, "hourly_price": 0.103, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "MEMORY3-X32C-256G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 640000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 1203.0, "hourly_price": 1.648, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 8000000000, "sum_internet_bandwidth": 8000000000, "interfaces": [{"internal_bandwidth": 8000000000, "internet_bandwidth": 8000000000}]}, "block_bandwidth": 1000341504, "end_of_service": false}, "MEMORY3-X48C-384G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 412316860416, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 960000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1804.0, "hourly_price": 2.472, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "MEMORY3-X4C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 80000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 150.0, "hourly_price": 0.206, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "MEMORY3-X8C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 160000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 300.0, "hourly_price": 0.412, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "PLAY2-MICRO": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 39.42, "hourly_price": 0.054, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 167772160, "end_of_service": false}, "PLAY2-NANO": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 19.71, "hourly_price": 0.027, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 83886080, "end_of_service": false}}}'
+        headers:
+            Content-Length:
+                - "41245"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:03:57 GMT
+            Link:
+                - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=3&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - 708fe6ef-7db9-4b1d-a5a8-926a8e2315e9
+            X-Total-Count:
+                - "112"
+        status: 200 OK
+        code: 200
+        duration: 52.378599ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "2"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 40884
+        body: '{"servers": {"PLAY2-PICO": {"alt_names": [], "arch": "x86_64", "ncpus": 1, "ram": 2147483648, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 10.22, "hourly_price": 0.014, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]}, "block_bandwidth": 41943040, "end_of_service": false}, "POP2-16C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 430.7, "hourly_price": 0.59, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-16C-64G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1063.391, "hourly_price": 1.4567, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-2C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 53.66, "hourly_price": 0.0735, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-2C-8G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 133.079, "hourly_price": 0.1823, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-32C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 861.4, "hourly_price": 1.18, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-32C-128G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 2126.709, "hourly_price": 2.9133, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-48C-192G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1274.4, "hourly_price": 1.77, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-4C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 107.31, "hourly_price": 0.147, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-4C-16G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 265.501, "hourly_price": 0.3637, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-64C-256G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1715.5, "hourly_price": 2.35, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-8C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 211.7, "hourly_price": 0.29, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-8C-32G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 528.009, "hourly_price": 0.7233, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HC-16C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 310.69, "hourly_price": 0.4256, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-HC-2C-4G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 38.84, "hourly_price": 0.0532, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HC-32C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 621.38, "hourly_price": 0.8512, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HC-48C-96G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 103079215104, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 914.4, "hourly_price": 1.27, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HC-4C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 77.67, "hourly_price": 0.1064, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HC-64C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1242.75, "hourly_price": 1.7024, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HC-8C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 155.34, "hourly_price": 0.2128, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HM-16C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 601.52, "hourly_price": 0.824, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-HM-2C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 75.19, "hourly_price": 0.103, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HM-32C-256G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1203.04, "hourly_price": 1.648, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HM-48C-384G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 412316860416, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1778.4, "hourly_price": 2.47, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HM-4C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 150.38, "hourly_price": 0.206, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HM-64C-512G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 549755813888, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 2406.08, "hourly_price": 3.296, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HM-8C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 300.76, "hourly_price": 0.412, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HN-10": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 530.29, "hourly_price": 0.7264, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HN-3": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 186.49, "hourly_price": 0.2554, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HN-5": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 330.29, "hourly_price": 0.4524, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "PRO2-L": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 640.21, "hourly_price": 0.877, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6000000000, "sum_internet_bandwidth": 6000000000, "interfaces": [{"internal_bandwidth": 6000000000, "internet_bandwidth": 6000000000}]}, "block_bandwidth": 2097152000, "end_of_service": false}, "PRO2-M": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 319.74, "hourly_price": 0.438, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]}, "block_bandwidth": 1048576000, "end_of_service": false}, "PRO2-S": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 159.87, "hourly_price": 0.219, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]}, "block_bandwidth": 524288000, "end_of_service": false}, "PRO2-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 80.3, "hourly_price": 0.11, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth": 700000000, "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth": 700000000}]}, "block_bandwidth": 262144000, "end_of_service": false}, "PRO2-XXS": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 40.15, "hourly_price": 0.055, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth": 350000000, "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth": 350000000}]}, "block_bandwidth": 131072000, "end_of_service": false}, "RENDER-S": {"alt_names": [], "arch": "x86_64", "ncpus": 10, "ram": 45097156608, "gpu": 1, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "P100", "gpu_memory": 17179869184}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 400000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 891.33, "hourly_price": 1.221, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 2000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth": 2000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 2147483648, "end_of_service": false}, "STANDARD2-A16C-64G": {"alt_names": [], "arch": "arm64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 367.8324, "hourly_price": 0.5039, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "STANDARD2-A2C-8G": {"alt_names": [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 42.7525, "hourly_price": 0.0586, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "STANDARD2-A32C-128G": {"alt_names": [], "arch": "arm64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 735.7269, "hourly_price": 1.0078, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5033164800, "end_of_service": false}, "STANDARD2-A48C-192G": {"alt_names": [], "arch": "arm64", "ncpus": 48, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1103.5593, "hourly_price": 1.5117, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5033164800, "end_of_service": false}, "STANDARD2-A4C-16G": {"alt_names": [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 85.5049, "hourly_price": 0.1171, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "STANDARD2-A64C-256G": {"alt_names": [], "arch": "arm64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1470.366, "hourly_price": 2.0142, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5033164800, "end_of_service": false}, "STANDARD2-A8C-32G": {"alt_names": [], "arch": "arm64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 171.0098, "hourly_price": 0.2343, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "STANDARD3-X16C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 320000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 430.0, "hourly_price": 0.59, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 4000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 4000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "STANDARD3-X2C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 40000000000, "scratch_storage_max_volumes_count": 1, "monthly_price": 54.0, "hourly_price": 0.074, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "STANDARD3-X32C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 640000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 861.0, "hourly_price": 1.18, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 8000000000, "sum_internet_bandwidth": 8000000000, "interfaces": [{"internal_bandwidth": 8000000000, "internet_bandwidth": 8000000000}]}, "block_bandwidth": 1000341504, "end_of_service": false}, "STANDARD3-X48C-192G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 960000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1292.1, "hourly_price": 1.77, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "STANDARD3-X4C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 80000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 107.0, "hourly_price": 0.147, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "STANDARD3-X64C-256G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 1280000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1715.0, "hourly_price": 2.35, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "STANDARD3-X8C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 160000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 211.0, "hourly_price": 0.29, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}}}'
+        headers:
+            Content-Length:
+                - "40884"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:03:57 GMT
+            Link:
+                - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>; rel="previous",</products/servers?page=3&per_page=50&>; rel="next",</products/servers?page=3&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - f810deb8-33e5-4c1d-bf92-5de93875cb29
+            X-Total-Count:
+                - "112"
+        status: 200 OK
+        code: 200
+        duration: 46.947942ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "3"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 10027
+        body: '{"servers": {"STARDUST1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 1, "ram": 1073741824, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 10000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 0.1095, "hourly_price": 0.00015, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]}, "block_bandwidth": 52428800, "end_of_service": false}, "START1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 26.864, "hourly_price": 0.0368, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "START1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 100000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 14.162, "hourly_price": 0.0194, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 300000000, "sum_internet_bandwidth": 300000000, "interfaces": [{"internal_bandwidth": 300000000, "internet_bandwidth": 300000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "START1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 50000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 7.738, "hourly_price": 0.0106, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "START1-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 1, "ram": 1073741824, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 25000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 4.526, "hourly_price": 0.0062, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "VC1L": {"alt_names": ["X64-8GB"], "arch": "x86_64", "ncpus": 6, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 18.0164, "hourly_price": 0.02468, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "VC1M": {"alt_names": ["X64-4GB"], "arch": "x86_64", "ncpus": 4, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 100000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 11.3515, "hourly_price": 0.01555, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "VC1S": {"alt_names": ["X64-2GB"], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 50000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 6.2926, "hourly_price": 0.00862, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "X64-120GB": {"alt_names": [], "arch": "x86_64", "ncpus": 12, "ram": 128849018880, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 800000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 310.7902, "hourly_price": 0.42574, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 1000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "X64-15GB": {"alt_names": [], "arch": "x86_64", "ncpus": 6, "ram": 16106127360, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 44.0336, "hourly_price": 0.06032, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 250000000, "sum_internet_bandwidth": 250000000, "interfaces": [{"internal_bandwidth": 250000000, "internet_bandwidth": 250000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "X64-30GB": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 32212254720, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 400000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 86.9138, "hourly_price": 0.11906, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "X64-60GB": {"alt_names": [], "arch": "x86_64", "ncpus": 10, "ram": 64424509440, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 700000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 155.49, "hourly_price": 0.213, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 1000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 41943040, "end_of_service": true}}}'
+        headers:
+            Content-Length:
+                - "10027"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:03:57 GMT
+            Link:
+                - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=2&per_page=50&>; rel="previous",</products/servers?page=3&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - ee4d4a2a-1e00-498d-abfe-2543bcdced38
+            X-Total-Count:
+                - "112"
+        status: 200 OK
+        code: 200
+        duration: 50.187265ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1642
+        body: '{"region":"fr-par","id":"1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:02:05.628299Z","updated_at":"2026-04-14T16:03:54.257711Z","type":"kapsule-dedicated-4","name":"test-pool-validate-size-dedi","description":"","status":"ready","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","validate-size-dedi"],"cluster_url":"https://1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":0},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"2d8463c9-1f6a-46c3-b7c5-12918cf80a3e","commitment_ends_at":"2026-05-14T16:02:05.628306Z","acl_available":true,"iam_nodes_group_id":"7ce2e2eb-69ce-4e3c-a744-d42d2f1ddf21","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1642"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:03:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - 92b43933-db45-46da-93d6-fa2bb0cf36aa
+        status: 200 OK
+        code: 200
+        duration: 24.83957ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 391
+        host: api.scaleway.com
+        body: '{"name":"test-pool-validate-size-dedi","node_type":"pro2_xxs","autoscaling":false,"size":0,"min_size":0,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","validate-size-dedi"],"kubelet_args":{},"zone":"fr-par-1","root_volume_type":"default_volume_type","public_ip_disabled":false,"labels":null,"taints":null,"startup_taints":null}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8/pools
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 779
+        body: '{"region":"fr-par","id":"657b45d7-c855-4f18-90e0-0e9373ef1147","cluster_id":"1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8","created_at":"2026-04-14T16:03:58.005096Z","updated_at":"2026-04-14T16:03:58.005096Z","name":"test-pool-validate-size-dedi","status":"scaling","version":"1.35.3","node_type":"pro2_xxs","autoscaling":false,"size":0,"min_size":0,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","validate-size-dedi"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{},"taints":[],"startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "779"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:03:58 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - 500aa870-2d32-4936-ab6d-12727a48a8ff
+        status: 200 OK
+        code: 200
+        duration: 102.046569ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/657b45d7-c855-4f18-90e0-0e9373ef1147
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 779
+        body: '{"region":"fr-par","id":"657b45d7-c855-4f18-90e0-0e9373ef1147","cluster_id":"1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8","created_at":"2026-04-14T16:03:58.005096Z","updated_at":"2026-04-14T16:03:58.005096Z","name":"test-pool-validate-size-dedi","status":"scaling","version":"1.35.3","node_type":"pro2_xxs","autoscaling":false,"size":0,"min_size":0,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","validate-size-dedi"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{},"taints":[],"startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "779"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:03:58 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - 4f7d1e5e-a9be-4054-8051-506ed72afb6d
+        status: 200 OK
+        code: 200
+        duration: 31.473306ms
+    - id: 25
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/657b45d7-c855-4f18-90e0-0e9373ef1147
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 777
+        body: '{"region":"fr-par","id":"657b45d7-c855-4f18-90e0-0e9373ef1147","cluster_id":"1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8","created_at":"2026-04-14T16:03:58.005096Z","updated_at":"2026-04-14T16:03:58.431365Z","name":"test-pool-validate-size-dedi","status":"ready","version":"1.35.3","node_type":"pro2_xxs","autoscaling":false,"size":0,"min_size":0,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","validate-size-dedi"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{},"taints":[],"startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "777"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:04:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - 2986fdd5-4ccd-443a-95ee-63d24f4e72bb
+        status: 200 OK
+        code: 200
+        duration: 33.5044ms
+    - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1642
+        body: '{"region":"fr-par","id":"1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:02:05.628299Z","updated_at":"2026-04-14T16:03:54.257711Z","type":"kapsule-dedicated-4","name":"test-pool-validate-size-dedi","description":"","status":"ready","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","validate-size-dedi"],"cluster_url":"https://1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":0},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"2d8463c9-1f6a-46c3-b7c5-12918cf80a3e","commitment_ends_at":"2026-05-14T16:02:05.628306Z","acl_available":true,"iam_nodes_group_id":"7ce2e2eb-69ce-4e3c-a744-d42d2f1ddf21","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1642"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:04:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - 9f525ce7-6ea3-4f17-aa15-d1161c97ac82
+        status: 200 OK
+        code: 200
+        duration: 29.372332ms
+    - id: 27
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/657b45d7-c855-4f18-90e0-0e9373ef1147
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 777
+        body: '{"region":"fr-par","id":"657b45d7-c855-4f18-90e0-0e9373ef1147","cluster_id":"1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8","created_at":"2026-04-14T16:03:58.005096Z","updated_at":"2026-04-14T16:03:58.431365Z","name":"test-pool-validate-size-dedi","status":"ready","version":"1.35.3","node_type":"pro2_xxs","autoscaling":false,"size":0,"min_size":0,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","validate-size-dedi"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{},"taints":[],"startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "777"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:04:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - d4020eb9-9b56-4398-aa72-bc4a205cb1ff
+        status: 200 OK
+        code: 200
+        duration: 27.025274ms
+    - id: 28
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_asc
+            page:
+                - "1"
+            pool_id:
+                - 657b45d7-c855-4f18-90e0-0e9373ef1147
+            status:
+                - unknown
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8/nodes?order_by=created_at_asc&page=1&pool_id=657b45d7-c855-4f18-90e0-0e9373ef1147&status=unknown
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 28
+        body: '{"total_count":0,"nodes":[]}'
+        headers:
+            Content-Length:
+                - "28"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:04:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - ec2ee24e-3a7e-4db5-89c4-8d07faccaac3
+        status: 200 OK
+        code: 200
+        duration: 24.076678ms
+    - id: 29
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1642
+        body: '{"region":"fr-par","id":"1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:02:05.628299Z","updated_at":"2026-04-14T16:03:54.257711Z","type":"kapsule-dedicated-4","name":"test-pool-validate-size-dedi","description":"","status":"ready","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","validate-size-dedi"],"cluster_url":"https://1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":0},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"2d8463c9-1f6a-46c3-b7c5-12918cf80a3e","commitment_ends_at":"2026-05-14T16:02:05.628306Z","acl_available":true,"iam_nodes_group_id":"7ce2e2eb-69ce-4e3c-a744-d42d2f1ddf21","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1642"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:04:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - 7c41d0fd-9a20-4194-bb44-23e2596603ff
+        status: 200 OK
+        code: 200
+        duration: 31.220622ms
+    - id: 30
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1642
+        body: '{"region":"fr-par","id":"1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:02:05.628299Z","updated_at":"2026-04-14T16:03:54.257711Z","type":"kapsule-dedicated-4","name":"test-pool-validate-size-dedi","description":"","status":"ready","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","validate-size-dedi"],"cluster_url":"https://1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":0},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"2d8463c9-1f6a-46c3-b7c5-12918cf80a3e","commitment_ends_at":"2026-05-14T16:02:05.628306Z","acl_available":true,"iam_nodes_group_id":"7ce2e2eb-69ce-4e3c-a744-d42d2f1ddf21","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1642"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:04:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - 73b1b29a-ab39-40a3-a596-48ab04e8a325
+        status: 200 OK
+        code: 200
+        duration: 22.453049ms
+    - id: 31
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/657b45d7-c855-4f18-90e0-0e9373ef1147
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 777
+        body: '{"region":"fr-par","id":"657b45d7-c855-4f18-90e0-0e9373ef1147","cluster_id":"1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8","created_at":"2026-04-14T16:03:58.005096Z","updated_at":"2026-04-14T16:03:58.431365Z","name":"test-pool-validate-size-dedi","status":"ready","version":"1.35.3","node_type":"pro2_xxs","autoscaling":false,"size":0,"min_size":0,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","validate-size-dedi"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{},"taints":[],"startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "777"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:04:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - d2192d12-5731-41bf-a17a-ac6373a8a38f
+        status: 200 OK
+        code: 200
+        duration: 27.700863ms
+    - id: 32
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/6529612e-91e2-4668-b4cb-3425c9cbc505
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 415
+        body: '{"id":"6529612e-91e2-4668-b4cb-3425c9cbc505","name":"tf-vpc-flamboyant-archimedes","tags":[],"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:02:04.566296Z","updated_at":"2026-04-14T16:02:04.566296Z","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","is_default":false,"private_network_count":1,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "415"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:04:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - 1c42ba6d-c313-4973-a4e3-6ac02bde1a86
+        status: 200 OK
+        code: 200
+        duration: 52.780444ms
+    - id: 33
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/2d8463c9-1f6a-46c3-b7c5-12918cf80a3e
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1073
+        body: '{"id":"2d8463c9-1f6a-46c3-b7c5-12918cf80a3e","name":"test-pool-validate-size-dedi","tags":[],"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:02:04.695148Z","updated_at":"2026-04-14T16:02:04.695148Z","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnets":[{"id":"f4730d51-9d91-4769-963e-fa31668f6722","created_at":"2026-04-14T16:02:04.695148Z","updated_at":"2026-04-14T16:02:04.695148Z","subnet":"172.16.8.0/22","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"2d8463c9-1f6a-46c3-b7c5-12918cf80a3e","vpc_id":"6529612e-91e2-4668-b4cb-3425c9cbc505"},{"id":"af4a68ee-46ab-4424-9334-fe24f2a4e30a","created_at":"2026-04-14T16:02:04.695148Z","updated_at":"2026-04-14T16:02:04.695148Z","subnet":"fd63:256c:45f7:844f::/64","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"2d8463c9-1f6a-46c3-b7c5-12918cf80a3e","vpc_id":"6529612e-91e2-4668-b4cb-3425c9cbc505"}],"vpc_id":"6529612e-91e2-4668-b4cb-3425c9cbc505","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1073"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:04:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - 940b0862-b552-4830-b311-265dfa904871
+        status: 200 OK
+        code: 200
+        duration: 48.80541ms
+    - id: 34
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1642
+        body: '{"region":"fr-par","id":"1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:02:05.628299Z","updated_at":"2026-04-14T16:03:54.257711Z","type":"kapsule-dedicated-4","name":"test-pool-validate-size-dedi","description":"","status":"ready","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","validate-size-dedi"],"cluster_url":"https://1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":0},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"2d8463c9-1f6a-46c3-b7c5-12918cf80a3e","commitment_ends_at":"2026-05-14T16:02:05.628306Z","acl_available":true,"iam_nodes_group_id":"7ce2e2eb-69ce-4e3c-a744-d42d2f1ddf21","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1642"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:04:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - 4ceb839b-c196-496d-9691-f5cff5154b77
+        status: 200 OK
+        code: 200
+        duration: 24.866531ms
+    - id: 35
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8/kubeconfig
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1764
+        body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC12YWxpZGF0ZS1zaXplLWRlZGkiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VKWVJFTkRRVkZIWjBGM1NVSkJaMGxDUVVSQlMwSm5aM0ZvYTJwUFVGRlJSRUZxUVZaTlVrMTNSVkZaUkZaUlVVUkZkM0J5WkZkS2JHTnROV3dLWkVkV2VrMUNORmhFVkVreVRVUlJlRTE2UlRKTlJFbDRUVVp2V0VSVVRUSk5SRkY0VFhwRk1rMUVTWGhOUm05M1JsUkZWRTFDUlVkQk1WVkZRWGhOU3dwaE0xWnBXbGhLZFZwWVVteGpla0phVFVKTlIwSjVjVWRUVFRRNVFXZEZSME5EY1VkVFRUUTVRWGRGU0VFd1NVRkNSMHMwV1ZablVXNTBlVE5pYm05UkNrMUtMMFpCZGpWVGVtUnNObm93UVhZNVRDdG5ibE16ZVRoc05sRmxiRzF6UWxka05UQXZVakIyUTNGVmMzVnFNMlY1WWtGNmJWZHhhRWRNV2t0SmNuSUtOWFZ2VnpWWU1tcFJha0pCVFVFMFIwRXhWV1JFZDBWQ0wzZFJSVUYzU1VOd1JFRlFRbWRPVmtoU1RVSkJaamhGUWxSQlJFRlJTQzlOUWpCSFFURlZaQXBFWjFGWFFrSlRha2xFWWl0TFFXYzFiWFozYkZKeFkycFlObUY1VDFGcVNYZEVRVXRDWjJkeGFHdHFUMUJSVVVSQlowNUtRVVJDUjBGcFJVRnVhMVJVQ25Ka1JHdFNlVXR3VUdGS1RXMUdlRVpyZG14RFZ6Rk1TME5PTmtGaVozbDVjamg1WWpoemEwTkpVVVJYVkZWS1JqSkhkWHBDZG5OQ2NWQkVUV2xDV2pJS2RrZElLeTluT1ZoTFducHRXWE5xSzNaU1pGZDVVVDA5Q2kwdExTMHRSVTVFSUVORlVsUkpSa2xEUVZSRkxTMHRMUzBLCiAgICBzZXJ2ZXI6IGh0dHBzOi8vMWJiMzRiZmItNzFlNy00OWY4LWJkYjAtYTcwNWMyMGVmOGE4LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC12YWxpZGF0ZS1zaXplLWRlZGkKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC12YWxpZGF0ZS1zaXplLWRlZGkiCiAgICB1c2VyOiB0ZXN0LXBvb2wtdmFsaWRhdGUtc2l6ZS1kZWRpLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXZhbGlkYXRlLXNpemUtZGVkaQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC12YWxpZGF0ZS1zaXplLWRlZGktYWRtaW4KICB1c2VyOgogICAgdG9rZW46IGh4T2hOcncxbGxGdlRDVDNhNlcydW9qTHY1OERPcUVDV281SGx1ZU44MG5pNmNsQmNjVjRMenZn"}'
+        headers:
+            Content-Length:
+                - "1764"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:04:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - 03fee13d-b8cf-4a5c-9cc7-4119167715b8
+        status: 200 OK
+        code: 200
+        duration: 40.679682ms
+    - id: 36
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/657b45d7-c855-4f18-90e0-0e9373ef1147
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 777
+        body: '{"region":"fr-par","id":"657b45d7-c855-4f18-90e0-0e9373ef1147","cluster_id":"1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8","created_at":"2026-04-14T16:03:58.005096Z","updated_at":"2026-04-14T16:03:58.431365Z","name":"test-pool-validate-size-dedi","status":"ready","version":"1.35.3","node_type":"pro2_xxs","autoscaling":false,"size":0,"min_size":0,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","validate-size-dedi"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{},"taints":[],"startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "777"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:04:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - 6bb7af09-9948-4903-a96b-78bb8d6a230b
+        status: 200 OK
+        code: 200
+        duration: 20.638482ms
+    - id: 37
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_asc
+            page:
+                - "1"
+            pool_id:
+                - 657b45d7-c855-4f18-90e0-0e9373ef1147
+            status:
+                - unknown
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8/nodes?order_by=created_at_asc&page=1&pool_id=657b45d7-c855-4f18-90e0-0e9373ef1147&status=unknown
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 28
+        body: '{"total_count":0,"nodes":[]}'
+        headers:
+            Content-Length:
+                - "28"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:04:04 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - d8773bff-efe1-4608-ac3e-a20b52291881
+        status: 200 OK
+        code: 200
+        duration: 27.772587ms
+    - id: 38
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1642
+        body: '{"region":"fr-par","id":"1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:02:05.628299Z","updated_at":"2026-04-14T16:03:54.257711Z","type":"kapsule-dedicated-4","name":"test-pool-validate-size-dedi","description":"","status":"ready","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","validate-size-dedi"],"cluster_url":"https://1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":0},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"2d8463c9-1f6a-46c3-b7c5-12918cf80a3e","commitment_ends_at":"2026-05-14T16:02:05.628306Z","acl_available":true,"iam_nodes_group_id":"7ce2e2eb-69ce-4e3c-a744-d42d2f1ddf21","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1642"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:04:04 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - edd27869-b7d5-4f9d-98f4-9e07a1a4043c
+        status: 200 OK
+        code: 200
+        duration: 37.285229ms
+    - id: 39
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/657b45d7-c855-4f18-90e0-0e9373ef1147
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 780
+        body: '{"region":"fr-par","id":"657b45d7-c855-4f18-90e0-0e9373ef1147","cluster_id":"1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8","created_at":"2026-04-14T16:03:58.005096Z","updated_at":"2026-04-14T16:04:04.369657Z","name":"test-pool-validate-size-dedi","status":"deleting","version":"1.35.3","node_type":"pro2_xxs","autoscaling":false,"size":0,"min_size":0,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","validate-size-dedi"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{},"taints":[],"startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "780"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:04:04 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - ca8d9dd4-f2bf-4ee3-a87f-5b2baf8554ce
+        status: 200 OK
+        code: 200
+        duration: 47.884881ms
+    - id: 40
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/657b45d7-c855-4f18-90e0-0e9373ef1147
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 780
+        body: '{"region":"fr-par","id":"657b45d7-c855-4f18-90e0-0e9373ef1147","cluster_id":"1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8","created_at":"2026-04-14T16:03:58.005096Z","updated_at":"2026-04-14T16:04:04.369657Z","name":"test-pool-validate-size-dedi","status":"deleting","version":"1.35.3","node_type":"pro2_xxs","autoscaling":false,"size":0,"min_size":0,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","validate-size-dedi"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{},"taints":[],"startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "780"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:04:04 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - 6502efe4-faab-4f6d-beb1-e0aa8bdd9834
+        status: 200 OK
+        code: 200
+        duration: 48.499656ms
+    - id: 41
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/657b45d7-c855-4f18-90e0-0e9373ef1147
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 125
+        body: '{"message":"resource is not found","resource":"pool","resource_id":"657b45d7-c855-4f18-90e0-0e9373ef1147","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "125"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:04:19 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - 77b0048a-01ef-467b-9e77-c98c09447ad7
+        status: 404 Not Found
+        code: 404
+        duration: 24.040891ms
+    - id: 42
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            with_additional_resources:
+                - "false"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8?with_additional_resources=false
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1645
+        body: '{"region":"fr-par","id":"1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:02:05.628299Z","updated_at":"2026-04-14T16:04:19.525522Z","type":"kapsule-dedicated-4","name":"test-pool-validate-size-dedi","description":"","status":"deleting","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","validate-size-dedi"],"cluster_url":"https://1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":0},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"2d8463c9-1f6a-46c3-b7c5-12918cf80a3e","commitment_ends_at":"2026-05-14T16:02:05.628306Z","acl_available":true,"iam_nodes_group_id":"7ce2e2eb-69ce-4e3c-a744-d42d2f1ddf21","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1645"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:04:19 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - 0b18f017-e435-47a3-a7ad-f18c9fb02c3e
+        status: 200 OK
+        code: 200
+        duration: 148.244194ms
+    - id: 43
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1645
+        body: '{"region":"fr-par","id":"1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:02:05.628299Z","updated_at":"2026-04-14T16:04:19.525522Z","type":"kapsule-dedicated-4","name":"test-pool-validate-size-dedi","description":"","status":"deleting","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","validate-size-dedi"],"cluster_url":"https://1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":0},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"2d8463c9-1f6a-46c3-b7c5-12918cf80a3e","commitment_ends_at":"2026-05-14T16:02:05.628306Z","acl_available":true,"iam_nodes_group_id":"7ce2e2eb-69ce-4e3c-a744-d42d2f1ddf21","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1645"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:04:19 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - 942eb265-461f-4a43-87c0-5d106d5c5334
+        status: 200 OK
+        code: 200
+        duration: 43.451067ms
+    - id: 44
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 128
+        body: '{"message":"resource is not found","resource":"cluster","resource_id":"1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "128"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - baec5228-ccf6-451b-b5ce-1c3294c8aa3c
+        status: 404 Not Found
+        code: 404
+        duration: 18.270714ms
+    - id: 45
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/2d8463c9-1f6a-46c3-b7c5-12918cf80a3e
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:47 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - efbf9208-6296-43c5-9031-a8fd0f3a6116
+        status: 204 No Content
+        code: 204
+        duration: 1.394446556s
+    - id: 46
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/6529612e-91e2-4668-b4cb-3425c9cbc505
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:47 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - 72900632-2f1c-493d-8fac-92bdd4f99e44
+        status: 204 No Content
+        code: 204
+        duration: 595.899895ms
+    - id: 47
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/657b45d7-c855-4f18-90e0-0e9373ef1147
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 125
+        body: '{"message":"resource is not found","resource":"pool","resource_id":"657b45d7-c855-4f18-90e0-0e9373ef1147","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "125"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:47 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - 12523302-6a54-41dd-a659-67752cbd3687
+        status: 404 Not Found
+        code: 404
+        duration: 23.138416ms
+    - id: 48
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 128
+        body: '{"message":"resource is not found","resource":"cluster","resource_id":"1bb34bfb-71e7-49f8-bdb0-a705c20ef8a8","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "128"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:47 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - afc227eb-6a87-44bb-9c8a-146c60cf2c75
+        status: 404 Not Found
+        code: 404
+        duration: 29.169203ms
+    - id: 49
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/2d8463c9-1f6a-46c3-b7c5-12918cf80a3e
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 136
+        body: '{"message":"resource is not found","resource":"private_network","resource_id":"2d8463c9-1f6a-46c3-b7c5-12918cf80a3e","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "136"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge01)
+            X-Request-Id:
+                - dc4b0a5b-2ef2-4490-ba92-7409ab24a851
+        status: 404 Not Found
+        code: 404
+        duration: 26.278823ms

--- a/internal/services/k8s/testdata/pool-validate-size-mutualized.cassette.yaml
+++ b/internal/services/k8s/testdata/pool-validate-size-mutualized.cassette.yaml
@@ -1,0 +1,2459 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/versions
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 4355
+        body: '{"versions":[{"region":"fr-par","name":"1.35.3","label":"Kubernetes 1.35.3","available_cnis":["cilium","cilium_native","calico","kilo","none"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","CPUManagerPolicyAlphaOptions","ImageVolume","MutatingAdmissionPolicy"],"available_admission_plugins":["AlwaysPullImages","PodNodeSelector","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","cpuManagerPolicyOptions":"map[string]string","enableDebuggingHandlers":"bool","evictionHard":"map[string]string","evictionMinimumReclaim":"map[string]string","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxParallelImagePulls":"int32","maxPods":"uint16","registryBurst":"int32","registryPullQPS":"int32","serializeImagePulls":"bool"},"deprecated_at":"2027-01-19T00:00:00Z","end_of_life_at":"2027-03-19T00:00:00Z","released_at":"2026-01-19T00:00:00Z"},{"region":"fr-par","name":"1.34.6","label":"Kubernetes 1.34.6","available_cnis":["cilium","cilium_native","calico","kilo","none"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","CPUManagerPolicyAlphaOptions","ImageVolume","MutatingAdmissionPolicy"],"available_admission_plugins":["AlwaysPullImages","PodNodeSelector","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","cpuManagerPolicyOptions":"map[string]string","enableDebuggingHandlers":"bool","evictionHard":"map[string]string","evictionMinimumReclaim":"map[string]string","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxParallelImagePulls":"int32","maxPods":"uint16","registryBurst":"int32","registryPullQPS":"int32","serializeImagePulls":"bool"},"deprecated_at":"2026-09-29T00:00:00Z","end_of_life_at":"2026-11-29T00:00:00Z","released_at":"2025-09-29T00:00:00Z"},{"region":"fr-par","name":"1.33.10","label":"Kubernetes 1.33.10","available_cnis":["cilium","calico","kilo","none"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","DRAAdminAccess","DynamicResourceAllocation","PodLevelResources","CPUManagerPolicyAlphaOptions","ImageVolume"],"available_admission_plugins":["AlwaysPullImages","PodNodeSelector","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","cpuManagerPolicyOptions":"map[string]string","enableDebuggingHandlers":"bool","evictionHard":"map[string]string","evictionMinimumReclaim":"map[string]string","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxParallelImagePulls":"int32","maxPods":"uint16","registryBurst":"int32","registryPullQPS":"int32","serializeImagePulls":"bool"},"deprecated_at":"2026-09-04T00:00:00Z","end_of_life_at":"2026-11-04T00:00:00Z","released_at":"2025-09-04T00:00:00Z"},{"region":"fr-par","name":"1.32.13","label":"Kubernetes 1.32.13","available_cnis":["cilium","calico","kilo","none"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","InPlacePodVerticalScaling","SidecarContainers","DRAAdminAccess","DRAResourceClaimDeviceStatus","DynamicResourceAllocation","PodLevelResources","CPUManagerPolicyAlphaOptions","ImageVolume"],"available_admission_plugins":["AlwaysPullImages","PodNodeSelector","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","cpuManagerPolicyOptions":"map[string]string","enableDebuggingHandlers":"bool","evictionHard":"map[string]string","evictionMinimumReclaim":"map[string]string","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxParallelImagePulls":"int32","maxPods":"uint16","registryBurst":"int32","registryPullQPS":"int32","serializeImagePulls":"bool"},"deprecated_at":"2026-03-24T00:00:00Z","end_of_life_at":"2026-06-24T00:00:00Z","released_at":"2025-03-24T00:00:00Z"}]}'
+        headers:
+            Content-Length:
+                - "4355"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:01:59 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - 59aad5db-1586-4459-8a74-c05492b516cb
+        status: 200 OK
+        code: 200
+        duration: 64.326008ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 117
+        host: api.scaleway.com
+        body: '{"name":"tf-vpc-hopeful-wilson","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"enable_routing":false}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 408
+        body: '{"id":"e7815bf0-5d3f-4e0a-aadb-c224ed23c413","name":"tf-vpc-hopeful-wilson","tags":[],"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:02:00.342502Z","updated_at":"2026-04-14T16:02:00.342502Z","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","is_default":false,"private_network_count":0,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "408"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:02:00 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - fb2b2966-dca4-44b1-b231-4566cac5fec8
+        status: 200 OK
+        code: 200
+        duration: 86.148182ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/e7815bf0-5d3f-4e0a-aadb-c224ed23c413
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 408
+        body: '{"id":"e7815bf0-5d3f-4e0a-aadb-c224ed23c413","name":"tf-vpc-hopeful-wilson","tags":[],"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:02:00.342502Z","updated_at":"2026-04-14T16:02:00.342502Z","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","is_default":false,"private_network_count":0,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "408"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:02:00 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - 5f8a4bc4-ca43-4a6e-bb7b-52093d5a6725
+        status: 200 OK
+        code: 200
+        duration: 72.538728ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 206
+        host: api.scaleway.com
+        body: '{"name":"test-pool-validate-size-mutu","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"subnets":null,"vpc_id":"e7815bf0-5d3f-4e0a-aadb-c224ed23c413","default_route_propagation_enabled":false}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1073
+        body: '{"id":"bacaf9bc-6bf2-45c1-8d45-d74d1b78cecf","name":"test-pool-validate-size-mutu","tags":[],"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:02:00.511641Z","updated_at":"2026-04-14T16:02:00.511641Z","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnets":[{"id":"8d0b31ea-0e89-471f-8fa3-9ae4ded56867","created_at":"2026-04-14T16:02:00.511641Z","updated_at":"2026-04-14T16:02:00.511641Z","subnet":"172.16.0.0/22","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"bacaf9bc-6bf2-45c1-8d45-d74d1b78cecf","vpc_id":"e7815bf0-5d3f-4e0a-aadb-c224ed23c413"},{"id":"2bde632d-99ef-4d13-81a0-2fce035faa2c","created_at":"2026-04-14T16:02:00.511641Z","updated_at":"2026-04-14T16:02:00.511641Z","subnet":"fd63:256c:45f7:92f0::/64","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"bacaf9bc-6bf2-45c1-8d45-d74d1b78cecf","vpc_id":"e7815bf0-5d3f-4e0a-aadb-c224ed23c413"}],"vpc_id":"e7815bf0-5d3f-4e0a-aadb-c224ed23c413","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1073"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:02:01 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - 451502cf-7f6b-4dba-bb06-5690489f906c
+        status: 200 OK
+        code: 200
+        duration: 718.942554ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/bacaf9bc-6bf2-45c1-8d45-d74d1b78cecf
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1073
+        body: '{"id":"bacaf9bc-6bf2-45c1-8d45-d74d1b78cecf","name":"test-pool-validate-size-mutu","tags":[],"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:02:00.511641Z","updated_at":"2026-04-14T16:02:00.511641Z","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnets":[{"id":"8d0b31ea-0e89-471f-8fa3-9ae4ded56867","created_at":"2026-04-14T16:02:00.511641Z","updated_at":"2026-04-14T16:02:00.511641Z","subnet":"172.16.0.0/22","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"bacaf9bc-6bf2-45c1-8d45-d74d1b78cecf","vpc_id":"e7815bf0-5d3f-4e0a-aadb-c224ed23c413"},{"id":"2bde632d-99ef-4d13-81a0-2fce035faa2c","created_at":"2026-04-14T16:02:00.511641Z","updated_at":"2026-04-14T16:02:00.511641Z","subnet":"fd63:256c:45f7:92f0::/64","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"bacaf9bc-6bf2-45c1-8d45-d74d1b78cecf","vpc_id":"e7815bf0-5d3f-4e0a-aadb-c224ed23c413"}],"vpc_id":"e7815bf0-5d3f-4e0a-aadb-c224ed23c413","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1073"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:02:01 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - a80c5b9d-be36-47d2-8f86-11e7ff86c974
+        status: 200 OK
+        code: 200
+        duration: 32.55189ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 717
+        host: api.scaleway.com
+        body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-pool-validate-size-mutu","description":"","tags":["terraform-test","scaleway_k8s_pool","validate-size-mutu"],"version":"1.35.3","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":[],"admission_plugins":[],"apiserver_cert_sans":[],"private_network_id":"bacaf9bc-6bf2-45c1-8d45-d74d1b78cecf"}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1597
+        body: '{"region":"fr-par","id":"9bc4ec66-c6b0-435f-89d4-8387b7296354","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:02:01.558575Z","updated_at":"2026-04-14T16:02:01.558575Z","type":"kapsule","name":"test-pool-validate-size-mutu","description":"","status":"creating","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","validate-size-mutu"],"cluster_url":"https://9bc4ec66-c6b0-435f-89d4-8387b7296354.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.9bc4ec66-c6b0-435f-89d4-8387b7296354.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":0},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"bacaf9bc-6bf2-45c1-8d45-d74d1b78cecf","commitment_ends_at":"2026-04-14T16:02:01.558579Z","acl_available":true,"iam_nodes_group_id":"","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1597"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:02:01 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - 4320414c-4089-4365-a29c-2ab1b5b952c2
+        status: 200 OK
+        code: 200
+        duration: 388.094544ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9bc4ec66-c6b0-435f-89d4-8387b7296354
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1597
+        body: '{"region":"fr-par","id":"9bc4ec66-c6b0-435f-89d4-8387b7296354","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:02:01.558575Z","updated_at":"2026-04-14T16:02:01.558575Z","type":"kapsule","name":"test-pool-validate-size-mutu","description":"","status":"creating","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","validate-size-mutu"],"cluster_url":"https://9bc4ec66-c6b0-435f-89d4-8387b7296354.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.9bc4ec66-c6b0-435f-89d4-8387b7296354.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":0},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"bacaf9bc-6bf2-45c1-8d45-d74d1b78cecf","commitment_ends_at":"2026-04-14T16:02:01.558579Z","acl_available":true,"iam_nodes_group_id":"","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1597"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:02:01 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - b7bb85df-5dbf-4693-8bf6-2c2d2bbf32f9
+        status: 200 OK
+        code: 200
+        duration: 38.966673ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9bc4ec66-c6b0-435f-89d4-8387b7296354
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1638
+        body: '{"region":"fr-par","id":"9bc4ec66-c6b0-435f-89d4-8387b7296354","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:02:01.558575Z","updated_at":"2026-04-14T16:02:08.747882Z","type":"kapsule","name":"test-pool-validate-size-mutu","description":"","status":"pool_required","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","validate-size-mutu"],"cluster_url":"https://9bc4ec66-c6b0-435f-89d4-8387b7296354.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.9bc4ec66-c6b0-435f-89d4-8387b7296354.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":0},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"bacaf9bc-6bf2-45c1-8d45-d74d1b78cecf","commitment_ends_at":"2026-04-14T16:02:01.558579Z","acl_available":true,"iam_nodes_group_id":"dca3da3d-b07b-440b-ae09-9591cf5e3828","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1638"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:02:11 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - 2726b6f0-bc06-4e10-a60d-a78a7fb34f11
+        status: 200 OK
+        code: 200
+        duration: 55.344735ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_asc
+            page:
+                - "1"
+            status:
+                - unknown
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9bc4ec66-c6b0-435f-89d4-8387b7296354/pools?order_by=created_at_asc&page=1&status=unknown
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 28
+        body: '{"total_count":0,"pools":[]}'
+        headers:
+            Content-Length:
+                - "28"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:02:11 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - 50dc71dc-de0e-48f6-a97b-29c02344a7aa
+        status: 200 OK
+        code: 200
+        duration: 22.106748ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9bc4ec66-c6b0-435f-89d4-8387b7296354
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1638
+        body: '{"region":"fr-par","id":"9bc4ec66-c6b0-435f-89d4-8387b7296354","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:02:01.558575Z","updated_at":"2026-04-14T16:02:08.747882Z","type":"kapsule","name":"test-pool-validate-size-mutu","description":"","status":"pool_required","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","validate-size-mutu"],"cluster_url":"https://9bc4ec66-c6b0-435f-89d4-8387b7296354.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.9bc4ec66-c6b0-435f-89d4-8387b7296354.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":0},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"bacaf9bc-6bf2-45c1-8d45-d74d1b78cecf","commitment_ends_at":"2026-04-14T16:02:01.558579Z","acl_available":true,"iam_nodes_group_id":"dca3da3d-b07b-440b-ae09-9591cf5e3828","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1638"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:02:11 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - 425f93ce-c6a8-4f10-8703-d66e99bce355
+        status: 200 OK
+        code: 200
+        duration: 35.965669ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9bc4ec66-c6b0-435f-89d4-8387b7296354/kubeconfig
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1760
+        body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC12YWxpZGF0ZS1zaXplLW11dHUiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VKWGFrTkRRVkZIWjBGM1NVSkJaMGxDUVVSQlMwSm5aM0ZvYTJwUFVGRlJSRUZxUVZaTlVrMTNSVkZaUkZaUlVVUkZkM0J5WkZkS2JHTnROV3dLWkVkV2VrMUNORmhFVkVreVRVUlJlRTE2UlRKTlJFbDNUMFp2V0VSVVRUSk5SRkY0VFhwRk1rMUVTWGRQUm05M1JsUkZWRTFDUlVkQk1WVkZRWGhOU3dwaE0xWnBXbGhLZFZwWVVteGpla0phVFVKTlIwSjVjVWRUVFRRNVFXZEZSME5EY1VkVFRUUTVRWGRGU0VFd1NVRkNVRVZvUWxOR1RGQjFPSGxyZFZkbENuWXlOMFJtUjJOSmFXOVVUamgzVVdweFltWXlSRVl5Y0hsbWNrNU9jMGxWZEhoek4zZDNlWFpEWXpaWFZFeDZOa3d6VVdrelVtazJNV2RSY1hkSldIZ0tXRzFVVGtjNVUycFJha0pCVFVFMFIwRXhWV1JFZDBWQ0wzZFJSVUYzU1VOd1JFRlFRbWRPVmtoU1RVSkJaamhGUWxSQlJFRlJTQzlOUWpCSFFURlZaQXBFWjFGWFFrSlNNamhaZDJRNVdIZ3dNMFUyTkVOTFNGZzBkek5VTTBJMGNqZHFRVXRDWjJkeGFHdHFUMUJSVVVSQlowNUlRVVJDUlVGcFFYRlFkVEJKQ2k4MU1ubFBSMUJwTmtkb2NVaDJTMGg2TlVwRE5HOTFaR2hUWWpNMmJsbHdUemxvUTFKQlNXZEZhRkYzUm5wc1NTOUVkVXRpU2tOaFQyaEtkR0UwUjNVS1IzSjFVMnRDTVVSS0wwNHdOVGxDTUd4d2R6MEtMUzB0TFMxRlRrUWdRMFZTVkVsR1NVTkJWRVV0TFMwdExRbz0KICAgIHNlcnZlcjogaHR0cHM6Ly85YmM0ZWM2Ni1jNmIwLTQzNWYtODlkNC04Mzg3YjcyOTYzNTQuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXZhbGlkYXRlLXNpemUtbXV0dQogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXZhbGlkYXRlLXNpemUtbXV0dSIKICAgIHVzZXI6IHRlc3QtcG9vbC12YWxpZGF0ZS1zaXplLW11dHUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtdmFsaWRhdGUtc2l6ZS1tdXR1CmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXZhbGlkYXRlLXNpemUtbXV0dS1hZG1pbgogIHVzZXI6CiAgICB0b2tlbjoganNPYXZKTWR6czFiOVdLQlUxbXM0Q0xUVm5ESzd2QnVXcVA0ODlYV1dGQ1FnSTd4QmhCV2tmV3Y="}'
+        headers:
+            Content-Length:
+                - "1760"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:02:11 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - 0054a27a-979b-4c08-9637-814c1f2fd0b7
+        status: 200 OK
+        code: 200
+        duration: 62.220385ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 41245
+        body: '{"servers": {"BASIC2-A16C-32G": {"alt_names": [], "arch": "arm64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 150.89, "hourly_price": 0.2067, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 503316480, "end_of_service": false}, "BASIC2-A16C-64G": {"alt_names": [], "arch": "arm64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 201.19, "hourly_price": 0.2756, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 503316480, "end_of_service": false}, "BASIC2-A2C-4G": {"alt_names": [], "arch": "arm64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 16.79, "hourly_price": 0.023, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 83886080, "end_of_service": false}, "BASIC2-A2C-8G": {"alt_names": [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 25.19, "hourly_price": 0.0345, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 83886080, "end_of_service": false}, "BASIC2-A4C-16G": {"alt_names": [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 50.3, "hourly_price": 0.0689, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 125829120, "end_of_service": false}, "BASIC2-A4C-8G": {"alt_names": [], "arch": "arm64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 37.74, "hourly_price": 0.0517, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 125829120, "end_of_service": false}, "BASIC2-A8C-16G": {"alt_names": [], "arch": "arm64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 75.48, "hourly_price": 0.1034, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 251658240, "end_of_service": false}, "BASIC2-A8C-32G": {"alt_names": [], "arch": "arm64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 100.59, "hourly_price": 0.1378, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 251658240, "end_of_service": false}, "BASIC3-X16C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 240.9, "hourly_price": 0.33, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]}, "block_bandwidth": 1048576000, "end_of_service": false}, "BASIC3-X16C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 321.2, "hourly_price": 0.44, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]}, "block_bandwidth": 1048576000, "end_of_service": false}, "BASIC3-X2C-4G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 26.791, "hourly_price": 0.0367, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth": 350000000, "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth": 350000000}]}, "block_bandwidth": 131072000, "end_of_service": false}, "BASIC3-X2C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 40.15, "hourly_price": 0.055, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth": 350000000, "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth": 350000000}]}, "block_bandwidth": 131072000, "end_of_service": false}, "BASIC3-X4C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 80.3, "hourly_price": 0.11, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth": 700000000, "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth": 700000000}]}, "block_bandwidth": 262144000, "end_of_service": false}, "BASIC3-X4C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 53.509, "hourly_price": 0.0733, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth": 700000000, "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth": 700000000}]}, "block_bandwidth": 262144000, "end_of_service": false}, "BASIC3-X8C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 120.45, "hourly_price": 0.165, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]}, "block_bandwidth": 524288000, "end_of_service": false}, "BASIC3-X8C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 160.6, "hourly_price": 0.22, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]}, "block_bandwidth": 524288000, "end_of_service": false}, "COMPUTE3-X16C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 320000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 341.786, "hourly_price": 0.4682, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 4000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 4000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "COMPUTE3-X2C-4G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 40000000000, "scratch_storage_max_volumes_count": 1, "monthly_price": 42.705, "hourly_price": 0.0585, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "COMPUTE3-X32C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 640000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 683.499, "hourly_price": 0.9363, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 8000000000, "sum_internet_bandwidth": 8000000000, "interfaces": [{"internal_bandwidth": 8000000000, "internet_bandwidth": 8000000000}]}, "block_bandwidth": 1000341504, "end_of_service": false}, "COMPUTE3-X48C-96G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 103079215104, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 960000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1019.81, "hourly_price": 1.397, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "COMPUTE3-X4C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 80000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 85.41, "hourly_price": 0.117, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "COMPUTE3-X64C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 1280000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1366.998, "hourly_price": 1.8726, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "COMPUTE3-X8C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 160000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 170.893, "hourly_price": 0.2341, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "COMPUTE3-X96C-192G": {"alt_names": [], "arch": "x86_64", "ncpus": 96, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 1280000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 2039.62, "hourly_price": 2.794, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "COPARM1-16C-64G": {"alt_names": [], "arch": "arm64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 252.14, "hourly_price": 0.3454, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 671088640, "end_of_service": false}, "COPARM1-2C-8G": {"alt_names": [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 31.1, "hourly_price": 0.0426, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 83886080, "end_of_service": false}, "COPARM1-32C-128G": {"alt_names": [], "arch": "arm64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 506.26, "hourly_price": 0.6935, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 1342177280, "end_of_service": false}, "COPARM1-4C-16G": {"alt_names": [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 62.56, "hourly_price": 0.0857, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 167772160, "end_of_service": false}, "COPARM1-8C-32G": {"alt_names": [], "arch": "arm64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 125.85, "hourly_price": 0.1724, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 335544320, "end_of_service": false}, "DEV1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 80000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 30.66, "hourly_price": 0.042, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 209715200, "end_of_service": false}, "DEV1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 3, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 40000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 14.454, "hourly_price": 0.0198, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 300000000, "sum_internet_bandwidth": 300000000, "interfaces": [{"internal_bandwidth": 300000000, "internet_bandwidth": 300000000}]}, "block_bandwidth": 157286400, "end_of_service": false}, "DEV1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 20000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 6.424, "hourly_price": 0.0088, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 104857600, "end_of_service": false}, "DEV1-XL": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 12884901888, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 120000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 46.5734, "hourly_price": 0.06378, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 262144000, "end_of_service": false}, "GP1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 554.07, "hourly_price": 0.759, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]}, "block_bandwidth": 1073741824, "end_of_service": false}, "GP1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 274.48, "hourly_price": 0.376, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "GP1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 300000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 136.51, "hourly_price": 0.187, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 524288000, "end_of_service": false}, "GP1-XL": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1197.93, "hourly_price": 1.641, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]}, "block_bandwidth": 2147483648, "end_of_service": false}, "GP1-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 150000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 66.43, "hourly_price": 0.091, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 314572800, "end_of_service": false}, "L4-1-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 51539607552, "gpu": 1, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 547.5, "hourly_price": 0.75, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 2500000000, "sum_internet_bandwidth": 2500000000, "interfaces": [{"internal_bandwidth": 2500000000, "internet_bandwidth": 2500000000}]}, "block_bandwidth": 1048576000, "end_of_service": false}, "L4-2-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 103079215104, "gpu": 2, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1095.0, "hourly_price": 1.5, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]}, "block_bandwidth": 1572864000, "end_of_service": false}, "L4-4-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 206158430208, "gpu": 4, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 2190.0, "hourly_price": 3.0, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]}, "block_bandwidth": 2621440000, "end_of_service": false}, "L4-8-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 412316860416, "gpu": 8, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 4380.0, "hourly_price": 6.0, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 20000000000, "sum_internet_bandwidth": 20000000000, "interfaces": [{"internal_bandwidth": 20000000000, "internet_bandwidth": 20000000000}]}, "block_bandwidth": 5242880000, "end_of_service": false}, "MEMORY3-X16C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 320000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 601.0, "hourly_price": 0.824, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 4000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 4000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "MEMORY3-X2C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 40000000000, "scratch_storage_max_volumes_count": 1, "monthly_price": 75.0, "hourly_price": 0.103, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "MEMORY3-X32C-256G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 640000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 1203.0, "hourly_price": 1.648, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 8000000000, "sum_internet_bandwidth": 8000000000, "interfaces": [{"internal_bandwidth": 8000000000, "internet_bandwidth": 8000000000}]}, "block_bandwidth": 1000341504, "end_of_service": false}, "MEMORY3-X48C-384G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 412316860416, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 960000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1804.0, "hourly_price": 2.472, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "MEMORY3-X4C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 80000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 150.0, "hourly_price": 0.206, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "MEMORY3-X8C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 160000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 300.0, "hourly_price": 0.412, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "PLAY2-MICRO": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 39.42, "hourly_price": 0.054, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 167772160, "end_of_service": false}, "PLAY2-NANO": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 19.71, "hourly_price": 0.027, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 83886080, "end_of_service": false}}}'
+        headers:
+            Content-Length:
+                - "41245"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:02:11 GMT
+            Link:
+                - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=3&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - 1e93aa82-49df-4f35-b5e8-a082f05f4728
+            X-Total-Count:
+                - "112"
+        status: 200 OK
+        code: 200
+        duration: 46.148128ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "2"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 40884
+        body: '{"servers": {"PLAY2-PICO": {"alt_names": [], "arch": "x86_64", "ncpus": 1, "ram": 2147483648, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 10.22, "hourly_price": 0.014, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]}, "block_bandwidth": 41943040, "end_of_service": false}, "POP2-16C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 430.7, "hourly_price": 0.59, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-16C-64G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1063.391, "hourly_price": 1.4567, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-2C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 53.66, "hourly_price": 0.0735, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-2C-8G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 133.079, "hourly_price": 0.1823, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-32C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 861.4, "hourly_price": 1.18, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-32C-128G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 2126.709, "hourly_price": 2.9133, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-48C-192G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1274.4, "hourly_price": 1.77, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-4C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 107.31, "hourly_price": 0.147, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-4C-16G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 265.501, "hourly_price": 0.3637, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-64C-256G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1715.5, "hourly_price": 2.35, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-8C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 211.7, "hourly_price": 0.29, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-8C-32G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 528.009, "hourly_price": 0.7233, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HC-16C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 310.69, "hourly_price": 0.4256, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-HC-2C-4G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 38.84, "hourly_price": 0.0532, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HC-32C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 621.38, "hourly_price": 0.8512, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HC-48C-96G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 103079215104, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 914.4, "hourly_price": 1.27, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HC-4C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 77.67, "hourly_price": 0.1064, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HC-64C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1242.75, "hourly_price": 1.7024, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HC-8C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 155.34, "hourly_price": 0.2128, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HM-16C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 601.52, "hourly_price": 0.824, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-HM-2C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 75.19, "hourly_price": 0.103, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HM-32C-256G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1203.04, "hourly_price": 1.648, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HM-48C-384G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 412316860416, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1778.4, "hourly_price": 2.47, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HM-4C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 150.38, "hourly_price": 0.206, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HM-64C-512G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 549755813888, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 2406.08, "hourly_price": 3.296, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HM-8C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 300.76, "hourly_price": 0.412, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HN-10": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 530.29, "hourly_price": 0.7264, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HN-3": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 186.49, "hourly_price": 0.2554, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HN-5": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 330.29, "hourly_price": 0.4524, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "PRO2-L": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 640.21, "hourly_price": 0.877, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6000000000, "sum_internet_bandwidth": 6000000000, "interfaces": [{"internal_bandwidth": 6000000000, "internet_bandwidth": 6000000000}]}, "block_bandwidth": 2097152000, "end_of_service": false}, "PRO2-M": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 319.74, "hourly_price": 0.438, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]}, "block_bandwidth": 1048576000, "end_of_service": false}, "PRO2-S": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 159.87, "hourly_price": 0.219, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]}, "block_bandwidth": 524288000, "end_of_service": false}, "PRO2-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 80.3, "hourly_price": 0.11, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth": 700000000, "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth": 700000000}]}, "block_bandwidth": 262144000, "end_of_service": false}, "PRO2-XXS": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 40.15, "hourly_price": 0.055, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth": 350000000, "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth": 350000000}]}, "block_bandwidth": 131072000, "end_of_service": false}, "RENDER-S": {"alt_names": [], "arch": "x86_64", "ncpus": 10, "ram": 45097156608, "gpu": 1, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "P100", "gpu_memory": 17179869184}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 400000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 891.33, "hourly_price": 1.221, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 2000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth": 2000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 2147483648, "end_of_service": false}, "STANDARD2-A16C-64G": {"alt_names": [], "arch": "arm64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 367.8324, "hourly_price": 0.5039, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "STANDARD2-A2C-8G": {"alt_names": [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 42.7525, "hourly_price": 0.0586, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "STANDARD2-A32C-128G": {"alt_names": [], "arch": "arm64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 735.7269, "hourly_price": 1.0078, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5033164800, "end_of_service": false}, "STANDARD2-A48C-192G": {"alt_names": [], "arch": "arm64", "ncpus": 48, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1103.5593, "hourly_price": 1.5117, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5033164800, "end_of_service": false}, "STANDARD2-A4C-16G": {"alt_names": [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 85.5049, "hourly_price": 0.1171, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "STANDARD2-A64C-256G": {"alt_names": [], "arch": "arm64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1470.366, "hourly_price": 2.0142, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5033164800, "end_of_service": false}, "STANDARD2-A8C-32G": {"alt_names": [], "arch": "arm64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 171.0098, "hourly_price": 0.2343, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "STANDARD3-X16C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 320000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 430.0, "hourly_price": 0.59, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 4000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 4000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "STANDARD3-X2C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 40000000000, "scratch_storage_max_volumes_count": 1, "monthly_price": 54.0, "hourly_price": 0.074, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "STANDARD3-X32C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 640000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 861.0, "hourly_price": 1.18, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 8000000000, "sum_internet_bandwidth": 8000000000, "interfaces": [{"internal_bandwidth": 8000000000, "internet_bandwidth": 8000000000}]}, "block_bandwidth": 1000341504, "end_of_service": false}, "STANDARD3-X48C-192G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 960000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1292.1, "hourly_price": 1.77, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "STANDARD3-X4C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 80000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 107.0, "hourly_price": 0.147, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "STANDARD3-X64C-256G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 1280000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1715.0, "hourly_price": 2.35, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "STANDARD3-X8C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 160000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 211.0, "hourly_price": 0.29, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}}}'
+        headers:
+            Content-Length:
+                - "40884"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:02:12 GMT
+            Link:
+                - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>; rel="previous",</products/servers?page=3&per_page=50&>; rel="next",</products/servers?page=3&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - 8a43b53a-93c9-4648-8026-2ac66e881e93
+            X-Total-Count:
+                - "112"
+        status: 200 OK
+        code: 200
+        duration: 54.864183ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "3"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 10027
+        body: '{"servers": {"STARDUST1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 1, "ram": 1073741824, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 10000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 0.1095, "hourly_price": 0.00015, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]}, "block_bandwidth": 52428800, "end_of_service": false}, "START1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 26.864, "hourly_price": 0.0368, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "START1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 100000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 14.162, "hourly_price": 0.0194, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 300000000, "sum_internet_bandwidth": 300000000, "interfaces": [{"internal_bandwidth": 300000000, "internet_bandwidth": 300000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "START1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 50000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 7.738, "hourly_price": 0.0106, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "START1-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 1, "ram": 1073741824, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 25000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 4.526, "hourly_price": 0.0062, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "VC1L": {"alt_names": ["X64-8GB"], "arch": "x86_64", "ncpus": 6, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 18.0164, "hourly_price": 0.02468, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "VC1M": {"alt_names": ["X64-4GB"], "arch": "x86_64", "ncpus": 4, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 100000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 11.3515, "hourly_price": 0.01555, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "VC1S": {"alt_names": ["X64-2GB"], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 50000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 6.2926, "hourly_price": 0.00862, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "X64-120GB": {"alt_names": [], "arch": "x86_64", "ncpus": 12, "ram": 128849018880, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 800000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 310.7902, "hourly_price": 0.42574, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 1000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "X64-15GB": {"alt_names": [], "arch": "x86_64", "ncpus": 6, "ram": 16106127360, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 44.0336, "hourly_price": 0.06032, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 250000000, "sum_internet_bandwidth": 250000000, "interfaces": [{"internal_bandwidth": 250000000, "internet_bandwidth": 250000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "X64-30GB": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 32212254720, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 400000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 86.9138, "hourly_price": 0.11906, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "X64-60GB": {"alt_names": [], "arch": "x86_64", "ncpus": 10, "ram": 64424509440, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 700000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 155.49, "hourly_price": 0.213, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 1000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 41943040, "end_of_service": true}}}'
+        headers:
+            Content-Length:
+                - "10027"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:02:12 GMT
+            Link:
+                - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=2&per_page=50&>; rel="previous",</products/servers?page=3&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - 94b6c6b9-3b01-4d8b-9092-2d0fd17d2858
+            X-Total-Count:
+                - "112"
+        status: 200 OK
+        code: 200
+        duration: 47.848821ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9bc4ec66-c6b0-435f-89d4-8387b7296354
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1638
+        body: '{"region":"fr-par","id":"9bc4ec66-c6b0-435f-89d4-8387b7296354","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:02:01.558575Z","updated_at":"2026-04-14T16:02:08.747882Z","type":"kapsule","name":"test-pool-validate-size-mutu","description":"","status":"pool_required","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","validate-size-mutu"],"cluster_url":"https://9bc4ec66-c6b0-435f-89d4-8387b7296354.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.9bc4ec66-c6b0-435f-89d4-8387b7296354.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":0},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"bacaf9bc-6bf2-45c1-8d45-d74d1b78cecf","commitment_ends_at":"2026-04-14T16:02:01.558579Z","acl_available":true,"iam_nodes_group_id":"dca3da3d-b07b-440b-ae09-9591cf5e3828","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1638"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:02:12 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - c81f3433-f571-454f-b4b5-69d5f9ae02bc
+        status: 200 OK
+        code: 200
+        duration: 34.738656ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_asc
+            page:
+                - "1"
+            status:
+                - unknown
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9bc4ec66-c6b0-435f-89d4-8387b7296354/pools?order_by=created_at_asc&page=1&status=unknown
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 28
+        body: '{"total_count":0,"pools":[]}'
+        headers:
+            Content-Length:
+                - "28"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:02:12 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - 769b729c-26d1-42b2-a5ca-207cbe8f1ee3
+        status: 200 OK
+        code: 200
+        duration: 21.127168ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/e7815bf0-5d3f-4e0a-aadb-c224ed23c413
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 408
+        body: '{"id":"e7815bf0-5d3f-4e0a-aadb-c224ed23c413","name":"tf-vpc-hopeful-wilson","tags":[],"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:02:00.342502Z","updated_at":"2026-04-14T16:02:00.342502Z","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","is_default":false,"private_network_count":1,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "408"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:02:12 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - 58d6d706-bdf0-4605-8df5-9d6bdd85100d
+        status: 200 OK
+        code: 200
+        duration: 66.149142ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/bacaf9bc-6bf2-45c1-8d45-d74d1b78cecf
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1073
+        body: '{"id":"bacaf9bc-6bf2-45c1-8d45-d74d1b78cecf","name":"test-pool-validate-size-mutu","tags":[],"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:02:00.511641Z","updated_at":"2026-04-14T16:02:00.511641Z","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnets":[{"id":"8d0b31ea-0e89-471f-8fa3-9ae4ded56867","created_at":"2026-04-14T16:02:00.511641Z","updated_at":"2026-04-14T16:02:00.511641Z","subnet":"172.16.0.0/22","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"bacaf9bc-6bf2-45c1-8d45-d74d1b78cecf","vpc_id":"e7815bf0-5d3f-4e0a-aadb-c224ed23c413"},{"id":"2bde632d-99ef-4d13-81a0-2fce035faa2c","created_at":"2026-04-14T16:02:00.511641Z","updated_at":"2026-04-14T16:02:00.511641Z","subnet":"fd63:256c:45f7:92f0::/64","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"bacaf9bc-6bf2-45c1-8d45-d74d1b78cecf","vpc_id":"e7815bf0-5d3f-4e0a-aadb-c224ed23c413"}],"vpc_id":"e7815bf0-5d3f-4e0a-aadb-c224ed23c413","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1073"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:02:12 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - c0a5135a-20e9-49b7-aee1-598fa123a05c
+        status: 200 OK
+        code: 200
+        duration: 47.397193ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9bc4ec66-c6b0-435f-89d4-8387b7296354
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1638
+        body: '{"region":"fr-par","id":"9bc4ec66-c6b0-435f-89d4-8387b7296354","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:02:01.558575Z","updated_at":"2026-04-14T16:02:08.747882Z","type":"kapsule","name":"test-pool-validate-size-mutu","description":"","status":"pool_required","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","validate-size-mutu"],"cluster_url":"https://9bc4ec66-c6b0-435f-89d4-8387b7296354.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.9bc4ec66-c6b0-435f-89d4-8387b7296354.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":0},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"bacaf9bc-6bf2-45c1-8d45-d74d1b78cecf","commitment_ends_at":"2026-04-14T16:02:01.558579Z","acl_available":true,"iam_nodes_group_id":"dca3da3d-b07b-440b-ae09-9591cf5e3828","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1638"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:02:12 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - 0242d605-0505-4d6e-8ff5-673ad28acb89
+        status: 200 OK
+        code: 200
+        duration: 17.912423ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9bc4ec66-c6b0-435f-89d4-8387b7296354/kubeconfig
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1760
+        body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC12YWxpZGF0ZS1zaXplLW11dHUiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VKWGFrTkRRVkZIWjBGM1NVSkJaMGxDUVVSQlMwSm5aM0ZvYTJwUFVGRlJSRUZxUVZaTlVrMTNSVkZaUkZaUlVVUkZkM0J5WkZkS2JHTnROV3dLWkVkV2VrMUNORmhFVkVreVRVUlJlRTE2UlRKTlJFbDNUMFp2V0VSVVRUSk5SRkY0VFhwRk1rMUVTWGRQUm05M1JsUkZWRTFDUlVkQk1WVkZRWGhOU3dwaE0xWnBXbGhLZFZwWVVteGpla0phVFVKTlIwSjVjVWRUVFRRNVFXZEZSME5EY1VkVFRUUTVRWGRGU0VFd1NVRkNVRVZvUWxOR1RGQjFPSGxyZFZkbENuWXlOMFJtUjJOSmFXOVVUamgzVVdweFltWXlSRVl5Y0hsbWNrNU9jMGxWZEhoek4zZDNlWFpEWXpaWFZFeDZOa3d6VVdrelVtazJNV2RSY1hkSldIZ0tXRzFVVGtjNVUycFJha0pCVFVFMFIwRXhWV1JFZDBWQ0wzZFJSVUYzU1VOd1JFRlFRbWRPVmtoU1RVSkJaamhGUWxSQlJFRlJTQzlOUWpCSFFURlZaQXBFWjFGWFFrSlNNamhaZDJRNVdIZ3dNMFUyTkVOTFNGZzBkek5VTTBJMGNqZHFRVXRDWjJkeGFHdHFUMUJSVVVSQlowNUlRVVJDUlVGcFFYRlFkVEJKQ2k4MU1ubFBSMUJwTmtkb2NVaDJTMGg2TlVwRE5HOTFaR2hUWWpNMmJsbHdUemxvUTFKQlNXZEZhRkYzUm5wc1NTOUVkVXRpU2tOaFQyaEtkR0UwUjNVS1IzSjFVMnRDTVVSS0wwNHdOVGxDTUd4d2R6MEtMUzB0TFMxRlRrUWdRMFZTVkVsR1NVTkJWRVV0TFMwdExRbz0KICAgIHNlcnZlcjogaHR0cHM6Ly85YmM0ZWM2Ni1jNmIwLTQzNWYtODlkNC04Mzg3YjcyOTYzNTQuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXZhbGlkYXRlLXNpemUtbXV0dQogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXZhbGlkYXRlLXNpemUtbXV0dSIKICAgIHVzZXI6IHRlc3QtcG9vbC12YWxpZGF0ZS1zaXplLW11dHUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtdmFsaWRhdGUtc2l6ZS1tdXR1CmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXZhbGlkYXRlLXNpemUtbXV0dS1hZG1pbgogIHVzZXI6CiAgICB0b2tlbjoganNPYXZKTWR6czFiOVdLQlUxbXM0Q0xUVm5ESzd2QnVXcVA0ODlYV1dGQ1FnSTd4QmhCV2tmV3Y="}'
+        headers:
+            Content-Length:
+                - "1760"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:02:12 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - eab59777-3237-4cf0-845d-4cc83f9335c6
+        status: 200 OK
+        code: 200
+        duration: 23.696433ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 41245
+        body: '{"servers": {"BASIC2-A16C-32G": {"alt_names": [], "arch": "arm64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 150.89, "hourly_price": 0.2067, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 503316480, "end_of_service": false}, "BASIC2-A16C-64G": {"alt_names": [], "arch": "arm64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 201.19, "hourly_price": 0.2756, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 503316480, "end_of_service": false}, "BASIC2-A2C-4G": {"alt_names": [], "arch": "arm64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 16.79, "hourly_price": 0.023, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 83886080, "end_of_service": false}, "BASIC2-A2C-8G": {"alt_names": [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 25.19, "hourly_price": 0.0345, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 83886080, "end_of_service": false}, "BASIC2-A4C-16G": {"alt_names": [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 50.3, "hourly_price": 0.0689, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 125829120, "end_of_service": false}, "BASIC2-A4C-8G": {"alt_names": [], "arch": "arm64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 37.74, "hourly_price": 0.0517, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 125829120, "end_of_service": false}, "BASIC2-A8C-16G": {"alt_names": [], "arch": "arm64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 75.48, "hourly_price": 0.1034, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 251658240, "end_of_service": false}, "BASIC2-A8C-32G": {"alt_names": [], "arch": "arm64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 100.59, "hourly_price": 0.1378, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 251658240, "end_of_service": false}, "BASIC3-X16C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 240.9, "hourly_price": 0.33, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]}, "block_bandwidth": 1048576000, "end_of_service": false}, "BASIC3-X16C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 321.2, "hourly_price": 0.44, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]}, "block_bandwidth": 1048576000, "end_of_service": false}, "BASIC3-X2C-4G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 26.791, "hourly_price": 0.0367, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth": 350000000, "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth": 350000000}]}, "block_bandwidth": 131072000, "end_of_service": false}, "BASIC3-X2C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 40.15, "hourly_price": 0.055, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth": 350000000, "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth": 350000000}]}, "block_bandwidth": 131072000, "end_of_service": false}, "BASIC3-X4C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 80.3, "hourly_price": 0.11, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth": 700000000, "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth": 700000000}]}, "block_bandwidth": 262144000, "end_of_service": false}, "BASIC3-X4C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 53.509, "hourly_price": 0.0733, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth": 700000000, "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth": 700000000}]}, "block_bandwidth": 262144000, "end_of_service": false}, "BASIC3-X8C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 120.45, "hourly_price": 0.165, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]}, "block_bandwidth": 524288000, "end_of_service": false}, "BASIC3-X8C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 160.6, "hourly_price": 0.22, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]}, "block_bandwidth": 524288000, "end_of_service": false}, "COMPUTE3-X16C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 320000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 341.786, "hourly_price": 0.4682, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 4000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 4000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "COMPUTE3-X2C-4G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 40000000000, "scratch_storage_max_volumes_count": 1, "monthly_price": 42.705, "hourly_price": 0.0585, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "COMPUTE3-X32C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 640000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 683.499, "hourly_price": 0.9363, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 8000000000, "sum_internet_bandwidth": 8000000000, "interfaces": [{"internal_bandwidth": 8000000000, "internet_bandwidth": 8000000000}]}, "block_bandwidth": 1000341504, "end_of_service": false}, "COMPUTE3-X48C-96G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 103079215104, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 960000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1019.81, "hourly_price": 1.397, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "COMPUTE3-X4C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 80000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 85.41, "hourly_price": 0.117, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "COMPUTE3-X64C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 1280000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1366.998, "hourly_price": 1.8726, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "COMPUTE3-X8C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 160000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 170.893, "hourly_price": 0.2341, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "COMPUTE3-X96C-192G": {"alt_names": [], "arch": "x86_64", "ncpus": 96, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 1280000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 2039.62, "hourly_price": 2.794, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "COPARM1-16C-64G": {"alt_names": [], "arch": "arm64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 252.14, "hourly_price": 0.3454, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 671088640, "end_of_service": false}, "COPARM1-2C-8G": {"alt_names": [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 31.1, "hourly_price": 0.0426, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 83886080, "end_of_service": false}, "COPARM1-32C-128G": {"alt_names": [], "arch": "arm64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 506.26, "hourly_price": 0.6935, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 1342177280, "end_of_service": false}, "COPARM1-4C-16G": {"alt_names": [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 62.56, "hourly_price": 0.0857, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 167772160, "end_of_service": false}, "COPARM1-8C-32G": {"alt_names": [], "arch": "arm64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 125.85, "hourly_price": 0.1724, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 335544320, "end_of_service": false}, "DEV1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 80000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 30.66, "hourly_price": 0.042, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 209715200, "end_of_service": false}, "DEV1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 3, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 40000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 14.454, "hourly_price": 0.0198, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 300000000, "sum_internet_bandwidth": 300000000, "interfaces": [{"internal_bandwidth": 300000000, "internet_bandwidth": 300000000}]}, "block_bandwidth": 157286400, "end_of_service": false}, "DEV1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 20000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 6.424, "hourly_price": 0.0088, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 104857600, "end_of_service": false}, "DEV1-XL": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 12884901888, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 120000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 46.5734, "hourly_price": 0.06378, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 262144000, "end_of_service": false}, "GP1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 554.07, "hourly_price": 0.759, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]}, "block_bandwidth": 1073741824, "end_of_service": false}, "GP1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 274.48, "hourly_price": 0.376, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "GP1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 300000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 136.51, "hourly_price": 0.187, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 524288000, "end_of_service": false}, "GP1-XL": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1197.93, "hourly_price": 1.641, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]}, "block_bandwidth": 2147483648, "end_of_service": false}, "GP1-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 150000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 66.43, "hourly_price": 0.091, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 314572800, "end_of_service": false}, "L4-1-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 51539607552, "gpu": 1, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 547.5, "hourly_price": 0.75, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 2500000000, "sum_internet_bandwidth": 2500000000, "interfaces": [{"internal_bandwidth": 2500000000, "internet_bandwidth": 2500000000}]}, "block_bandwidth": 1048576000, "end_of_service": false}, "L4-2-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 103079215104, "gpu": 2, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1095.0, "hourly_price": 1.5, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]}, "block_bandwidth": 1572864000, "end_of_service": false}, "L4-4-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 206158430208, "gpu": 4, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 2190.0, "hourly_price": 3.0, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]}, "block_bandwidth": 2621440000, "end_of_service": false}, "L4-8-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 412316860416, "gpu": 8, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 4380.0, "hourly_price": 6.0, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 20000000000, "sum_internet_bandwidth": 20000000000, "interfaces": [{"internal_bandwidth": 20000000000, "internet_bandwidth": 20000000000}]}, "block_bandwidth": 5242880000, "end_of_service": false}, "MEMORY3-X16C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 320000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 601.0, "hourly_price": 0.824, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 4000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 4000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "MEMORY3-X2C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 40000000000, "scratch_storage_max_volumes_count": 1, "monthly_price": 75.0, "hourly_price": 0.103, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "MEMORY3-X32C-256G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 640000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 1203.0, "hourly_price": 1.648, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 8000000000, "sum_internet_bandwidth": 8000000000, "interfaces": [{"internal_bandwidth": 8000000000, "internet_bandwidth": 8000000000}]}, "block_bandwidth": 1000341504, "end_of_service": false}, "MEMORY3-X48C-384G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 412316860416, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 960000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1804.0, "hourly_price": 2.472, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "MEMORY3-X4C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 80000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 150.0, "hourly_price": 0.206, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "MEMORY3-X8C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 160000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 300.0, "hourly_price": 0.412, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "PLAY2-MICRO": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 39.42, "hourly_price": 0.054, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 167772160, "end_of_service": false}, "PLAY2-NANO": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 19.71, "hourly_price": 0.027, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 83886080, "end_of_service": false}}}'
+        headers:
+            Content-Length:
+                - "41245"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:02:12 GMT
+            Link:
+                - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=3&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - acf9470f-9da9-4d5b-835e-61c8a413ed76
+            X-Total-Count:
+                - "112"
+        status: 200 OK
+        code: 200
+        duration: 44.058224ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "2"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 40884
+        body: '{"servers": {"PLAY2-PICO": {"alt_names": [], "arch": "x86_64", "ncpus": 1, "ram": 2147483648, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 10.22, "hourly_price": 0.014, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]}, "block_bandwidth": 41943040, "end_of_service": false}, "POP2-16C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 430.7, "hourly_price": 0.59, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-16C-64G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1063.391, "hourly_price": 1.4567, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-2C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 53.66, "hourly_price": 0.0735, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-2C-8G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 133.079, "hourly_price": 0.1823, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-32C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 861.4, "hourly_price": 1.18, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-32C-128G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 2126.709, "hourly_price": 2.9133, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-48C-192G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1274.4, "hourly_price": 1.77, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-4C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 107.31, "hourly_price": 0.147, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-4C-16G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 265.501, "hourly_price": 0.3637, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-64C-256G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1715.5, "hourly_price": 2.35, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-8C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 211.7, "hourly_price": 0.29, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-8C-32G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 528.009, "hourly_price": 0.7233, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HC-16C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 310.69, "hourly_price": 0.4256, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-HC-2C-4G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 38.84, "hourly_price": 0.0532, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HC-32C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 621.38, "hourly_price": 0.8512, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HC-48C-96G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 103079215104, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 914.4, "hourly_price": 1.27, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HC-4C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 77.67, "hourly_price": 0.1064, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HC-64C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1242.75, "hourly_price": 1.7024, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HC-8C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 155.34, "hourly_price": 0.2128, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HM-16C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 601.52, "hourly_price": 0.824, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-HM-2C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 75.19, "hourly_price": 0.103, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HM-32C-256G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1203.04, "hourly_price": 1.648, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HM-48C-384G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 412316860416, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1778.4, "hourly_price": 2.47, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HM-4C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 150.38, "hourly_price": 0.206, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HM-64C-512G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 549755813888, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 2406.08, "hourly_price": 3.296, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HM-8C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 300.76, "hourly_price": 0.412, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HN-10": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 530.29, "hourly_price": 0.7264, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HN-3": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 186.49, "hourly_price": 0.2554, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HN-5": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 330.29, "hourly_price": 0.4524, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "PRO2-L": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 640.21, "hourly_price": 0.877, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6000000000, "sum_internet_bandwidth": 6000000000, "interfaces": [{"internal_bandwidth": 6000000000, "internet_bandwidth": 6000000000}]}, "block_bandwidth": 2097152000, "end_of_service": false}, "PRO2-M": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 319.74, "hourly_price": 0.438, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]}, "block_bandwidth": 1048576000, "end_of_service": false}, "PRO2-S": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 159.87, "hourly_price": 0.219, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]}, "block_bandwidth": 524288000, "end_of_service": false}, "PRO2-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 80.3, "hourly_price": 0.11, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth": 700000000, "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth": 700000000}]}, "block_bandwidth": 262144000, "end_of_service": false}, "PRO2-XXS": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 40.15, "hourly_price": 0.055, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth": 350000000, "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth": 350000000}]}, "block_bandwidth": 131072000, "end_of_service": false}, "RENDER-S": {"alt_names": [], "arch": "x86_64", "ncpus": 10, "ram": 45097156608, "gpu": 1, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "P100", "gpu_memory": 17179869184}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 400000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 891.33, "hourly_price": 1.221, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 2000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth": 2000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 2147483648, "end_of_service": false}, "STANDARD2-A16C-64G": {"alt_names": [], "arch": "arm64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 367.8324, "hourly_price": 0.5039, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "STANDARD2-A2C-8G": {"alt_names": [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 42.7525, "hourly_price": 0.0586, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "STANDARD2-A32C-128G": {"alt_names": [], "arch": "arm64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 735.7269, "hourly_price": 1.0078, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5033164800, "end_of_service": false}, "STANDARD2-A48C-192G": {"alt_names": [], "arch": "arm64", "ncpus": 48, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1103.5593, "hourly_price": 1.5117, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5033164800, "end_of_service": false}, "STANDARD2-A4C-16G": {"alt_names": [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 85.5049, "hourly_price": 0.1171, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "STANDARD2-A64C-256G": {"alt_names": [], "arch": "arm64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1470.366, "hourly_price": 2.0142, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5033164800, "end_of_service": false}, "STANDARD2-A8C-32G": {"alt_names": [], "arch": "arm64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 171.0098, "hourly_price": 0.2343, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "STANDARD3-X16C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 320000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 430.0, "hourly_price": 0.59, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 4000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 4000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "STANDARD3-X2C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 40000000000, "scratch_storage_max_volumes_count": 1, "monthly_price": 54.0, "hourly_price": 0.074, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "STANDARD3-X32C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 640000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 861.0, "hourly_price": 1.18, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 8000000000, "sum_internet_bandwidth": 8000000000, "interfaces": [{"internal_bandwidth": 8000000000, "internet_bandwidth": 8000000000}]}, "block_bandwidth": 1000341504, "end_of_service": false}, "STANDARD3-X48C-192G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 960000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1292.1, "hourly_price": 1.77, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "STANDARD3-X4C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 80000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 107.0, "hourly_price": 0.147, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "STANDARD3-X64C-256G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 1280000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1715.0, "hourly_price": 2.35, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "STANDARD3-X8C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 160000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 211.0, "hourly_price": 0.29, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}}}'
+        headers:
+            Content-Length:
+                - "40884"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:02:12 GMT
+            Link:
+                - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>; rel="previous",</products/servers?page=3&per_page=50&>; rel="next",</products/servers?page=3&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - 2ad3a900-1294-43e0-9b35-97cf1c694979
+            X-Total-Count:
+                - "112"
+        status: 200 OK
+        code: 200
+        duration: 39.998011ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "3"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 10027
+        body: '{"servers": {"STARDUST1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 1, "ram": 1073741824, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 10000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 0.1095, "hourly_price": 0.00015, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]}, "block_bandwidth": 52428800, "end_of_service": false}, "START1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 26.864, "hourly_price": 0.0368, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "START1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 100000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 14.162, "hourly_price": 0.0194, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 300000000, "sum_internet_bandwidth": 300000000, "interfaces": [{"internal_bandwidth": 300000000, "internet_bandwidth": 300000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "START1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 50000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 7.738, "hourly_price": 0.0106, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "START1-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 1, "ram": 1073741824, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 25000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 4.526, "hourly_price": 0.0062, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "VC1L": {"alt_names": ["X64-8GB"], "arch": "x86_64", "ncpus": 6, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 18.0164, "hourly_price": 0.02468, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "VC1M": {"alt_names": ["X64-4GB"], "arch": "x86_64", "ncpus": 4, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 100000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 11.3515, "hourly_price": 0.01555, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "VC1S": {"alt_names": ["X64-2GB"], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 50000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 6.2926, "hourly_price": 0.00862, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "X64-120GB": {"alt_names": [], "arch": "x86_64", "ncpus": 12, "ram": 128849018880, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 800000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 310.7902, "hourly_price": 0.42574, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 1000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "X64-15GB": {"alt_names": [], "arch": "x86_64", "ncpus": 6, "ram": 16106127360, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 44.0336, "hourly_price": 0.06032, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 250000000, "sum_internet_bandwidth": 250000000, "interfaces": [{"internal_bandwidth": 250000000, "internet_bandwidth": 250000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "X64-30GB": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 32212254720, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 400000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 86.9138, "hourly_price": 0.11906, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "X64-60GB": {"alt_names": [], "arch": "x86_64", "ncpus": 10, "ram": 64424509440, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 700000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 155.49, "hourly_price": 0.213, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 1000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 41943040, "end_of_service": true}}}'
+        headers:
+            Content-Length:
+                - "10027"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:02:12 GMT
+            Link:
+                - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=2&per_page=50&>; rel="previous",</products/servers?page=3&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - d5150866-40f7-4c41-af00-7221e77b946b
+            X-Total-Count:
+                - "112"
+        status: 200 OK
+        code: 200
+        duration: 86.927144ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9bc4ec66-c6b0-435f-89d4-8387b7296354
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1638
+        body: '{"region":"fr-par","id":"9bc4ec66-c6b0-435f-89d4-8387b7296354","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:02:01.558575Z","updated_at":"2026-04-14T16:02:08.747882Z","type":"kapsule","name":"test-pool-validate-size-mutu","description":"","status":"pool_required","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","validate-size-mutu"],"cluster_url":"https://9bc4ec66-c6b0-435f-89d4-8387b7296354.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.9bc4ec66-c6b0-435f-89d4-8387b7296354.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":0},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"bacaf9bc-6bf2-45c1-8d45-d74d1b78cecf","commitment_ends_at":"2026-04-14T16:02:01.558579Z","acl_available":true,"iam_nodes_group_id":"dca3da3d-b07b-440b-ae09-9591cf5e3828","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1638"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:02:12 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - 3382993c-9b4c-4676-a5db-33f789640e21
+        status: 200 OK
+        code: 200
+        duration: 46.978987ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 397
+        host: api.scaleway.com
+        body: '{"name":"test-pool-validate-size-mutu-other","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","validate-size-mutu"],"kubelet_args":{},"zone":"fr-par-1","root_volume_type":"default_volume_type","public_ip_disabled":false,"labels":null,"taints":null,"startup_taints":null}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9bc4ec66-c6b0-435f-89d4-8387b7296354/pools
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 785
+        body: '{"region":"fr-par","id":"be0004d1-11ef-43dc-a330-c1ad4f27cb87","cluster_id":"9bc4ec66-c6b0-435f-89d4-8387b7296354","created_at":"2026-04-14T16:02:12.945634Z","updated_at":"2026-04-14T16:02:12.945634Z","name":"test-pool-validate-size-mutu-other","status":"scaling","version":"1.35.3","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","validate-size-mutu"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{},"taints":[],"startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "785"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:02:13 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - a98b5ff2-e3f5-472d-8284-98bf822db0db
+        status: 200 OK
+        code: 200
+        duration: 127.796381ms
+    - id: 25
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/be0004d1-11ef-43dc-a330-c1ad4f27cb87
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 785
+        body: '{"region":"fr-par","id":"be0004d1-11ef-43dc-a330-c1ad4f27cb87","cluster_id":"9bc4ec66-c6b0-435f-89d4-8387b7296354","created_at":"2026-04-14T16:02:12.945634Z","updated_at":"2026-04-14T16:02:12.945634Z","name":"test-pool-validate-size-mutu-other","status":"scaling","version":"1.35.3","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","validate-size-mutu"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{},"taints":[],"startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "785"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:02:13 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - fff8db59-6e1d-4dd2-995b-7d5fae5c13e5
+        status: 200 OK
+        code: 200
+        duration: 28.383683ms
+    - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/be0004d1-11ef-43dc-a330-c1ad4f27cb87
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 783
+        body: '{"region":"fr-par","id":"be0004d1-11ef-43dc-a330-c1ad4f27cb87","cluster_id":"9bc4ec66-c6b0-435f-89d4-8387b7296354","created_at":"2026-04-14T16:02:12.945634Z","updated_at":"2026-04-14T16:04:54.036668Z","name":"test-pool-validate-size-mutu-other","status":"ready","version":"1.35.3","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","validate-size-mutu"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{},"taints":[],"startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "783"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:04:54 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - 90a04f5c-fb11-4c00-8ac4-d0bba4a11f3b
+        status: 200 OK
+        code: 200
+        duration: 30.045324ms
+    - id: 27
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9bc4ec66-c6b0-435f-89d4-8387b7296354
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1630
+        body: '{"region":"fr-par","id":"9bc4ec66-c6b0-435f-89d4-8387b7296354","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:02:01.558575Z","updated_at":"2026-04-14T16:03:33.928001Z","type":"kapsule","name":"test-pool-validate-size-mutu","description":"","status":"ready","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","validate-size-mutu"],"cluster_url":"https://9bc4ec66-c6b0-435f-89d4-8387b7296354.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.9bc4ec66-c6b0-435f-89d4-8387b7296354.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":0},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"bacaf9bc-6bf2-45c1-8d45-d74d1b78cecf","commitment_ends_at":"2026-04-14T16:02:01.558579Z","acl_available":true,"iam_nodes_group_id":"dca3da3d-b07b-440b-ae09-9591cf5e3828","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1630"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:04:54 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - 141350c3-b20a-4a64-b6f1-6e5864f74899
+        status: 200 OK
+        code: 200
+        duration: 32.455043ms
+    - id: 28
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/be0004d1-11ef-43dc-a330-c1ad4f27cb87
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 783
+        body: '{"region":"fr-par","id":"be0004d1-11ef-43dc-a330-c1ad4f27cb87","cluster_id":"9bc4ec66-c6b0-435f-89d4-8387b7296354","created_at":"2026-04-14T16:02:12.945634Z","updated_at":"2026-04-14T16:04:54.036668Z","name":"test-pool-validate-size-mutu-other","status":"ready","version":"1.35.3","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","validate-size-mutu"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{},"taints":[],"startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "783"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:04:54 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - 6a7ef29e-3286-4d72-8acb-d1e663cec523
+        status: 200 OK
+        code: 200
+        duration: 25.163159ms
+    - id: 29
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_asc
+            page:
+                - "1"
+            pool_id:
+                - be0004d1-11ef-43dc-a330-c1ad4f27cb87
+            status:
+                - unknown
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9bc4ec66-c6b0-435f-89d4-8387b7296354/nodes?order_by=created_at_asc&page=1&pool_id=be0004d1-11ef-43dc-a330-c1ad4f27cb87&status=unknown
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 603
+        body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"032d30b6-d286-4ffc-a59f-e05a8a907f3b","cluster_id":"9bc4ec66-c6b0-435f-89d4-8387b7296354","created_at":"2026-04-14T16:03:48.505608Z","updated_at":"2026-04-14T16:04:54.023247Z","pool_id":"be0004d1-11ef-43dc-a330-c1ad4f27cb87","status":"ready","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"name":"scw-test-pool-vali-test-pool-validate-s-032d30","public_ip_v4":"212.47.248.67","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/54cf5c9b-d29e-408f-8702-aa85389d06f6","error_message":""}]}'
+        headers:
+            Content-Length:
+                - "603"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:04:54 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - 8e69c072-e644-4702-84f7-7346f99f1e4a
+        status: 200 OK
+        code: 200
+        duration: 18.954714ms
+    - id: 30
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9bc4ec66-c6b0-435f-89d4-8387b7296354
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1630
+        body: '{"region":"fr-par","id":"9bc4ec66-c6b0-435f-89d4-8387b7296354","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:02:01.558575Z","updated_at":"2026-04-14T16:03:33.928001Z","type":"kapsule","name":"test-pool-validate-size-mutu","description":"","status":"ready","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","validate-size-mutu"],"cluster_url":"https://9bc4ec66-c6b0-435f-89d4-8387b7296354.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.9bc4ec66-c6b0-435f-89d4-8387b7296354.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":0},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"bacaf9bc-6bf2-45c1-8d45-d74d1b78cecf","commitment_ends_at":"2026-04-14T16:02:01.558579Z","acl_available":true,"iam_nodes_group_id":"dca3da3d-b07b-440b-ae09-9591cf5e3828","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1630"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:04:54 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - edbda0a1-bb57-490c-a5fa-fd8e8e473016
+        status: 200 OK
+        code: 200
+        duration: 23.501952ms
+    - id: 31
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_desc
+            project_id:
+                - fa1e3217-dc80-42ac-85c3-3f034b78b552
+            resource_name:
+                - scw-test-pool-vali-test-pool-validate-s-032d30
+            resource_type:
+                - unknown_type
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=fa1e3217-dc80-42ac-85c3-3f034b78b552&resource_name=scw-test-pool-vali-test-pool-validate-s-032d30&resource_type=unknown_type
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1090
+        body: '{"total_count":2,"ips":[{"id":"89a604f2-d247-4ae1-abc5-9018e1398c1b","address":"fd63:256c:45f7:92f0:f71:8efb:dd8e:f14f/64","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","is_ipv6":true,"created_at":"2026-04-14T16:03:50.839691Z","updated_at":"2026-04-14T16:03:50.839691Z","source":{"subnet_id":"2bde632d-99ef-4d13-81a0-2fce035faa2c"},"resource":{"type":"instance_private_nic","id":"f7b44b24-a6a9-4c34-aa0b-b58561a4f660","mac_address":"02:00:00:15:5D:5F","name":"scw-test-pool-vali-test-pool-validate-s-032d30"},"tags":[],"reverses":[],"region":"fr-par","zone":null},{"id":"c1ca81ca-fbb0-4f95-baf7-c6ddb5f942b5","address":"172.16.0.3/22","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","is_ipv6":false,"created_at":"2026-04-14T16:03:50.729620Z","updated_at":"2026-04-14T16:03:50.729620Z","source":{"subnet_id":"8d0b31ea-0e89-471f-8fa3-9ae4ded56867"},"resource":{"type":"instance_private_nic","id":"f7b44b24-a6a9-4c34-aa0b-b58561a4f660","mac_address":"02:00:00:15:5D:5F","name":"scw-test-pool-vali-test-pool-validate-s-032d30"},"tags":[],"reverses":[],"region":"fr-par","zone":null}]}'
+        headers:
+            Content-Length:
+                - "1090"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:04:54 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - a71b88b0-dfdb-4abd-9de7-51db242bc0db
+        status: 200 OK
+        code: 200
+        duration: 57.322109ms
+    - id: 32
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 41245
+        body: '{"servers": {"BASIC2-A16C-32G": {"alt_names": [], "arch": "arm64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 150.89, "hourly_price": 0.2067, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 503316480, "end_of_service": false}, "BASIC2-A16C-64G": {"alt_names": [], "arch": "arm64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 201.19, "hourly_price": 0.2756, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 503316480, "end_of_service": false}, "BASIC2-A2C-4G": {"alt_names": [], "arch": "arm64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 16.79, "hourly_price": 0.023, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 83886080, "end_of_service": false}, "BASIC2-A2C-8G": {"alt_names": [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 25.19, "hourly_price": 0.0345, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 83886080, "end_of_service": false}, "BASIC2-A4C-16G": {"alt_names": [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 50.3, "hourly_price": 0.0689, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 125829120, "end_of_service": false}, "BASIC2-A4C-8G": {"alt_names": [], "arch": "arm64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 37.74, "hourly_price": 0.0517, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 125829120, "end_of_service": false}, "BASIC2-A8C-16G": {"alt_names": [], "arch": "arm64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 75.48, "hourly_price": 0.1034, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 251658240, "end_of_service": false}, "BASIC2-A8C-32G": {"alt_names": [], "arch": "arm64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 100.59, "hourly_price": 0.1378, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 251658240, "end_of_service": false}, "BASIC3-X16C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 240.9, "hourly_price": 0.33, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]}, "block_bandwidth": 1048576000, "end_of_service": false}, "BASIC3-X16C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 321.2, "hourly_price": 0.44, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]}, "block_bandwidth": 1048576000, "end_of_service": false}, "BASIC3-X2C-4G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 26.791, "hourly_price": 0.0367, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth": 350000000, "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth": 350000000}]}, "block_bandwidth": 131072000, "end_of_service": false}, "BASIC3-X2C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 40.15, "hourly_price": 0.055, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth": 350000000, "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth": 350000000}]}, "block_bandwidth": 131072000, "end_of_service": false}, "BASIC3-X4C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 80.3, "hourly_price": 0.11, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth": 700000000, "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth": 700000000}]}, "block_bandwidth": 262144000, "end_of_service": false}, "BASIC3-X4C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 53.509, "hourly_price": 0.0733, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth": 700000000, "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth": 700000000}]}, "block_bandwidth": 262144000, "end_of_service": false}, "BASIC3-X8C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 120.45, "hourly_price": 0.165, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]}, "block_bandwidth": 524288000, "end_of_service": false}, "BASIC3-X8C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 160.6, "hourly_price": 0.22, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]}, "block_bandwidth": 524288000, "end_of_service": false}, "COMPUTE3-X16C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 320000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 341.786, "hourly_price": 0.4682, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 4000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 4000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "COMPUTE3-X2C-4G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 40000000000, "scratch_storage_max_volumes_count": 1, "monthly_price": 42.705, "hourly_price": 0.0585, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "COMPUTE3-X32C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 640000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 683.499, "hourly_price": 0.9363, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 8000000000, "sum_internet_bandwidth": 8000000000, "interfaces": [{"internal_bandwidth": 8000000000, "internet_bandwidth": 8000000000}]}, "block_bandwidth": 1000341504, "end_of_service": false}, "COMPUTE3-X48C-96G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 103079215104, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 960000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1019.81, "hourly_price": 1.397, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "COMPUTE3-X4C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 80000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 85.41, "hourly_price": 0.117, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "COMPUTE3-X64C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 1280000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1366.998, "hourly_price": 1.8726, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "COMPUTE3-X8C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 160000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 170.893, "hourly_price": 0.2341, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "COMPUTE3-X96C-192G": {"alt_names": [], "arch": "x86_64", "ncpus": 96, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 1280000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 2039.62, "hourly_price": 2.794, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "COPARM1-16C-64G": {"alt_names": [], "arch": "arm64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 252.14, "hourly_price": 0.3454, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 671088640, "end_of_service": false}, "COPARM1-2C-8G": {"alt_names": [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 31.1, "hourly_price": 0.0426, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 83886080, "end_of_service": false}, "COPARM1-32C-128G": {"alt_names": [], "arch": "arm64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 506.26, "hourly_price": 0.6935, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 1342177280, "end_of_service": false}, "COPARM1-4C-16G": {"alt_names": [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 62.56, "hourly_price": 0.0857, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 167772160, "end_of_service": false}, "COPARM1-8C-32G": {"alt_names": [], "arch": "arm64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 125.85, "hourly_price": 0.1724, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 335544320, "end_of_service": false}, "DEV1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 80000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 30.66, "hourly_price": 0.042, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 209715200, "end_of_service": false}, "DEV1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 3, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 40000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 14.454, "hourly_price": 0.0198, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 300000000, "sum_internet_bandwidth": 300000000, "interfaces": [{"internal_bandwidth": 300000000, "internet_bandwidth": 300000000}]}, "block_bandwidth": 157286400, "end_of_service": false}, "DEV1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 20000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 6.424, "hourly_price": 0.0088, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 104857600, "end_of_service": false}, "DEV1-XL": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 12884901888, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 120000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 46.5734, "hourly_price": 0.06378, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 262144000, "end_of_service": false}, "GP1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 554.07, "hourly_price": 0.759, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]}, "block_bandwidth": 1073741824, "end_of_service": false}, "GP1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 274.48, "hourly_price": 0.376, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "GP1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 300000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 136.51, "hourly_price": 0.187, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 524288000, "end_of_service": false}, "GP1-XL": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1197.93, "hourly_price": 1.641, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]}, "block_bandwidth": 2147483648, "end_of_service": false}, "GP1-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 150000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 66.43, "hourly_price": 0.091, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 314572800, "end_of_service": false}, "L4-1-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 51539607552, "gpu": 1, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 547.5, "hourly_price": 0.75, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 2500000000, "sum_internet_bandwidth": 2500000000, "interfaces": [{"internal_bandwidth": 2500000000, "internet_bandwidth": 2500000000}]}, "block_bandwidth": 1048576000, "end_of_service": false}, "L4-2-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 103079215104, "gpu": 2, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1095.0, "hourly_price": 1.5, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]}, "block_bandwidth": 1572864000, "end_of_service": false}, "L4-4-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 206158430208, "gpu": 4, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 2190.0, "hourly_price": 3.0, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]}, "block_bandwidth": 2621440000, "end_of_service": false}, "L4-8-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 412316860416, "gpu": 8, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 4380.0, "hourly_price": 6.0, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 20000000000, "sum_internet_bandwidth": 20000000000, "interfaces": [{"internal_bandwidth": 20000000000, "internet_bandwidth": 20000000000}]}, "block_bandwidth": 5242880000, "end_of_service": false}, "MEMORY3-X16C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 320000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 601.0, "hourly_price": 0.824, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 4000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 4000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "MEMORY3-X2C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 40000000000, "scratch_storage_max_volumes_count": 1, "monthly_price": 75.0, "hourly_price": 0.103, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "MEMORY3-X32C-256G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 640000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 1203.0, "hourly_price": 1.648, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 8000000000, "sum_internet_bandwidth": 8000000000, "interfaces": [{"internal_bandwidth": 8000000000, "internet_bandwidth": 8000000000}]}, "block_bandwidth": 1000341504, "end_of_service": false}, "MEMORY3-X48C-384G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 412316860416, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 960000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1804.0, "hourly_price": 2.472, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "MEMORY3-X4C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 80000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 150.0, "hourly_price": 0.206, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "MEMORY3-X8C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 160000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 300.0, "hourly_price": 0.412, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "PLAY2-MICRO": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 39.42, "hourly_price": 0.054, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 167772160, "end_of_service": false}, "PLAY2-NANO": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 19.71, "hourly_price": 0.027, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 83886080, "end_of_service": false}}}'
+        headers:
+            Content-Length:
+                - "41245"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:04:54 GMT
+            Link:
+                - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=3&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - 4d725ba2-6ae3-4857-91c5-835c1ac1ff30
+            X-Total-Count:
+                - "112"
+        status: 200 OK
+        code: 200
+        duration: 43.320171ms
+    - id: 33
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "2"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 40884
+        body: '{"servers": {"PLAY2-PICO": {"alt_names": [], "arch": "x86_64", "ncpus": 1, "ram": 2147483648, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 10.22, "hourly_price": 0.014, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]}, "block_bandwidth": 41943040, "end_of_service": false}, "POP2-16C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 430.7, "hourly_price": 0.59, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-16C-64G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1063.391, "hourly_price": 1.4567, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-2C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 53.66, "hourly_price": 0.0735, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-2C-8G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 133.079, "hourly_price": 0.1823, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-32C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 861.4, "hourly_price": 1.18, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-32C-128G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 2126.709, "hourly_price": 2.9133, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-48C-192G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1274.4, "hourly_price": 1.77, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-4C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 107.31, "hourly_price": 0.147, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-4C-16G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 265.501, "hourly_price": 0.3637, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-64C-256G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1715.5, "hourly_price": 2.35, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-8C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 211.7, "hourly_price": 0.29, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-8C-32G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 528.009, "hourly_price": 0.7233, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HC-16C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 310.69, "hourly_price": 0.4256, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-HC-2C-4G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 38.84, "hourly_price": 0.0532, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HC-32C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 621.38, "hourly_price": 0.8512, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HC-48C-96G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 103079215104, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 914.4, "hourly_price": 1.27, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HC-4C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 77.67, "hourly_price": 0.1064, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HC-64C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1242.75, "hourly_price": 1.7024, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HC-8C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 155.34, "hourly_price": 0.2128, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HM-16C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 601.52, "hourly_price": 0.824, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-HM-2C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 75.19, "hourly_price": 0.103, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HM-32C-256G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1203.04, "hourly_price": 1.648, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HM-48C-384G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 412316860416, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1778.4, "hourly_price": 2.47, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HM-4C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 150.38, "hourly_price": 0.206, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HM-64C-512G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 549755813888, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 2406.08, "hourly_price": 3.296, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HM-8C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 300.76, "hourly_price": 0.412, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HN-10": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 530.29, "hourly_price": 0.7264, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HN-3": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 186.49, "hourly_price": 0.2554, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HN-5": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 330.29, "hourly_price": 0.4524, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "PRO2-L": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 640.21, "hourly_price": 0.877, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6000000000, "sum_internet_bandwidth": 6000000000, "interfaces": [{"internal_bandwidth": 6000000000, "internet_bandwidth": 6000000000}]}, "block_bandwidth": 2097152000, "end_of_service": false}, "PRO2-M": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 319.74, "hourly_price": 0.438, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]}, "block_bandwidth": 1048576000, "end_of_service": false}, "PRO2-S": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 159.87, "hourly_price": 0.219, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]}, "block_bandwidth": 524288000, "end_of_service": false}, "PRO2-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 80.3, "hourly_price": 0.11, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth": 700000000, "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth": 700000000}]}, "block_bandwidth": 262144000, "end_of_service": false}, "PRO2-XXS": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 40.15, "hourly_price": 0.055, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth": 350000000, "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth": 350000000}]}, "block_bandwidth": 131072000, "end_of_service": false}, "RENDER-S": {"alt_names": [], "arch": "x86_64", "ncpus": 10, "ram": 45097156608, "gpu": 1, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "P100", "gpu_memory": 17179869184}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 400000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 891.33, "hourly_price": 1.221, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 2000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth": 2000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 2147483648, "end_of_service": false}, "STANDARD2-A16C-64G": {"alt_names": [], "arch": "arm64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 367.8324, "hourly_price": 0.5039, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "STANDARD2-A2C-8G": {"alt_names": [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 42.7525, "hourly_price": 0.0586, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "STANDARD2-A32C-128G": {"alt_names": [], "arch": "arm64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 735.7269, "hourly_price": 1.0078, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5033164800, "end_of_service": false}, "STANDARD2-A48C-192G": {"alt_names": [], "arch": "arm64", "ncpus": 48, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1103.5593, "hourly_price": 1.5117, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5033164800, "end_of_service": false}, "STANDARD2-A4C-16G": {"alt_names": [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 85.5049, "hourly_price": 0.1171, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "STANDARD2-A64C-256G": {"alt_names": [], "arch": "arm64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1470.366, "hourly_price": 2.0142, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5033164800, "end_of_service": false}, "STANDARD2-A8C-32G": {"alt_names": [], "arch": "arm64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 171.0098, "hourly_price": 0.2343, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "STANDARD3-X16C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 320000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 430.0, "hourly_price": 0.59, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 4000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 4000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "STANDARD3-X2C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 40000000000, "scratch_storage_max_volumes_count": 1, "monthly_price": 54.0, "hourly_price": 0.074, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "STANDARD3-X32C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 640000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 861.0, "hourly_price": 1.18, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 8000000000, "sum_internet_bandwidth": 8000000000, "interfaces": [{"internal_bandwidth": 8000000000, "internet_bandwidth": 8000000000}]}, "block_bandwidth": 1000341504, "end_of_service": false}, "STANDARD3-X48C-192G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 960000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1292.1, "hourly_price": 1.77, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "STANDARD3-X4C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 80000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 107.0, "hourly_price": 0.147, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "STANDARD3-X64C-256G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 1280000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1715.0, "hourly_price": 2.35, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "STANDARD3-X8C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 160000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 211.0, "hourly_price": 0.29, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}}}'
+        headers:
+            Content-Length:
+                - "40884"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:04:55 GMT
+            Link:
+                - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>; rel="previous",</products/servers?page=3&per_page=50&>; rel="next",</products/servers?page=3&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - 4213604c-cb6d-4691-812a-1b77d1252d7f
+            X-Total-Count:
+                - "112"
+        status: 200 OK
+        code: 200
+        duration: 45.34992ms
+    - id: 34
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "3"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 10027
+        body: '{"servers": {"STARDUST1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 1, "ram": 1073741824, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 10000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 0.1095, "hourly_price": 0.00015, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]}, "block_bandwidth": 52428800, "end_of_service": false}, "START1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 26.864, "hourly_price": 0.0368, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "START1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 100000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 14.162, "hourly_price": 0.0194, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 300000000, "sum_internet_bandwidth": 300000000, "interfaces": [{"internal_bandwidth": 300000000, "internet_bandwidth": 300000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "START1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 50000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 7.738, "hourly_price": 0.0106, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "START1-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 1, "ram": 1073741824, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 25000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 4.526, "hourly_price": 0.0062, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "VC1L": {"alt_names": ["X64-8GB"], "arch": "x86_64", "ncpus": 6, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 18.0164, "hourly_price": 0.02468, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "VC1M": {"alt_names": ["X64-4GB"], "arch": "x86_64", "ncpus": 4, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 100000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 11.3515, "hourly_price": 0.01555, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "VC1S": {"alt_names": ["X64-2GB"], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 50000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 6.2926, "hourly_price": 0.00862, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "X64-120GB": {"alt_names": [], "arch": "x86_64", "ncpus": 12, "ram": 128849018880, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 800000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 310.7902, "hourly_price": 0.42574, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 1000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "X64-15GB": {"alt_names": [], "arch": "x86_64", "ncpus": 6, "ram": 16106127360, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 44.0336, "hourly_price": 0.06032, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 250000000, "sum_internet_bandwidth": 250000000, "interfaces": [{"internal_bandwidth": 250000000, "internet_bandwidth": 250000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "X64-30GB": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 32212254720, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 400000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 86.9138, "hourly_price": 0.11906, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "X64-60GB": {"alt_names": [], "arch": "x86_64", "ncpus": 10, "ram": 64424509440, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 700000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 155.49, "hourly_price": 0.213, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 1000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 41943040, "end_of_service": true}}}'
+        headers:
+            Content-Length:
+                - "10027"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:04:55 GMT
+            Link:
+                - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=2&per_page=50&>; rel="previous",</products/servers?page=3&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - 30dc1359-97d5-4646-8d3b-b70e03956bb3
+            X-Total-Count:
+                - "112"
+        status: 200 OK
+        code: 200
+        duration: 48.882548ms
+    - id: 35
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9bc4ec66-c6b0-435f-89d4-8387b7296354
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1630
+        body: '{"region":"fr-par","id":"9bc4ec66-c6b0-435f-89d4-8387b7296354","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:02:01.558575Z","updated_at":"2026-04-14T16:03:33.928001Z","type":"kapsule","name":"test-pool-validate-size-mutu","description":"","status":"ready","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","validate-size-mutu"],"cluster_url":"https://9bc4ec66-c6b0-435f-89d4-8387b7296354.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.9bc4ec66-c6b0-435f-89d4-8387b7296354.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":0},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"bacaf9bc-6bf2-45c1-8d45-d74d1b78cecf","commitment_ends_at":"2026-04-14T16:02:01.558579Z","acl_available":true,"iam_nodes_group_id":"dca3da3d-b07b-440b-ae09-9591cf5e3828","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1630"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:04:55 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - b2bcb958-b77d-4d7b-b735-01783bedd0eb
+        status: 200 OK
+        code: 200
+        duration: 21.248236ms
+    - id: 36
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_asc
+            page:
+                - "1"
+            status:
+                - unknown
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9bc4ec66-c6b0-435f-89d4-8387b7296354/pools?order_by=created_at_asc&page=1&status=unknown
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 811
+        body: '{"total_count":1,"pools":[{"region":"fr-par","id":"be0004d1-11ef-43dc-a330-c1ad4f27cb87","cluster_id":"9bc4ec66-c6b0-435f-89d4-8387b7296354","created_at":"2026-04-14T16:02:12.945634Z","updated_at":"2026-04-14T16:04:54.036668Z","name":"test-pool-validate-size-mutu-other","status":"ready","version":"1.35.3","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","validate-size-mutu"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{},"taints":[],"startup_taints":[]}]}'
+        headers:
+            Content-Length:
+                - "811"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:04:55 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - 6f052c20-59e3-4046-848f-e89e066c286d
+        status: 200 OK
+        code: 200
+        duration: 21.301214ms
+    - id: 37
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 391
+        host: api.scaleway.com
+        body: '{"name":"test-pool-validate-size-mutu","node_type":"pro2_xxs","autoscaling":false,"size":0,"min_size":0,"max_size":0,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","validate-size-mutu"],"kubelet_args":{},"zone":"fr-par-1","root_volume_type":"default_volume_type","public_ip_disabled":false,"labels":null,"taints":null,"startup_taints":null}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9bc4ec66-c6b0-435f-89d4-8387b7296354/pools
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 779
+        body: '{"region":"fr-par","id":"7849c2c1-ad50-4f7e-ba9e-469d625fefc7","cluster_id":"9bc4ec66-c6b0-435f-89d4-8387b7296354","created_at":"2026-04-14T16:04:55.166608Z","updated_at":"2026-04-14T16:04:55.166608Z","name":"test-pool-validate-size-mutu","status":"scaling","version":"1.35.3","node_type":"pro2_xxs","autoscaling":false,"size":0,"min_size":0,"max_size":0,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","validate-size-mutu"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{},"taints":[],"startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "779"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:04:55 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - e641324d-a56c-432f-9214-82c9887cbcc6
+        status: 200 OK
+        code: 200
+        duration: 141.563965ms
+    - id: 38
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7849c2c1-ad50-4f7e-ba9e-469d625fefc7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 779
+        body: '{"region":"fr-par","id":"7849c2c1-ad50-4f7e-ba9e-469d625fefc7","cluster_id":"9bc4ec66-c6b0-435f-89d4-8387b7296354","created_at":"2026-04-14T16:04:55.166608Z","updated_at":"2026-04-14T16:04:55.166608Z","name":"test-pool-validate-size-mutu","status":"scaling","version":"1.35.3","node_type":"pro2_xxs","autoscaling":false,"size":0,"min_size":0,"max_size":0,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","validate-size-mutu"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{},"taints":[],"startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "779"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:04:55 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - 2bd0868b-5b19-4fec-b338-c1adb7b349d3
+        status: 200 OK
+        code: 200
+        duration: 25.653508ms
+    - id: 39
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7849c2c1-ad50-4f7e-ba9e-469d625fefc7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 777
+        body: '{"region":"fr-par","id":"7849c2c1-ad50-4f7e-ba9e-469d625fefc7","cluster_id":"9bc4ec66-c6b0-435f-89d4-8387b7296354","created_at":"2026-04-14T16:04:55.166608Z","updated_at":"2026-04-14T16:04:55.502493Z","name":"test-pool-validate-size-mutu","status":"ready","version":"1.35.3","node_type":"pro2_xxs","autoscaling":false,"size":0,"min_size":0,"max_size":0,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","validate-size-mutu"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{},"taints":[],"startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "777"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:00 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - da566470-642e-4c11-8395-052da2f6bc24
+        status: 200 OK
+        code: 200
+        duration: 31.573596ms
+    - id: 40
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9bc4ec66-c6b0-435f-89d4-8387b7296354
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1630
+        body: '{"region":"fr-par","id":"9bc4ec66-c6b0-435f-89d4-8387b7296354","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:02:01.558575Z","updated_at":"2026-04-14T16:03:33.928001Z","type":"kapsule","name":"test-pool-validate-size-mutu","description":"","status":"ready","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","validate-size-mutu"],"cluster_url":"https://9bc4ec66-c6b0-435f-89d4-8387b7296354.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.9bc4ec66-c6b0-435f-89d4-8387b7296354.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":0},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"bacaf9bc-6bf2-45c1-8d45-d74d1b78cecf","commitment_ends_at":"2026-04-14T16:02:01.558579Z","acl_available":true,"iam_nodes_group_id":"dca3da3d-b07b-440b-ae09-9591cf5e3828","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1630"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:00 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - c986354b-a392-4064-9c0c-17c88ca3f02f
+        status: 200 OK
+        code: 200
+        duration: 44.598306ms
+    - id: 41
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7849c2c1-ad50-4f7e-ba9e-469d625fefc7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 777
+        body: '{"region":"fr-par","id":"7849c2c1-ad50-4f7e-ba9e-469d625fefc7","cluster_id":"9bc4ec66-c6b0-435f-89d4-8387b7296354","created_at":"2026-04-14T16:04:55.166608Z","updated_at":"2026-04-14T16:04:55.502493Z","name":"test-pool-validate-size-mutu","status":"ready","version":"1.35.3","node_type":"pro2_xxs","autoscaling":false,"size":0,"min_size":0,"max_size":0,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","validate-size-mutu"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{},"taints":[],"startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "777"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:00 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - 38bb12a4-a251-4dca-a21a-731febcfa7c0
+        status: 200 OK
+        code: 200
+        duration: 24.895431ms
+    - id: 42
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_asc
+            page:
+                - "1"
+            pool_id:
+                - 7849c2c1-ad50-4f7e-ba9e-469d625fefc7
+            status:
+                - unknown
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9bc4ec66-c6b0-435f-89d4-8387b7296354/nodes?order_by=created_at_asc&page=1&pool_id=7849c2c1-ad50-4f7e-ba9e-469d625fefc7&status=unknown
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 28
+        body: '{"total_count":0,"nodes":[]}'
+        headers:
+            Content-Length:
+                - "28"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:00 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - edce36c1-10af-4ce7-ae38-a8c82f82067b
+        status: 200 OK
+        code: 200
+        duration: 25.149967ms
+    - id: 43
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9bc4ec66-c6b0-435f-89d4-8387b7296354
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1630
+        body: '{"region":"fr-par","id":"9bc4ec66-c6b0-435f-89d4-8387b7296354","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:02:01.558575Z","updated_at":"2026-04-14T16:03:33.928001Z","type":"kapsule","name":"test-pool-validate-size-mutu","description":"","status":"ready","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","validate-size-mutu"],"cluster_url":"https://9bc4ec66-c6b0-435f-89d4-8387b7296354.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.9bc4ec66-c6b0-435f-89d4-8387b7296354.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":0},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"bacaf9bc-6bf2-45c1-8d45-d74d1b78cecf","commitment_ends_at":"2026-04-14T16:02:01.558579Z","acl_available":true,"iam_nodes_group_id":"dca3da3d-b07b-440b-ae09-9591cf5e3828","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1630"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:00 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - ab352445-cf7e-4aa6-8c5f-55c28bfbd960
+        status: 200 OK
+        code: 200
+        duration: 26.484915ms
+    - id: 44
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9bc4ec66-c6b0-435f-89d4-8387b7296354
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1630
+        body: '{"region":"fr-par","id":"9bc4ec66-c6b0-435f-89d4-8387b7296354","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:02:01.558575Z","updated_at":"2026-04-14T16:03:33.928001Z","type":"kapsule","name":"test-pool-validate-size-mutu","description":"","status":"ready","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","validate-size-mutu"],"cluster_url":"https://9bc4ec66-c6b0-435f-89d4-8387b7296354.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.9bc4ec66-c6b0-435f-89d4-8387b7296354.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":0},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"bacaf9bc-6bf2-45c1-8d45-d74d1b78cecf","commitment_ends_at":"2026-04-14T16:02:01.558579Z","acl_available":true,"iam_nodes_group_id":"dca3da3d-b07b-440b-ae09-9591cf5e3828","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1630"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:00 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - 06bd596d-0ecf-4cd8-9c3d-b4b8ce4be886
+        status: 200 OK
+        code: 200
+        duration: 18.544949ms
+    - id: 45
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/be0004d1-11ef-43dc-a330-c1ad4f27cb87
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 783
+        body: '{"region":"fr-par","id":"be0004d1-11ef-43dc-a330-c1ad4f27cb87","cluster_id":"9bc4ec66-c6b0-435f-89d4-8387b7296354","created_at":"2026-04-14T16:02:12.945634Z","updated_at":"2026-04-14T16:04:54.036668Z","name":"test-pool-validate-size-mutu-other","status":"ready","version":"1.35.3","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","validate-size-mutu"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{},"taints":[],"startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "783"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:00 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - 1ad84452-96ef-41e0-8273-32fb771dd4d7
+        status: 200 OK
+        code: 200
+        duration: 17.625338ms
+    - id: 46
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7849c2c1-ad50-4f7e-ba9e-469d625fefc7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 777
+        body: '{"region":"fr-par","id":"7849c2c1-ad50-4f7e-ba9e-469d625fefc7","cluster_id":"9bc4ec66-c6b0-435f-89d4-8387b7296354","created_at":"2026-04-14T16:04:55.166608Z","updated_at":"2026-04-14T16:04:55.502493Z","name":"test-pool-validate-size-mutu","status":"ready","version":"1.35.3","node_type":"pro2_xxs","autoscaling":false,"size":0,"min_size":0,"max_size":0,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","validate-size-mutu"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{},"taints":[],"startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "777"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:00 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - 35bb5027-1bb0-4ab7-9d2c-71dd8af45964
+        status: 200 OK
+        code: 200
+        duration: 27.781931ms
+    - id: 47
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/e7815bf0-5d3f-4e0a-aadb-c224ed23c413
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 408
+        body: '{"id":"e7815bf0-5d3f-4e0a-aadb-c224ed23c413","name":"tf-vpc-hopeful-wilson","tags":[],"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:02:00.342502Z","updated_at":"2026-04-14T16:02:00.342502Z","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","is_default":false,"private_network_count":1,"routing_enabled":true,"custom_routes_propagation_enabled":true,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "408"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:00 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - d6760372-9053-47b3-943f-4edec37d8481
+        status: 200 OK
+        code: 200
+        duration: 23.942938ms
+    - id: 48
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/bacaf9bc-6bf2-45c1-8d45-d74d1b78cecf
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1073
+        body: '{"id":"bacaf9bc-6bf2-45c1-8d45-d74d1b78cecf","name":"test-pool-validate-size-mutu","tags":[],"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:02:00.511641Z","updated_at":"2026-04-14T16:02:00.511641Z","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnets":[{"id":"8d0b31ea-0e89-471f-8fa3-9ae4ded56867","created_at":"2026-04-14T16:02:00.511641Z","updated_at":"2026-04-14T16:02:00.511641Z","subnet":"172.16.0.0/22","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"bacaf9bc-6bf2-45c1-8d45-d74d1b78cecf","vpc_id":"e7815bf0-5d3f-4e0a-aadb-c224ed23c413"},{"id":"2bde632d-99ef-4d13-81a0-2fce035faa2c","created_at":"2026-04-14T16:02:00.511641Z","updated_at":"2026-04-14T16:02:00.511641Z","subnet":"fd63:256c:45f7:92f0::/64","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"bacaf9bc-6bf2-45c1-8d45-d74d1b78cecf","vpc_id":"e7815bf0-5d3f-4e0a-aadb-c224ed23c413"}],"vpc_id":"e7815bf0-5d3f-4e0a-aadb-c224ed23c413","dhcp_enabled":true,"default_route_propagation_enabled":false,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1073"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:00 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - 5072520a-20af-46b3-bb38-4a5183292f8d
+        status: 200 OK
+        code: 200
+        duration: 22.087607ms
+    - id: 49
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9bc4ec66-c6b0-435f-89d4-8387b7296354
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1630
+        body: '{"region":"fr-par","id":"9bc4ec66-c6b0-435f-89d4-8387b7296354","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:02:01.558575Z","updated_at":"2026-04-14T16:03:33.928001Z","type":"kapsule","name":"test-pool-validate-size-mutu","description":"","status":"ready","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","validate-size-mutu"],"cluster_url":"https://9bc4ec66-c6b0-435f-89d4-8387b7296354.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.9bc4ec66-c6b0-435f-89d4-8387b7296354.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":0},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"bacaf9bc-6bf2-45c1-8d45-d74d1b78cecf","commitment_ends_at":"2026-04-14T16:02:01.558579Z","acl_available":true,"iam_nodes_group_id":"dca3da3d-b07b-440b-ae09-9591cf5e3828","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1630"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:00 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - 8423872d-5554-4cc9-948b-a6c09d355f89
+        status: 200 OK
+        code: 200
+        duration: 36.874715ms
+    - id: 50
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9bc4ec66-c6b0-435f-89d4-8387b7296354/kubeconfig
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1760
+        body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC12YWxpZGF0ZS1zaXplLW11dHUiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VKWGFrTkRRVkZIWjBGM1NVSkJaMGxDUVVSQlMwSm5aM0ZvYTJwUFVGRlJSRUZxUVZaTlVrMTNSVkZaUkZaUlVVUkZkM0J5WkZkS2JHTnROV3dLWkVkV2VrMUNORmhFVkVreVRVUlJlRTE2UlRKTlJFbDNUMFp2V0VSVVRUSk5SRkY0VFhwRk1rMUVTWGRQUm05M1JsUkZWRTFDUlVkQk1WVkZRWGhOU3dwaE0xWnBXbGhLZFZwWVVteGpla0phVFVKTlIwSjVjVWRUVFRRNVFXZEZSME5EY1VkVFRUUTVRWGRGU0VFd1NVRkNVRVZvUWxOR1RGQjFPSGxyZFZkbENuWXlOMFJtUjJOSmFXOVVUamgzVVdweFltWXlSRVl5Y0hsbWNrNU9jMGxWZEhoek4zZDNlWFpEWXpaWFZFeDZOa3d6VVdrelVtazJNV2RSY1hkSldIZ0tXRzFVVGtjNVUycFJha0pCVFVFMFIwRXhWV1JFZDBWQ0wzZFJSVUYzU1VOd1JFRlFRbWRPVmtoU1RVSkJaamhGUWxSQlJFRlJTQzlOUWpCSFFURlZaQXBFWjFGWFFrSlNNamhaZDJRNVdIZ3dNMFUyTkVOTFNGZzBkek5VTTBJMGNqZHFRVXRDWjJkeGFHdHFUMUJSVVVSQlowNUlRVVJDUlVGcFFYRlFkVEJKQ2k4MU1ubFBSMUJwTmtkb2NVaDJTMGg2TlVwRE5HOTFaR2hUWWpNMmJsbHdUemxvUTFKQlNXZEZhRkYzUm5wc1NTOUVkVXRpU2tOaFQyaEtkR0UwUjNVS1IzSjFVMnRDTVVSS0wwNHdOVGxDTUd4d2R6MEtMUzB0TFMxRlRrUWdRMFZTVkVsR1NVTkJWRVV0TFMwdExRbz0KICAgIHNlcnZlcjogaHR0cHM6Ly85YmM0ZWM2Ni1jNmIwLTQzNWYtODlkNC04Mzg3YjcyOTYzNTQuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXZhbGlkYXRlLXNpemUtbXV0dQogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXZhbGlkYXRlLXNpemUtbXV0dSIKICAgIHVzZXI6IHRlc3QtcG9vbC12YWxpZGF0ZS1zaXplLW11dHUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtdmFsaWRhdGUtc2l6ZS1tdXR1CmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXZhbGlkYXRlLXNpemUtbXV0dS1hZG1pbgogIHVzZXI6CiAgICB0b2tlbjoganNPYXZKTWR6czFiOVdLQlUxbXM0Q0xUVm5ESzd2QnVXcVA0ODlYV1dGQ1FnSTd4QmhCV2tmV3Y="}'
+        headers:
+            Content-Length:
+                - "1760"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:01 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - 9edeada0-e5a0-4ecb-8f2d-a2d148b50824
+        status: 200 OK
+        code: 200
+        duration: 41.080945ms
+    - id: 51
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/be0004d1-11ef-43dc-a330-c1ad4f27cb87
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 783
+        body: '{"region":"fr-par","id":"be0004d1-11ef-43dc-a330-c1ad4f27cb87","cluster_id":"9bc4ec66-c6b0-435f-89d4-8387b7296354","created_at":"2026-04-14T16:02:12.945634Z","updated_at":"2026-04-14T16:04:54.036668Z","name":"test-pool-validate-size-mutu-other","status":"ready","version":"1.35.3","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","validate-size-mutu"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{},"taints":[],"startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "783"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:01 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - 1fc37c29-5056-4205-8f99-23e4558d5d0b
+        status: 200 OK
+        code: 200
+        duration: 24.40847ms
+    - id: 52
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_asc
+            page:
+                - "1"
+            pool_id:
+                - be0004d1-11ef-43dc-a330-c1ad4f27cb87
+            status:
+                - unknown
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9bc4ec66-c6b0-435f-89d4-8387b7296354/nodes?order_by=created_at_asc&page=1&pool_id=be0004d1-11ef-43dc-a330-c1ad4f27cb87&status=unknown
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 603
+        body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"032d30b6-d286-4ffc-a59f-e05a8a907f3b","cluster_id":"9bc4ec66-c6b0-435f-89d4-8387b7296354","created_at":"2026-04-14T16:03:48.505608Z","updated_at":"2026-04-14T16:04:55.517905Z","pool_id":"be0004d1-11ef-43dc-a330-c1ad4f27cb87","status":"ready","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"name":"scw-test-pool-vali-test-pool-validate-s-032d30","public_ip_v4":"212.47.248.67","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/54cf5c9b-d29e-408f-8702-aa85389d06f6","error_message":""}]}'
+        headers:
+            Content-Length:
+                - "603"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:01 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - 37cbe2e8-7fce-4ea6-aac2-7c47bf16dc39
+        status: 200 OK
+        code: 200
+        duration: 28.824122ms
+    - id: 53
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9bc4ec66-c6b0-435f-89d4-8387b7296354
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1630
+        body: '{"region":"fr-par","id":"9bc4ec66-c6b0-435f-89d4-8387b7296354","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:02:01.558575Z","updated_at":"2026-04-14T16:03:33.928001Z","type":"kapsule","name":"test-pool-validate-size-mutu","description":"","status":"ready","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","validate-size-mutu"],"cluster_url":"https://9bc4ec66-c6b0-435f-89d4-8387b7296354.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.9bc4ec66-c6b0-435f-89d4-8387b7296354.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":0},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"bacaf9bc-6bf2-45c1-8d45-d74d1b78cecf","commitment_ends_at":"2026-04-14T16:02:01.558579Z","acl_available":true,"iam_nodes_group_id":"dca3da3d-b07b-440b-ae09-9591cf5e3828","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1630"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:01 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - 866eaffb-e0ee-46f5-98c5-cdf26721e597
+        status: 200 OK
+        code: 200
+        duration: 22.168017ms
+    - id: 54
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_desc
+            project_id:
+                - fa1e3217-dc80-42ac-85c3-3f034b78b552
+            resource_name:
+                - scw-test-pool-vali-test-pool-validate-s-032d30
+            resource_type:
+                - unknown_type
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=fa1e3217-dc80-42ac-85c3-3f034b78b552&resource_name=scw-test-pool-vali-test-pool-validate-s-032d30&resource_type=unknown_type
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1090
+        body: '{"total_count":2,"ips":[{"id":"89a604f2-d247-4ae1-abc5-9018e1398c1b","address":"fd63:256c:45f7:92f0:f71:8efb:dd8e:f14f/64","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","is_ipv6":true,"created_at":"2026-04-14T16:03:50.839691Z","updated_at":"2026-04-14T16:03:50.839691Z","source":{"subnet_id":"2bde632d-99ef-4d13-81a0-2fce035faa2c"},"resource":{"type":"instance_private_nic","id":"f7b44b24-a6a9-4c34-aa0b-b58561a4f660","mac_address":"02:00:00:15:5D:5F","name":"scw-test-pool-vali-test-pool-validate-s-032d30"},"tags":[],"reverses":[],"region":"fr-par","zone":null},{"id":"c1ca81ca-fbb0-4f95-baf7-c6ddb5f942b5","address":"172.16.0.3/22","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","is_ipv6":false,"created_at":"2026-04-14T16:03:50.729620Z","updated_at":"2026-04-14T16:03:50.729620Z","source":{"subnet_id":"8d0b31ea-0e89-471f-8fa3-9ae4ded56867"},"resource":{"type":"instance_private_nic","id":"f7b44b24-a6a9-4c34-aa0b-b58561a4f660","mac_address":"02:00:00:15:5D:5F","name":"scw-test-pool-vali-test-pool-validate-s-032d30"},"tags":[],"reverses":[],"region":"fr-par","zone":null}]}'
+        headers:
+            Content-Length:
+                - "1090"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:01 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - a1b10be1-d3a1-43c6-a303-a126318d73e5
+        status: 200 OK
+        code: 200
+        duration: 51.273215ms
+    - id: 55
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7849c2c1-ad50-4f7e-ba9e-469d625fefc7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 777
+        body: '{"region":"fr-par","id":"7849c2c1-ad50-4f7e-ba9e-469d625fefc7","cluster_id":"9bc4ec66-c6b0-435f-89d4-8387b7296354","created_at":"2026-04-14T16:04:55.166608Z","updated_at":"2026-04-14T16:04:55.502493Z","name":"test-pool-validate-size-mutu","status":"ready","version":"1.35.3","node_type":"pro2_xxs","autoscaling":false,"size":0,"min_size":0,"max_size":0,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","validate-size-mutu"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{},"taints":[],"startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "777"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:01 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - 1e502bf3-26de-43a2-b4d5-03f93a405aef
+        status: 200 OK
+        code: 200
+        duration: 25.858823ms
+    - id: 56
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_asc
+            page:
+                - "1"
+            pool_id:
+                - 7849c2c1-ad50-4f7e-ba9e-469d625fefc7
+            status:
+                - unknown
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9bc4ec66-c6b0-435f-89d4-8387b7296354/nodes?order_by=created_at_asc&page=1&pool_id=7849c2c1-ad50-4f7e-ba9e-469d625fefc7&status=unknown
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 28
+        body: '{"total_count":0,"nodes":[]}'
+        headers:
+            Content-Length:
+                - "28"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:01 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - 2bd706ff-38ec-4007-9d41-935241ab812e
+        status: 200 OK
+        code: 200
+        duration: 20.033705ms
+    - id: 57
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9bc4ec66-c6b0-435f-89d4-8387b7296354
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1630
+        body: '{"region":"fr-par","id":"9bc4ec66-c6b0-435f-89d4-8387b7296354","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:02:01.558575Z","updated_at":"2026-04-14T16:03:33.928001Z","type":"kapsule","name":"test-pool-validate-size-mutu","description":"","status":"ready","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","validate-size-mutu"],"cluster_url":"https://9bc4ec66-c6b0-435f-89d4-8387b7296354.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.9bc4ec66-c6b0-435f-89d4-8387b7296354.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":0},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"bacaf9bc-6bf2-45c1-8d45-d74d1b78cecf","commitment_ends_at":"2026-04-14T16:02:01.558579Z","acl_available":true,"iam_nodes_group_id":"dca3da3d-b07b-440b-ae09-9591cf5e3828","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1630"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:01 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - 96e7a32c-ee86-48b5-98d2-e818616bb8b7
+        status: 200 OK
+        code: 200
+        duration: 22.057521ms
+    - id: 58
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7849c2c1-ad50-4f7e-ba9e-469d625fefc7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 780
+        body: '{"region":"fr-par","id":"7849c2c1-ad50-4f7e-ba9e-469d625fefc7","cluster_id":"9bc4ec66-c6b0-435f-89d4-8387b7296354","created_at":"2026-04-14T16:04:55.166608Z","updated_at":"2026-04-14T16:05:01.675687Z","name":"test-pool-validate-size-mutu","status":"deleting","version":"1.35.3","node_type":"pro2_xxs","autoscaling":false,"size":0,"min_size":0,"max_size":0,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","validate-size-mutu"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{},"taints":[],"startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "780"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:01 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - 60a9e038-7985-46ce-8d19-0bcaf11e7891
+        status: 200 OK
+        code: 200
+        duration: 283.962641ms
+    - id: 59
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7849c2c1-ad50-4f7e-ba9e-469d625fefc7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 780
+        body: '{"region":"fr-par","id":"7849c2c1-ad50-4f7e-ba9e-469d625fefc7","cluster_id":"9bc4ec66-c6b0-435f-89d4-8387b7296354","created_at":"2026-04-14T16:04:55.166608Z","updated_at":"2026-04-14T16:05:01.675687Z","name":"test-pool-validate-size-mutu","status":"deleting","version":"1.35.3","node_type":"pro2_xxs","autoscaling":false,"size":0,"min_size":0,"max_size":0,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","validate-size-mutu"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{},"taints":[],"startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "780"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:01 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - 4d8bc55f-3160-4e6f-bb7f-c1c96825d663
+        status: 200 OK
+        code: 200
+        duration: 33.331605ms
+    - id: 60
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7849c2c1-ad50-4f7e-ba9e-469d625fefc7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 125
+        body: '{"message":"resource is not found","resource":"pool","resource_id":"7849c2c1-ad50-4f7e-ba9e-469d625fefc7","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "125"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:16 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - 0e948a23-6915-4422-94f2-be5c7f53fc12
+        status: 404 Not Found
+        code: 404
+        duration: 25.385713ms
+    - id: 61
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/be0004d1-11ef-43dc-a330-c1ad4f27cb87
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 786
+        body: '{"region":"fr-par","id":"be0004d1-11ef-43dc-a330-c1ad4f27cb87","cluster_id":"9bc4ec66-c6b0-435f-89d4-8387b7296354","created_at":"2026-04-14T16:02:12.945634Z","updated_at":"2026-04-14T16:05:16.914776Z","name":"test-pool-validate-size-mutu-other","status":"deleting","version":"1.35.3","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","validate-size-mutu"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{},"taints":[],"startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "786"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:16 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - ad801c03-7cf4-47f5-b554-7dabd789f533
+        status: 200 OK
+        code: 200
+        duration: 77.843243ms
+    - id: 62
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/be0004d1-11ef-43dc-a330-c1ad4f27cb87
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 786
+        body: '{"region":"fr-par","id":"be0004d1-11ef-43dc-a330-c1ad4f27cb87","cluster_id":"9bc4ec66-c6b0-435f-89d4-8387b7296354","created_at":"2026-04-14T16:02:12.945634Z","updated_at":"2026-04-14T16:05:16.914776Z","name":"test-pool-validate-size-mutu-other","status":"deleting","version":"1.35.3","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","scaleway_k8s_pool","validate-size-mutu"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"sbs_5k","root_volume_size":20000000000,"public_ip_disabled":false,"security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b","labels":{},"taints":[],"startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "786"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:05:16 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - 116cad25-3ef8-431c-b340-ec9e22872091
+        status: 200 OK
+        code: 200
+        duration: 32.010559ms
+    - id: 63
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/be0004d1-11ef-43dc-a330-c1ad4f27cb87
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 125
+        body: '{"message":"resource is not found","resource":"pool","resource_id":"be0004d1-11ef-43dc-a330-c1ad4f27cb87","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "125"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:06:32 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - ddc5bfd1-45a8-411c-8f7e-86eae043e499
+        status: 404 Not Found
+        code: 404
+        duration: 21.528402ms
+    - id: 64
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            with_additional_resources:
+                - "false"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9bc4ec66-c6b0-435f-89d4-8387b7296354?with_additional_resources=false
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1633
+        body: '{"region":"fr-par","id":"9bc4ec66-c6b0-435f-89d4-8387b7296354","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:02:01.558575Z","updated_at":"2026-04-14T16:06:32.264186Z","type":"kapsule","name":"test-pool-validate-size-mutu","description":"","status":"deleting","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","validate-size-mutu"],"cluster_url":"https://9bc4ec66-c6b0-435f-89d4-8387b7296354.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.9bc4ec66-c6b0-435f-89d4-8387b7296354.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":0},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"bacaf9bc-6bf2-45c1-8d45-d74d1b78cecf","commitment_ends_at":"2026-04-14T16:02:01.558579Z","acl_available":true,"iam_nodes_group_id":"dca3da3d-b07b-440b-ae09-9591cf5e3828","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1633"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:06:32 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - 7d405d13-68e1-4ab5-9f6c-aec812934db0
+        status: 200 OK
+        code: 200
+        duration: 151.90864ms
+    - id: 65
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9bc4ec66-c6b0-435f-89d4-8387b7296354
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1633
+        body: '{"region":"fr-par","id":"9bc4ec66-c6b0-435f-89d4-8387b7296354","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-04-14T16:02:01.558575Z","updated_at":"2026-04-14T16:06:32.264186Z","type":"kapsule","name":"test-pool-validate-size-mutu","description":"","status":"deleting","version":"1.35.3","cni":"cilium","tags":["terraform-test","scaleway_k8s_pool","validate-size-mutu"],"cluster_url":"https://9bc4ec66-c6b0-435f-89d4-8387b7296354.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.9bc4ec66-c6b0-435f-89d4-8387b7296354.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0,"skip_nodes_with_local_storage":false,"log_level":0},"auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[],"private_network_id":"bacaf9bc-6bf2-45c1-8d45-d74d1b78cecf","commitment_ends_at":"2026-04-14T16:02:01.558579Z","acl_available":true,"iam_nodes_group_id":"dca3da3d-b07b-440b-ae09-9591cf5e3828","pod_cidr":"100.64.0.0/15","service_cidr":"10.32.0.0/20","service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1633"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:06:32 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - d669edcb-6203-464b-93d8-d50303cc410d
+        status: 200 OK
+        code: 200
+        duration: 48.103262ms
+    - id: 66
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9bc4ec66-c6b0-435f-89d4-8387b7296354
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 128
+        body: '{"message":"resource is not found","resource":"cluster","resource_id":"9bc4ec66-c6b0-435f-89d4-8387b7296354","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "128"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:06:47 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - 00e27b20-6e4d-4b80-a733-b80528399c8e
+        status: 404 Not Found
+        code: 404
+        duration: 32.162175ms
+    - id: 67
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/bacaf9bc-6bf2-45c1-8d45-d74d1b78cecf
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:06:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - e05cb8c0-8093-4a5b-8c52-30caf334b0b1
+        status: 204 No Content
+        code: 204
+        duration: 1.469611336s
+    - id: 68
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/e7815bf0-5d3f-4e0a-aadb-c224ed23c413
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:06:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - 555430d6-362e-4741-9786-ec2e18daac87
+        status: 204 No Content
+        code: 204
+        duration: 335.500898ms
+    - id: 69
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7849c2c1-ad50-4f7e-ba9e-469d625fefc7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 125
+        body: '{"message":"resource is not found","resource":"pool","resource_id":"7849c2c1-ad50-4f7e-ba9e-469d625fefc7","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "125"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:06:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - dd20b553-a8a1-43f5-8ff1-e6fb83912215
+        status: 404 Not Found
+        code: 404
+        duration: 19.172776ms
+    - id: 70
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9bc4ec66-c6b0-435f-89d4-8387b7296354
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 128
+        body: '{"message":"resource is not found","resource":"cluster","resource_id":"9bc4ec66-c6b0-435f-89d4-8387b7296354","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "128"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:06:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - dd063c49-b586-4643-9a26-11db30292f37
+        status: 404 Not Found
+        code: 404
+        duration: 20.247227ms
+    - id: 71
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/bacaf9bc-6bf2-45c1-8d45-d74d1b78cecf
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 136
+        body: '{"message":"resource is not found","resource":"private_network","resource_id":"bacaf9bc-6bf2-45c1-8d45-d74d1b78cecf","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "136"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 14 Apr 2026 16:06:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-1;edge02)
+            X-Request-Id:
+                - 61a32c2c-5844-43c5-831b-62ccf48b6d3e
+        status: 404 Not Found
+        code: 404
+        duration: 22.152043ms

--- a/internal/services/k8s/testdata/pool-wait.cassette.yaml
+++ b/internal/services/k8s/testdata/pool-wait.cassette.yaml
@@ -1,5802 +1,6100 @@
 ---
 version: 2
 interactions:
-- id: 0
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/versions
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 4476
-    body: "{\"versions\":[{\"region\":\"fr-par\", \"name\":\"1.34.1\", \"label\":\"Kubernetes 1.34.1\", \"available_cnis\":[\"cilium\", \"cilium_native\", \"calico\", \"kilo\", \"none\"], \"available_container_runtimes\":[\"containerd\"], \"available_feature_gates\":[\"HPAScaleToZero\", \"CPUManagerPolicyAlphaOptions\", \"ImageVolume\"], \"available_admission_plugins\":[\"AlwaysPullImages\", \"PodNodeSelector\", \"PodTolerationRestriction\"], \"available_kubelet_args\":{\"containerLogMaxFiles\":\"uint16\", \"containerLogMaxSize\":\"quantity\", \"cpuCFSQuota\":\"bool\", \"cpuCFSQuotaPeriod\":\"duration\", \"cpuManagerPolicy\":\"enum:none|static\", \"cpuManagerPolicyOptions\":\"map[string]string\", \"enableDebuggingHandlers\":\"bool\", \"evictionHard\":\"map[string]string\", \"evictionMinimumReclaim\":\"map[string]string\", \"imageGCHighThresholdPercent\":\"uint32\", \"imageGCLowThresholdPercent\":\"uint32\", \"maxParallelImagePulls\":\"int32\", \"maxPods\":\"uint16\", \"registryBurst\":\"int32\", \"registryPullQPS\":\"int32\", \"serializeImagePulls\":\"bool\"}, \"deprecated_at\":\"2026-09-29T00:00:00Z\", \"end_of_life_at\":\"2026-11-29T00:00:00Z\", \"released_at\":\"2025-09-29T00:00:00Z\"}, {\"region\":\"fr-par\", \"name\":\"1.33.4\", \"label\":\"Kubernetes 1.33.4\", \"available_cnis\":[\"cilium\", \"calico\", \"kilo\", \"none\"], \"available_container_runtimes\":[\"containerd\"], \"available_feature_gates\":[\"HPAScaleToZero\", \"DRAAdminAccess\", \"DynamicResourceAllocation\", \"PodLevelResources\", \"CPUManagerPolicyAlphaOptions\", \"ImageVolume\"], \"available_admission_plugins\":[\"AlwaysPullImages\", \"PodNodeSelector\", \"PodTolerationRestriction\"], \"available_kubelet_args\":{\"containerLogMaxFiles\":\"uint16\", \"containerLogMaxSize\":\"quantity\", \"cpuCFSQuota\":\"bool\", \"cpuCFSQuotaPeriod\":\"duration\", \"cpuManagerPolicy\":\"enum:none|static\", \"cpuManagerPolicyOptions\":\"map[string]string\", \"enableDebuggingHandlers\":\"bool\", \"evictionHard\":\"map[string]string\", \"evictionMinimumReclaim\":\"map[string]string\", \"imageGCHighThresholdPercent\":\"uint32\", \"imageGCLowThresholdPercent\":\"uint32\", \"maxParallelImagePulls\":\"int32\", \"maxPods\":\"uint16\", \"registryBurst\":\"int32\", \"registryPullQPS\":\"int32\", \"serializeImagePulls\":\"bool\"}, \"deprecated_at\":\"2026-09-04T00:00:00Z\", \"end_of_life_at\":\"2026-11-04T00:00:00Z\", \"released_at\":\"2025-09-04T00:00:00Z\"}, {\"region\":\"fr-par\", \"name\":\"1.32.8\", \"label\":\"Kubernetes 1.32.8\", \"available_cnis\":[\"cilium\", \"calico\", \"kilo\", \"none\"], \"available_container_runtimes\":[\"containerd\"], \"available_feature_gates\":[\"HPAScaleToZero\", \"InPlacePodVerticalScaling\", \"SidecarContainers\", \"DRAAdminAccess\", \"DRAResourceClaimDeviceStatus\", \"DynamicResourceAllocation\", \"PodLevelResources\", \"CPUManagerPolicyAlphaOptions\", \"ImageVolume\"], \"available_admission_plugins\":[\"AlwaysPullImages\", \"PodNodeSelector\", \"PodTolerationRestriction\"], \"available_kubelet_args\":{\"containerLogMaxFiles\":\"uint16\", \"containerLogMaxSize\":\"quantity\", \"cpuCFSQuota\":\"bool\", \"cpuCFSQuotaPeriod\":\"duration\", \"cpuManagerPolicy\":\"enum:none|static\", \"cpuManagerPolicyOptions\":\"map[string]string\", \"enableDebuggingHandlers\":\"bool\", \"evictionHard\":\"map[string]string\", \"evictionMinimumReclaim\":\"map[string]string\", \"imageGCHighThresholdPercent\":\"uint32\", \"imageGCLowThresholdPercent\":\"uint32\", \"maxParallelImagePulls\":\"int32\", \"maxPods\":\"uint16\", \"registryBurst\":\"int32\", \"registryPullQPS\":\"int32\", \"serializeImagePulls\":\"bool\"}, \"deprecated_at\":\"2026-03-24T00:00:00Z\", \"end_of_life_at\":\"2025-05-24T00:00:00Z\", \"released_at\":\"2025-03-24T00:00:00Z\"}, {\"region\":\"fr-par\", \"name\":\"1.31.12\", \"label\":\"Kubernetes 1.31.12\", \"available_cnis\":[\"cilium\", \"calico\", \"kilo\", \"none\"], \"available_container_runtimes\":[\"containerd\"], \"available_feature_gates\":[\"HPAScaleToZero\", \"InPlacePodVerticalScaling\", \"SidecarContainers\", \"CPUManagerPolicyAlphaOptions\", \"ImageVolume\"], \"available_admission_plugins\":[\"AlwaysPullImages\", \"PodNodeSelector\", \"PodTolerationRestriction\"], \"available_kubelet_args\":{\"containerLogMaxFiles\":\"uint16\", \"containerLogMaxSize\":\"quantity\", \"cpuCFSQuota\":\"bool\", \"cpuCFSQuotaPeriod\":\"duration\", \"cpuManagerPolicy\":\"enum:none|static\", \"cpuManagerPolicyOptions\":\"map[string]string\", \"enableDebuggingHandlers\":\"bool\", \"evictionHard\":\"map[string]string\", \"evictionMinimumReclaim\":\"map[string]string\", \"imageGCHighThresholdPercent\":\"uint32\", \"imageGCLowThresholdPercent\":\"uint32\", \"maxParallelImagePulls\":\"int32\", \"maxPods\":\"uint16\", \"registryBurst\":\"int32\", \"registryPullQPS\":\"int32\", \"serializeImagePulls\":\"bool\"}, \"deprecated_at\":\"2025-12-02T00:00:00Z\", \"end_of_life_at\":\"2026-02-02T00:00:00Z\", \"released_at\":\"2024-12-02T00:00:00Z\"}]}"
-    headers:
-      Content-Length:
-      - "4476"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:48:59 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 56bb22ea-2460-4d12-84f0-597ffe638a91
-    status: 200 OK
-    code: 200
-    duration: 70.578643ms
-- id: 1
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 117
-    host: api.scaleway.com
-    body: "{\"name\":\"tf-vpc-confident-bose\",\"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\",\"tags\":[],\"enable_routing\":false}"
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs
-    method: POST
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 419
-    body: "{\"id\":\"1a7a1e1e-2b33-478e-8f1a-faa0303a1c43\", \"name\":\"tf-vpc-confident-bose\", \"tags\":[], \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:00.136298Z\", \"updated_at\":\"2025-10-30T16:49:00.136298Z\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_default\":false, \"private_network_count\":0, \"routing_enabled\":true, \"custom_routes_propagation_enabled\":true, \"region\":\"fr-par\"}"
-    headers:
-      Content-Length:
-      - "419"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:49:00 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 92bd5519-03c8-441e-9bb5-b422bacd361d
-    status: 200 OK
-    code: 200
-    duration: 144.417556ms
-- id: 2
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/1a7a1e1e-2b33-478e-8f1a-faa0303a1c43
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 419
-    body: "{\"id\":\"1a7a1e1e-2b33-478e-8f1a-faa0303a1c43\", \"name\":\"tf-vpc-confident-bose\", \"tags\":[], \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:00.136298Z\", \"updated_at\":\"2025-10-30T16:49:00.136298Z\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_default\":false, \"private_network_count\":0, \"routing_enabled\":true, \"custom_routes_propagation_enabled\":true, \"region\":\"fr-par\"}"
-    headers:
-      Content-Length:
-      - "419"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:49:00 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - a6e043f9-4f9e-45bb-9794-57abac4d6abf
-    status: 200 OK
-    code: 200
-    duration: 107.635573ms
-- id: 3
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 192
-    host: api.scaleway.com
-    body: "{\"name\":\"test-pool-wait\",\"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\",\"tags\":[],\"subnets\":null,\"vpc_id\":\"1a7a1e1e-2b33-478e-8f1a-faa0303a1c43\",\"default_route_propagation_enabled\":false}"
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
-    method: POST
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1084
-    body: "{\"id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"name\":\"test-pool-wait\", \"tags\":[], \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:00.384609Z\", \"updated_at\":\"2025-10-30T16:49:00.384609Z\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"subnets\":[{\"id\":\"da10d014-609b-48cc-9b9a-437dc31f4497\", \"created_at\":\"2025-10-30T16:49:00.384609Z\", \"updated_at\":\"2025-10-30T16:49:00.384609Z\", \"subnet\":\"172.18.20.0/22\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"vpc_id\":\"1a7a1e1e-2b33-478e-8f1a-faa0303a1c43\"}, {\"id\":\"7493d1b7-5773-41c2-be8c-52e4ec098fc3\", \"created_at\":\"2025-10-30T16:49:00.384609Z\", \"updated_at\":\"2025-10-30T16:49:00.384609Z\", \"subnet\":\"fd5f:519c:6d46:90dd::/64\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"vpc_id\":\"1a7a1e1e-2b33-478e-8f1a-faa0303a1c43\"}], \"vpc_id\":\"1a7a1e1e-2b33-478e-8f1a-faa0303a1c43\", \"dhcp_enabled\":true, \"default_route_propagation_enabled\":false, \"region\":\"fr-par\"}"
-    headers:
-      Content-Length:
-      - "1084"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:49:00 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 172760f2-6b09-41f2-85f8-5817dddcf984
-    status: 200 OK
-    code: 200
-    duration: 663.481036ms
-- id: 4
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/363e7214-8a98-40d0-9357-9e4026c21b76
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1084
-    body: "{\"id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"name\":\"test-pool-wait\", \"tags\":[], \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:00.384609Z\", \"updated_at\":\"2025-10-30T16:49:00.384609Z\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"subnets\":[{\"id\":\"da10d014-609b-48cc-9b9a-437dc31f4497\", \"created_at\":\"2025-10-30T16:49:00.384609Z\", \"updated_at\":\"2025-10-30T16:49:00.384609Z\", \"subnet\":\"172.18.20.0/22\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"vpc_id\":\"1a7a1e1e-2b33-478e-8f1a-faa0303a1c43\"}, {\"id\":\"7493d1b7-5773-41c2-be8c-52e4ec098fc3\", \"created_at\":\"2025-10-30T16:49:00.384609Z\", \"updated_at\":\"2025-10-30T16:49:00.384609Z\", \"subnet\":\"fd5f:519c:6d46:90dd::/64\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"vpc_id\":\"1a7a1e1e-2b33-478e-8f1a-faa0303a1c43\"}], \"vpc_id\":\"1a7a1e1e-2b33-478e-8f1a-faa0303a1c43\", \"dhcp_enabled\":true, \"default_route_propagation_enabled\":false, \"region\":\"fr-par\"}"
-    headers:
-      Content-Length:
-      - "1084"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:49:01 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 261a7c45-8f6d-45b2-bc3d-84e20016ae60
-    status: 200 OK
-    code: 200
-    duration: 97.114628ms
-- id: 5
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 695
-    host: api.scaleway.com
-    body: "{\"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\",\"type\":\"\",\"name\":\"test-pool-wait\",\"description\":\"\",\"tags\":[\"terraform-test\",\"scaleway_k8s_cluster\",\"minimal\"],\"version\":\"1.34.1\",\"cni\":\"calico\",\"pools\":null,\"autoscaler_config\":{\"scale_down_disabled\":null,\"scale_down_delay_after_add\":null,\"estimator\":\"unknown_estimator\",\"expander\":\"unknown_expander\",\"ignore_daemonsets_utilization\":null,\"balance_similar_node_groups\":null,\"expendable_pods_priority_cutoff\":0,\"scale_down_unneeded_time\":null,\"scale_down_utilization_threshold\":null,\"max_graceful_termination_sec\":0},\"feature_gates\":[],\"admission_plugins\":[],\"apiserver_cert_sans\":[],\"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\"}"
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
-    method: POST
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1598
-    body: "{\"region\":\"fr-par\", \"id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:01.607119Z\", \"updated_at\":\"2025-10-30T16:49:01.607120Z\", \"type\":\"kapsule\", \"name\":\"test-pool-wait\", \"description\":\"\", \"status\":\"creating\", \"version\":\"1.34.1\", \"cni\":\"calico\", \"tags\":[\"terraform-test\", \"scaleway_k8s_cluster\", \"minimal\"], \"cluster_url\":\"https://5114e066-aa93-4560-9be0-5ae445715a75.api.k8s.fr-par.scw.cloud:6443\", \"dns_wildcard\":\"*.5114e066-aa93-4560-9be0-5ae445715a75.nodes.k8s.fr-par.scw.cloud\", \"autoscaler_config\":{\"scale_down_disabled\":false, \"scale_down_delay_after_add\":\"10m\", \"estimator\":\"binpacking\", \"expander\":\"random\", \"ignore_daemonsets_utilization\":false, \"balance_similar_node_groups\":false, \"expendable_pods_priority_cutoff\":0, \"scale_down_unneeded_time\":\"10m\", \"scale_down_utilization_threshold\":0.5, \"max_graceful_termination_sec\":0}, \"auto_upgrade\":{\"enabled\":false, \"maintenance_window\":{\"start_hour\":0, \"day\":\"any\"}}, \"upgrade_available\":false, \"feature_gates\":[], \"admission_plugins\":[], \"open_id_connect_config\":{\"issuer_url\":\"\", \"client_id\":\"\", \"username_claim\":\"\", \"username_prefix\":\"\", \"groups_claim\":[], \"groups_prefix\":\"\", \"required_claim\":[]}, \"apiserver_cert_sans\":[], \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"commitment_ends_at\":\"2025-10-30T16:49:01.607128Z\", \"acl_available\":true, \"iam_nodes_group_id\":\"\", \"new_images_enabled\":false, \"pod_cidr\":\"100.64.0.0/15\", \"service_cidr\":\"10.32.0.0/20\", \"service_dns_ip\":\"10.32.0.10\"}"
-    headers:
-      Content-Length:
-      - "1598"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:49:01 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 48a0aaa1-2ecd-4647-b347-9661e5125fdc
-    status: 200 OK
-    code: 200
-    duration: 624.563876ms
-- id: 6
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1597
-    body: "{\"region\":\"fr-par\", \"id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:01.607119Z\", \"updated_at\":\"2025-10-30T16:49:01.607120Z\", \"type\":\"kapsule\", \"name\":\"test-pool-wait\", \"description\":\"\", \"status\":\"creating\", \"version\":\"1.34.1\", \"cni\":\"calico\", \"tags\":[\"terraform-test\", \"scaleway_k8s_cluster\", \"minimal\"], \"cluster_url\":\"https://5114e066-aa93-4560-9be0-5ae445715a75.api.k8s.fr-par.scw.cloud:6443\", \"dns_wildcard\":\"*.5114e066-aa93-4560-9be0-5ae445715a75.nodes.k8s.fr-par.scw.cloud\", \"autoscaler_config\":{\"scale_down_disabled\":false, \"scale_down_delay_after_add\":\"10m\", \"estimator\":\"binpacking\", \"expander\":\"random\", \"ignore_daemonsets_utilization\":false, \"balance_similar_node_groups\":false, \"expendable_pods_priority_cutoff\":0, \"scale_down_unneeded_time\":\"10m\", \"scale_down_utilization_threshold\":0.5, \"max_graceful_termination_sec\":0}, \"auto_upgrade\":{\"enabled\":false, \"maintenance_window\":{\"start_hour\":0, \"day\":\"any\"}}, \"upgrade_available\":false, \"feature_gates\":[], \"admission_plugins\":[], \"open_id_connect_config\":{\"issuer_url\":\"\", \"client_id\":\"\", \"username_claim\":\"\", \"username_prefix\":\"\", \"groups_claim\":[], \"groups_prefix\":\"\", \"required_claim\":[]}, \"apiserver_cert_sans\":[], \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"commitment_ends_at\":\"2025-10-30T16:49:01.607128Z\", \"acl_available\":true, \"iam_nodes_group_id\":\"\", \"new_images_enabled\":true, \"pod_cidr\":\"100.64.0.0/15\", \"service_cidr\":\"10.32.0.0/20\", \"service_dns_ip\":\"10.32.0.10\"}"
-    headers:
-      Content-Length:
-      - "1597"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:49:01 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - af2bd7d7-1a1e-471b-ac88-39a54506d002
-    status: 200 OK
-    code: 200
-    duration: 100.359668ms
-- id: 7
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1638
-    body: "{\"region\":\"fr-par\", \"id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:01.607119Z\", \"updated_at\":\"2025-10-30T16:49:02.140189Z\", \"type\":\"kapsule\", \"name\":\"test-pool-wait\", \"description\":\"\", \"status\":\"pool_required\", \"version\":\"1.34.1\", \"cni\":\"calico\", \"tags\":[\"terraform-test\", \"scaleway_k8s_cluster\", \"minimal\"], \"cluster_url\":\"https://5114e066-aa93-4560-9be0-5ae445715a75.api.k8s.fr-par.scw.cloud:6443\", \"dns_wildcard\":\"*.5114e066-aa93-4560-9be0-5ae445715a75.nodes.k8s.fr-par.scw.cloud\", \"autoscaler_config\":{\"scale_down_disabled\":false, \"scale_down_delay_after_add\":\"10m\", \"estimator\":\"binpacking\", \"expander\":\"random\", \"ignore_daemonsets_utilization\":false, \"balance_similar_node_groups\":false, \"expendable_pods_priority_cutoff\":0, \"scale_down_unneeded_time\":\"10m\", \"scale_down_utilization_threshold\":0.5, \"max_graceful_termination_sec\":0}, \"auto_upgrade\":{\"enabled\":false, \"maintenance_window\":{\"start_hour\":0, \"day\":\"any\"}}, \"upgrade_available\":false, \"feature_gates\":[], \"admission_plugins\":[], \"open_id_connect_config\":{\"issuer_url\":\"\", \"client_id\":\"\", \"username_claim\":\"\", \"username_prefix\":\"\", \"groups_claim\":[], \"groups_prefix\":\"\", \"required_claim\":[]}, \"apiserver_cert_sans\":[], \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"commitment_ends_at\":\"2025-10-30T16:49:01.607128Z\", \"acl_available\":true, \"iam_nodes_group_id\":\"6c8f211e-8819-44e2-93ca-fda367c9ca2a\", \"new_images_enabled\":true, \"pod_cidr\":\"100.64.0.0/15\", \"service_cidr\":\"10.32.0.0/20\", \"service_dns_ip\":\"10.32.0.10\"}"
-    headers:
-      Content-Length:
-      - "1638"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:49:06 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 3a6416d2-f503-4ca1-9675-0ded987196f5
-    status: 200 OK
-    code: 200
-    duration: 86.69451ms
-- id: 8
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    form:
-      order_by:
-      - created_at_asc
-      page:
-      - "1"
-      status:
-      - unknown
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75/pools?order_by=created_at_asc&page=1&status=unknown
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 29
-    body: "{\"total_count\":0, \"pools\":[]}"
-    headers:
-      Content-Length:
-      - "29"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:49:06 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 11fefa5c-2b9b-465e-8cef-1cc284372674
-    status: 200 OK
-    code: 200
-    duration: 79.143649ms
-- id: 9
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1638
-    body: "{\"region\":\"fr-par\", \"id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:01.607119Z\", \"updated_at\":\"2025-10-30T16:49:02.140189Z\", \"type\":\"kapsule\", \"name\":\"test-pool-wait\", \"description\":\"\", \"status\":\"pool_required\", \"version\":\"1.34.1\", \"cni\":\"calico\", \"tags\":[\"terraform-test\", \"scaleway_k8s_cluster\", \"minimal\"], \"cluster_url\":\"https://5114e066-aa93-4560-9be0-5ae445715a75.api.k8s.fr-par.scw.cloud:6443\", \"dns_wildcard\":\"*.5114e066-aa93-4560-9be0-5ae445715a75.nodes.k8s.fr-par.scw.cloud\", \"autoscaler_config\":{\"scale_down_disabled\":false, \"scale_down_delay_after_add\":\"10m\", \"estimator\":\"binpacking\", \"expander\":\"random\", \"ignore_daemonsets_utilization\":false, \"balance_similar_node_groups\":false, \"expendable_pods_priority_cutoff\":0, \"scale_down_unneeded_time\":\"10m\", \"scale_down_utilization_threshold\":0.5, \"max_graceful_termination_sec\":0}, \"auto_upgrade\":{\"enabled\":false, \"maintenance_window\":{\"start_hour\":0, \"day\":\"any\"}}, \"upgrade_available\":false, \"feature_gates\":[], \"admission_plugins\":[], \"open_id_connect_config\":{\"issuer_url\":\"\", \"client_id\":\"\", \"username_claim\":\"\", \"username_prefix\":\"\", \"groups_claim\":[], \"groups_prefix\":\"\", \"required_claim\":[]}, \"apiserver_cert_sans\":[], \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"commitment_ends_at\":\"2025-10-30T16:49:01.607128Z\", \"acl_available\":true, \"iam_nodes_group_id\":\"6c8f211e-8819-44e2-93ca-fda367c9ca2a\", \"new_images_enabled\":true, \"pod_cidr\":\"100.64.0.0/15\", \"service_cidr\":\"10.32.0.0/20\", \"service_dns_ip\":\"10.32.0.10\"}"
-    headers:
-      Content-Length:
-      - "1638"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:49:06 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - f077f155-ac27-4a0a-b77f-cc95fb88b782
-    status: 200 OK
-    code: 200
-    duration: 53.043613ms
-- id: 10
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75/kubeconfig
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1654
-    body: "{\"name\":\"kubeconfig\", \"content_type\":\"application/octet-stream\", \"content\":\"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVSllSRU5EUVZGSFowRjNTVUpCWjBsQ1FVUkJTMEpuWjNGb2EycFBVRkZSUkVGcVFWWk5VazEzUlZGWlJGWlJVVVJGZDNCeVpGZEtiR050Tld3S1pFZFdlazFDTkZoRVZFa3hUVlJCZVU5VVJUSk9SR3QzVFZadldFUlVUVEZOVkVGNVQxUkZNazVFYTNkTlZtOTNSbFJGVkUxQ1JVZEJNVlZGUVhoTlN3cGhNMVpwV2xoS2RWcFlVbXhqZWtKYVRVSk5SMEo1Y1VkVFRUUTVRV2RGUjBORGNVZFRUVFE1UVhkRlNFRXdTVUZDVFhsNllqUkdTbVozWTFOM01tZEZDbEppVFRkVFZpOUpiM0ZXU21oWWVIbGxObHB1UkZOWlZ6WmxRbU4yV2tJM1RXVnVMMWxPYm5wM2F6QkpRazF2VDFkUFRXeHRlVGxJWVU5NE1XVkxaSFlLTUVRNE9XZDVZV3BSYWtKQlRVRTBSMEV4VldSRWQwVkNMM2RSUlVGM1NVTndSRUZRUW1kT1ZraFNUVUpCWmpoRlFsUkJSRUZSU0M5TlFqQkhRVEZWWkFwRVoxRlhRa0pTVTFsU1NtTm9UV1l3V0U5YWNtUkJhV1JMYkdOUWEyTklZeTlVUVV0Q1oyZHhhR3RxVDFCUlVVUkJaMDVLUVVSQ1IwRnBSVUY1Ym0xd0NqbFpkWG80VWpGVWFtNDBiV2RqYWpaV2QycFVTM2gzUm5KS1VrdFZTVVpIUTFwR2VsbEtWVU5KVVVSSWRERkNXalpHYUZrdlVUWlRabloxTVhCNmJEWUtNWG80VkhCMlNIQkxVa0pIY1RscmNVVlJOa3hPZHowOUNpMHRMUzB0UlU1RUlFTkZVbFJKUmtsRFFWUkZMUzB0TFMwSwogICAgc2VydmVyOiBodHRwczovLzUxMTRlMDY2LWFhOTMtNDU2MC05YmUwLTVhZTQ0NTcxNWE3NS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wtd2FpdAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXdhaXQiCiAgICB1c2VyOiB0ZXN0LXBvb2wtd2FpdC1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC13YWl0CmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXdhaXQtYWRtaW4KICB1c2VyOgogICAgdG9rZW46IGttQTQ5c2F6N1V4dVJSOHZ1UzIxMWpxN2NzVzNobFF1QzQ3QjRla3BobjE3UXBMcVRiVGJGelVO\"}"
-    headers:
-      Content-Length:
-      - "1654"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:49:07 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 9ecbe4f9-c7e3-4dea-939a-af8b6a38d749
-    status: 200 OK
-    code: 200
-    duration: 84.6214ms
-- id: 11
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1638
-    body: "{\"region\":\"fr-par\", \"id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:01.607119Z\", \"updated_at\":\"2025-10-30T16:49:02.140189Z\", \"type\":\"kapsule\", \"name\":\"test-pool-wait\", \"description\":\"\", \"status\":\"pool_required\", \"version\":\"1.34.1\", \"cni\":\"calico\", \"tags\":[\"terraform-test\", \"scaleway_k8s_cluster\", \"minimal\"], \"cluster_url\":\"https://5114e066-aa93-4560-9be0-5ae445715a75.api.k8s.fr-par.scw.cloud:6443\", \"dns_wildcard\":\"*.5114e066-aa93-4560-9be0-5ae445715a75.nodes.k8s.fr-par.scw.cloud\", \"autoscaler_config\":{\"scale_down_disabled\":false, \"scale_down_delay_after_add\":\"10m\", \"estimator\":\"binpacking\", \"expander\":\"random\", \"ignore_daemonsets_utilization\":false, \"balance_similar_node_groups\":false, \"expendable_pods_priority_cutoff\":0, \"scale_down_unneeded_time\":\"10m\", \"scale_down_utilization_threshold\":0.5, \"max_graceful_termination_sec\":0}, \"auto_upgrade\":{\"enabled\":false, \"maintenance_window\":{\"start_hour\":0, \"day\":\"any\"}}, \"upgrade_available\":false, \"feature_gates\":[], \"admission_plugins\":[], \"open_id_connect_config\":{\"issuer_url\":\"\", \"client_id\":\"\", \"username_claim\":\"\", \"username_prefix\":\"\", \"groups_claim\":[], \"groups_prefix\":\"\", \"required_claim\":[]}, \"apiserver_cert_sans\":[], \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"commitment_ends_at\":\"2025-10-30T16:49:01.607128Z\", \"acl_available\":true, \"iam_nodes_group_id\":\"6c8f211e-8819-44e2-93ca-fda367c9ca2a\", \"new_images_enabled\":true, \"pod_cidr\":\"100.64.0.0/15\", \"service_cidr\":\"10.32.0.0/20\", \"service_dns_ip\":\"10.32.0.10\"}"
-    headers:
-      Content-Length:
-      - "1638"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:49:07 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 09679ad2-3d56-4c4a-8d73-ba10a5e99fa5
-    status: 200 OK
-    code: 200
-    duration: 27.694598ms
-- id: 12
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 270
-    host: api.scaleway.com
-    body: "{\"name\":\"test-pool-wait\",\"node_type\":\"pro2_xxs\",\"autoscaling\":false,\"size\":1,\"min_size\":1,\"max_size\":1,\"container_runtime\":\"containerd\",\"autohealing\":false,\"tags\":[],\"kubelet_args\":{},\"zone\":\"fr-par-1\",\"root_volume_type\":\"default_volume_type\",\"public_ip_disabled\":false}"
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75/pools
-    method: POST
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 715
-    body: "{\"region\":\"fr-par\", \"id\":\"034a502a-1d52-470d-84bd-4a8edd935ba3\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:49:07.243810Z\", \"updated_at\":\"2025-10-30T16:49:07.243810Z\", \"name\":\"test-pool-wait\", \"status\":\"scaling\", \"version\":\"1.34.1\", \"node_type\":\"pro2_xxs\", \"autoscaling\":false, \"size\":1, \"min_size\":1, \"max_size\":1, \"container_runtime\":\"containerd\", \"autohealing\":false, \"tags\":[], \"placement_group_id\":null, \"kubelet_args\":{}, \"upgrade_policy\":{\"max_unavailable\":1, \"max_surge\":0}, \"zone\":\"fr-par-1\", \"root_volume_type\":\"sbs_5k\", \"root_volume_size\":20000000000, \"public_ip_disabled\":false, \"new_images_enabled\":true, \"security_group_id\":\"4ef16f7a-478c-4b72-b932-982f4b04974b\"}"
-    headers:
-      Content-Length:
-      - "715"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:49:07 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 17dc64ce-f738-4a2e-bf0b-f9962d68b5e4
-    status: 200 OK
-    code: 200
-    duration: 193.175497ms
-- id: 13
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/034a502a-1d52-470d-84bd-4a8edd935ba3
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 715
-    body: "{\"region\":\"fr-par\", \"id\":\"034a502a-1d52-470d-84bd-4a8edd935ba3\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:49:07.243810Z\", \"updated_at\":\"2025-10-30T16:49:07.243810Z\", \"name\":\"test-pool-wait\", \"status\":\"scaling\", \"version\":\"1.34.1\", \"node_type\":\"pro2_xxs\", \"autoscaling\":false, \"size\":1, \"min_size\":1, \"max_size\":1, \"container_runtime\":\"containerd\", \"autohealing\":false, \"tags\":[], \"placement_group_id\":null, \"kubelet_args\":{}, \"upgrade_policy\":{\"max_unavailable\":1, \"max_surge\":0}, \"zone\":\"fr-par-1\", \"root_volume_type\":\"sbs_5k\", \"root_volume_size\":20000000000, \"public_ip_disabled\":false, \"new_images_enabled\":true, \"security_group_id\":\"4ef16f7a-478c-4b72-b932-982f4b04974b\"}"
-    headers:
-      Content-Length:
-      - "715"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:49:07 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - f33bdd28-2964-4004-a263-027eda75915c
-    status: 200 OK
-    code: 200
-    duration: 21.851482ms
-- id: 14
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/034a502a-1d52-470d-84bd-4a8edd935ba3
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 713
-    body: "{\"region\":\"fr-par\", \"id\":\"034a502a-1d52-470d-84bd-4a8edd935ba3\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:49:07.243810Z\", \"updated_at\":\"2025-10-30T16:52:20.261969Z\", \"name\":\"test-pool-wait\", \"status\":\"ready\", \"version\":\"1.34.1\", \"node_type\":\"pro2_xxs\", \"autoscaling\":false, \"size\":1, \"min_size\":1, \"max_size\":1, \"container_runtime\":\"containerd\", \"autohealing\":false, \"tags\":[], \"placement_group_id\":null, \"kubelet_args\":{}, \"upgrade_policy\":{\"max_unavailable\":1, \"max_surge\":0}, \"zone\":\"fr-par-1\", \"root_volume_type\":\"sbs_5k\", \"root_volume_size\":20000000000, \"public_ip_disabled\":false, \"new_images_enabled\":true, \"security_group_id\":\"4ef16f7a-478c-4b72-b932-982f4b04974b\"}"
-    headers:
-      Content-Length:
-      - "713"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:52:21 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 797dbe7d-8def-448a-8d0c-9ecd6cc81adc
-    status: 200 OK
-    code: 200
-    duration: 145.773451ms
-- id: 15
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1630
-    body: "{\"region\":\"fr-par\", \"id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:01.607119Z\", \"updated_at\":\"2025-10-30T16:50:36.155897Z\", \"type\":\"kapsule\", \"name\":\"test-pool-wait\", \"description\":\"\", \"status\":\"ready\", \"version\":\"1.34.1\", \"cni\":\"calico\", \"tags\":[\"terraform-test\", \"scaleway_k8s_cluster\", \"minimal\"], \"cluster_url\":\"https://5114e066-aa93-4560-9be0-5ae445715a75.api.k8s.fr-par.scw.cloud:6443\", \"dns_wildcard\":\"*.5114e066-aa93-4560-9be0-5ae445715a75.nodes.k8s.fr-par.scw.cloud\", \"autoscaler_config\":{\"scale_down_disabled\":false, \"scale_down_delay_after_add\":\"10m\", \"estimator\":\"binpacking\", \"expander\":\"random\", \"ignore_daemonsets_utilization\":false, \"balance_similar_node_groups\":false, \"expendable_pods_priority_cutoff\":0, \"scale_down_unneeded_time\":\"10m\", \"scale_down_utilization_threshold\":0.5, \"max_graceful_termination_sec\":0}, \"auto_upgrade\":{\"enabled\":false, \"maintenance_window\":{\"start_hour\":0, \"day\":\"any\"}}, \"upgrade_available\":false, \"feature_gates\":[], \"admission_plugins\":[], \"open_id_connect_config\":{\"issuer_url\":\"\", \"client_id\":\"\", \"username_claim\":\"\", \"username_prefix\":\"\", \"groups_claim\":[], \"groups_prefix\":\"\", \"required_claim\":[]}, \"apiserver_cert_sans\":[], \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"commitment_ends_at\":\"2025-10-30T16:49:01.607128Z\", \"acl_available\":true, \"iam_nodes_group_id\":\"6c8f211e-8819-44e2-93ca-fda367c9ca2a\", \"new_images_enabled\":true, \"pod_cidr\":\"100.64.0.0/15\", \"service_cidr\":\"10.32.0.0/20\", \"service_dns_ip\":\"10.32.0.10\"}"
-    headers:
-      Content-Length:
-      - "1630"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:52:21 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 6c4dca8d-9442-4486-8b21-37ad285bcee4
-    status: 200 OK
-    code: 200
-    duration: 19.320692ms
-- id: 16
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/034a502a-1d52-470d-84bd-4a8edd935ba3
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 713
-    body: "{\"region\":\"fr-par\", \"id\":\"034a502a-1d52-470d-84bd-4a8edd935ba3\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:49:07.243810Z\", \"updated_at\":\"2025-10-30T16:52:20.261969Z\", \"name\":\"test-pool-wait\", \"status\":\"ready\", \"version\":\"1.34.1\", \"node_type\":\"pro2_xxs\", \"autoscaling\":false, \"size\":1, \"min_size\":1, \"max_size\":1, \"container_runtime\":\"containerd\", \"autohealing\":false, \"tags\":[], \"placement_group_id\":null, \"kubelet_args\":{}, \"upgrade_policy\":{\"max_unavailable\":1, \"max_surge\":0}, \"zone\":\"fr-par-1\", \"root_volume_type\":\"sbs_5k\", \"root_volume_size\":20000000000, \"public_ip_disabled\":false, \"new_images_enabled\":true, \"security_group_id\":\"4ef16f7a-478c-4b72-b932-982f4b04974b\"}"
-    headers:
-      Content-Length:
-      - "713"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:52:21 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - a7994219-3a2a-4f2a-8e51-d5347c7cb655
-    status: 200 OK
-    code: 200
-    duration: 101.27191ms
-- id: 17
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    form:
-      order_by:
-      - created_at_asc
-      page:
-      - "1"
-      pool_id:
-      - 034a502a-1d52-470d-84bd-4a8edd935ba3
-      status:
-      - unknown
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75/nodes?order_by=created_at_asc&page=1&pool_id=034a502a-1d52-470d-84bd-4a8edd935ba3&status=unknown
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 618
-    body: "{\"total_count\":1, \"nodes\":[{\"region\":\"fr-par\", \"id\":\"3e073c76-a98f-4e6b-ad3c-7a6ca77e15fd\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:51:15.736647Z\", \"updated_at\":\"2025-10-30T16:52:20.249886Z\", \"pool_id\":\"034a502a-1d52-470d-84bd-4a8edd935ba3\", \"status\":\"ready\", \"conditions\":{\"DiskPressure\":\"False\", \"MemoryPressure\":\"False\", \"PIDPressure\":\"False\", \"Ready\":\"True\"}, \"name\":\"scw-test-pool-wait-test-pool-wait-3e073c76a98f\", \"public_ip_v4\":\"51.158.97.50\", \"public_ip_v6\":null, \"provider_id\":\"scaleway://instance/fr-par-1/6ba8f808-ce5f-4e0a-b30e-a83f7f79f945\", \"error_message\":\"\"}]}"
-    headers:
-      Content-Length:
-      - "618"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:52:21 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - f06d89cd-88e2-4002-8e61-5a861a50b103
-    status: 200 OK
-    code: 200
-    duration: 31.958661ms
-- id: 18
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1630
-    body: "{\"region\":\"fr-par\", \"id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:01.607119Z\", \"updated_at\":\"2025-10-30T16:50:36.155897Z\", \"type\":\"kapsule\", \"name\":\"test-pool-wait\", \"description\":\"\", \"status\":\"ready\", \"version\":\"1.34.1\", \"cni\":\"calico\", \"tags\":[\"terraform-test\", \"scaleway_k8s_cluster\", \"minimal\"], \"cluster_url\":\"https://5114e066-aa93-4560-9be0-5ae445715a75.api.k8s.fr-par.scw.cloud:6443\", \"dns_wildcard\":\"*.5114e066-aa93-4560-9be0-5ae445715a75.nodes.k8s.fr-par.scw.cloud\", \"autoscaler_config\":{\"scale_down_disabled\":false, \"scale_down_delay_after_add\":\"10m\", \"estimator\":\"binpacking\", \"expander\":\"random\", \"ignore_daemonsets_utilization\":false, \"balance_similar_node_groups\":false, \"expendable_pods_priority_cutoff\":0, \"scale_down_unneeded_time\":\"10m\", \"scale_down_utilization_threshold\":0.5, \"max_graceful_termination_sec\":0}, \"auto_upgrade\":{\"enabled\":false, \"maintenance_window\":{\"start_hour\":0, \"day\":\"any\"}}, \"upgrade_available\":false, \"feature_gates\":[], \"admission_plugins\":[], \"open_id_connect_config\":{\"issuer_url\":\"\", \"client_id\":\"\", \"username_claim\":\"\", \"username_prefix\":\"\", \"groups_claim\":[], \"groups_prefix\":\"\", \"required_claim\":[]}, \"apiserver_cert_sans\":[], \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"commitment_ends_at\":\"2025-10-30T16:49:01.607128Z\", \"acl_available\":true, \"iam_nodes_group_id\":\"6c8f211e-8819-44e2-93ca-fda367c9ca2a\", \"new_images_enabled\":true, \"pod_cidr\":\"100.64.0.0/15\", \"service_cidr\":\"10.32.0.0/20\", \"service_dns_ip\":\"10.32.0.10\"}"
-    headers:
-      Content-Length:
-      - "1630"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:52:21 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - c2db3854-b0d4-4876-ad95-f26fec26f5dd
-    status: 200 OK
-    code: 200
-    duration: 25.597752ms
-- id: 19
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    form:
-      order_by:
-      - created_at_desc
-      project_id:
-      - 105bdce1-64c0-48ab-899d-868455867ecf
-      resource_name:
-      - scw-test-pool-wait-test-pool-wait-3e073c76a98f
-      resource_type:
-      - unknown_type
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=105bdce1-64c0-48ab-899d-868455867ecf&resource_name=scw-test-pool-wait-test-pool-wait-3e073c76a98f&resource_type=unknown_type
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1122
-    body: "{\"total_count\":2, \"ips\":[{\"id\":\"54c6f7a2-4ca0-43bb-bc9a-b4a3905c0487\", \"address\":\"fd5f:519c:6d46:90dd:c183:ab7b:59b9:fc92/64\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_ipv6\":true, \"created_at\":\"2025-10-30T16:51:19.698188Z\", \"updated_at\":\"2025-10-30T16:51:19.698188Z\", \"source\":{\"subnet_id\":\"7493d1b7-5773-41c2-be8c-52e4ec098fc3\"}, \"resource\":{\"type\":\"instance_private_nic\", \"id\":\"45715cb9-7532-4c78-93a4-2fef3fa3b71a\", \"mac_address\":\"02:00:00:1D:E4:BA\", \"name\":\"scw-test-pool-wait-test-pool-wait-3e073c76a98f\"}, \"tags\":[], \"reverses\":[], \"region\":\"fr-par\", \"zone\":null}, {\"id\":\"ddc7378f-48eb-4ae3-af3e-4d5ee60054c4\", \"address\":\"172.18.20.3/22\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_ipv6\":false, \"created_at\":\"2025-10-30T16:51:19.565119Z\", \"updated_at\":\"2025-10-30T16:51:19.565119Z\", \"source\":{\"subnet_id\":\"da10d014-609b-48cc-9b9a-437dc31f4497\"}, \"resource\":{\"type\":\"instance_private_nic\", \"id\":\"45715cb9-7532-4c78-93a4-2fef3fa3b71a\", \"mac_address\":\"02:00:00:1D:E4:BA\", \"name\":\"scw-test-pool-wait-test-pool-wait-3e073c76a98f\"}, \"tags\":[], \"reverses\":[], \"region\":\"fr-par\", \"zone\":null}]}"
-    headers:
-      Content-Length:
-      - "1122"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:52:21 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 5a9b7607-43b7-4e85-bb7a-291e12c4888f
-    status: 200 OK
-    code: 200
-    duration: 31.920799ms
-- id: 20
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1630
-    body: "{\"region\":\"fr-par\", \"id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:01.607119Z\", \"updated_at\":\"2025-10-30T16:50:36.155897Z\", \"type\":\"kapsule\", \"name\":\"test-pool-wait\", \"description\":\"\", \"status\":\"ready\", \"version\":\"1.34.1\", \"cni\":\"calico\", \"tags\":[\"terraform-test\", \"scaleway_k8s_cluster\", \"minimal\"], \"cluster_url\":\"https://5114e066-aa93-4560-9be0-5ae445715a75.api.k8s.fr-par.scw.cloud:6443\", \"dns_wildcard\":\"*.5114e066-aa93-4560-9be0-5ae445715a75.nodes.k8s.fr-par.scw.cloud\", \"autoscaler_config\":{\"scale_down_disabled\":false, \"scale_down_delay_after_add\":\"10m\", \"estimator\":\"binpacking\", \"expander\":\"random\", \"ignore_daemonsets_utilization\":false, \"balance_similar_node_groups\":false, \"expendable_pods_priority_cutoff\":0, \"scale_down_unneeded_time\":\"10m\", \"scale_down_utilization_threshold\":0.5, \"max_graceful_termination_sec\":0}, \"auto_upgrade\":{\"enabled\":false, \"maintenance_window\":{\"start_hour\":0, \"day\":\"any\"}}, \"upgrade_available\":false, \"feature_gates\":[], \"admission_plugins\":[], \"open_id_connect_config\":{\"issuer_url\":\"\", \"client_id\":\"\", \"username_claim\":\"\", \"username_prefix\":\"\", \"groups_claim\":[], \"groups_prefix\":\"\", \"required_claim\":[]}, \"apiserver_cert_sans\":[], \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"commitment_ends_at\":\"2025-10-30T16:49:01.607128Z\", \"acl_available\":true, \"iam_nodes_group_id\":\"6c8f211e-8819-44e2-93ca-fda367c9ca2a\", \"new_images_enabled\":true, \"pod_cidr\":\"100.64.0.0/15\", \"service_cidr\":\"10.32.0.0/20\", \"service_dns_ip\":\"10.32.0.10\"}"
-    headers:
-      Content-Length:
-      - "1630"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:52:21 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 593b456a-ae0f-41db-8a59-aea71d68abeb
-    status: 200 OK
-    code: 200
-    duration: 21.654822ms
-- id: 21
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/034a502a-1d52-470d-84bd-4a8edd935ba3
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 713
-    body: "{\"region\":\"fr-par\", \"id\":\"034a502a-1d52-470d-84bd-4a8edd935ba3\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:49:07.243810Z\", \"updated_at\":\"2025-10-30T16:52:20.261969Z\", \"name\":\"test-pool-wait\", \"status\":\"ready\", \"version\":\"1.34.1\", \"node_type\":\"pro2_xxs\", \"autoscaling\":false, \"size\":1, \"min_size\":1, \"max_size\":1, \"container_runtime\":\"containerd\", \"autohealing\":false, \"tags\":[], \"placement_group_id\":null, \"kubelet_args\":{}, \"upgrade_policy\":{\"max_unavailable\":1, \"max_surge\":0}, \"zone\":\"fr-par-1\", \"root_volume_type\":\"sbs_5k\", \"root_volume_size\":20000000000, \"public_ip_disabled\":false, \"new_images_enabled\":true, \"security_group_id\":\"4ef16f7a-478c-4b72-b932-982f4b04974b\"}"
-    headers:
-      Content-Length:
-      - "713"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:52:21 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 17a3d234-a046-40b3-8787-bd86d0a4f0e9
-    status: 200 OK
-    code: 200
-    duration: 97.493317ms
-- id: 22
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/1a7a1e1e-2b33-478e-8f1a-faa0303a1c43
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 419
-    body: "{\"id\":\"1a7a1e1e-2b33-478e-8f1a-faa0303a1c43\", \"name\":\"tf-vpc-confident-bose\", \"tags\":[], \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:00.136298Z\", \"updated_at\":\"2025-10-30T16:49:00.136298Z\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_default\":false, \"private_network_count\":1, \"routing_enabled\":true, \"custom_routes_propagation_enabled\":true, \"region\":\"fr-par\"}"
-    headers:
-      Content-Length:
-      - "419"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:52:21 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 939dbd29-e776-4b65-92cf-c829471cb125
-    status: 200 OK
-    code: 200
-    duration: 26.889697ms
-- id: 23
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/363e7214-8a98-40d0-9357-9e4026c21b76
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1084
-    body: "{\"id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"name\":\"test-pool-wait\", \"tags\":[], \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:00.384609Z\", \"updated_at\":\"2025-10-30T16:49:00.384609Z\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"subnets\":[{\"id\":\"da10d014-609b-48cc-9b9a-437dc31f4497\", \"created_at\":\"2025-10-30T16:49:00.384609Z\", \"updated_at\":\"2025-10-30T16:49:00.384609Z\", \"subnet\":\"172.18.20.0/22\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"vpc_id\":\"1a7a1e1e-2b33-478e-8f1a-faa0303a1c43\"}, {\"id\":\"7493d1b7-5773-41c2-be8c-52e4ec098fc3\", \"created_at\":\"2025-10-30T16:49:00.384609Z\", \"updated_at\":\"2025-10-30T16:49:00.384609Z\", \"subnet\":\"fd5f:519c:6d46:90dd::/64\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"vpc_id\":\"1a7a1e1e-2b33-478e-8f1a-faa0303a1c43\"}], \"vpc_id\":\"1a7a1e1e-2b33-478e-8f1a-faa0303a1c43\", \"dhcp_enabled\":true, \"default_route_propagation_enabled\":false, \"region\":\"fr-par\"}"
-    headers:
-      Content-Length:
-      - "1084"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:52:21 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - fe1afd5e-f49c-48d5-b9c0-30d845843e1c
-    status: 200 OK
-    code: 200
-    duration: 21.752636ms
-- id: 24
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1630
-    body: "{\"region\":\"fr-par\", \"id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:01.607119Z\", \"updated_at\":\"2025-10-30T16:50:36.155897Z\", \"type\":\"kapsule\", \"name\":\"test-pool-wait\", \"description\":\"\", \"status\":\"ready\", \"version\":\"1.34.1\", \"cni\":\"calico\", \"tags\":[\"terraform-test\", \"scaleway_k8s_cluster\", \"minimal\"], \"cluster_url\":\"https://5114e066-aa93-4560-9be0-5ae445715a75.api.k8s.fr-par.scw.cloud:6443\", \"dns_wildcard\":\"*.5114e066-aa93-4560-9be0-5ae445715a75.nodes.k8s.fr-par.scw.cloud\", \"autoscaler_config\":{\"scale_down_disabled\":false, \"scale_down_delay_after_add\":\"10m\", \"estimator\":\"binpacking\", \"expander\":\"random\", \"ignore_daemonsets_utilization\":false, \"balance_similar_node_groups\":false, \"expendable_pods_priority_cutoff\":0, \"scale_down_unneeded_time\":\"10m\", \"scale_down_utilization_threshold\":0.5, \"max_graceful_termination_sec\":0}, \"auto_upgrade\":{\"enabled\":false, \"maintenance_window\":{\"start_hour\":0, \"day\":\"any\"}}, \"upgrade_available\":false, \"feature_gates\":[], \"admission_plugins\":[], \"open_id_connect_config\":{\"issuer_url\":\"\", \"client_id\":\"\", \"username_claim\":\"\", \"username_prefix\":\"\", \"groups_claim\":[], \"groups_prefix\":\"\", \"required_claim\":[]}, \"apiserver_cert_sans\":[], \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"commitment_ends_at\":\"2025-10-30T16:49:01.607128Z\", \"acl_available\":true, \"iam_nodes_group_id\":\"6c8f211e-8819-44e2-93ca-fda367c9ca2a\", \"new_images_enabled\":true, \"pod_cidr\":\"100.64.0.0/15\", \"service_cidr\":\"10.32.0.0/20\", \"service_dns_ip\":\"10.32.0.10\"}"
-    headers:
-      Content-Length:
-      - "1630"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:52:21 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - db4839b8-b0b8-4590-b3c7-543b6e10a342
-    status: 200 OK
-    code: 200
-    duration: 23.441827ms
-- id: 25
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75/kubeconfig
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1654
-    body: "{\"name\":\"kubeconfig\", \"content_type\":\"application/octet-stream\", \"content\":\"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVSllSRU5EUVZGSFowRjNTVUpCWjBsQ1FVUkJTMEpuWjNGb2EycFBVRkZSUkVGcVFWWk5VazEzUlZGWlJGWlJVVVJGZDNCeVpGZEtiR050Tld3S1pFZFdlazFDTkZoRVZFa3hUVlJCZVU5VVJUSk9SR3QzVFZadldFUlVUVEZOVkVGNVQxUkZNazVFYTNkTlZtOTNSbFJGVkUxQ1JVZEJNVlZGUVhoTlN3cGhNMVpwV2xoS2RWcFlVbXhqZWtKYVRVSk5SMEo1Y1VkVFRUUTVRV2RGUjBORGNVZFRUVFE1UVhkRlNFRXdTVUZDVFhsNllqUkdTbVozWTFOM01tZEZDbEppVFRkVFZpOUpiM0ZXU21oWWVIbGxObHB1UkZOWlZ6WmxRbU4yV2tJM1RXVnVMMWxPYm5wM2F6QkpRazF2VDFkUFRXeHRlVGxJWVU5NE1XVkxaSFlLTUVRNE9XZDVZV3BSYWtKQlRVRTBSMEV4VldSRWQwVkNMM2RSUlVGM1NVTndSRUZRUW1kT1ZraFNUVUpCWmpoRlFsUkJSRUZSU0M5TlFqQkhRVEZWWkFwRVoxRlhRa0pTVTFsU1NtTm9UV1l3V0U5YWNtUkJhV1JMYkdOUWEyTklZeTlVUVV0Q1oyZHhhR3RxVDFCUlVVUkJaMDVLUVVSQ1IwRnBSVUY1Ym0xd0NqbFpkWG80VWpGVWFtNDBiV2RqYWpaV2QycFVTM2gzUm5KS1VrdFZTVVpIUTFwR2VsbEtWVU5KVVVSSWRERkNXalpHYUZrdlVUWlRabloxTVhCNmJEWUtNWG80VkhCMlNIQkxVa0pIY1RscmNVVlJOa3hPZHowOUNpMHRMUzB0UlU1RUlFTkZVbFJKUmtsRFFWUkZMUzB0TFMwSwogICAgc2VydmVyOiBodHRwczovLzUxMTRlMDY2LWFhOTMtNDU2MC05YmUwLTVhZTQ0NTcxNWE3NS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wtd2FpdAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXdhaXQiCiAgICB1c2VyOiB0ZXN0LXBvb2wtd2FpdC1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC13YWl0CmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXdhaXQtYWRtaW4KICB1c2VyOgogICAgdG9rZW46IGttQTQ5c2F6N1V4dVJSOHZ1UzIxMWpxN2NzVzNobFF1QzQ3QjRla3BobjE3UXBMcVRiVGJGelVO\"}"
-    headers:
-      Content-Length:
-      - "1654"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:52:21 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - ab292c81-a46a-472f-a054-a093dff4c583
-    status: 200 OK
-    code: 200
-    duration: 89.728896ms
-- id: 26
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/034a502a-1d52-470d-84bd-4a8edd935ba3
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 713
-    body: "{\"region\":\"fr-par\", \"id\":\"034a502a-1d52-470d-84bd-4a8edd935ba3\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:49:07.243810Z\", \"updated_at\":\"2025-10-30T16:52:20.261969Z\", \"name\":\"test-pool-wait\", \"status\":\"ready\", \"version\":\"1.34.1\", \"node_type\":\"pro2_xxs\", \"autoscaling\":false, \"size\":1, \"min_size\":1, \"max_size\":1, \"container_runtime\":\"containerd\", \"autohealing\":false, \"tags\":[], \"placement_group_id\":null, \"kubelet_args\":{}, \"upgrade_policy\":{\"max_unavailable\":1, \"max_surge\":0}, \"zone\":\"fr-par-1\", \"root_volume_type\":\"sbs_5k\", \"root_volume_size\":20000000000, \"public_ip_disabled\":false, \"new_images_enabled\":true, \"security_group_id\":\"4ef16f7a-478c-4b72-b932-982f4b04974b\"}"
-    headers:
-      Content-Length:
-      - "713"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:52:21 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - ef2183bf-c7ab-48ad-b49c-651a43b00b6f
-    status: 200 OK
-    code: 200
-    duration: 21.734462ms
-- id: 27
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    form:
-      order_by:
-      - created_at_asc
-      page:
-      - "1"
-      pool_id:
-      - 034a502a-1d52-470d-84bd-4a8edd935ba3
-      status:
-      - unknown
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75/nodes?order_by=created_at_asc&page=1&pool_id=034a502a-1d52-470d-84bd-4a8edd935ba3&status=unknown
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 618
-    body: "{\"total_count\":1, \"nodes\":[{\"region\":\"fr-par\", \"id\":\"3e073c76-a98f-4e6b-ad3c-7a6ca77e15fd\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:51:15.736647Z\", \"updated_at\":\"2025-10-30T16:52:20.249886Z\", \"pool_id\":\"034a502a-1d52-470d-84bd-4a8edd935ba3\", \"status\":\"ready\", \"conditions\":{\"DiskPressure\":\"False\", \"MemoryPressure\":\"False\", \"PIDPressure\":\"False\", \"Ready\":\"True\"}, \"name\":\"scw-test-pool-wait-test-pool-wait-3e073c76a98f\", \"public_ip_v4\":\"51.158.97.50\", \"public_ip_v6\":null, \"provider_id\":\"scaleway://instance/fr-par-1/6ba8f808-ce5f-4e0a-b30e-a83f7f79f945\", \"error_message\":\"\"}]}"
-    headers:
-      Content-Length:
-      - "618"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:52:21 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 04c909c1-c347-4369-a9f8-0ee959f665c8
-    status: 200 OK
-    code: 200
-    duration: 25.054693ms
-- id: 28
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1630
-    body: "{\"region\":\"fr-par\", \"id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:01.607119Z\", \"updated_at\":\"2025-10-30T16:50:36.155897Z\", \"type\":\"kapsule\", \"name\":\"test-pool-wait\", \"description\":\"\", \"status\":\"ready\", \"version\":\"1.34.1\", \"cni\":\"calico\", \"tags\":[\"terraform-test\", \"scaleway_k8s_cluster\", \"minimal\"], \"cluster_url\":\"https://5114e066-aa93-4560-9be0-5ae445715a75.api.k8s.fr-par.scw.cloud:6443\", \"dns_wildcard\":\"*.5114e066-aa93-4560-9be0-5ae445715a75.nodes.k8s.fr-par.scw.cloud\", \"autoscaler_config\":{\"scale_down_disabled\":false, \"scale_down_delay_after_add\":\"10m\", \"estimator\":\"binpacking\", \"expander\":\"random\", \"ignore_daemonsets_utilization\":false, \"balance_similar_node_groups\":false, \"expendable_pods_priority_cutoff\":0, \"scale_down_unneeded_time\":\"10m\", \"scale_down_utilization_threshold\":0.5, \"max_graceful_termination_sec\":0}, \"auto_upgrade\":{\"enabled\":false, \"maintenance_window\":{\"start_hour\":0, \"day\":\"any\"}}, \"upgrade_available\":false, \"feature_gates\":[], \"admission_plugins\":[], \"open_id_connect_config\":{\"issuer_url\":\"\", \"client_id\":\"\", \"username_claim\":\"\", \"username_prefix\":\"\", \"groups_claim\":[], \"groups_prefix\":\"\", \"required_claim\":[]}, \"apiserver_cert_sans\":[], \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"commitment_ends_at\":\"2025-10-30T16:49:01.607128Z\", \"acl_available\":true, \"iam_nodes_group_id\":\"6c8f211e-8819-44e2-93ca-fda367c9ca2a\", \"new_images_enabled\":true, \"pod_cidr\":\"100.64.0.0/15\", \"service_cidr\":\"10.32.0.0/20\", \"service_dns_ip\":\"10.32.0.10\"}"
-    headers:
-      Content-Length:
-      - "1630"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:52:21 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - d48e6179-b998-482b-8ebe-0001a00fa6c8
-    status: 200 OK
-    code: 200
-    duration: 27.251046ms
-- id: 29
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    form:
-      order_by:
-      - created_at_desc
-      project_id:
-      - 105bdce1-64c0-48ab-899d-868455867ecf
-      resource_name:
-      - scw-test-pool-wait-test-pool-wait-3e073c76a98f
-      resource_type:
-      - unknown_type
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=105bdce1-64c0-48ab-899d-868455867ecf&resource_name=scw-test-pool-wait-test-pool-wait-3e073c76a98f&resource_type=unknown_type
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1122
-    body: "{\"total_count\":2, \"ips\":[{\"id\":\"54c6f7a2-4ca0-43bb-bc9a-b4a3905c0487\", \"address\":\"fd5f:519c:6d46:90dd:c183:ab7b:59b9:fc92/64\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_ipv6\":true, \"created_at\":\"2025-10-30T16:51:19.698188Z\", \"updated_at\":\"2025-10-30T16:51:19.698188Z\", \"source\":{\"subnet_id\":\"7493d1b7-5773-41c2-be8c-52e4ec098fc3\"}, \"resource\":{\"type\":\"instance_private_nic\", \"id\":\"45715cb9-7532-4c78-93a4-2fef3fa3b71a\", \"mac_address\":\"02:00:00:1D:E4:BA\", \"name\":\"scw-test-pool-wait-test-pool-wait-3e073c76a98f\"}, \"tags\":[], \"reverses\":[], \"region\":\"fr-par\", \"zone\":null}, {\"id\":\"ddc7378f-48eb-4ae3-af3e-4d5ee60054c4\", \"address\":\"172.18.20.3/22\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_ipv6\":false, \"created_at\":\"2025-10-30T16:51:19.565119Z\", \"updated_at\":\"2025-10-30T16:51:19.565119Z\", \"source\":{\"subnet_id\":\"da10d014-609b-48cc-9b9a-437dc31f4497\"}, \"resource\":{\"type\":\"instance_private_nic\", \"id\":\"45715cb9-7532-4c78-93a4-2fef3fa3b71a\", \"mac_address\":\"02:00:00:1D:E4:BA\", \"name\":\"scw-test-pool-wait-test-pool-wait-3e073c76a98f\"}, \"tags\":[], \"reverses\":[], \"region\":\"fr-par\", \"zone\":null}]}"
-    headers:
-      Content-Length:
-      - "1122"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:52:22 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - a3a9a288-fc90-4906-abbd-d66f78436a31
-    status: 200 OK
-    code: 200
-    duration: 37.224965ms
-- id: 30
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/1a7a1e1e-2b33-478e-8f1a-faa0303a1c43
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 419
-    body: "{\"id\":\"1a7a1e1e-2b33-478e-8f1a-faa0303a1c43\", \"name\":\"tf-vpc-confident-bose\", \"tags\":[], \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:00.136298Z\", \"updated_at\":\"2025-10-30T16:49:00.136298Z\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_default\":false, \"private_network_count\":1, \"routing_enabled\":true, \"custom_routes_propagation_enabled\":true, \"region\":\"fr-par\"}"
-    headers:
-      Content-Length:
-      - "419"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:52:22 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 9f207063-cd2d-435a-a97a-ad363e29405e
-    status: 200 OK
-    code: 200
-    duration: 43.821455ms
-- id: 31
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/363e7214-8a98-40d0-9357-9e4026c21b76
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1084
-    body: "{\"id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"name\":\"test-pool-wait\", \"tags\":[], \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:00.384609Z\", \"updated_at\":\"2025-10-30T16:49:00.384609Z\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"subnets\":[{\"id\":\"da10d014-609b-48cc-9b9a-437dc31f4497\", \"created_at\":\"2025-10-30T16:49:00.384609Z\", \"updated_at\":\"2025-10-30T16:49:00.384609Z\", \"subnet\":\"172.18.20.0/22\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"vpc_id\":\"1a7a1e1e-2b33-478e-8f1a-faa0303a1c43\"}, {\"id\":\"7493d1b7-5773-41c2-be8c-52e4ec098fc3\", \"created_at\":\"2025-10-30T16:49:00.384609Z\", \"updated_at\":\"2025-10-30T16:49:00.384609Z\", \"subnet\":\"fd5f:519c:6d46:90dd::/64\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"vpc_id\":\"1a7a1e1e-2b33-478e-8f1a-faa0303a1c43\"}], \"vpc_id\":\"1a7a1e1e-2b33-478e-8f1a-faa0303a1c43\", \"dhcp_enabled\":true, \"default_route_propagation_enabled\":false, \"region\":\"fr-par\"}"
-    headers:
-      Content-Length:
-      - "1084"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:52:22 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 69471a4e-88c3-4ba2-91ee-6f94df53b09f
-    status: 200 OK
-    code: 200
-    duration: 36.278588ms
-- id: 32
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1630
-    body: "{\"region\":\"fr-par\", \"id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:01.607119Z\", \"updated_at\":\"2025-10-30T16:50:36.155897Z\", \"type\":\"kapsule\", \"name\":\"test-pool-wait\", \"description\":\"\", \"status\":\"ready\", \"version\":\"1.34.1\", \"cni\":\"calico\", \"tags\":[\"terraform-test\", \"scaleway_k8s_cluster\", \"minimal\"], \"cluster_url\":\"https://5114e066-aa93-4560-9be0-5ae445715a75.api.k8s.fr-par.scw.cloud:6443\", \"dns_wildcard\":\"*.5114e066-aa93-4560-9be0-5ae445715a75.nodes.k8s.fr-par.scw.cloud\", \"autoscaler_config\":{\"scale_down_disabled\":false, \"scale_down_delay_after_add\":\"10m\", \"estimator\":\"binpacking\", \"expander\":\"random\", \"ignore_daemonsets_utilization\":false, \"balance_similar_node_groups\":false, \"expendable_pods_priority_cutoff\":0, \"scale_down_unneeded_time\":\"10m\", \"scale_down_utilization_threshold\":0.5, \"max_graceful_termination_sec\":0}, \"auto_upgrade\":{\"enabled\":false, \"maintenance_window\":{\"start_hour\":0, \"day\":\"any\"}}, \"upgrade_available\":false, \"feature_gates\":[], \"admission_plugins\":[], \"open_id_connect_config\":{\"issuer_url\":\"\", \"client_id\":\"\", \"username_claim\":\"\", \"username_prefix\":\"\", \"groups_claim\":[], \"groups_prefix\":\"\", \"required_claim\":[]}, \"apiserver_cert_sans\":[], \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"commitment_ends_at\":\"2025-10-30T16:49:01.607128Z\", \"acl_available\":true, \"iam_nodes_group_id\":\"6c8f211e-8819-44e2-93ca-fda367c9ca2a\", \"new_images_enabled\":true, \"pod_cidr\":\"100.64.0.0/15\", \"service_cidr\":\"10.32.0.0/20\", \"service_dns_ip\":\"10.32.0.10\"}"
-    headers:
-      Content-Length:
-      - "1630"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:52:22 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 21b7407c-68a5-4ff4-9daf-6b003a411d4d
-    status: 200 OK
-    code: 200
-    duration: 107.181961ms
-- id: 33
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75/kubeconfig
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1654
-    body: "{\"name\":\"kubeconfig\", \"content_type\":\"application/octet-stream\", \"content\":\"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVSllSRU5EUVZGSFowRjNTVUpCWjBsQ1FVUkJTMEpuWjNGb2EycFBVRkZSUkVGcVFWWk5VazEzUlZGWlJGWlJVVVJGZDNCeVpGZEtiR050Tld3S1pFZFdlazFDTkZoRVZFa3hUVlJCZVU5VVJUSk9SR3QzVFZadldFUlVUVEZOVkVGNVQxUkZNazVFYTNkTlZtOTNSbFJGVkUxQ1JVZEJNVlZGUVhoTlN3cGhNMVpwV2xoS2RWcFlVbXhqZWtKYVRVSk5SMEo1Y1VkVFRUUTVRV2RGUjBORGNVZFRUVFE1UVhkRlNFRXdTVUZDVFhsNllqUkdTbVozWTFOM01tZEZDbEppVFRkVFZpOUpiM0ZXU21oWWVIbGxObHB1UkZOWlZ6WmxRbU4yV2tJM1RXVnVMMWxPYm5wM2F6QkpRazF2VDFkUFRXeHRlVGxJWVU5NE1XVkxaSFlLTUVRNE9XZDVZV3BSYWtKQlRVRTBSMEV4VldSRWQwVkNMM2RSUlVGM1NVTndSRUZRUW1kT1ZraFNUVUpCWmpoRlFsUkJSRUZSU0M5TlFqQkhRVEZWWkFwRVoxRlhRa0pTVTFsU1NtTm9UV1l3V0U5YWNtUkJhV1JMYkdOUWEyTklZeTlVUVV0Q1oyZHhhR3RxVDFCUlVVUkJaMDVLUVVSQ1IwRnBSVUY1Ym0xd0NqbFpkWG80VWpGVWFtNDBiV2RqYWpaV2QycFVTM2gzUm5KS1VrdFZTVVpIUTFwR2VsbEtWVU5KVVVSSWRERkNXalpHYUZrdlVUWlRabloxTVhCNmJEWUtNWG80VkhCMlNIQkxVa0pIY1RscmNVVlJOa3hPZHowOUNpMHRMUzB0UlU1RUlFTkZVbFJKUmtsRFFWUkZMUzB0TFMwSwogICAgc2VydmVyOiBodHRwczovLzUxMTRlMDY2LWFhOTMtNDU2MC05YmUwLTVhZTQ0NTcxNWE3NS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wtd2FpdAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXdhaXQiCiAgICB1c2VyOiB0ZXN0LXBvb2wtd2FpdC1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC13YWl0CmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXdhaXQtYWRtaW4KICB1c2VyOgogICAgdG9rZW46IGttQTQ5c2F6N1V4dVJSOHZ1UzIxMWpxN2NzVzNobFF1QzQ3QjRla3BobjE3UXBMcVRiVGJGelVO\"}"
-    headers:
-      Content-Length:
-      - "1654"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:52:22 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - e6b137d2-0017-4e4b-baea-2b0ae637c05d
-    status: 200 OK
-    code: 200
-    duration: 31.917734ms
-- id: 34
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/034a502a-1d52-470d-84bd-4a8edd935ba3
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 713
-    body: "{\"region\":\"fr-par\", \"id\":\"034a502a-1d52-470d-84bd-4a8edd935ba3\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:49:07.243810Z\", \"updated_at\":\"2025-10-30T16:52:20.261969Z\", \"name\":\"test-pool-wait\", \"status\":\"ready\", \"version\":\"1.34.1\", \"node_type\":\"pro2_xxs\", \"autoscaling\":false, \"size\":1, \"min_size\":1, \"max_size\":1, \"container_runtime\":\"containerd\", \"autohealing\":false, \"tags\":[], \"placement_group_id\":null, \"kubelet_args\":{}, \"upgrade_policy\":{\"max_unavailable\":1, \"max_surge\":0}, \"zone\":\"fr-par-1\", \"root_volume_type\":\"sbs_5k\", \"root_volume_size\":20000000000, \"public_ip_disabled\":false, \"new_images_enabled\":true, \"security_group_id\":\"4ef16f7a-478c-4b72-b932-982f4b04974b\"}"
-    headers:
-      Content-Length:
-      - "713"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:52:22 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 2eb7e7df-4111-46a5-aea6-c05409c986de
-    status: 200 OK
-    code: 200
-    duration: 25.599827ms
-- id: 35
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    form:
-      order_by:
-      - created_at_asc
-      page:
-      - "1"
-      pool_id:
-      - 034a502a-1d52-470d-84bd-4a8edd935ba3
-      status:
-      - unknown
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75/nodes?order_by=created_at_asc&page=1&pool_id=034a502a-1d52-470d-84bd-4a8edd935ba3&status=unknown
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 618
-    body: "{\"total_count\":1, \"nodes\":[{\"region\":\"fr-par\", \"id\":\"3e073c76-a98f-4e6b-ad3c-7a6ca77e15fd\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:51:15.736647Z\", \"updated_at\":\"2025-10-30T16:52:20.249886Z\", \"pool_id\":\"034a502a-1d52-470d-84bd-4a8edd935ba3\", \"status\":\"ready\", \"conditions\":{\"DiskPressure\":\"False\", \"MemoryPressure\":\"False\", \"PIDPressure\":\"False\", \"Ready\":\"True\"}, \"name\":\"scw-test-pool-wait-test-pool-wait-3e073c76a98f\", \"public_ip_v4\":\"51.158.97.50\", \"public_ip_v6\":null, \"provider_id\":\"scaleway://instance/fr-par-1/6ba8f808-ce5f-4e0a-b30e-a83f7f79f945\", \"error_message\":\"\"}]}"
-    headers:
-      Content-Length:
-      - "618"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:52:22 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 2d5150b3-a77e-4c3a-9a31-8a48ad592f8d
-    status: 200 OK
-    code: 200
-    duration: 43.343318ms
-- id: 36
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1630
-    body: "{\"region\":\"fr-par\", \"id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:01.607119Z\", \"updated_at\":\"2025-10-30T16:50:36.155897Z\", \"type\":\"kapsule\", \"name\":\"test-pool-wait\", \"description\":\"\", \"status\":\"ready\", \"version\":\"1.34.1\", \"cni\":\"calico\", \"tags\":[\"terraform-test\", \"scaleway_k8s_cluster\", \"minimal\"], \"cluster_url\":\"https://5114e066-aa93-4560-9be0-5ae445715a75.api.k8s.fr-par.scw.cloud:6443\", \"dns_wildcard\":\"*.5114e066-aa93-4560-9be0-5ae445715a75.nodes.k8s.fr-par.scw.cloud\", \"autoscaler_config\":{\"scale_down_disabled\":false, \"scale_down_delay_after_add\":\"10m\", \"estimator\":\"binpacking\", \"expander\":\"random\", \"ignore_daemonsets_utilization\":false, \"balance_similar_node_groups\":false, \"expendable_pods_priority_cutoff\":0, \"scale_down_unneeded_time\":\"10m\", \"scale_down_utilization_threshold\":0.5, \"max_graceful_termination_sec\":0}, \"auto_upgrade\":{\"enabled\":false, \"maintenance_window\":{\"start_hour\":0, \"day\":\"any\"}}, \"upgrade_available\":false, \"feature_gates\":[], \"admission_plugins\":[], \"open_id_connect_config\":{\"issuer_url\":\"\", \"client_id\":\"\", \"username_claim\":\"\", \"username_prefix\":\"\", \"groups_claim\":[], \"groups_prefix\":\"\", \"required_claim\":[]}, \"apiserver_cert_sans\":[], \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"commitment_ends_at\":\"2025-10-30T16:49:01.607128Z\", \"acl_available\":true, \"iam_nodes_group_id\":\"6c8f211e-8819-44e2-93ca-fda367c9ca2a\", \"new_images_enabled\":true, \"pod_cidr\":\"100.64.0.0/15\", \"service_cidr\":\"10.32.0.0/20\", \"service_dns_ip\":\"10.32.0.10\"}"
-    headers:
-      Content-Length:
-      - "1630"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:52:22 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 5602e3cd-4a6b-45b6-9d6e-8e490e80af64
-    status: 200 OK
-    code: 200
-    duration: 23.510054ms
-- id: 37
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    form:
-      order_by:
-      - created_at_desc
-      project_id:
-      - 105bdce1-64c0-48ab-899d-868455867ecf
-      resource_name:
-      - scw-test-pool-wait-test-pool-wait-3e073c76a98f
-      resource_type:
-      - unknown_type
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=105bdce1-64c0-48ab-899d-868455867ecf&resource_name=scw-test-pool-wait-test-pool-wait-3e073c76a98f&resource_type=unknown_type
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1122
-    body: "{\"total_count\":2, \"ips\":[{\"id\":\"54c6f7a2-4ca0-43bb-bc9a-b4a3905c0487\", \"address\":\"fd5f:519c:6d46:90dd:c183:ab7b:59b9:fc92/64\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_ipv6\":true, \"created_at\":\"2025-10-30T16:51:19.698188Z\", \"updated_at\":\"2025-10-30T16:51:19.698188Z\", \"source\":{\"subnet_id\":\"7493d1b7-5773-41c2-be8c-52e4ec098fc3\"}, \"resource\":{\"type\":\"instance_private_nic\", \"id\":\"45715cb9-7532-4c78-93a4-2fef3fa3b71a\", \"mac_address\":\"02:00:00:1D:E4:BA\", \"name\":\"scw-test-pool-wait-test-pool-wait-3e073c76a98f\"}, \"tags\":[], \"reverses\":[], \"region\":\"fr-par\", \"zone\":null}, {\"id\":\"ddc7378f-48eb-4ae3-af3e-4d5ee60054c4\", \"address\":\"172.18.20.3/22\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_ipv6\":false, \"created_at\":\"2025-10-30T16:51:19.565119Z\", \"updated_at\":\"2025-10-30T16:51:19.565119Z\", \"source\":{\"subnet_id\":\"da10d014-609b-48cc-9b9a-437dc31f4497\"}, \"resource\":{\"type\":\"instance_private_nic\", \"id\":\"45715cb9-7532-4c78-93a4-2fef3fa3b71a\", \"mac_address\":\"02:00:00:1D:E4:BA\", \"name\":\"scw-test-pool-wait-test-pool-wait-3e073c76a98f\"}, \"tags\":[], \"reverses\":[], \"region\":\"fr-par\", \"zone\":null}]}"
-    headers:
-      Content-Length:
-      - "1122"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:52:22 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - f2441186-ef39-43b2-8e4c-79570be40674
-    status: 200 OK
-    code: 200
-    duration: 24.484573ms
-- id: 38
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1630
-    body: "{\"region\":\"fr-par\", \"id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:01.607119Z\", \"updated_at\":\"2025-10-30T16:50:36.155897Z\", \"type\":\"kapsule\", \"name\":\"test-pool-wait\", \"description\":\"\", \"status\":\"ready\", \"version\":\"1.34.1\", \"cni\":\"calico\", \"tags\":[\"terraform-test\", \"scaleway_k8s_cluster\", \"minimal\"], \"cluster_url\":\"https://5114e066-aa93-4560-9be0-5ae445715a75.api.k8s.fr-par.scw.cloud:6443\", \"dns_wildcard\":\"*.5114e066-aa93-4560-9be0-5ae445715a75.nodes.k8s.fr-par.scw.cloud\", \"autoscaler_config\":{\"scale_down_disabled\":false, \"scale_down_delay_after_add\":\"10m\", \"estimator\":\"binpacking\", \"expander\":\"random\", \"ignore_daemonsets_utilization\":false, \"balance_similar_node_groups\":false, \"expendable_pods_priority_cutoff\":0, \"scale_down_unneeded_time\":\"10m\", \"scale_down_utilization_threshold\":0.5, \"max_graceful_termination_sec\":0}, \"auto_upgrade\":{\"enabled\":false, \"maintenance_window\":{\"start_hour\":0, \"day\":\"any\"}}, \"upgrade_available\":false, \"feature_gates\":[], \"admission_plugins\":[], \"open_id_connect_config\":{\"issuer_url\":\"\", \"client_id\":\"\", \"username_claim\":\"\", \"username_prefix\":\"\", \"groups_claim\":[], \"groups_prefix\":\"\", \"required_claim\":[]}, \"apiserver_cert_sans\":[], \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"commitment_ends_at\":\"2025-10-30T16:49:01.607128Z\", \"acl_available\":true, \"iam_nodes_group_id\":\"6c8f211e-8819-44e2-93ca-fda367c9ca2a\", \"new_images_enabled\":true, \"pod_cidr\":\"100.64.0.0/15\", \"service_cidr\":\"10.32.0.0/20\", \"service_dns_ip\":\"10.32.0.10\"}"
-    headers:
-      Content-Length:
-      - "1630"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:52:22 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 02358d8b-c5e5-4303-808d-525743a7c871
-    status: 200 OK
-    code: 200
-    duration: 23.862716ms
-- id: 39
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 272
-    host: api.scaleway.com
-    body: "{\"name\":\"test-pool-wait-2\",\"node_type\":\"pro2_xxs\",\"autoscaling\":false,\"size\":1,\"min_size\":1,\"max_size\":1,\"container_runtime\":\"containerd\",\"autohealing\":false,\"tags\":[],\"kubelet_args\":{},\"zone\":\"fr-par-1\",\"root_volume_type\":\"default_volume_type\",\"public_ip_disabled\":false}"
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75/pools
-    method: POST
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 717
-    body: "{\"region\":\"fr-par\", \"id\":\"b0c262ac-e3c4-4a41-9b7c-fac43b180e81\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:52:22.689840Z\", \"updated_at\":\"2025-10-30T16:52:22.689840Z\", \"name\":\"test-pool-wait-2\", \"status\":\"scaling\", \"version\":\"1.34.1\", \"node_type\":\"pro2_xxs\", \"autoscaling\":false, \"size\":1, \"min_size\":1, \"max_size\":1, \"container_runtime\":\"containerd\", \"autohealing\":false, \"tags\":[], \"placement_group_id\":null, \"kubelet_args\":{}, \"upgrade_policy\":{\"max_unavailable\":1, \"max_surge\":0}, \"zone\":\"fr-par-1\", \"root_volume_type\":\"sbs_5k\", \"root_volume_size\":20000000000, \"public_ip_disabled\":false, \"new_images_enabled\":true, \"security_group_id\":\"4ef16f7a-478c-4b72-b932-982f4b04974b\"}"
-    headers:
-      Content-Length:
-      - "717"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:52:22 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 6a7dd2ee-645c-4b43-9930-5cd67eb9b370
-    status: 200 OK
-    code: 200
-    duration: 143.875238ms
-- id: 40
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/b0c262ac-e3c4-4a41-9b7c-fac43b180e81
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 717
-    body: "{\"region\":\"fr-par\", \"id\":\"b0c262ac-e3c4-4a41-9b7c-fac43b180e81\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:52:22.689840Z\", \"updated_at\":\"2025-10-30T16:52:22.689840Z\", \"name\":\"test-pool-wait-2\", \"status\":\"scaling\", \"version\":\"1.34.1\", \"node_type\":\"pro2_xxs\", \"autoscaling\":false, \"size\":1, \"min_size\":1, \"max_size\":1, \"container_runtime\":\"containerd\", \"autohealing\":false, \"tags\":[], \"placement_group_id\":null, \"kubelet_args\":{}, \"upgrade_policy\":{\"max_unavailable\":1, \"max_surge\":0}, \"zone\":\"fr-par-1\", \"root_volume_type\":\"sbs_5k\", \"root_volume_size\":20000000000, \"public_ip_disabled\":false, \"new_images_enabled\":true, \"security_group_id\":\"4ef16f7a-478c-4b72-b932-982f4b04974b\"}"
-    headers:
-      Content-Length:
-      - "717"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:52:22 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 241425ac-9d81-44c0-9023-9b9a7624a671
-    status: 200 OK
-    code: 200
-    duration: 22.269527ms
-- id: 41
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/b0c262ac-e3c4-4a41-9b7c-fac43b180e81
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 715
-    body: "{\"region\":\"fr-par\", \"id\":\"b0c262ac-e3c4-4a41-9b7c-fac43b180e81\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:52:22.689840Z\", \"updated_at\":\"2025-10-30T16:53:10.546154Z\", \"name\":\"test-pool-wait-2\", \"status\":\"ready\", \"version\":\"1.34.1\", \"node_type\":\"pro2_xxs\", \"autoscaling\":false, \"size\":1, \"min_size\":1, \"max_size\":1, \"container_runtime\":\"containerd\", \"autohealing\":false, \"tags\":[], \"placement_group_id\":null, \"kubelet_args\":{}, \"upgrade_policy\":{\"max_unavailable\":1, \"max_surge\":0}, \"zone\":\"fr-par-1\", \"root_volume_type\":\"sbs_5k\", \"root_volume_size\":20000000000, \"public_ip_disabled\":false, \"new_images_enabled\":true, \"security_group_id\":\"4ef16f7a-478c-4b72-b932-982f4b04974b\"}"
-    headers:
-      Content-Length:
-      - "715"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:53:13 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - b14ff2ec-1e26-49a3-9597-76bfc69c8045
-    status: 200 OK
-    code: 200
-    duration: 94.082386ms
-- id: 42
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1630
-    body: "{\"region\":\"fr-par\", \"id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:01.607119Z\", \"updated_at\":\"2025-10-30T16:50:36.155897Z\", \"type\":\"kapsule\", \"name\":\"test-pool-wait\", \"description\":\"\", \"status\":\"ready\", \"version\":\"1.34.1\", \"cni\":\"calico\", \"tags\":[\"terraform-test\", \"scaleway_k8s_cluster\", \"minimal\"], \"cluster_url\":\"https://5114e066-aa93-4560-9be0-5ae445715a75.api.k8s.fr-par.scw.cloud:6443\", \"dns_wildcard\":\"*.5114e066-aa93-4560-9be0-5ae445715a75.nodes.k8s.fr-par.scw.cloud\", \"autoscaler_config\":{\"scale_down_disabled\":false, \"scale_down_delay_after_add\":\"10m\", \"estimator\":\"binpacking\", \"expander\":\"random\", \"ignore_daemonsets_utilization\":false, \"balance_similar_node_groups\":false, \"expendable_pods_priority_cutoff\":0, \"scale_down_unneeded_time\":\"10m\", \"scale_down_utilization_threshold\":0.5, \"max_graceful_termination_sec\":0}, \"auto_upgrade\":{\"enabled\":false, \"maintenance_window\":{\"start_hour\":0, \"day\":\"any\"}}, \"upgrade_available\":false, \"feature_gates\":[], \"admission_plugins\":[], \"open_id_connect_config\":{\"issuer_url\":\"\", \"client_id\":\"\", \"username_claim\":\"\", \"username_prefix\":\"\", \"groups_claim\":[], \"groups_prefix\":\"\", \"required_claim\":[]}, \"apiserver_cert_sans\":[], \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"commitment_ends_at\":\"2025-10-30T16:49:01.607128Z\", \"acl_available\":true, \"iam_nodes_group_id\":\"6c8f211e-8819-44e2-93ca-fda367c9ca2a\", \"new_images_enabled\":true, \"pod_cidr\":\"100.64.0.0/15\", \"service_cidr\":\"10.32.0.0/20\", \"service_dns_ip\":\"10.32.0.10\"}"
-    headers:
-      Content-Length:
-      - "1630"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:53:13 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 160d7502-633a-4f72-a822-cf9a8075d4f7
-    status: 200 OK
-    code: 200
-    duration: 25.08467ms
-- id: 43
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/b0c262ac-e3c4-4a41-9b7c-fac43b180e81
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 715
-    body: "{\"region\":\"fr-par\", \"id\":\"b0c262ac-e3c4-4a41-9b7c-fac43b180e81\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:52:22.689840Z\", \"updated_at\":\"2025-10-30T16:53:10.546154Z\", \"name\":\"test-pool-wait-2\", \"status\":\"ready\", \"version\":\"1.34.1\", \"node_type\":\"pro2_xxs\", \"autoscaling\":false, \"size\":1, \"min_size\":1, \"max_size\":1, \"container_runtime\":\"containerd\", \"autohealing\":false, \"tags\":[], \"placement_group_id\":null, \"kubelet_args\":{}, \"upgrade_policy\":{\"max_unavailable\":1, \"max_surge\":0}, \"zone\":\"fr-par-1\", \"root_volume_type\":\"sbs_5k\", \"root_volume_size\":20000000000, \"public_ip_disabled\":false, \"new_images_enabled\":true, \"security_group_id\":\"4ef16f7a-478c-4b72-b932-982f4b04974b\"}"
-    headers:
-      Content-Length:
-      - "715"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:53:13 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 41e29722-ebe0-4d58-a6b2-8085e4cd020c
-    status: 200 OK
-    code: 200
-    duration: 89.459791ms
-- id: 44
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    form:
-      order_by:
-      - created_at_asc
-      page:
-      - "1"
-      pool_id:
-      - b0c262ac-e3c4-4a41-9b7c-fac43b180e81
-      status:
-      - unknown
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75/nodes?order_by=created_at_asc&page=1&pool_id=b0c262ac-e3c4-4a41-9b7c-fac43b180e81&status=unknown
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 618
-    body: "{\"total_count\":1, \"nodes\":[{\"region\":\"fr-par\", \"id\":\"803259ac-2333-4048-8fec-ae14c9eff6df\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:52:23.157062Z\", \"updated_at\":\"2025-10-30T16:53:10.533820Z\", \"pool_id\":\"b0c262ac-e3c4-4a41-9b7c-fac43b180e81\", \"status\":\"ready\", \"conditions\":{\"DiskPressure\":\"False\", \"MemoryPressure\":\"False\", \"PIDPressure\":\"False\", \"Ready\":\"True\"}, \"name\":\"scw-test-pool-wait-test-pool-wait-2-803259ac23\", \"public_ip_v4\":\"51.158.65.45\", \"public_ip_v6\":null, \"provider_id\":\"scaleway://instance/fr-par-1/f94c2846-a5e6-44e2-823b-e4da6094250f\", \"error_message\":\"\"}]}"
-    headers:
-      Content-Length:
-      - "618"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:53:13 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 0c4497f5-0d1f-4b00-96d2-b24332045f71
-    status: 200 OK
-    code: 200
-    duration: 20.312823ms
-- id: 45
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1630
-    body: "{\"region\":\"fr-par\", \"id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:01.607119Z\", \"updated_at\":\"2025-10-30T16:50:36.155897Z\", \"type\":\"kapsule\", \"name\":\"test-pool-wait\", \"description\":\"\", \"status\":\"ready\", \"version\":\"1.34.1\", \"cni\":\"calico\", \"tags\":[\"terraform-test\", \"scaleway_k8s_cluster\", \"minimal\"], \"cluster_url\":\"https://5114e066-aa93-4560-9be0-5ae445715a75.api.k8s.fr-par.scw.cloud:6443\", \"dns_wildcard\":\"*.5114e066-aa93-4560-9be0-5ae445715a75.nodes.k8s.fr-par.scw.cloud\", \"autoscaler_config\":{\"scale_down_disabled\":false, \"scale_down_delay_after_add\":\"10m\", \"estimator\":\"binpacking\", \"expander\":\"random\", \"ignore_daemonsets_utilization\":false, \"balance_similar_node_groups\":false, \"expendable_pods_priority_cutoff\":0, \"scale_down_unneeded_time\":\"10m\", \"scale_down_utilization_threshold\":0.5, \"max_graceful_termination_sec\":0}, \"auto_upgrade\":{\"enabled\":false, \"maintenance_window\":{\"start_hour\":0, \"day\":\"any\"}}, \"upgrade_available\":false, \"feature_gates\":[], \"admission_plugins\":[], \"open_id_connect_config\":{\"issuer_url\":\"\", \"client_id\":\"\", \"username_claim\":\"\", \"username_prefix\":\"\", \"groups_claim\":[], \"groups_prefix\":\"\", \"required_claim\":[]}, \"apiserver_cert_sans\":[], \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"commitment_ends_at\":\"2025-10-30T16:49:01.607128Z\", \"acl_available\":true, \"iam_nodes_group_id\":\"6c8f211e-8819-44e2-93ca-fda367c9ca2a\", \"new_images_enabled\":true, \"pod_cidr\":\"100.64.0.0/15\", \"service_cidr\":\"10.32.0.0/20\", \"service_dns_ip\":\"10.32.0.10\"}"
-    headers:
-      Content-Length:
-      - "1630"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:53:13 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - f6b52ef4-a81b-4bc0-9fde-7e7c13aa6b09
-    status: 200 OK
-    code: 200
-    duration: 20.801451ms
-- id: 46
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    form:
-      order_by:
-      - created_at_desc
-      project_id:
-      - 105bdce1-64c0-48ab-899d-868455867ecf
-      resource_name:
-      - scw-test-pool-wait-test-pool-wait-2-803259ac23
-      resource_type:
-      - unknown_type
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=105bdce1-64c0-48ab-899d-868455867ecf&resource_name=scw-test-pool-wait-test-pool-wait-2-803259ac23&resource_type=unknown_type
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1122
-    body: "{\"total_count\":2, \"ips\":[{\"id\":\"35d11f02-76e3-4fe4-a39b-c2df537169d7\", \"address\":\"fd5f:519c:6d46:90dd:ab00:4e62:584d:4783/64\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_ipv6\":true, \"created_at\":\"2025-10-30T16:52:26.776899Z\", \"updated_at\":\"2025-10-30T16:52:26.776899Z\", \"source\":{\"subnet_id\":\"7493d1b7-5773-41c2-be8c-52e4ec098fc3\"}, \"resource\":{\"type\":\"instance_private_nic\", \"id\":\"6f4c43ec-ff56-4721-ab5d-fdf2a12b8f2e\", \"mac_address\":\"02:00:00:12:65:C5\", \"name\":\"scw-test-pool-wait-test-pool-wait-2-803259ac23\"}, \"tags\":[], \"reverses\":[], \"region\":\"fr-par\", \"zone\":null}, {\"id\":\"878dc0d8-d3e7-4ab9-b890-f5352063637c\", \"address\":\"172.18.20.4/22\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_ipv6\":false, \"created_at\":\"2025-10-30T16:52:26.654069Z\", \"updated_at\":\"2025-10-30T16:52:26.654069Z\", \"source\":{\"subnet_id\":\"da10d014-609b-48cc-9b9a-437dc31f4497\"}, \"resource\":{\"type\":\"instance_private_nic\", \"id\":\"6f4c43ec-ff56-4721-ab5d-fdf2a12b8f2e\", \"mac_address\":\"02:00:00:12:65:C5\", \"name\":\"scw-test-pool-wait-test-pool-wait-2-803259ac23\"}, \"tags\":[], \"reverses\":[], \"region\":\"fr-par\", \"zone\":null}]}"
-    headers:
-      Content-Length:
-      - "1122"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:53:14 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 60d9b96e-7457-45bb-927f-53189a54dd9b
-    status: 200 OK
-    code: 200
-    duration: 99.662659ms
-- id: 47
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1630
-    body: "{\"region\":\"fr-par\", \"id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:01.607119Z\", \"updated_at\":\"2025-10-30T16:50:36.155897Z\", \"type\":\"kapsule\", \"name\":\"test-pool-wait\", \"description\":\"\", \"status\":\"ready\", \"version\":\"1.34.1\", \"cni\":\"calico\", \"tags\":[\"terraform-test\", \"scaleway_k8s_cluster\", \"minimal\"], \"cluster_url\":\"https://5114e066-aa93-4560-9be0-5ae445715a75.api.k8s.fr-par.scw.cloud:6443\", \"dns_wildcard\":\"*.5114e066-aa93-4560-9be0-5ae445715a75.nodes.k8s.fr-par.scw.cloud\", \"autoscaler_config\":{\"scale_down_disabled\":false, \"scale_down_delay_after_add\":\"10m\", \"estimator\":\"binpacking\", \"expander\":\"random\", \"ignore_daemonsets_utilization\":false, \"balance_similar_node_groups\":false, \"expendable_pods_priority_cutoff\":0, \"scale_down_unneeded_time\":\"10m\", \"scale_down_utilization_threshold\":0.5, \"max_graceful_termination_sec\":0}, \"auto_upgrade\":{\"enabled\":false, \"maintenance_window\":{\"start_hour\":0, \"day\":\"any\"}}, \"upgrade_available\":false, \"feature_gates\":[], \"admission_plugins\":[], \"open_id_connect_config\":{\"issuer_url\":\"\", \"client_id\":\"\", \"username_claim\":\"\", \"username_prefix\":\"\", \"groups_claim\":[], \"groups_prefix\":\"\", \"required_claim\":[]}, \"apiserver_cert_sans\":[], \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"commitment_ends_at\":\"2025-10-30T16:49:01.607128Z\", \"acl_available\":true, \"iam_nodes_group_id\":\"6c8f211e-8819-44e2-93ca-fda367c9ca2a\", \"new_images_enabled\":true, \"pod_cidr\":\"100.64.0.0/15\", \"service_cidr\":\"10.32.0.0/20\", \"service_dns_ip\":\"10.32.0.10\"}"
-    headers:
-      Content-Length:
-      - "1630"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:53:14 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 58932961-9842-45f7-8f70-45a605c94258
-    status: 200 OK
-    code: 200
-    duration: 20.450251ms
-- id: 48
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/b0c262ac-e3c4-4a41-9b7c-fac43b180e81
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 715
-    body: "{\"region\":\"fr-par\", \"id\":\"b0c262ac-e3c4-4a41-9b7c-fac43b180e81\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:52:22.689840Z\", \"updated_at\":\"2025-10-30T16:53:10.546154Z\", \"name\":\"test-pool-wait-2\", \"status\":\"ready\", \"version\":\"1.34.1\", \"node_type\":\"pro2_xxs\", \"autoscaling\":false, \"size\":1, \"min_size\":1, \"max_size\":1, \"container_runtime\":\"containerd\", \"autohealing\":false, \"tags\":[], \"placement_group_id\":null, \"kubelet_args\":{}, \"upgrade_policy\":{\"max_unavailable\":1, \"max_surge\":0}, \"zone\":\"fr-par-1\", \"root_volume_type\":\"sbs_5k\", \"root_volume_size\":20000000000, \"public_ip_disabled\":false, \"new_images_enabled\":true, \"security_group_id\":\"4ef16f7a-478c-4b72-b932-982f4b04974b\"}"
-    headers:
-      Content-Length:
-      - "715"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:53:14 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - cef30e48-8802-490a-850c-cacd6ae617e0
-    status: 200 OK
-    code: 200
-    duration: 25.174247ms
-- id: 49
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/1a7a1e1e-2b33-478e-8f1a-faa0303a1c43
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 419
-    body: "{\"id\":\"1a7a1e1e-2b33-478e-8f1a-faa0303a1c43\", \"name\":\"tf-vpc-confident-bose\", \"tags\":[], \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:00.136298Z\", \"updated_at\":\"2025-10-30T16:49:00.136298Z\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_default\":false, \"private_network_count\":1, \"routing_enabled\":true, \"custom_routes_propagation_enabled\":true, \"region\":\"fr-par\"}"
-    headers:
-      Content-Length:
-      - "419"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:53:14 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - b410560a-c10d-43b9-928d-bf8864b14e43
-    status: 200 OK
-    code: 200
-    duration: 24.171706ms
-- id: 50
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/363e7214-8a98-40d0-9357-9e4026c21b76
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1084
-    body: "{\"id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"name\":\"test-pool-wait\", \"tags\":[], \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:00.384609Z\", \"updated_at\":\"2025-10-30T16:49:00.384609Z\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"subnets\":[{\"id\":\"da10d014-609b-48cc-9b9a-437dc31f4497\", \"created_at\":\"2025-10-30T16:49:00.384609Z\", \"updated_at\":\"2025-10-30T16:49:00.384609Z\", \"subnet\":\"172.18.20.0/22\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"vpc_id\":\"1a7a1e1e-2b33-478e-8f1a-faa0303a1c43\"}, {\"id\":\"7493d1b7-5773-41c2-be8c-52e4ec098fc3\", \"created_at\":\"2025-10-30T16:49:00.384609Z\", \"updated_at\":\"2025-10-30T16:49:00.384609Z\", \"subnet\":\"fd5f:519c:6d46:90dd::/64\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"vpc_id\":\"1a7a1e1e-2b33-478e-8f1a-faa0303a1c43\"}], \"vpc_id\":\"1a7a1e1e-2b33-478e-8f1a-faa0303a1c43\", \"dhcp_enabled\":true, \"default_route_propagation_enabled\":false, \"region\":\"fr-par\"}"
-    headers:
-      Content-Length:
-      - "1084"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:53:14 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - b2955d58-e958-4b15-904d-2a9a5ae86ea5
-    status: 200 OK
-    code: 200
-    duration: 27.040189ms
-- id: 51
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1630
-    body: "{\"region\":\"fr-par\", \"id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:01.607119Z\", \"updated_at\":\"2025-10-30T16:50:36.155897Z\", \"type\":\"kapsule\", \"name\":\"test-pool-wait\", \"description\":\"\", \"status\":\"ready\", \"version\":\"1.34.1\", \"cni\":\"calico\", \"tags\":[\"terraform-test\", \"scaleway_k8s_cluster\", \"minimal\"], \"cluster_url\":\"https://5114e066-aa93-4560-9be0-5ae445715a75.api.k8s.fr-par.scw.cloud:6443\", \"dns_wildcard\":\"*.5114e066-aa93-4560-9be0-5ae445715a75.nodes.k8s.fr-par.scw.cloud\", \"autoscaler_config\":{\"scale_down_disabled\":false, \"scale_down_delay_after_add\":\"10m\", \"estimator\":\"binpacking\", \"expander\":\"random\", \"ignore_daemonsets_utilization\":false, \"balance_similar_node_groups\":false, \"expendable_pods_priority_cutoff\":0, \"scale_down_unneeded_time\":\"10m\", \"scale_down_utilization_threshold\":0.5, \"max_graceful_termination_sec\":0}, \"auto_upgrade\":{\"enabled\":false, \"maintenance_window\":{\"start_hour\":0, \"day\":\"any\"}}, \"upgrade_available\":false, \"feature_gates\":[], \"admission_plugins\":[], \"open_id_connect_config\":{\"issuer_url\":\"\", \"client_id\":\"\", \"username_claim\":\"\", \"username_prefix\":\"\", \"groups_claim\":[], \"groups_prefix\":\"\", \"required_claim\":[]}, \"apiserver_cert_sans\":[], \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"commitment_ends_at\":\"2025-10-30T16:49:01.607128Z\", \"acl_available\":true, \"iam_nodes_group_id\":\"6c8f211e-8819-44e2-93ca-fda367c9ca2a\", \"new_images_enabled\":true, \"pod_cidr\":\"100.64.0.0/15\", \"service_cidr\":\"10.32.0.0/20\", \"service_dns_ip\":\"10.32.0.10\"}"
-    headers:
-      Content-Length:
-      - "1630"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:53:14 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - b9831e25-d9f6-4af4-ad4d-380bedf6aeb0
-    status: 200 OK
-    code: 200
-    duration: 21.017556ms
-- id: 52
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75/kubeconfig
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1654
-    body: "{\"name\":\"kubeconfig\", \"content_type\":\"application/octet-stream\", \"content\":\"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVSllSRU5EUVZGSFowRjNTVUpCWjBsQ1FVUkJTMEpuWjNGb2EycFBVRkZSUkVGcVFWWk5VazEzUlZGWlJGWlJVVVJGZDNCeVpGZEtiR050Tld3S1pFZFdlazFDTkZoRVZFa3hUVlJCZVU5VVJUSk9SR3QzVFZadldFUlVUVEZOVkVGNVQxUkZNazVFYTNkTlZtOTNSbFJGVkUxQ1JVZEJNVlZGUVhoTlN3cGhNMVpwV2xoS2RWcFlVbXhqZWtKYVRVSk5SMEo1Y1VkVFRUUTVRV2RGUjBORGNVZFRUVFE1UVhkRlNFRXdTVUZDVFhsNllqUkdTbVozWTFOM01tZEZDbEppVFRkVFZpOUpiM0ZXU21oWWVIbGxObHB1UkZOWlZ6WmxRbU4yV2tJM1RXVnVMMWxPYm5wM2F6QkpRazF2VDFkUFRXeHRlVGxJWVU5NE1XVkxaSFlLTUVRNE9XZDVZV3BSYWtKQlRVRTBSMEV4VldSRWQwVkNMM2RSUlVGM1NVTndSRUZRUW1kT1ZraFNUVUpCWmpoRlFsUkJSRUZSU0M5TlFqQkhRVEZWWkFwRVoxRlhRa0pTVTFsU1NtTm9UV1l3V0U5YWNtUkJhV1JMYkdOUWEyTklZeTlVUVV0Q1oyZHhhR3RxVDFCUlVVUkJaMDVLUVVSQ1IwRnBSVUY1Ym0xd0NqbFpkWG80VWpGVWFtNDBiV2RqYWpaV2QycFVTM2gzUm5KS1VrdFZTVVpIUTFwR2VsbEtWVU5KVVVSSWRERkNXalpHYUZrdlVUWlRabloxTVhCNmJEWUtNWG80VkhCMlNIQkxVa0pIY1RscmNVVlJOa3hPZHowOUNpMHRMUzB0UlU1RUlFTkZVbFJKUmtsRFFWUkZMUzB0TFMwSwogICAgc2VydmVyOiBodHRwczovLzUxMTRlMDY2LWFhOTMtNDU2MC05YmUwLTVhZTQ0NTcxNWE3NS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wtd2FpdAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXdhaXQiCiAgICB1c2VyOiB0ZXN0LXBvb2wtd2FpdC1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC13YWl0CmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXdhaXQtYWRtaW4KICB1c2VyOgogICAgdG9rZW46IGttQTQ5c2F6N1V4dVJSOHZ1UzIxMWpxN2NzVzNobFF1QzQ3QjRla3BobjE3UXBMcVRiVGJGelVO\"}"
-    headers:
-      Content-Length:
-      - "1654"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:53:14 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 8a5454d7-3d31-4f9a-8352-878905400340
-    status: 200 OK
-    code: 200
-    duration: 88.227377ms
-- id: 53
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/034a502a-1d52-470d-84bd-4a8edd935ba3
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 713
-    body: "{\"region\":\"fr-par\", \"id\":\"034a502a-1d52-470d-84bd-4a8edd935ba3\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:49:07.243810Z\", \"updated_at\":\"2025-10-30T16:52:20.261969Z\", \"name\":\"test-pool-wait\", \"status\":\"ready\", \"version\":\"1.34.1\", \"node_type\":\"pro2_xxs\", \"autoscaling\":false, \"size\":1, \"min_size\":1, \"max_size\":1, \"container_runtime\":\"containerd\", \"autohealing\":false, \"tags\":[], \"placement_group_id\":null, \"kubelet_args\":{}, \"upgrade_policy\":{\"max_unavailable\":1, \"max_surge\":0}, \"zone\":\"fr-par-1\", \"root_volume_type\":\"sbs_5k\", \"root_volume_size\":20000000000, \"public_ip_disabled\":false, \"new_images_enabled\":true, \"security_group_id\":\"4ef16f7a-478c-4b72-b932-982f4b04974b\"}"
-    headers:
-      Content-Length:
-      - "713"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:53:14 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 19fc9f25-2122-4e87-84ab-61fa1e0d7061
-    status: 200 OK
-    code: 200
-    duration: 26.034572ms
-- id: 54
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/b0c262ac-e3c4-4a41-9b7c-fac43b180e81
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 715
-    body: "{\"region\":\"fr-par\", \"id\":\"b0c262ac-e3c4-4a41-9b7c-fac43b180e81\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:52:22.689840Z\", \"updated_at\":\"2025-10-30T16:53:10.546154Z\", \"name\":\"test-pool-wait-2\", \"status\":\"ready\", \"version\":\"1.34.1\", \"node_type\":\"pro2_xxs\", \"autoscaling\":false, \"size\":1, \"min_size\":1, \"max_size\":1, \"container_runtime\":\"containerd\", \"autohealing\":false, \"tags\":[], \"placement_group_id\":null, \"kubelet_args\":{}, \"upgrade_policy\":{\"max_unavailable\":1, \"max_surge\":0}, \"zone\":\"fr-par-1\", \"root_volume_type\":\"sbs_5k\", \"root_volume_size\":20000000000, \"public_ip_disabled\":false, \"new_images_enabled\":true, \"security_group_id\":\"4ef16f7a-478c-4b72-b932-982f4b04974b\"}"
-    headers:
-      Content-Length:
-      - "715"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:53:14 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 5c174d33-0c9d-44d4-8343-852d24fc4493
-    status: 200 OK
-    code: 200
-    duration: 26.960049ms
-- id: 55
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    form:
-      order_by:
-      - created_at_asc
-      page:
-      - "1"
-      pool_id:
-      - 034a502a-1d52-470d-84bd-4a8edd935ba3
-      status:
-      - unknown
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75/nodes?order_by=created_at_asc&page=1&pool_id=034a502a-1d52-470d-84bd-4a8edd935ba3&status=unknown
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 648
-    body: "{\"total_count\":1, \"nodes\":[{\"region\":\"fr-par\", \"id\":\"3e073c76-a98f-4e6b-ad3c-7a6ca77e15fd\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:51:15.736647Z\", \"updated_at\":\"2025-10-30T16:53:10.517490Z\", \"pool_id\":\"034a502a-1d52-470d-84bd-4a8edd935ba3\", \"status\":\"ready\", \"conditions\":{\"DiskPressure\":\"False\", \"MemoryPressure\":\"False\", \"NetworkUnavailable\":\"False\", \"PIDPressure\":\"False\", \"Ready\":\"True\"}, \"name\":\"scw-test-pool-wait-test-pool-wait-3e073c76a98f\", \"public_ip_v4\":\"51.158.97.50\", \"public_ip_v6\":null, \"provider_id\":\"scaleway://instance/fr-par-1/6ba8f808-ce5f-4e0a-b30e-a83f7f79f945\", \"error_message\":\"\"}]}"
-    headers:
-      Content-Length:
-      - "648"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:53:14 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 67d66ddf-5887-4d95-bdee-e5816032c8dc
-    status: 200 OK
-    code: 200
-    duration: 19.400762ms
-- id: 56
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    form:
-      order_by:
-      - created_at_asc
-      page:
-      - "1"
-      pool_id:
-      - b0c262ac-e3c4-4a41-9b7c-fac43b180e81
-      status:
-      - unknown
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75/nodes?order_by=created_at_asc&page=1&pool_id=b0c262ac-e3c4-4a41-9b7c-fac43b180e81&status=unknown
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 618
-    body: "{\"total_count\":1, \"nodes\":[{\"region\":\"fr-par\", \"id\":\"803259ac-2333-4048-8fec-ae14c9eff6df\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:52:23.157062Z\", \"updated_at\":\"2025-10-30T16:53:10.533820Z\", \"pool_id\":\"b0c262ac-e3c4-4a41-9b7c-fac43b180e81\", \"status\":\"ready\", \"conditions\":{\"DiskPressure\":\"False\", \"MemoryPressure\":\"False\", \"PIDPressure\":\"False\", \"Ready\":\"True\"}, \"name\":\"scw-test-pool-wait-test-pool-wait-2-803259ac23\", \"public_ip_v4\":\"51.158.65.45\", \"public_ip_v6\":null, \"provider_id\":\"scaleway://instance/fr-par-1/f94c2846-a5e6-44e2-823b-e4da6094250f\", \"error_message\":\"\"}]}"
-    headers:
-      Content-Length:
-      - "618"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:53:14 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 93300ece-717b-4222-a946-771ac6fc544a
-    status: 200 OK
-    code: 200
-    duration: 26.171208ms
-- id: 57
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1630
-    body: "{\"region\":\"fr-par\", \"id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:01.607119Z\", \"updated_at\":\"2025-10-30T16:50:36.155897Z\", \"type\":\"kapsule\", \"name\":\"test-pool-wait\", \"description\":\"\", \"status\":\"ready\", \"version\":\"1.34.1\", \"cni\":\"calico\", \"tags\":[\"terraform-test\", \"scaleway_k8s_cluster\", \"minimal\"], \"cluster_url\":\"https://5114e066-aa93-4560-9be0-5ae445715a75.api.k8s.fr-par.scw.cloud:6443\", \"dns_wildcard\":\"*.5114e066-aa93-4560-9be0-5ae445715a75.nodes.k8s.fr-par.scw.cloud\", \"autoscaler_config\":{\"scale_down_disabled\":false, \"scale_down_delay_after_add\":\"10m\", \"estimator\":\"binpacking\", \"expander\":\"random\", \"ignore_daemonsets_utilization\":false, \"balance_similar_node_groups\":false, \"expendable_pods_priority_cutoff\":0, \"scale_down_unneeded_time\":\"10m\", \"scale_down_utilization_threshold\":0.5, \"max_graceful_termination_sec\":0}, \"auto_upgrade\":{\"enabled\":false, \"maintenance_window\":{\"start_hour\":0, \"day\":\"any\"}}, \"upgrade_available\":false, \"feature_gates\":[], \"admission_plugins\":[], \"open_id_connect_config\":{\"issuer_url\":\"\", \"client_id\":\"\", \"username_claim\":\"\", \"username_prefix\":\"\", \"groups_claim\":[], \"groups_prefix\":\"\", \"required_claim\":[]}, \"apiserver_cert_sans\":[], \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"commitment_ends_at\":\"2025-10-30T16:49:01.607128Z\", \"acl_available\":true, \"iam_nodes_group_id\":\"6c8f211e-8819-44e2-93ca-fda367c9ca2a\", \"new_images_enabled\":true, \"pod_cidr\":\"100.64.0.0/15\", \"service_cidr\":\"10.32.0.0/20\", \"service_dns_ip\":\"10.32.0.10\"}"
-    headers:
-      Content-Length:
-      - "1630"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:53:14 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 153230ae-90eb-4d2b-ad2d-861b6b0c8af4
-    status: 200 OK
-    code: 200
-    duration: 24.893881ms
-- id: 58
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1630
-    body: "{\"region\":\"fr-par\", \"id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:01.607119Z\", \"updated_at\":\"2025-10-30T16:50:36.155897Z\", \"type\":\"kapsule\", \"name\":\"test-pool-wait\", \"description\":\"\", \"status\":\"ready\", \"version\":\"1.34.1\", \"cni\":\"calico\", \"tags\":[\"terraform-test\", \"scaleway_k8s_cluster\", \"minimal\"], \"cluster_url\":\"https://5114e066-aa93-4560-9be0-5ae445715a75.api.k8s.fr-par.scw.cloud:6443\", \"dns_wildcard\":\"*.5114e066-aa93-4560-9be0-5ae445715a75.nodes.k8s.fr-par.scw.cloud\", \"autoscaler_config\":{\"scale_down_disabled\":false, \"scale_down_delay_after_add\":\"10m\", \"estimator\":\"binpacking\", \"expander\":\"random\", \"ignore_daemonsets_utilization\":false, \"balance_similar_node_groups\":false, \"expendable_pods_priority_cutoff\":0, \"scale_down_unneeded_time\":\"10m\", \"scale_down_utilization_threshold\":0.5, \"max_graceful_termination_sec\":0}, \"auto_upgrade\":{\"enabled\":false, \"maintenance_window\":{\"start_hour\":0, \"day\":\"any\"}}, \"upgrade_available\":false, \"feature_gates\":[], \"admission_plugins\":[], \"open_id_connect_config\":{\"issuer_url\":\"\", \"client_id\":\"\", \"username_claim\":\"\", \"username_prefix\":\"\", \"groups_claim\":[], \"groups_prefix\":\"\", \"required_claim\":[]}, \"apiserver_cert_sans\":[], \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"commitment_ends_at\":\"2025-10-30T16:49:01.607128Z\", \"acl_available\":true, \"iam_nodes_group_id\":\"6c8f211e-8819-44e2-93ca-fda367c9ca2a\", \"new_images_enabled\":true, \"pod_cidr\":\"100.64.0.0/15\", \"service_cidr\":\"10.32.0.0/20\", \"service_dns_ip\":\"10.32.0.10\"}"
-    headers:
-      Content-Length:
-      - "1630"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:53:14 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 62a9bce9-3154-4eb2-ae95-54694df92c06
-    status: 200 OK
-    code: 200
-    duration: 30.586155ms
-- id: 59
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    form:
-      order_by:
-      - created_at_desc
-      project_id:
-      - 105bdce1-64c0-48ab-899d-868455867ecf
-      resource_name:
-      - scw-test-pool-wait-test-pool-wait-2-803259ac23
-      resource_type:
-      - unknown_type
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=105bdce1-64c0-48ab-899d-868455867ecf&resource_name=scw-test-pool-wait-test-pool-wait-2-803259ac23&resource_type=unknown_type
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1122
-    body: "{\"total_count\":2, \"ips\":[{\"id\":\"35d11f02-76e3-4fe4-a39b-c2df537169d7\", \"address\":\"fd5f:519c:6d46:90dd:ab00:4e62:584d:4783/64\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_ipv6\":true, \"created_at\":\"2025-10-30T16:52:26.776899Z\", \"updated_at\":\"2025-10-30T16:52:26.776899Z\", \"source\":{\"subnet_id\":\"7493d1b7-5773-41c2-be8c-52e4ec098fc3\"}, \"resource\":{\"type\":\"instance_private_nic\", \"id\":\"6f4c43ec-ff56-4721-ab5d-fdf2a12b8f2e\", \"mac_address\":\"02:00:00:12:65:C5\", \"name\":\"scw-test-pool-wait-test-pool-wait-2-803259ac23\"}, \"tags\":[], \"reverses\":[], \"region\":\"fr-par\", \"zone\":null}, {\"id\":\"878dc0d8-d3e7-4ab9-b890-f5352063637c\", \"address\":\"172.18.20.4/22\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_ipv6\":false, \"created_at\":\"2025-10-30T16:52:26.654069Z\", \"updated_at\":\"2025-10-30T16:52:26.654069Z\", \"source\":{\"subnet_id\":\"da10d014-609b-48cc-9b9a-437dc31f4497\"}, \"resource\":{\"type\":\"instance_private_nic\", \"id\":\"6f4c43ec-ff56-4721-ab5d-fdf2a12b8f2e\", \"mac_address\":\"02:00:00:12:65:C5\", \"name\":\"scw-test-pool-wait-test-pool-wait-2-803259ac23\"}, \"tags\":[], \"reverses\":[], \"region\":\"fr-par\", \"zone\":null}]}"
-    headers:
-      Content-Length:
-      - "1122"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:53:14 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 188845c7-9540-4028-ad0b-1755b398668e
-    status: 200 OK
-    code: 200
-    duration: 42.741218ms
-- id: 60
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    form:
-      order_by:
-      - created_at_desc
-      project_id:
-      - 105bdce1-64c0-48ab-899d-868455867ecf
-      resource_name:
-      - scw-test-pool-wait-test-pool-wait-3e073c76a98f
-      resource_type:
-      - unknown_type
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=105bdce1-64c0-48ab-899d-868455867ecf&resource_name=scw-test-pool-wait-test-pool-wait-3e073c76a98f&resource_type=unknown_type
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1122
-    body: "{\"total_count\":2, \"ips\":[{\"id\":\"54c6f7a2-4ca0-43bb-bc9a-b4a3905c0487\", \"address\":\"fd5f:519c:6d46:90dd:c183:ab7b:59b9:fc92/64\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_ipv6\":true, \"created_at\":\"2025-10-30T16:51:19.698188Z\", \"updated_at\":\"2025-10-30T16:51:19.698188Z\", \"source\":{\"subnet_id\":\"7493d1b7-5773-41c2-be8c-52e4ec098fc3\"}, \"resource\":{\"type\":\"instance_private_nic\", \"id\":\"45715cb9-7532-4c78-93a4-2fef3fa3b71a\", \"mac_address\":\"02:00:00:1D:E4:BA\", \"name\":\"scw-test-pool-wait-test-pool-wait-3e073c76a98f\"}, \"tags\":[], \"reverses\":[], \"region\":\"fr-par\", \"zone\":null}, {\"id\":\"ddc7378f-48eb-4ae3-af3e-4d5ee60054c4\", \"address\":\"172.18.20.3/22\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_ipv6\":false, \"created_at\":\"2025-10-30T16:51:19.565119Z\", \"updated_at\":\"2025-10-30T16:51:19.565119Z\", \"source\":{\"subnet_id\":\"da10d014-609b-48cc-9b9a-437dc31f4497\"}, \"resource\":{\"type\":\"instance_private_nic\", \"id\":\"45715cb9-7532-4c78-93a4-2fef3fa3b71a\", \"mac_address\":\"02:00:00:1D:E4:BA\", \"name\":\"scw-test-pool-wait-test-pool-wait-3e073c76a98f\"}, \"tags\":[], \"reverses\":[], \"region\":\"fr-par\", \"zone\":null}]}"
-    headers:
-      Content-Length:
-      - "1122"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:53:14 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - d7440368-0e37-4217-aeac-b1555819c6ce
-    status: 200 OK
-    code: 200
-    duration: 100.172266ms
-- id: 61
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/1a7a1e1e-2b33-478e-8f1a-faa0303a1c43
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 419
-    body: "{\"id\":\"1a7a1e1e-2b33-478e-8f1a-faa0303a1c43\", \"name\":\"tf-vpc-confident-bose\", \"tags\":[], \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:00.136298Z\", \"updated_at\":\"2025-10-30T16:49:00.136298Z\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_default\":false, \"private_network_count\":1, \"routing_enabled\":true, \"custom_routes_propagation_enabled\":true, \"region\":\"fr-par\"}"
-    headers:
-      Content-Length:
-      - "419"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:53:14 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - d481907e-eb2f-4754-bfb4-6e414f60ba29
-    status: 200 OK
-    code: 200
-    duration: 26.002662ms
-- id: 62
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/363e7214-8a98-40d0-9357-9e4026c21b76
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1084
-    body: "{\"id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"name\":\"test-pool-wait\", \"tags\":[], \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:00.384609Z\", \"updated_at\":\"2025-10-30T16:49:00.384609Z\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"subnets\":[{\"id\":\"da10d014-609b-48cc-9b9a-437dc31f4497\", \"created_at\":\"2025-10-30T16:49:00.384609Z\", \"updated_at\":\"2025-10-30T16:49:00.384609Z\", \"subnet\":\"172.18.20.0/22\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"vpc_id\":\"1a7a1e1e-2b33-478e-8f1a-faa0303a1c43\"}, {\"id\":\"7493d1b7-5773-41c2-be8c-52e4ec098fc3\", \"created_at\":\"2025-10-30T16:49:00.384609Z\", \"updated_at\":\"2025-10-30T16:49:00.384609Z\", \"subnet\":\"fd5f:519c:6d46:90dd::/64\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"vpc_id\":\"1a7a1e1e-2b33-478e-8f1a-faa0303a1c43\"}], \"vpc_id\":\"1a7a1e1e-2b33-478e-8f1a-faa0303a1c43\", \"dhcp_enabled\":true, \"default_route_propagation_enabled\":false, \"region\":\"fr-par\"}"
-    headers:
-      Content-Length:
-      - "1084"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:53:14 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 131deb5c-20ef-44e9-81ae-c6729e20013f
-    status: 200 OK
-    code: 200
-    duration: 22.478338ms
-- id: 63
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1630
-    body: "{\"region\":\"fr-par\", \"id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:01.607119Z\", \"updated_at\":\"2025-10-30T16:50:36.155897Z\", \"type\":\"kapsule\", \"name\":\"test-pool-wait\", \"description\":\"\", \"status\":\"ready\", \"version\":\"1.34.1\", \"cni\":\"calico\", \"tags\":[\"terraform-test\", \"scaleway_k8s_cluster\", \"minimal\"], \"cluster_url\":\"https://5114e066-aa93-4560-9be0-5ae445715a75.api.k8s.fr-par.scw.cloud:6443\", \"dns_wildcard\":\"*.5114e066-aa93-4560-9be0-5ae445715a75.nodes.k8s.fr-par.scw.cloud\", \"autoscaler_config\":{\"scale_down_disabled\":false, \"scale_down_delay_after_add\":\"10m\", \"estimator\":\"binpacking\", \"expander\":\"random\", \"ignore_daemonsets_utilization\":false, \"balance_similar_node_groups\":false, \"expendable_pods_priority_cutoff\":0, \"scale_down_unneeded_time\":\"10m\", \"scale_down_utilization_threshold\":0.5, \"max_graceful_termination_sec\":0}, \"auto_upgrade\":{\"enabled\":false, \"maintenance_window\":{\"start_hour\":0, \"day\":\"any\"}}, \"upgrade_available\":false, \"feature_gates\":[], \"admission_plugins\":[], \"open_id_connect_config\":{\"issuer_url\":\"\", \"client_id\":\"\", \"username_claim\":\"\", \"username_prefix\":\"\", \"groups_claim\":[], \"groups_prefix\":\"\", \"required_claim\":[]}, \"apiserver_cert_sans\":[], \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"commitment_ends_at\":\"2025-10-30T16:49:01.607128Z\", \"acl_available\":true, \"iam_nodes_group_id\":\"6c8f211e-8819-44e2-93ca-fda367c9ca2a\", \"new_images_enabled\":true, \"pod_cidr\":\"100.64.0.0/15\", \"service_cidr\":\"10.32.0.0/20\", \"service_dns_ip\":\"10.32.0.10\"}"
-    headers:
-      Content-Length:
-      - "1630"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:53:15 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - ddc0a8be-4994-4574-bd9e-64361050dd14
-    status: 200 OK
-    code: 200
-    duration: 95.207107ms
-- id: 64
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75/kubeconfig
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1654
-    body: "{\"name\":\"kubeconfig\", \"content_type\":\"application/octet-stream\", \"content\":\"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVSllSRU5EUVZGSFowRjNTVUpCWjBsQ1FVUkJTMEpuWjNGb2EycFBVRkZSUkVGcVFWWk5VazEzUlZGWlJGWlJVVVJGZDNCeVpGZEtiR050Tld3S1pFZFdlazFDTkZoRVZFa3hUVlJCZVU5VVJUSk9SR3QzVFZadldFUlVUVEZOVkVGNVQxUkZNazVFYTNkTlZtOTNSbFJGVkUxQ1JVZEJNVlZGUVhoTlN3cGhNMVpwV2xoS2RWcFlVbXhqZWtKYVRVSk5SMEo1Y1VkVFRUUTVRV2RGUjBORGNVZFRUVFE1UVhkRlNFRXdTVUZDVFhsNllqUkdTbVozWTFOM01tZEZDbEppVFRkVFZpOUpiM0ZXU21oWWVIbGxObHB1UkZOWlZ6WmxRbU4yV2tJM1RXVnVMMWxPYm5wM2F6QkpRazF2VDFkUFRXeHRlVGxJWVU5NE1XVkxaSFlLTUVRNE9XZDVZV3BSYWtKQlRVRTBSMEV4VldSRWQwVkNMM2RSUlVGM1NVTndSRUZRUW1kT1ZraFNUVUpCWmpoRlFsUkJSRUZSU0M5TlFqQkhRVEZWWkFwRVoxRlhRa0pTVTFsU1NtTm9UV1l3V0U5YWNtUkJhV1JMYkdOUWEyTklZeTlVUVV0Q1oyZHhhR3RxVDFCUlVVUkJaMDVLUVVSQ1IwRnBSVUY1Ym0xd0NqbFpkWG80VWpGVWFtNDBiV2RqYWpaV2QycFVTM2gzUm5KS1VrdFZTVVpIUTFwR2VsbEtWVU5KVVVSSWRERkNXalpHYUZrdlVUWlRabloxTVhCNmJEWUtNWG80VkhCMlNIQkxVa0pIY1RscmNVVlJOa3hPZHowOUNpMHRMUzB0UlU1RUlFTkZVbFJKUmtsRFFWUkZMUzB0TFMwSwogICAgc2VydmVyOiBodHRwczovLzUxMTRlMDY2LWFhOTMtNDU2MC05YmUwLTVhZTQ0NTcxNWE3NS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wtd2FpdAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXdhaXQiCiAgICB1c2VyOiB0ZXN0LXBvb2wtd2FpdC1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC13YWl0CmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXdhaXQtYWRtaW4KICB1c2VyOgogICAgdG9rZW46IGttQTQ5c2F6N1V4dVJSOHZ1UzIxMWpxN2NzVzNobFF1QzQ3QjRla3BobjE3UXBMcVRiVGJGelVO\"}"
-    headers:
-      Content-Length:
-      - "1654"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:53:15 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 829de7ee-a55d-41ed-9de9-47c8a0cdad6e
-    status: 200 OK
-    code: 200
-    duration: 23.89674ms
-- id: 65
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/034a502a-1d52-470d-84bd-4a8edd935ba3
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 713
-    body: "{\"region\":\"fr-par\", \"id\":\"034a502a-1d52-470d-84bd-4a8edd935ba3\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:49:07.243810Z\", \"updated_at\":\"2025-10-30T16:52:20.261969Z\", \"name\":\"test-pool-wait\", \"status\":\"ready\", \"version\":\"1.34.1\", \"node_type\":\"pro2_xxs\", \"autoscaling\":false, \"size\":1, \"min_size\":1, \"max_size\":1, \"container_runtime\":\"containerd\", \"autohealing\":false, \"tags\":[], \"placement_group_id\":null, \"kubelet_args\":{}, \"upgrade_policy\":{\"max_unavailable\":1, \"max_surge\":0}, \"zone\":\"fr-par-1\", \"root_volume_type\":\"sbs_5k\", \"root_volume_size\":20000000000, \"public_ip_disabled\":false, \"new_images_enabled\":true, \"security_group_id\":\"4ef16f7a-478c-4b72-b932-982f4b04974b\"}"
-    headers:
-      Content-Length:
-      - "713"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:53:15 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 8f46b7ac-4115-48b2-b6f3-28ced83f555a
-    status: 200 OK
-    code: 200
-    duration: 20.949408ms
-- id: 66
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/b0c262ac-e3c4-4a41-9b7c-fac43b180e81
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 715
-    body: "{\"region\":\"fr-par\", \"id\":\"b0c262ac-e3c4-4a41-9b7c-fac43b180e81\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:52:22.689840Z\", \"updated_at\":\"2025-10-30T16:53:10.546154Z\", \"name\":\"test-pool-wait-2\", \"status\":\"ready\", \"version\":\"1.34.1\", \"node_type\":\"pro2_xxs\", \"autoscaling\":false, \"size\":1, \"min_size\":1, \"max_size\":1, \"container_runtime\":\"containerd\", \"autohealing\":false, \"tags\":[], \"placement_group_id\":null, \"kubelet_args\":{}, \"upgrade_policy\":{\"max_unavailable\":1, \"max_surge\":0}, \"zone\":\"fr-par-1\", \"root_volume_type\":\"sbs_5k\", \"root_volume_size\":20000000000, \"public_ip_disabled\":false, \"new_images_enabled\":true, \"security_group_id\":\"4ef16f7a-478c-4b72-b932-982f4b04974b\"}"
-    headers:
-      Content-Length:
-      - "715"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:53:15 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 8ec43d58-3d5a-4d7f-b69d-190deaf8a6fc
-    status: 200 OK
-    code: 200
-    duration: 24.16835ms
-- id: 67
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    form:
-      order_by:
-      - created_at_asc
-      page:
-      - "1"
-      pool_id:
-      - b0c262ac-e3c4-4a41-9b7c-fac43b180e81
-      status:
-      - unknown
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75/nodes?order_by=created_at_asc&page=1&pool_id=b0c262ac-e3c4-4a41-9b7c-fac43b180e81&status=unknown
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 618
-    body: "{\"total_count\":1, \"nodes\":[{\"region\":\"fr-par\", \"id\":\"803259ac-2333-4048-8fec-ae14c9eff6df\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:52:23.157062Z\", \"updated_at\":\"2025-10-30T16:53:10.533820Z\", \"pool_id\":\"b0c262ac-e3c4-4a41-9b7c-fac43b180e81\", \"status\":\"ready\", \"conditions\":{\"DiskPressure\":\"False\", \"MemoryPressure\":\"False\", \"PIDPressure\":\"False\", \"Ready\":\"True\"}, \"name\":\"scw-test-pool-wait-test-pool-wait-2-803259ac23\", \"public_ip_v4\":\"51.158.65.45\", \"public_ip_v6\":null, \"provider_id\":\"scaleway://instance/fr-par-1/f94c2846-a5e6-44e2-823b-e4da6094250f\", \"error_message\":\"\"}]}"
-    headers:
-      Content-Length:
-      - "618"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:53:15 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 34257fe2-14cd-4135-9331-703b22500dfc
-    status: 200 OK
-    code: 200
-    duration: 21.769327ms
-- id: 68
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1630
-    body: "{\"region\":\"fr-par\", \"id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:01.607119Z\", \"updated_at\":\"2025-10-30T16:50:36.155897Z\", \"type\":\"kapsule\", \"name\":\"test-pool-wait\", \"description\":\"\", \"status\":\"ready\", \"version\":\"1.34.1\", \"cni\":\"calico\", \"tags\":[\"terraform-test\", \"scaleway_k8s_cluster\", \"minimal\"], \"cluster_url\":\"https://5114e066-aa93-4560-9be0-5ae445715a75.api.k8s.fr-par.scw.cloud:6443\", \"dns_wildcard\":\"*.5114e066-aa93-4560-9be0-5ae445715a75.nodes.k8s.fr-par.scw.cloud\", \"autoscaler_config\":{\"scale_down_disabled\":false, \"scale_down_delay_after_add\":\"10m\", \"estimator\":\"binpacking\", \"expander\":\"random\", \"ignore_daemonsets_utilization\":false, \"balance_similar_node_groups\":false, \"expendable_pods_priority_cutoff\":0, \"scale_down_unneeded_time\":\"10m\", \"scale_down_utilization_threshold\":0.5, \"max_graceful_termination_sec\":0}, \"auto_upgrade\":{\"enabled\":false, \"maintenance_window\":{\"start_hour\":0, \"day\":\"any\"}}, \"upgrade_available\":false, \"feature_gates\":[], \"admission_plugins\":[], \"open_id_connect_config\":{\"issuer_url\":\"\", \"client_id\":\"\", \"username_claim\":\"\", \"username_prefix\":\"\", \"groups_claim\":[], \"groups_prefix\":\"\", \"required_claim\":[]}, \"apiserver_cert_sans\":[], \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"commitment_ends_at\":\"2025-10-30T16:49:01.607128Z\", \"acl_available\":true, \"iam_nodes_group_id\":\"6c8f211e-8819-44e2-93ca-fda367c9ca2a\", \"new_images_enabled\":true, \"pod_cidr\":\"100.64.0.0/15\", \"service_cidr\":\"10.32.0.0/20\", \"service_dns_ip\":\"10.32.0.10\"}"
-    headers:
-      Content-Length:
-      - "1630"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:53:15 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 26e326ff-e6bc-4516-a4db-c78e0dab0cc0
-    status: 200 OK
-    code: 200
-    duration: 62.348848ms
-- id: 69
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    form:
-      order_by:
-      - created_at_asc
-      page:
-      - "1"
-      pool_id:
-      - 034a502a-1d52-470d-84bd-4a8edd935ba3
-      status:
-      - unknown
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75/nodes?order_by=created_at_asc&page=1&pool_id=034a502a-1d52-470d-84bd-4a8edd935ba3&status=unknown
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 648
-    body: "{\"total_count\":1, \"nodes\":[{\"region\":\"fr-par\", \"id\":\"3e073c76-a98f-4e6b-ad3c-7a6ca77e15fd\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:51:15.736647Z\", \"updated_at\":\"2025-10-30T16:53:10.517490Z\", \"pool_id\":\"034a502a-1d52-470d-84bd-4a8edd935ba3\", \"status\":\"ready\", \"conditions\":{\"DiskPressure\":\"False\", \"MemoryPressure\":\"False\", \"NetworkUnavailable\":\"False\", \"PIDPressure\":\"False\", \"Ready\":\"True\"}, \"name\":\"scw-test-pool-wait-test-pool-wait-3e073c76a98f\", \"public_ip_v4\":\"51.158.97.50\", \"public_ip_v6\":null, \"provider_id\":\"scaleway://instance/fr-par-1/6ba8f808-ce5f-4e0a-b30e-a83f7f79f945\", \"error_message\":\"\"}]}"
-    headers:
-      Content-Length:
-      - "648"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:53:15 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 0a41abc8-4a2c-43a8-8234-018b011c99c9
-    status: 200 OK
-    code: 200
-    duration: 87.482439ms
-- id: 70
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1630
-    body: "{\"region\":\"fr-par\", \"id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:01.607119Z\", \"updated_at\":\"2025-10-30T16:50:36.155897Z\", \"type\":\"kapsule\", \"name\":\"test-pool-wait\", \"description\":\"\", \"status\":\"ready\", \"version\":\"1.34.1\", \"cni\":\"calico\", \"tags\":[\"terraform-test\", \"scaleway_k8s_cluster\", \"minimal\"], \"cluster_url\":\"https://5114e066-aa93-4560-9be0-5ae445715a75.api.k8s.fr-par.scw.cloud:6443\", \"dns_wildcard\":\"*.5114e066-aa93-4560-9be0-5ae445715a75.nodes.k8s.fr-par.scw.cloud\", \"autoscaler_config\":{\"scale_down_disabled\":false, \"scale_down_delay_after_add\":\"10m\", \"estimator\":\"binpacking\", \"expander\":\"random\", \"ignore_daemonsets_utilization\":false, \"balance_similar_node_groups\":false, \"expendable_pods_priority_cutoff\":0, \"scale_down_unneeded_time\":\"10m\", \"scale_down_utilization_threshold\":0.5, \"max_graceful_termination_sec\":0}, \"auto_upgrade\":{\"enabled\":false, \"maintenance_window\":{\"start_hour\":0, \"day\":\"any\"}}, \"upgrade_available\":false, \"feature_gates\":[], \"admission_plugins\":[], \"open_id_connect_config\":{\"issuer_url\":\"\", \"client_id\":\"\", \"username_claim\":\"\", \"username_prefix\":\"\", \"groups_claim\":[], \"groups_prefix\":\"\", \"required_claim\":[]}, \"apiserver_cert_sans\":[], \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"commitment_ends_at\":\"2025-10-30T16:49:01.607128Z\", \"acl_available\":true, \"iam_nodes_group_id\":\"6c8f211e-8819-44e2-93ca-fda367c9ca2a\", \"new_images_enabled\":true, \"pod_cidr\":\"100.64.0.0/15\", \"service_cidr\":\"10.32.0.0/20\", \"service_dns_ip\":\"10.32.0.10\"}"
-    headers:
-      Content-Length:
-      - "1630"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:53:15 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 1f027b3e-2ac9-4c0e-bf81-8eb123257a0a
-    status: 200 OK
-    code: 200
-    duration: 22.531738ms
-- id: 71
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    form:
-      order_by:
-      - created_at_desc
-      project_id:
-      - 105bdce1-64c0-48ab-899d-868455867ecf
-      resource_name:
-      - scw-test-pool-wait-test-pool-wait-2-803259ac23
-      resource_type:
-      - unknown_type
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=105bdce1-64c0-48ab-899d-868455867ecf&resource_name=scw-test-pool-wait-test-pool-wait-2-803259ac23&resource_type=unknown_type
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1122
-    body: "{\"total_count\":2, \"ips\":[{\"id\":\"35d11f02-76e3-4fe4-a39b-c2df537169d7\", \"address\":\"fd5f:519c:6d46:90dd:ab00:4e62:584d:4783/64\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_ipv6\":true, \"created_at\":\"2025-10-30T16:52:26.776899Z\", \"updated_at\":\"2025-10-30T16:52:26.776899Z\", \"source\":{\"subnet_id\":\"7493d1b7-5773-41c2-be8c-52e4ec098fc3\"}, \"resource\":{\"type\":\"instance_private_nic\", \"id\":\"6f4c43ec-ff56-4721-ab5d-fdf2a12b8f2e\", \"mac_address\":\"02:00:00:12:65:C5\", \"name\":\"scw-test-pool-wait-test-pool-wait-2-803259ac23\"}, \"tags\":[], \"reverses\":[], \"region\":\"fr-par\", \"zone\":null}, {\"id\":\"878dc0d8-d3e7-4ab9-b890-f5352063637c\", \"address\":\"172.18.20.4/22\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_ipv6\":false, \"created_at\":\"2025-10-30T16:52:26.654069Z\", \"updated_at\":\"2025-10-30T16:52:26.654069Z\", \"source\":{\"subnet_id\":\"da10d014-609b-48cc-9b9a-437dc31f4497\"}, \"resource\":{\"type\":\"instance_private_nic\", \"id\":\"6f4c43ec-ff56-4721-ab5d-fdf2a12b8f2e\", \"mac_address\":\"02:00:00:12:65:C5\", \"name\":\"scw-test-pool-wait-test-pool-wait-2-803259ac23\"}, \"tags\":[], \"reverses\":[], \"region\":\"fr-par\", \"zone\":null}]}"
-    headers:
-      Content-Length:
-      - "1122"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:53:15 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 6492c4ee-caad-4693-a86d-5854b9ba34ea
-    status: 200 OK
-    code: 200
-    duration: 33.453817ms
-- id: 72
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    form:
-      order_by:
-      - created_at_desc
-      project_id:
-      - 105bdce1-64c0-48ab-899d-868455867ecf
-      resource_name:
-      - scw-test-pool-wait-test-pool-wait-3e073c76a98f
-      resource_type:
-      - unknown_type
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=105bdce1-64c0-48ab-899d-868455867ecf&resource_name=scw-test-pool-wait-test-pool-wait-3e073c76a98f&resource_type=unknown_type
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1122
-    body: "{\"total_count\":2, \"ips\":[{\"id\":\"54c6f7a2-4ca0-43bb-bc9a-b4a3905c0487\", \"address\":\"fd5f:519c:6d46:90dd:c183:ab7b:59b9:fc92/64\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_ipv6\":true, \"created_at\":\"2025-10-30T16:51:19.698188Z\", \"updated_at\":\"2025-10-30T16:51:19.698188Z\", \"source\":{\"subnet_id\":\"7493d1b7-5773-41c2-be8c-52e4ec098fc3\"}, \"resource\":{\"type\":\"instance_private_nic\", \"id\":\"45715cb9-7532-4c78-93a4-2fef3fa3b71a\", \"mac_address\":\"02:00:00:1D:E4:BA\", \"name\":\"scw-test-pool-wait-test-pool-wait-3e073c76a98f\"}, \"tags\":[], \"reverses\":[], \"region\":\"fr-par\", \"zone\":null}, {\"id\":\"ddc7378f-48eb-4ae3-af3e-4d5ee60054c4\", \"address\":\"172.18.20.3/22\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_ipv6\":false, \"created_at\":\"2025-10-30T16:51:19.565119Z\", \"updated_at\":\"2025-10-30T16:51:19.565119Z\", \"source\":{\"subnet_id\":\"da10d014-609b-48cc-9b9a-437dc31f4497\"}, \"resource\":{\"type\":\"instance_private_nic\", \"id\":\"45715cb9-7532-4c78-93a4-2fef3fa3b71a\", \"mac_address\":\"02:00:00:1D:E4:BA\", \"name\":\"scw-test-pool-wait-test-pool-wait-3e073c76a98f\"}, \"tags\":[], \"reverses\":[], \"region\":\"fr-par\", \"zone\":null}]}"
-    headers:
-      Content-Length:
-      - "1122"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:53:15 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - d0d4b150-7987-436f-a4e7-0fe223111008
-    status: 200 OK
-    code: 200
-    duration: 24.490845ms
-- id: 73
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 82
-    host: api.scaleway.com
-    body: "{\"size\":2,\"max_size\":2,\"upgrade_policy\":{\"max_unavailable\":null,\"max_surge\":null}}"
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/b0c262ac-e3c4-4a41-9b7c-fac43b180e81
-    method: PATCH
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 717
-    body: "{\"region\":\"fr-par\", \"id\":\"b0c262ac-e3c4-4a41-9b7c-fac43b180e81\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:52:22.689840Z\", \"updated_at\":\"2025-10-30T16:53:15.362541Z\", \"name\":\"test-pool-wait-2\", \"status\":\"scaling\", \"version\":\"1.34.1\", \"node_type\":\"pro2_xxs\", \"autoscaling\":false, \"size\":2, \"min_size\":1, \"max_size\":2, \"container_runtime\":\"containerd\", \"autohealing\":false, \"tags\":[], \"placement_group_id\":null, \"kubelet_args\":{}, \"upgrade_policy\":{\"max_unavailable\":1, \"max_surge\":0}, \"zone\":\"fr-par-1\", \"root_volume_type\":\"sbs_5k\", \"root_volume_size\":20000000000, \"public_ip_disabled\":false, \"new_images_enabled\":true, \"security_group_id\":\"4ef16f7a-478c-4b72-b932-982f4b04974b\"}"
-    headers:
-      Content-Length:
-      - "717"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:53:15 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 8d2f00e4-2ff5-44dc-aa01-ed578d37d9ab
-    status: 200 OK
-    code: 200
-    duration: 49.069225ms
-- id: 74
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/b0c262ac-e3c4-4a41-9b7c-fac43b180e81
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 717
-    body: "{\"region\":\"fr-par\", \"id\":\"b0c262ac-e3c4-4a41-9b7c-fac43b180e81\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:52:22.689840Z\", \"updated_at\":\"2025-10-30T16:53:15.362541Z\", \"name\":\"test-pool-wait-2\", \"status\":\"scaling\", \"version\":\"1.34.1\", \"node_type\":\"pro2_xxs\", \"autoscaling\":false, \"size\":2, \"min_size\":1, \"max_size\":2, \"container_runtime\":\"containerd\", \"autohealing\":false, \"tags\":[], \"placement_group_id\":null, \"kubelet_args\":{}, \"upgrade_policy\":{\"max_unavailable\":1, \"max_surge\":0}, \"zone\":\"fr-par-1\", \"root_volume_type\":\"sbs_5k\", \"root_volume_size\":20000000000, \"public_ip_disabled\":false, \"new_images_enabled\":true, \"security_group_id\":\"4ef16f7a-478c-4b72-b932-982f4b04974b\"}"
-    headers:
-      Content-Length:
-      - "717"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:53:15 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 170c35a1-ae82-4b4d-ad1b-7723264afb33
-    status: 200 OK
-    code: 200
-    duration: 23.956101ms
-- id: 75
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/b0c262ac-e3c4-4a41-9b7c-fac43b180e81
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 715
-    body: "{\"region\":\"fr-par\", \"id\":\"b0c262ac-e3c4-4a41-9b7c-fac43b180e81\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:52:22.689840Z\", \"updated_at\":\"2025-10-30T16:54:20.584002Z\", \"name\":\"test-pool-wait-2\", \"status\":\"ready\", \"version\":\"1.34.1\", \"node_type\":\"pro2_xxs\", \"autoscaling\":false, \"size\":2, \"min_size\":1, \"max_size\":2, \"container_runtime\":\"containerd\", \"autohealing\":false, \"tags\":[], \"placement_group_id\":null, \"kubelet_args\":{}, \"upgrade_policy\":{\"max_unavailable\":1, \"max_surge\":0}, \"zone\":\"fr-par-1\", \"root_volume_type\":\"sbs_5k\", \"root_volume_size\":20000000000, \"public_ip_disabled\":false, \"new_images_enabled\":true, \"security_group_id\":\"4ef16f7a-478c-4b72-b932-982f4b04974b\"}"
-    headers:
-      Content-Length:
-      - "715"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:21 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 72e2d7d6-b055-4184-8885-561e31d4f7e0
-    status: 200 OK
-    code: 200
-    duration: 111.918562ms
-- id: 76
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/b0c262ac-e3c4-4a41-9b7c-fac43b180e81
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 715
-    body: "{\"region\":\"fr-par\", \"id\":\"b0c262ac-e3c4-4a41-9b7c-fac43b180e81\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:52:22.689840Z\", \"updated_at\":\"2025-10-30T16:54:20.584002Z\", \"name\":\"test-pool-wait-2\", \"status\":\"ready\", \"version\":\"1.34.1\", \"node_type\":\"pro2_xxs\", \"autoscaling\":false, \"size\":2, \"min_size\":1, \"max_size\":2, \"container_runtime\":\"containerd\", \"autohealing\":false, \"tags\":[], \"placement_group_id\":null, \"kubelet_args\":{}, \"upgrade_policy\":{\"max_unavailable\":1, \"max_surge\":0}, \"zone\":\"fr-par-1\", \"root_volume_type\":\"sbs_5k\", \"root_volume_size\":20000000000, \"public_ip_disabled\":false, \"new_images_enabled\":true, \"security_group_id\":\"4ef16f7a-478c-4b72-b932-982f4b04974b\"}"
-    headers:
-      Content-Length:
-      - "715"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:21 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 4a1b4cfe-1e89-436e-941b-38e0700ea753
-    status: 200 OK
-    code: 200
-    duration: 92.919663ms
-- id: 77
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    form:
-      order_by:
-      - created_at_asc
-      page:
-      - "1"
-      pool_id:
-      - b0c262ac-e3c4-4a41-9b7c-fac43b180e81
-      status:
-      - unknown
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75/nodes?order_by=created_at_asc&page=1&pool_id=b0c262ac-e3c4-4a41-9b7c-fac43b180e81&status=unknown
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1240
-    body: "{\"total_count\":2, \"nodes\":[{\"region\":\"fr-par\", \"id\":\"803259ac-2333-4048-8fec-ae14c9eff6df\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:52:23.157062Z\", \"updated_at\":\"2025-10-30T16:54:20.566320Z\", \"pool_id\":\"b0c262ac-e3c4-4a41-9b7c-fac43b180e81\", \"status\":\"ready\", \"conditions\":{\"DiskPressure\":\"False\", \"MemoryPressure\":\"False\", \"NetworkUnavailable\":\"False\", \"PIDPressure\":\"False\", \"Ready\":\"True\"}, \"name\":\"scw-test-pool-wait-test-pool-wait-2-803259ac23\", \"public_ip_v4\":\"51.158.65.45\", \"public_ip_v6\":null, \"provider_id\":\"scaleway://instance/fr-par-1/f94c2846-a5e6-44e2-823b-e4da6094250f\", \"error_message\":\"\"}, {\"region\":\"fr-par\", \"id\":\"0e5eed3b-53a4-46b8-9d82-8868a450287f\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:53:15.555152Z\", \"updated_at\":\"2025-10-30T16:54:20.575106Z\", \"pool_id\":\"b0c262ac-e3c4-4a41-9b7c-fac43b180e81\", \"status\":\"ready\", \"conditions\":{\"DiskPressure\":\"False\", \"MemoryPressure\":\"False\", \"PIDPressure\":\"False\", \"Ready\":\"True\"}, \"name\":\"scw-test-pool-wait-test-pool-wait-2-0e5eed3b53\", \"public_ip_v4\":\"51.158.76.222\", \"public_ip_v6\":null, \"provider_id\":\"scaleway://instance/fr-par-1/4af5920e-5aa3-4430-89d0-50a5680db098\", \"error_message\":\"\"}]}"
-    headers:
-      Content-Length:
-      - "1240"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:21 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - ca941c07-f468-4cb4-a5bb-59103b1e1c1e
-    status: 200 OK
-    code: 200
-    duration: 24.774919ms
-- id: 78
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1630
-    body: "{\"region\":\"fr-par\", \"id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:01.607119Z\", \"updated_at\":\"2025-10-30T16:50:36.155897Z\", \"type\":\"kapsule\", \"name\":\"test-pool-wait\", \"description\":\"\", \"status\":\"ready\", \"version\":\"1.34.1\", \"cni\":\"calico\", \"tags\":[\"terraform-test\", \"scaleway_k8s_cluster\", \"minimal\"], \"cluster_url\":\"https://5114e066-aa93-4560-9be0-5ae445715a75.api.k8s.fr-par.scw.cloud:6443\", \"dns_wildcard\":\"*.5114e066-aa93-4560-9be0-5ae445715a75.nodes.k8s.fr-par.scw.cloud\", \"autoscaler_config\":{\"scale_down_disabled\":false, \"scale_down_delay_after_add\":\"10m\", \"estimator\":\"binpacking\", \"expander\":\"random\", \"ignore_daemonsets_utilization\":false, \"balance_similar_node_groups\":false, \"expendable_pods_priority_cutoff\":0, \"scale_down_unneeded_time\":\"10m\", \"scale_down_utilization_threshold\":0.5, \"max_graceful_termination_sec\":0}, \"auto_upgrade\":{\"enabled\":false, \"maintenance_window\":{\"start_hour\":0, \"day\":\"any\"}}, \"upgrade_available\":false, \"feature_gates\":[], \"admission_plugins\":[], \"open_id_connect_config\":{\"issuer_url\":\"\", \"client_id\":\"\", \"username_claim\":\"\", \"username_prefix\":\"\", \"groups_claim\":[], \"groups_prefix\":\"\", \"required_claim\":[]}, \"apiserver_cert_sans\":[], \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"commitment_ends_at\":\"2025-10-30T16:49:01.607128Z\", \"acl_available\":true, \"iam_nodes_group_id\":\"6c8f211e-8819-44e2-93ca-fda367c9ca2a\", \"new_images_enabled\":true, \"pod_cidr\":\"100.64.0.0/15\", \"service_cidr\":\"10.32.0.0/20\", \"service_dns_ip\":\"10.32.0.10\"}"
-    headers:
-      Content-Length:
-      - "1630"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:21 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 743124a5-5cb9-4d93-a1a1-c9a11f281ae1
-    status: 200 OK
-    code: 200
-    duration: 21.32892ms
-- id: 79
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    form:
-      order_by:
-      - created_at_desc
-      project_id:
-      - 105bdce1-64c0-48ab-899d-868455867ecf
-      resource_name:
-      - scw-test-pool-wait-test-pool-wait-2-803259ac23
-      resource_type:
-      - unknown_type
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=105bdce1-64c0-48ab-899d-868455867ecf&resource_name=scw-test-pool-wait-test-pool-wait-2-803259ac23&resource_type=unknown_type
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1122
-    body: "{\"total_count\":2, \"ips\":[{\"id\":\"35d11f02-76e3-4fe4-a39b-c2df537169d7\", \"address\":\"fd5f:519c:6d46:90dd:ab00:4e62:584d:4783/64\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_ipv6\":true, \"created_at\":\"2025-10-30T16:52:26.776899Z\", \"updated_at\":\"2025-10-30T16:52:26.776899Z\", \"source\":{\"subnet_id\":\"7493d1b7-5773-41c2-be8c-52e4ec098fc3\"}, \"resource\":{\"type\":\"instance_private_nic\", \"id\":\"6f4c43ec-ff56-4721-ab5d-fdf2a12b8f2e\", \"mac_address\":\"02:00:00:12:65:C5\", \"name\":\"scw-test-pool-wait-test-pool-wait-2-803259ac23\"}, \"tags\":[], \"reverses\":[], \"region\":\"fr-par\", \"zone\":null}, {\"id\":\"878dc0d8-d3e7-4ab9-b890-f5352063637c\", \"address\":\"172.18.20.4/22\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_ipv6\":false, \"created_at\":\"2025-10-30T16:52:26.654069Z\", \"updated_at\":\"2025-10-30T16:52:26.654069Z\", \"source\":{\"subnet_id\":\"da10d014-609b-48cc-9b9a-437dc31f4497\"}, \"resource\":{\"type\":\"instance_private_nic\", \"id\":\"6f4c43ec-ff56-4721-ab5d-fdf2a12b8f2e\", \"mac_address\":\"02:00:00:12:65:C5\", \"name\":\"scw-test-pool-wait-test-pool-wait-2-803259ac23\"}, \"tags\":[], \"reverses\":[], \"region\":\"fr-par\", \"zone\":null}]}"
-    headers:
-      Content-Length:
-      - "1122"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:22 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 7d0a0533-40b1-453a-8215-2ff52918a46d
-    status: 200 OK
-    code: 200
-    duration: 154.323428ms
-- id: 80
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    form:
-      order_by:
-      - created_at_desc
-      project_id:
-      - 105bdce1-64c0-48ab-899d-868455867ecf
-      resource_name:
-      - scw-test-pool-wait-test-pool-wait-2-0e5eed3b53
-      resource_type:
-      - unknown_type
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=105bdce1-64c0-48ab-899d-868455867ecf&resource_name=scw-test-pool-wait-test-pool-wait-2-0e5eed3b53&resource_type=unknown_type
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1122
-    body: "{\"total_count\":2, \"ips\":[{\"id\":\"7e596df6-23ea-4a18-b40b-b04b6889b127\", \"address\":\"fd5f:519c:6d46:90dd:3968:9265:e922:7e76/64\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_ipv6\":true, \"created_at\":\"2025-10-30T16:53:19.349027Z\", \"updated_at\":\"2025-10-30T16:53:19.349027Z\", \"source\":{\"subnet_id\":\"7493d1b7-5773-41c2-be8c-52e4ec098fc3\"}, \"resource\":{\"type\":\"instance_private_nic\", \"id\":\"a3a5b239-815d-4735-b92e-16372f9e8741\", \"mac_address\":\"02:00:00:12:2E:F6\", \"name\":\"scw-test-pool-wait-test-pool-wait-2-0e5eed3b53\"}, \"tags\":[], \"reverses\":[], \"region\":\"fr-par\", \"zone\":null}, {\"id\":\"41cfcea9-5c9f-48bf-af2e-a1fe51acece8\", \"address\":\"172.18.20.5/22\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_ipv6\":false, \"created_at\":\"2025-10-30T16:53:19.175416Z\", \"updated_at\":\"2025-10-30T16:53:19.175416Z\", \"source\":{\"subnet_id\":\"da10d014-609b-48cc-9b9a-437dc31f4497\"}, \"resource\":{\"type\":\"instance_private_nic\", \"id\":\"a3a5b239-815d-4735-b92e-16372f9e8741\", \"mac_address\":\"02:00:00:12:2E:F6\", \"name\":\"scw-test-pool-wait-test-pool-wait-2-0e5eed3b53\"}, \"tags\":[], \"reverses\":[], \"region\":\"fr-par\", \"zone\":null}]}"
-    headers:
-      Content-Length:
-      - "1122"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:22 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 8df217e5-e786-400d-ad0d-5733400b39de
-    status: 200 OK
-    code: 200
-    duration: 99.691524ms
-- id: 81
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1630
-    body: "{\"region\":\"fr-par\", \"id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:01.607119Z\", \"updated_at\":\"2025-10-30T16:50:36.155897Z\", \"type\":\"kapsule\", \"name\":\"test-pool-wait\", \"description\":\"\", \"status\":\"ready\", \"version\":\"1.34.1\", \"cni\":\"calico\", \"tags\":[\"terraform-test\", \"scaleway_k8s_cluster\", \"minimal\"], \"cluster_url\":\"https://5114e066-aa93-4560-9be0-5ae445715a75.api.k8s.fr-par.scw.cloud:6443\", \"dns_wildcard\":\"*.5114e066-aa93-4560-9be0-5ae445715a75.nodes.k8s.fr-par.scw.cloud\", \"autoscaler_config\":{\"scale_down_disabled\":false, \"scale_down_delay_after_add\":\"10m\", \"estimator\":\"binpacking\", \"expander\":\"random\", \"ignore_daemonsets_utilization\":false, \"balance_similar_node_groups\":false, \"expendable_pods_priority_cutoff\":0, \"scale_down_unneeded_time\":\"10m\", \"scale_down_utilization_threshold\":0.5, \"max_graceful_termination_sec\":0}, \"auto_upgrade\":{\"enabled\":false, \"maintenance_window\":{\"start_hour\":0, \"day\":\"any\"}}, \"upgrade_available\":false, \"feature_gates\":[], \"admission_plugins\":[], \"open_id_connect_config\":{\"issuer_url\":\"\", \"client_id\":\"\", \"username_claim\":\"\", \"username_prefix\":\"\", \"groups_claim\":[], \"groups_prefix\":\"\", \"required_claim\":[]}, \"apiserver_cert_sans\":[], \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"commitment_ends_at\":\"2025-10-30T16:49:01.607128Z\", \"acl_available\":true, \"iam_nodes_group_id\":\"6c8f211e-8819-44e2-93ca-fda367c9ca2a\", \"new_images_enabled\":true, \"pod_cidr\":\"100.64.0.0/15\", \"service_cidr\":\"10.32.0.0/20\", \"service_dns_ip\":\"10.32.0.10\"}"
-    headers:
-      Content-Length:
-      - "1630"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:22 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - efd2f8f2-5ddb-47c3-b97c-3d57e6c8d39d
-    status: 200 OK
-    code: 200
-    duration: 24.135157ms
-- id: 82
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/b0c262ac-e3c4-4a41-9b7c-fac43b180e81
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 715
-    body: "{\"region\":\"fr-par\", \"id\":\"b0c262ac-e3c4-4a41-9b7c-fac43b180e81\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:52:22.689840Z\", \"updated_at\":\"2025-10-30T16:54:20.584002Z\", \"name\":\"test-pool-wait-2\", \"status\":\"ready\", \"version\":\"1.34.1\", \"node_type\":\"pro2_xxs\", \"autoscaling\":false, \"size\":2, \"min_size\":1, \"max_size\":2, \"container_runtime\":\"containerd\", \"autohealing\":false, \"tags\":[], \"placement_group_id\":null, \"kubelet_args\":{}, \"upgrade_policy\":{\"max_unavailable\":1, \"max_surge\":0}, \"zone\":\"fr-par-1\", \"root_volume_type\":\"sbs_5k\", \"root_volume_size\":20000000000, \"public_ip_disabled\":false, \"new_images_enabled\":true, \"security_group_id\":\"4ef16f7a-478c-4b72-b932-982f4b04974b\"}"
-    headers:
-      Content-Length:
-      - "715"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:22 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - b9a2e253-5dd0-4b43-8004-7d5d2b1ee3ee
-    status: 200 OK
-    code: 200
-    duration: 19.555151ms
-- id: 83
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/1a7a1e1e-2b33-478e-8f1a-faa0303a1c43
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 419
-    body: "{\"id\":\"1a7a1e1e-2b33-478e-8f1a-faa0303a1c43\", \"name\":\"tf-vpc-confident-bose\", \"tags\":[], \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:00.136298Z\", \"updated_at\":\"2025-10-30T16:49:00.136298Z\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_default\":false, \"private_network_count\":1, \"routing_enabled\":true, \"custom_routes_propagation_enabled\":true, \"region\":\"fr-par\"}"
-    headers:
-      Content-Length:
-      - "419"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:22 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 9a1197b1-9dbc-472c-b2b8-44f62bb0ab00
-    status: 200 OK
-    code: 200
-    duration: 28.682713ms
-- id: 84
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/363e7214-8a98-40d0-9357-9e4026c21b76
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1084
-    body: "{\"id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"name\":\"test-pool-wait\", \"tags\":[], \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:00.384609Z\", \"updated_at\":\"2025-10-30T16:49:00.384609Z\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"subnets\":[{\"id\":\"da10d014-609b-48cc-9b9a-437dc31f4497\", \"created_at\":\"2025-10-30T16:49:00.384609Z\", \"updated_at\":\"2025-10-30T16:49:00.384609Z\", \"subnet\":\"172.18.20.0/22\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"vpc_id\":\"1a7a1e1e-2b33-478e-8f1a-faa0303a1c43\"}, {\"id\":\"7493d1b7-5773-41c2-be8c-52e4ec098fc3\", \"created_at\":\"2025-10-30T16:49:00.384609Z\", \"updated_at\":\"2025-10-30T16:49:00.384609Z\", \"subnet\":\"fd5f:519c:6d46:90dd::/64\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"vpc_id\":\"1a7a1e1e-2b33-478e-8f1a-faa0303a1c43\"}], \"vpc_id\":\"1a7a1e1e-2b33-478e-8f1a-faa0303a1c43\", \"dhcp_enabled\":true, \"default_route_propagation_enabled\":false, \"region\":\"fr-par\"}"
-    headers:
-      Content-Length:
-      - "1084"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:22 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - bca19546-c387-471d-aefd-70c374c04fa0
-    status: 200 OK
-    code: 200
-    duration: 24.988769ms
-- id: 85
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1630
-    body: "{\"region\":\"fr-par\", \"id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:01.607119Z\", \"updated_at\":\"2025-10-30T16:50:36.155897Z\", \"type\":\"kapsule\", \"name\":\"test-pool-wait\", \"description\":\"\", \"status\":\"ready\", \"version\":\"1.34.1\", \"cni\":\"calico\", \"tags\":[\"terraform-test\", \"scaleway_k8s_cluster\", \"minimal\"], \"cluster_url\":\"https://5114e066-aa93-4560-9be0-5ae445715a75.api.k8s.fr-par.scw.cloud:6443\", \"dns_wildcard\":\"*.5114e066-aa93-4560-9be0-5ae445715a75.nodes.k8s.fr-par.scw.cloud\", \"autoscaler_config\":{\"scale_down_disabled\":false, \"scale_down_delay_after_add\":\"10m\", \"estimator\":\"binpacking\", \"expander\":\"random\", \"ignore_daemonsets_utilization\":false, \"balance_similar_node_groups\":false, \"expendable_pods_priority_cutoff\":0, \"scale_down_unneeded_time\":\"10m\", \"scale_down_utilization_threshold\":0.5, \"max_graceful_termination_sec\":0}, \"auto_upgrade\":{\"enabled\":false, \"maintenance_window\":{\"start_hour\":0, \"day\":\"any\"}}, \"upgrade_available\":false, \"feature_gates\":[], \"admission_plugins\":[], \"open_id_connect_config\":{\"issuer_url\":\"\", \"client_id\":\"\", \"username_claim\":\"\", \"username_prefix\":\"\", \"groups_claim\":[], \"groups_prefix\":\"\", \"required_claim\":[]}, \"apiserver_cert_sans\":[], \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"commitment_ends_at\":\"2025-10-30T16:49:01.607128Z\", \"acl_available\":true, \"iam_nodes_group_id\":\"6c8f211e-8819-44e2-93ca-fda367c9ca2a\", \"new_images_enabled\":true, \"pod_cidr\":\"100.64.0.0/15\", \"service_cidr\":\"10.32.0.0/20\", \"service_dns_ip\":\"10.32.0.10\"}"
-    headers:
-      Content-Length:
-      - "1630"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:22 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 40564288-995b-4ddc-9504-d04ec08f5b0a
-    status: 200 OK
-    code: 200
-    duration: 21.121401ms
-- id: 86
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75/kubeconfig
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1654
-    body: "{\"name\":\"kubeconfig\", \"content_type\":\"application/octet-stream\", \"content\":\"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVSllSRU5EUVZGSFowRjNTVUpCWjBsQ1FVUkJTMEpuWjNGb2EycFBVRkZSUkVGcVFWWk5VazEzUlZGWlJGWlJVVVJGZDNCeVpGZEtiR050Tld3S1pFZFdlazFDTkZoRVZFa3hUVlJCZVU5VVJUSk9SR3QzVFZadldFUlVUVEZOVkVGNVQxUkZNazVFYTNkTlZtOTNSbFJGVkUxQ1JVZEJNVlZGUVhoTlN3cGhNMVpwV2xoS2RWcFlVbXhqZWtKYVRVSk5SMEo1Y1VkVFRUUTVRV2RGUjBORGNVZFRUVFE1UVhkRlNFRXdTVUZDVFhsNllqUkdTbVozWTFOM01tZEZDbEppVFRkVFZpOUpiM0ZXU21oWWVIbGxObHB1UkZOWlZ6WmxRbU4yV2tJM1RXVnVMMWxPYm5wM2F6QkpRazF2VDFkUFRXeHRlVGxJWVU5NE1XVkxaSFlLTUVRNE9XZDVZV3BSYWtKQlRVRTBSMEV4VldSRWQwVkNMM2RSUlVGM1NVTndSRUZRUW1kT1ZraFNUVUpCWmpoRlFsUkJSRUZSU0M5TlFqQkhRVEZWWkFwRVoxRlhRa0pTVTFsU1NtTm9UV1l3V0U5YWNtUkJhV1JMYkdOUWEyTklZeTlVUVV0Q1oyZHhhR3RxVDFCUlVVUkJaMDVLUVVSQ1IwRnBSVUY1Ym0xd0NqbFpkWG80VWpGVWFtNDBiV2RqYWpaV2QycFVTM2gzUm5KS1VrdFZTVVpIUTFwR2VsbEtWVU5KVVVSSWRERkNXalpHYUZrdlVUWlRabloxTVhCNmJEWUtNWG80VkhCMlNIQkxVa0pIY1RscmNVVlJOa3hPZHowOUNpMHRMUzB0UlU1RUlFTkZVbFJKUmtsRFFWUkZMUzB0TFMwSwogICAgc2VydmVyOiBodHRwczovLzUxMTRlMDY2LWFhOTMtNDU2MC05YmUwLTVhZTQ0NTcxNWE3NS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wtd2FpdAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXdhaXQiCiAgICB1c2VyOiB0ZXN0LXBvb2wtd2FpdC1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC13YWl0CmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXdhaXQtYWRtaW4KICB1c2VyOgogICAgdG9rZW46IGttQTQ5c2F6N1V4dVJSOHZ1UzIxMWpxN2NzVzNobFF1QzQ3QjRla3BobjE3UXBMcVRiVGJGelVO\"}"
-    headers:
-      Content-Length:
-      - "1654"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:22 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 3d3f7c47-d7d9-49d8-9cbe-5ef2dd371582
-    status: 200 OK
-    code: 200
-    duration: 85.924115ms
-- id: 87
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/b0c262ac-e3c4-4a41-9b7c-fac43b180e81
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 715
-    body: "{\"region\":\"fr-par\", \"id\":\"b0c262ac-e3c4-4a41-9b7c-fac43b180e81\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:52:22.689840Z\", \"updated_at\":\"2025-10-30T16:54:20.584002Z\", \"name\":\"test-pool-wait-2\", \"status\":\"ready\", \"version\":\"1.34.1\", \"node_type\":\"pro2_xxs\", \"autoscaling\":false, \"size\":2, \"min_size\":1, \"max_size\":2, \"container_runtime\":\"containerd\", \"autohealing\":false, \"tags\":[], \"placement_group_id\":null, \"kubelet_args\":{}, \"upgrade_policy\":{\"max_unavailable\":1, \"max_surge\":0}, \"zone\":\"fr-par-1\", \"root_volume_type\":\"sbs_5k\", \"root_volume_size\":20000000000, \"public_ip_disabled\":false, \"new_images_enabled\":true, \"security_group_id\":\"4ef16f7a-478c-4b72-b932-982f4b04974b\"}"
-    headers:
-      Content-Length:
-      - "715"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:22 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 622853a1-a65b-420e-b654-b869ea2150e1
-    status: 200 OK
-    code: 200
-    duration: 21.270992ms
-- id: 88
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/034a502a-1d52-470d-84bd-4a8edd935ba3
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 713
-    body: "{\"region\":\"fr-par\", \"id\":\"034a502a-1d52-470d-84bd-4a8edd935ba3\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:49:07.243810Z\", \"updated_at\":\"2025-10-30T16:52:20.261969Z\", \"name\":\"test-pool-wait\", \"status\":\"ready\", \"version\":\"1.34.1\", \"node_type\":\"pro2_xxs\", \"autoscaling\":false, \"size\":1, \"min_size\":1, \"max_size\":1, \"container_runtime\":\"containerd\", \"autohealing\":false, \"tags\":[], \"placement_group_id\":null, \"kubelet_args\":{}, \"upgrade_policy\":{\"max_unavailable\":1, \"max_surge\":0}, \"zone\":\"fr-par-1\", \"root_volume_type\":\"sbs_5k\", \"root_volume_size\":20000000000, \"public_ip_disabled\":false, \"new_images_enabled\":true, \"security_group_id\":\"4ef16f7a-478c-4b72-b932-982f4b04974b\"}"
-    headers:
-      Content-Length:
-      - "713"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:22 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - dfe724f7-0448-4864-ada4-2984c44e7cc5
-    status: 200 OK
-    code: 200
-    duration: 22.742153ms
-- id: 89
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    form:
-      order_by:
-      - created_at_asc
-      page:
-      - "1"
-      pool_id:
-      - 034a502a-1d52-470d-84bd-4a8edd935ba3
-      status:
-      - unknown
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75/nodes?order_by=created_at_asc&page=1&pool_id=034a502a-1d52-470d-84bd-4a8edd935ba3&status=unknown
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 648
-    body: "{\"total_count\":1, \"nodes\":[{\"region\":\"fr-par\", \"id\":\"3e073c76-a98f-4e6b-ad3c-7a6ca77e15fd\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:51:15.736647Z\", \"updated_at\":\"2025-10-30T16:54:20.551105Z\", \"pool_id\":\"034a502a-1d52-470d-84bd-4a8edd935ba3\", \"status\":\"ready\", \"conditions\":{\"DiskPressure\":\"False\", \"MemoryPressure\":\"False\", \"NetworkUnavailable\":\"False\", \"PIDPressure\":\"False\", \"Ready\":\"True\"}, \"name\":\"scw-test-pool-wait-test-pool-wait-3e073c76a98f\", \"public_ip_v4\":\"51.158.97.50\", \"public_ip_v6\":null, \"provider_id\":\"scaleway://instance/fr-par-1/6ba8f808-ce5f-4e0a-b30e-a83f7f79f945\", \"error_message\":\"\"}]}"
-    headers:
-      Content-Length:
-      - "648"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:22 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 364387e1-3fa3-4352-b28e-ebfa5efe6446
-    status: 200 OK
-    code: 200
-    duration: 25.399781ms
-- id: 90
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    form:
-      order_by:
-      - created_at_asc
-      page:
-      - "1"
-      pool_id:
-      - b0c262ac-e3c4-4a41-9b7c-fac43b180e81
-      status:
-      - unknown
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75/nodes?order_by=created_at_asc&page=1&pool_id=b0c262ac-e3c4-4a41-9b7c-fac43b180e81&status=unknown
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1240
-    body: "{\"total_count\":2, \"nodes\":[{\"region\":\"fr-par\", \"id\":\"803259ac-2333-4048-8fec-ae14c9eff6df\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:52:23.157062Z\", \"updated_at\":\"2025-10-30T16:54:20.566320Z\", \"pool_id\":\"b0c262ac-e3c4-4a41-9b7c-fac43b180e81\", \"status\":\"ready\", \"conditions\":{\"DiskPressure\":\"False\", \"MemoryPressure\":\"False\", \"NetworkUnavailable\":\"False\", \"PIDPressure\":\"False\", \"Ready\":\"True\"}, \"name\":\"scw-test-pool-wait-test-pool-wait-2-803259ac23\", \"public_ip_v4\":\"51.158.65.45\", \"public_ip_v6\":null, \"provider_id\":\"scaleway://instance/fr-par-1/f94c2846-a5e6-44e2-823b-e4da6094250f\", \"error_message\":\"\"}, {\"region\":\"fr-par\", \"id\":\"0e5eed3b-53a4-46b8-9d82-8868a450287f\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:53:15.555152Z\", \"updated_at\":\"2025-10-30T16:54:20.575106Z\", \"pool_id\":\"b0c262ac-e3c4-4a41-9b7c-fac43b180e81\", \"status\":\"ready\", \"conditions\":{\"DiskPressure\":\"False\", \"MemoryPressure\":\"False\", \"PIDPressure\":\"False\", \"Ready\":\"True\"}, \"name\":\"scw-test-pool-wait-test-pool-wait-2-0e5eed3b53\", \"public_ip_v4\":\"51.158.76.222\", \"public_ip_v6\":null, \"provider_id\":\"scaleway://instance/fr-par-1/4af5920e-5aa3-4430-89d0-50a5680db098\", \"error_message\":\"\"}]}"
-    headers:
-      Content-Length:
-      - "1240"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:22 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 84fe55d1-8d76-47d5-a27d-2569d6e2b785
-    status: 200 OK
-    code: 200
-    duration: 36.517447ms
-- id: 91
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1630
-    body: "{\"region\":\"fr-par\", \"id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:01.607119Z\", \"updated_at\":\"2025-10-30T16:50:36.155897Z\", \"type\":\"kapsule\", \"name\":\"test-pool-wait\", \"description\":\"\", \"status\":\"ready\", \"version\":\"1.34.1\", \"cni\":\"calico\", \"tags\":[\"terraform-test\", \"scaleway_k8s_cluster\", \"minimal\"], \"cluster_url\":\"https://5114e066-aa93-4560-9be0-5ae445715a75.api.k8s.fr-par.scw.cloud:6443\", \"dns_wildcard\":\"*.5114e066-aa93-4560-9be0-5ae445715a75.nodes.k8s.fr-par.scw.cloud\", \"autoscaler_config\":{\"scale_down_disabled\":false, \"scale_down_delay_after_add\":\"10m\", \"estimator\":\"binpacking\", \"expander\":\"random\", \"ignore_daemonsets_utilization\":false, \"balance_similar_node_groups\":false, \"expendable_pods_priority_cutoff\":0, \"scale_down_unneeded_time\":\"10m\", \"scale_down_utilization_threshold\":0.5, \"max_graceful_termination_sec\":0}, \"auto_upgrade\":{\"enabled\":false, \"maintenance_window\":{\"start_hour\":0, \"day\":\"any\"}}, \"upgrade_available\":false, \"feature_gates\":[], \"admission_plugins\":[], \"open_id_connect_config\":{\"issuer_url\":\"\", \"client_id\":\"\", \"username_claim\":\"\", \"username_prefix\":\"\", \"groups_claim\":[], \"groups_prefix\":\"\", \"required_claim\":[]}, \"apiserver_cert_sans\":[], \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"commitment_ends_at\":\"2025-10-30T16:49:01.607128Z\", \"acl_available\":true, \"iam_nodes_group_id\":\"6c8f211e-8819-44e2-93ca-fda367c9ca2a\", \"new_images_enabled\":true, \"pod_cidr\":\"100.64.0.0/15\", \"service_cidr\":\"10.32.0.0/20\", \"service_dns_ip\":\"10.32.0.10\"}"
-    headers:
-      Content-Length:
-      - "1630"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:22 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - d68f0198-73b5-4860-9c13-97f971b0b7d4
-    status: 200 OK
-    code: 200
-    duration: 23.802533ms
-- id: 92
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1630
-    body: "{\"region\":\"fr-par\", \"id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:01.607119Z\", \"updated_at\":\"2025-10-30T16:50:36.155897Z\", \"type\":\"kapsule\", \"name\":\"test-pool-wait\", \"description\":\"\", \"status\":\"ready\", \"version\":\"1.34.1\", \"cni\":\"calico\", \"tags\":[\"terraform-test\", \"scaleway_k8s_cluster\", \"minimal\"], \"cluster_url\":\"https://5114e066-aa93-4560-9be0-5ae445715a75.api.k8s.fr-par.scw.cloud:6443\", \"dns_wildcard\":\"*.5114e066-aa93-4560-9be0-5ae445715a75.nodes.k8s.fr-par.scw.cloud\", \"autoscaler_config\":{\"scale_down_disabled\":false, \"scale_down_delay_after_add\":\"10m\", \"estimator\":\"binpacking\", \"expander\":\"random\", \"ignore_daemonsets_utilization\":false, \"balance_similar_node_groups\":false, \"expendable_pods_priority_cutoff\":0, \"scale_down_unneeded_time\":\"10m\", \"scale_down_utilization_threshold\":0.5, \"max_graceful_termination_sec\":0}, \"auto_upgrade\":{\"enabled\":false, \"maintenance_window\":{\"start_hour\":0, \"day\":\"any\"}}, \"upgrade_available\":false, \"feature_gates\":[], \"admission_plugins\":[], \"open_id_connect_config\":{\"issuer_url\":\"\", \"client_id\":\"\", \"username_claim\":\"\", \"username_prefix\":\"\", \"groups_claim\":[], \"groups_prefix\":\"\", \"required_claim\":[]}, \"apiserver_cert_sans\":[], \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"commitment_ends_at\":\"2025-10-30T16:49:01.607128Z\", \"acl_available\":true, \"iam_nodes_group_id\":\"6c8f211e-8819-44e2-93ca-fda367c9ca2a\", \"new_images_enabled\":true, \"pod_cidr\":\"100.64.0.0/15\", \"service_cidr\":\"10.32.0.0/20\", \"service_dns_ip\":\"10.32.0.10\"}"
-    headers:
-      Content-Length:
-      - "1630"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:22 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - aab6f3f2-ee38-470d-b3a0-b31cd7ec6a5b
-    status: 200 OK
-    code: 200
-    duration: 20.879387ms
-- id: 93
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    form:
-      order_by:
-      - created_at_desc
-      project_id:
-      - 105bdce1-64c0-48ab-899d-868455867ecf
-      resource_name:
-      - scw-test-pool-wait-test-pool-wait-3e073c76a98f
-      resource_type:
-      - unknown_type
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=105bdce1-64c0-48ab-899d-868455867ecf&resource_name=scw-test-pool-wait-test-pool-wait-3e073c76a98f&resource_type=unknown_type
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1122
-    body: "{\"total_count\":2, \"ips\":[{\"id\":\"54c6f7a2-4ca0-43bb-bc9a-b4a3905c0487\", \"address\":\"fd5f:519c:6d46:90dd:c183:ab7b:59b9:fc92/64\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_ipv6\":true, \"created_at\":\"2025-10-30T16:51:19.698188Z\", \"updated_at\":\"2025-10-30T16:51:19.698188Z\", \"source\":{\"subnet_id\":\"7493d1b7-5773-41c2-be8c-52e4ec098fc3\"}, \"resource\":{\"type\":\"instance_private_nic\", \"id\":\"45715cb9-7532-4c78-93a4-2fef3fa3b71a\", \"mac_address\":\"02:00:00:1D:E4:BA\", \"name\":\"scw-test-pool-wait-test-pool-wait-3e073c76a98f\"}, \"tags\":[], \"reverses\":[], \"region\":\"fr-par\", \"zone\":null}, {\"id\":\"ddc7378f-48eb-4ae3-af3e-4d5ee60054c4\", \"address\":\"172.18.20.3/22\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_ipv6\":false, \"created_at\":\"2025-10-30T16:51:19.565119Z\", \"updated_at\":\"2025-10-30T16:51:19.565119Z\", \"source\":{\"subnet_id\":\"da10d014-609b-48cc-9b9a-437dc31f4497\"}, \"resource\":{\"type\":\"instance_private_nic\", \"id\":\"45715cb9-7532-4c78-93a4-2fef3fa3b71a\", \"mac_address\":\"02:00:00:1D:E4:BA\", \"name\":\"scw-test-pool-wait-test-pool-wait-3e073c76a98f\"}, \"tags\":[], \"reverses\":[], \"region\":\"fr-par\", \"zone\":null}]}"
-    headers:
-      Content-Length:
-      - "1122"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:22 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - d25126bc-07ab-44f3-92d5-d78bff74fa9e
-    status: 200 OK
-    code: 200
-    duration: 32.80508ms
-- id: 94
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    form:
-      order_by:
-      - created_at_desc
-      project_id:
-      - 105bdce1-64c0-48ab-899d-868455867ecf
-      resource_name:
-      - scw-test-pool-wait-test-pool-wait-2-803259ac23
-      resource_type:
-      - unknown_type
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=105bdce1-64c0-48ab-899d-868455867ecf&resource_name=scw-test-pool-wait-test-pool-wait-2-803259ac23&resource_type=unknown_type
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1122
-    body: "{\"total_count\":2, \"ips\":[{\"id\":\"35d11f02-76e3-4fe4-a39b-c2df537169d7\", \"address\":\"fd5f:519c:6d46:90dd:ab00:4e62:584d:4783/64\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_ipv6\":true, \"created_at\":\"2025-10-30T16:52:26.776899Z\", \"updated_at\":\"2025-10-30T16:52:26.776899Z\", \"source\":{\"subnet_id\":\"7493d1b7-5773-41c2-be8c-52e4ec098fc3\"}, \"resource\":{\"type\":\"instance_private_nic\", \"id\":\"6f4c43ec-ff56-4721-ab5d-fdf2a12b8f2e\", \"mac_address\":\"02:00:00:12:65:C5\", \"name\":\"scw-test-pool-wait-test-pool-wait-2-803259ac23\"}, \"tags\":[], \"reverses\":[], \"region\":\"fr-par\", \"zone\":null}, {\"id\":\"878dc0d8-d3e7-4ab9-b890-f5352063637c\", \"address\":\"172.18.20.4/22\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_ipv6\":false, \"created_at\":\"2025-10-30T16:52:26.654069Z\", \"updated_at\":\"2025-10-30T16:52:26.654069Z\", \"source\":{\"subnet_id\":\"da10d014-609b-48cc-9b9a-437dc31f4497\"}, \"resource\":{\"type\":\"instance_private_nic\", \"id\":\"6f4c43ec-ff56-4721-ab5d-fdf2a12b8f2e\", \"mac_address\":\"02:00:00:12:65:C5\", \"name\":\"scw-test-pool-wait-test-pool-wait-2-803259ac23\"}, \"tags\":[], \"reverses\":[], \"region\":\"fr-par\", \"zone\":null}]}"
-    headers:
-      Content-Length:
-      - "1122"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:22 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - c1114941-6d4b-47ca-a070-37f6fcf540ac
-    status: 200 OK
-    code: 200
-    duration: 32.854402ms
-- id: 95
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    form:
-      order_by:
-      - created_at_desc
-      project_id:
-      - 105bdce1-64c0-48ab-899d-868455867ecf
-      resource_name:
-      - scw-test-pool-wait-test-pool-wait-2-0e5eed3b53
-      resource_type:
-      - unknown_type
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=105bdce1-64c0-48ab-899d-868455867ecf&resource_name=scw-test-pool-wait-test-pool-wait-2-0e5eed3b53&resource_type=unknown_type
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1122
-    body: "{\"total_count\":2, \"ips\":[{\"id\":\"7e596df6-23ea-4a18-b40b-b04b6889b127\", \"address\":\"fd5f:519c:6d46:90dd:3968:9265:e922:7e76/64\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_ipv6\":true, \"created_at\":\"2025-10-30T16:53:19.349027Z\", \"updated_at\":\"2025-10-30T16:53:19.349027Z\", \"source\":{\"subnet_id\":\"7493d1b7-5773-41c2-be8c-52e4ec098fc3\"}, \"resource\":{\"type\":\"instance_private_nic\", \"id\":\"a3a5b239-815d-4735-b92e-16372f9e8741\", \"mac_address\":\"02:00:00:12:2E:F6\", \"name\":\"scw-test-pool-wait-test-pool-wait-2-0e5eed3b53\"}, \"tags\":[], \"reverses\":[], \"region\":\"fr-par\", \"zone\":null}, {\"id\":\"41cfcea9-5c9f-48bf-af2e-a1fe51acece8\", \"address\":\"172.18.20.5/22\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_ipv6\":false, \"created_at\":\"2025-10-30T16:53:19.175416Z\", \"updated_at\":\"2025-10-30T16:53:19.175416Z\", \"source\":{\"subnet_id\":\"da10d014-609b-48cc-9b9a-437dc31f4497\"}, \"resource\":{\"type\":\"instance_private_nic\", \"id\":\"a3a5b239-815d-4735-b92e-16372f9e8741\", \"mac_address\":\"02:00:00:12:2E:F6\", \"name\":\"scw-test-pool-wait-test-pool-wait-2-0e5eed3b53\"}, \"tags\":[], \"reverses\":[], \"region\":\"fr-par\", \"zone\":null}]}"
-    headers:
-      Content-Length:
-      - "1122"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:22 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 24d5c5f4-f147-41ca-81a9-5cac5b3cdbb4
-    status: 200 OK
-    code: 200
-    duration: 35.400921ms
-- id: 96
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/1a7a1e1e-2b33-478e-8f1a-faa0303a1c43
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 419
-    body: "{\"id\":\"1a7a1e1e-2b33-478e-8f1a-faa0303a1c43\", \"name\":\"tf-vpc-confident-bose\", \"tags\":[], \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:00.136298Z\", \"updated_at\":\"2025-10-30T16:49:00.136298Z\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_default\":false, \"private_network_count\":1, \"routing_enabled\":true, \"custom_routes_propagation_enabled\":true, \"region\":\"fr-par\"}"
-    headers:
-      Content-Length:
-      - "419"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:23 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - d0dc9a20-c05a-4dff-aa54-17bb315c2e8f
-    status: 200 OK
-    code: 200
-    duration: 36.654173ms
-- id: 97
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/363e7214-8a98-40d0-9357-9e4026c21b76
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1084
-    body: "{\"id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"name\":\"test-pool-wait\", \"tags\":[], \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:00.384609Z\", \"updated_at\":\"2025-10-30T16:49:00.384609Z\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"subnets\":[{\"id\":\"da10d014-609b-48cc-9b9a-437dc31f4497\", \"created_at\":\"2025-10-30T16:49:00.384609Z\", \"updated_at\":\"2025-10-30T16:49:00.384609Z\", \"subnet\":\"172.18.20.0/22\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"vpc_id\":\"1a7a1e1e-2b33-478e-8f1a-faa0303a1c43\"}, {\"id\":\"7493d1b7-5773-41c2-be8c-52e4ec098fc3\", \"created_at\":\"2025-10-30T16:49:00.384609Z\", \"updated_at\":\"2025-10-30T16:49:00.384609Z\", \"subnet\":\"fd5f:519c:6d46:90dd::/64\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"vpc_id\":\"1a7a1e1e-2b33-478e-8f1a-faa0303a1c43\"}], \"vpc_id\":\"1a7a1e1e-2b33-478e-8f1a-faa0303a1c43\", \"dhcp_enabled\":true, \"default_route_propagation_enabled\":false, \"region\":\"fr-par\"}"
-    headers:
-      Content-Length:
-      - "1084"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:23 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - a389b905-63d7-4cc8-9f03-0de49412a19b
-    status: 200 OK
-    code: 200
-    duration: 34.312988ms
-- id: 98
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1630
-    body: "{\"region\":\"fr-par\", \"id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:01.607119Z\", \"updated_at\":\"2025-10-30T16:50:36.155897Z\", \"type\":\"kapsule\", \"name\":\"test-pool-wait\", \"description\":\"\", \"status\":\"ready\", \"version\":\"1.34.1\", \"cni\":\"calico\", \"tags\":[\"terraform-test\", \"scaleway_k8s_cluster\", \"minimal\"], \"cluster_url\":\"https://5114e066-aa93-4560-9be0-5ae445715a75.api.k8s.fr-par.scw.cloud:6443\", \"dns_wildcard\":\"*.5114e066-aa93-4560-9be0-5ae445715a75.nodes.k8s.fr-par.scw.cloud\", \"autoscaler_config\":{\"scale_down_disabled\":false, \"scale_down_delay_after_add\":\"10m\", \"estimator\":\"binpacking\", \"expander\":\"random\", \"ignore_daemonsets_utilization\":false, \"balance_similar_node_groups\":false, \"expendable_pods_priority_cutoff\":0, \"scale_down_unneeded_time\":\"10m\", \"scale_down_utilization_threshold\":0.5, \"max_graceful_termination_sec\":0}, \"auto_upgrade\":{\"enabled\":false, \"maintenance_window\":{\"start_hour\":0, \"day\":\"any\"}}, \"upgrade_available\":false, \"feature_gates\":[], \"admission_plugins\":[], \"open_id_connect_config\":{\"issuer_url\":\"\", \"client_id\":\"\", \"username_claim\":\"\", \"username_prefix\":\"\", \"groups_claim\":[], \"groups_prefix\":\"\", \"required_claim\":[]}, \"apiserver_cert_sans\":[], \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"commitment_ends_at\":\"2025-10-30T16:49:01.607128Z\", \"acl_available\":true, \"iam_nodes_group_id\":\"6c8f211e-8819-44e2-93ca-fda367c9ca2a\", \"new_images_enabled\":true, \"pod_cidr\":\"100.64.0.0/15\", \"service_cidr\":\"10.32.0.0/20\", \"service_dns_ip\":\"10.32.0.10\"}"
-    headers:
-      Content-Length:
-      - "1630"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:23 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 55c9f95c-f920-4b96-abdf-b4310e185611
-    status: 200 OK
-    code: 200
-    duration: 91.110249ms
-- id: 99
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75/kubeconfig
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1654
-    body: "{\"name\":\"kubeconfig\", \"content_type\":\"application/octet-stream\", \"content\":\"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVSllSRU5EUVZGSFowRjNTVUpCWjBsQ1FVUkJTMEpuWjNGb2EycFBVRkZSUkVGcVFWWk5VazEzUlZGWlJGWlJVVVJGZDNCeVpGZEtiR050Tld3S1pFZFdlazFDTkZoRVZFa3hUVlJCZVU5VVJUSk9SR3QzVFZadldFUlVUVEZOVkVGNVQxUkZNazVFYTNkTlZtOTNSbFJGVkUxQ1JVZEJNVlZGUVhoTlN3cGhNMVpwV2xoS2RWcFlVbXhqZWtKYVRVSk5SMEo1Y1VkVFRUUTVRV2RGUjBORGNVZFRUVFE1UVhkRlNFRXdTVUZDVFhsNllqUkdTbVozWTFOM01tZEZDbEppVFRkVFZpOUpiM0ZXU21oWWVIbGxObHB1UkZOWlZ6WmxRbU4yV2tJM1RXVnVMMWxPYm5wM2F6QkpRazF2VDFkUFRXeHRlVGxJWVU5NE1XVkxaSFlLTUVRNE9XZDVZV3BSYWtKQlRVRTBSMEV4VldSRWQwVkNMM2RSUlVGM1NVTndSRUZRUW1kT1ZraFNUVUpCWmpoRlFsUkJSRUZSU0M5TlFqQkhRVEZWWkFwRVoxRlhRa0pTVTFsU1NtTm9UV1l3V0U5YWNtUkJhV1JMYkdOUWEyTklZeTlVUVV0Q1oyZHhhR3RxVDFCUlVVUkJaMDVLUVVSQ1IwRnBSVUY1Ym0xd0NqbFpkWG80VWpGVWFtNDBiV2RqYWpaV2QycFVTM2gzUm5KS1VrdFZTVVpIUTFwR2VsbEtWVU5KVVVSSWRERkNXalpHYUZrdlVUWlRabloxTVhCNmJEWUtNWG80VkhCMlNIQkxVa0pIY1RscmNVVlJOa3hPZHowOUNpMHRMUzB0UlU1RUlFTkZVbFJKUmtsRFFWUkZMUzB0TFMwSwogICAgc2VydmVyOiBodHRwczovLzUxMTRlMDY2LWFhOTMtNDU2MC05YmUwLTVhZTQ0NTcxNWE3NS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wtd2FpdAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXdhaXQiCiAgICB1c2VyOiB0ZXN0LXBvb2wtd2FpdC1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC13YWl0CmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXdhaXQtYWRtaW4KICB1c2VyOgogICAgdG9rZW46IGttQTQ5c2F6N1V4dVJSOHZ1UzIxMWpxN2NzVzNobFF1QzQ3QjRla3BobjE3UXBMcVRiVGJGelVO\"}"
-    headers:
-      Content-Length:
-      - "1654"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:23 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 6d1852e9-0bc9-4f70-a526-d396122cb7cb
-    status: 200 OK
-    code: 200
-    duration: 82.675187ms
-- id: 100
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/b0c262ac-e3c4-4a41-9b7c-fac43b180e81
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 715
-    body: "{\"region\":\"fr-par\", \"id\":\"b0c262ac-e3c4-4a41-9b7c-fac43b180e81\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:52:22.689840Z\", \"updated_at\":\"2025-10-30T16:54:20.584002Z\", \"name\":\"test-pool-wait-2\", \"status\":\"ready\", \"version\":\"1.34.1\", \"node_type\":\"pro2_xxs\", \"autoscaling\":false, \"size\":2, \"min_size\":1, \"max_size\":2, \"container_runtime\":\"containerd\", \"autohealing\":false, \"tags\":[], \"placement_group_id\":null, \"kubelet_args\":{}, \"upgrade_policy\":{\"max_unavailable\":1, \"max_surge\":0}, \"zone\":\"fr-par-1\", \"root_volume_type\":\"sbs_5k\", \"root_volume_size\":20000000000, \"public_ip_disabled\":false, \"new_images_enabled\":true, \"security_group_id\":\"4ef16f7a-478c-4b72-b932-982f4b04974b\"}"
-    headers:
-      Content-Length:
-      - "715"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:23 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - b4159f89-c226-4314-b8ce-02d0c41a159b
-    status: 200 OK
-    code: 200
-    duration: 19.451537ms
-- id: 101
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/034a502a-1d52-470d-84bd-4a8edd935ba3
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 713
-    body: "{\"region\":\"fr-par\", \"id\":\"034a502a-1d52-470d-84bd-4a8edd935ba3\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:49:07.243810Z\", \"updated_at\":\"2025-10-30T16:52:20.261969Z\", \"name\":\"test-pool-wait\", \"status\":\"ready\", \"version\":\"1.34.1\", \"node_type\":\"pro2_xxs\", \"autoscaling\":false, \"size\":1, \"min_size\":1, \"max_size\":1, \"container_runtime\":\"containerd\", \"autohealing\":false, \"tags\":[], \"placement_group_id\":null, \"kubelet_args\":{}, \"upgrade_policy\":{\"max_unavailable\":1, \"max_surge\":0}, \"zone\":\"fr-par-1\", \"root_volume_type\":\"sbs_5k\", \"root_volume_size\":20000000000, \"public_ip_disabled\":false, \"new_images_enabled\":true, \"security_group_id\":\"4ef16f7a-478c-4b72-b932-982f4b04974b\"}"
-    headers:
-      Content-Length:
-      - "713"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:23 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 91f03531-413a-4bb6-8556-0a891ef8fbfd
-    status: 200 OK
-    code: 200
-    duration: 94.714502ms
-- id: 102
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    form:
-      order_by:
-      - created_at_asc
-      page:
-      - "1"
-      pool_id:
-      - b0c262ac-e3c4-4a41-9b7c-fac43b180e81
-      status:
-      - unknown
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75/nodes?order_by=created_at_asc&page=1&pool_id=b0c262ac-e3c4-4a41-9b7c-fac43b180e81&status=unknown
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1240
-    body: "{\"total_count\":2, \"nodes\":[{\"region\":\"fr-par\", \"id\":\"803259ac-2333-4048-8fec-ae14c9eff6df\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:52:23.157062Z\", \"updated_at\":\"2025-10-30T16:54:20.566320Z\", \"pool_id\":\"b0c262ac-e3c4-4a41-9b7c-fac43b180e81\", \"status\":\"ready\", \"conditions\":{\"DiskPressure\":\"False\", \"MemoryPressure\":\"False\", \"NetworkUnavailable\":\"False\", \"PIDPressure\":\"False\", \"Ready\":\"True\"}, \"name\":\"scw-test-pool-wait-test-pool-wait-2-803259ac23\", \"public_ip_v4\":\"51.158.65.45\", \"public_ip_v6\":null, \"provider_id\":\"scaleway://instance/fr-par-1/f94c2846-a5e6-44e2-823b-e4da6094250f\", \"error_message\":\"\"}, {\"region\":\"fr-par\", \"id\":\"0e5eed3b-53a4-46b8-9d82-8868a450287f\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:53:15.555152Z\", \"updated_at\":\"2025-10-30T16:54:20.575106Z\", \"pool_id\":\"b0c262ac-e3c4-4a41-9b7c-fac43b180e81\", \"status\":\"ready\", \"conditions\":{\"DiskPressure\":\"False\", \"MemoryPressure\":\"False\", \"PIDPressure\":\"False\", \"Ready\":\"True\"}, \"name\":\"scw-test-pool-wait-test-pool-wait-2-0e5eed3b53\", \"public_ip_v4\":\"51.158.76.222\", \"public_ip_v6\":null, \"provider_id\":\"scaleway://instance/fr-par-1/4af5920e-5aa3-4430-89d0-50a5680db098\", \"error_message\":\"\"}]}"
-    headers:
-      Content-Length:
-      - "1240"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:23 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 3f6170e1-0529-4f33-8abe-1d15d0b5a67a
-    status: 200 OK
-    code: 200
-    duration: 77.089173ms
-- id: 103
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    form:
-      order_by:
-      - created_at_asc
-      page:
-      - "1"
-      pool_id:
-      - 034a502a-1d52-470d-84bd-4a8edd935ba3
-      status:
-      - unknown
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75/nodes?order_by=created_at_asc&page=1&pool_id=034a502a-1d52-470d-84bd-4a8edd935ba3&status=unknown
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 648
-    body: "{\"total_count\":1, \"nodes\":[{\"region\":\"fr-par\", \"id\":\"3e073c76-a98f-4e6b-ad3c-7a6ca77e15fd\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:51:15.736647Z\", \"updated_at\":\"2025-10-30T16:54:20.551105Z\", \"pool_id\":\"034a502a-1d52-470d-84bd-4a8edd935ba3\", \"status\":\"ready\", \"conditions\":{\"DiskPressure\":\"False\", \"MemoryPressure\":\"False\", \"NetworkUnavailable\":\"False\", \"PIDPressure\":\"False\", \"Ready\":\"True\"}, \"name\":\"scw-test-pool-wait-test-pool-wait-3e073c76a98f\", \"public_ip_v4\":\"51.158.97.50\", \"public_ip_v6\":null, \"provider_id\":\"scaleway://instance/fr-par-1/6ba8f808-ce5f-4e0a-b30e-a83f7f79f945\", \"error_message\":\"\"}]}"
-    headers:
-      Content-Length:
-      - "648"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:23 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - f240360d-1b47-42a1-83e4-34264ee9e904
-    status: 200 OK
-    code: 200
-    duration: 25.473369ms
-- id: 104
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1630
-    body: "{\"region\":\"fr-par\", \"id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:01.607119Z\", \"updated_at\":\"2025-10-30T16:50:36.155897Z\", \"type\":\"kapsule\", \"name\":\"test-pool-wait\", \"description\":\"\", \"status\":\"ready\", \"version\":\"1.34.1\", \"cni\":\"calico\", \"tags\":[\"terraform-test\", \"scaleway_k8s_cluster\", \"minimal\"], \"cluster_url\":\"https://5114e066-aa93-4560-9be0-5ae445715a75.api.k8s.fr-par.scw.cloud:6443\", \"dns_wildcard\":\"*.5114e066-aa93-4560-9be0-5ae445715a75.nodes.k8s.fr-par.scw.cloud\", \"autoscaler_config\":{\"scale_down_disabled\":false, \"scale_down_delay_after_add\":\"10m\", \"estimator\":\"binpacking\", \"expander\":\"random\", \"ignore_daemonsets_utilization\":false, \"balance_similar_node_groups\":false, \"expendable_pods_priority_cutoff\":0, \"scale_down_unneeded_time\":\"10m\", \"scale_down_utilization_threshold\":0.5, \"max_graceful_termination_sec\":0}, \"auto_upgrade\":{\"enabled\":false, \"maintenance_window\":{\"start_hour\":0, \"day\":\"any\"}}, \"upgrade_available\":false, \"feature_gates\":[], \"admission_plugins\":[], \"open_id_connect_config\":{\"issuer_url\":\"\", \"client_id\":\"\", \"username_claim\":\"\", \"username_prefix\":\"\", \"groups_claim\":[], \"groups_prefix\":\"\", \"required_claim\":[]}, \"apiserver_cert_sans\":[], \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"commitment_ends_at\":\"2025-10-30T16:49:01.607128Z\", \"acl_available\":true, \"iam_nodes_group_id\":\"6c8f211e-8819-44e2-93ca-fda367c9ca2a\", \"new_images_enabled\":true, \"pod_cidr\":\"100.64.0.0/15\", \"service_cidr\":\"10.32.0.0/20\", \"service_dns_ip\":\"10.32.0.10\"}"
-    headers:
-      Content-Length:
-      - "1630"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:23 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 58eba6e7-c910-4e3f-ad05-12f9041962cd
-    status: 200 OK
-    code: 200
-    duration: 22.757933ms
-- id: 105
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1630
-    body: "{\"region\":\"fr-par\", \"id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:01.607119Z\", \"updated_at\":\"2025-10-30T16:50:36.155897Z\", \"type\":\"kapsule\", \"name\":\"test-pool-wait\", \"description\":\"\", \"status\":\"ready\", \"version\":\"1.34.1\", \"cni\":\"calico\", \"tags\":[\"terraform-test\", \"scaleway_k8s_cluster\", \"minimal\"], \"cluster_url\":\"https://5114e066-aa93-4560-9be0-5ae445715a75.api.k8s.fr-par.scw.cloud:6443\", \"dns_wildcard\":\"*.5114e066-aa93-4560-9be0-5ae445715a75.nodes.k8s.fr-par.scw.cloud\", \"autoscaler_config\":{\"scale_down_disabled\":false, \"scale_down_delay_after_add\":\"10m\", \"estimator\":\"binpacking\", \"expander\":\"random\", \"ignore_daemonsets_utilization\":false, \"balance_similar_node_groups\":false, \"expendable_pods_priority_cutoff\":0, \"scale_down_unneeded_time\":\"10m\", \"scale_down_utilization_threshold\":0.5, \"max_graceful_termination_sec\":0}, \"auto_upgrade\":{\"enabled\":false, \"maintenance_window\":{\"start_hour\":0, \"day\":\"any\"}}, \"upgrade_available\":false, \"feature_gates\":[], \"admission_plugins\":[], \"open_id_connect_config\":{\"issuer_url\":\"\", \"client_id\":\"\", \"username_claim\":\"\", \"username_prefix\":\"\", \"groups_claim\":[], \"groups_prefix\":\"\", \"required_claim\":[]}, \"apiserver_cert_sans\":[], \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"commitment_ends_at\":\"2025-10-30T16:49:01.607128Z\", \"acl_available\":true, \"iam_nodes_group_id\":\"6c8f211e-8819-44e2-93ca-fda367c9ca2a\", \"new_images_enabled\":true, \"pod_cidr\":\"100.64.0.0/15\", \"service_cidr\":\"10.32.0.0/20\", \"service_dns_ip\":\"10.32.0.10\"}"
-    headers:
-      Content-Length:
-      - "1630"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:23 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 0a9d8e78-859c-4539-9194-7536c23c7f19
-    status: 200 OK
-    code: 200
-    duration: 24.453835ms
-- id: 106
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    form:
-      order_by:
-      - created_at_desc
-      project_id:
-      - 105bdce1-64c0-48ab-899d-868455867ecf
-      resource_name:
-      - scw-test-pool-wait-test-pool-wait-2-803259ac23
-      resource_type:
-      - unknown_type
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=105bdce1-64c0-48ab-899d-868455867ecf&resource_name=scw-test-pool-wait-test-pool-wait-2-803259ac23&resource_type=unknown_type
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1122
-    body: "{\"total_count\":2, \"ips\":[{\"id\":\"35d11f02-76e3-4fe4-a39b-c2df537169d7\", \"address\":\"fd5f:519c:6d46:90dd:ab00:4e62:584d:4783/64\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_ipv6\":true, \"created_at\":\"2025-10-30T16:52:26.776899Z\", \"updated_at\":\"2025-10-30T16:52:26.776899Z\", \"source\":{\"subnet_id\":\"7493d1b7-5773-41c2-be8c-52e4ec098fc3\"}, \"resource\":{\"type\":\"instance_private_nic\", \"id\":\"6f4c43ec-ff56-4721-ab5d-fdf2a12b8f2e\", \"mac_address\":\"02:00:00:12:65:C5\", \"name\":\"scw-test-pool-wait-test-pool-wait-2-803259ac23\"}, \"tags\":[], \"reverses\":[], \"region\":\"fr-par\", \"zone\":null}, {\"id\":\"878dc0d8-d3e7-4ab9-b890-f5352063637c\", \"address\":\"172.18.20.4/22\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_ipv6\":false, \"created_at\":\"2025-10-30T16:52:26.654069Z\", \"updated_at\":\"2025-10-30T16:52:26.654069Z\", \"source\":{\"subnet_id\":\"da10d014-609b-48cc-9b9a-437dc31f4497\"}, \"resource\":{\"type\":\"instance_private_nic\", \"id\":\"6f4c43ec-ff56-4721-ab5d-fdf2a12b8f2e\", \"mac_address\":\"02:00:00:12:65:C5\", \"name\":\"scw-test-pool-wait-test-pool-wait-2-803259ac23\"}, \"tags\":[], \"reverses\":[], \"region\":\"fr-par\", \"zone\":null}]}"
-    headers:
-      Content-Length:
-      - "1122"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:23 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 3de1d11b-9298-4fd1-856f-5db0a6a82462
-    status: 200 OK
-    code: 200
-    duration: 29.089405ms
-- id: 107
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    form:
-      order_by:
-      - created_at_desc
-      project_id:
-      - 105bdce1-64c0-48ab-899d-868455867ecf
-      resource_name:
-      - scw-test-pool-wait-test-pool-wait-2-0e5eed3b53
-      resource_type:
-      - unknown_type
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=105bdce1-64c0-48ab-899d-868455867ecf&resource_name=scw-test-pool-wait-test-pool-wait-2-0e5eed3b53&resource_type=unknown_type
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1122
-    body: "{\"total_count\":2, \"ips\":[{\"id\":\"7e596df6-23ea-4a18-b40b-b04b6889b127\", \"address\":\"fd5f:519c:6d46:90dd:3968:9265:e922:7e76/64\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_ipv6\":true, \"created_at\":\"2025-10-30T16:53:19.349027Z\", \"updated_at\":\"2025-10-30T16:53:19.349027Z\", \"source\":{\"subnet_id\":\"7493d1b7-5773-41c2-be8c-52e4ec098fc3\"}, \"resource\":{\"type\":\"instance_private_nic\", \"id\":\"a3a5b239-815d-4735-b92e-16372f9e8741\", \"mac_address\":\"02:00:00:12:2E:F6\", \"name\":\"scw-test-pool-wait-test-pool-wait-2-0e5eed3b53\"}, \"tags\":[], \"reverses\":[], \"region\":\"fr-par\", \"zone\":null}, {\"id\":\"41cfcea9-5c9f-48bf-af2e-a1fe51acece8\", \"address\":\"172.18.20.5/22\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_ipv6\":false, \"created_at\":\"2025-10-30T16:53:19.175416Z\", \"updated_at\":\"2025-10-30T16:53:19.175416Z\", \"source\":{\"subnet_id\":\"da10d014-609b-48cc-9b9a-437dc31f4497\"}, \"resource\":{\"type\":\"instance_private_nic\", \"id\":\"a3a5b239-815d-4735-b92e-16372f9e8741\", \"mac_address\":\"02:00:00:12:2E:F6\", \"name\":\"scw-test-pool-wait-test-pool-wait-2-0e5eed3b53\"}, \"tags\":[], \"reverses\":[], \"region\":\"fr-par\", \"zone\":null}]}"
-    headers:
-      Content-Length:
-      - "1122"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:23 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 4b2030bb-73c7-4d6d-8665-0530741f83c8
-    status: 200 OK
-    code: 200
-    duration: 41.172233ms
-- id: 108
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    form:
-      order_by:
-      - created_at_desc
-      project_id:
-      - 105bdce1-64c0-48ab-899d-868455867ecf
-      resource_name:
-      - scw-test-pool-wait-test-pool-wait-3e073c76a98f
-      resource_type:
-      - unknown_type
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=105bdce1-64c0-48ab-899d-868455867ecf&resource_name=scw-test-pool-wait-test-pool-wait-3e073c76a98f&resource_type=unknown_type
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1122
-    body: "{\"total_count\":2, \"ips\":[{\"id\":\"54c6f7a2-4ca0-43bb-bc9a-b4a3905c0487\", \"address\":\"fd5f:519c:6d46:90dd:c183:ab7b:59b9:fc92/64\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_ipv6\":true, \"created_at\":\"2025-10-30T16:51:19.698188Z\", \"updated_at\":\"2025-10-30T16:51:19.698188Z\", \"source\":{\"subnet_id\":\"7493d1b7-5773-41c2-be8c-52e4ec098fc3\"}, \"resource\":{\"type\":\"instance_private_nic\", \"id\":\"45715cb9-7532-4c78-93a4-2fef3fa3b71a\", \"mac_address\":\"02:00:00:1D:E4:BA\", \"name\":\"scw-test-pool-wait-test-pool-wait-3e073c76a98f\"}, \"tags\":[], \"reverses\":[], \"region\":\"fr-par\", \"zone\":null}, {\"id\":\"ddc7378f-48eb-4ae3-af3e-4d5ee60054c4\", \"address\":\"172.18.20.3/22\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_ipv6\":false, \"created_at\":\"2025-10-30T16:51:19.565119Z\", \"updated_at\":\"2025-10-30T16:51:19.565119Z\", \"source\":{\"subnet_id\":\"da10d014-609b-48cc-9b9a-437dc31f4497\"}, \"resource\":{\"type\":\"instance_private_nic\", \"id\":\"45715cb9-7532-4c78-93a4-2fef3fa3b71a\", \"mac_address\":\"02:00:00:1D:E4:BA\", \"name\":\"scw-test-pool-wait-test-pool-wait-3e073c76a98f\"}, \"tags\":[], \"reverses\":[], \"region\":\"fr-par\", \"zone\":null}]}"
-    headers:
-      Content-Length:
-      - "1122"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:23 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 16200fe4-b65d-415d-ba23-e926d95c9575
-    status: 200 OK
-    code: 200
-    duration: 107.191751ms
-- id: 109
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 82
-    host: api.scaleway.com
-    body: "{\"size\":1,\"max_size\":1,\"upgrade_policy\":{\"max_unavailable\":null,\"max_surge\":null}}"
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/b0c262ac-e3c4-4a41-9b7c-fac43b180e81
-    method: PATCH
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 717
-    body: "{\"region\":\"fr-par\", \"id\":\"b0c262ac-e3c4-4a41-9b7c-fac43b180e81\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:52:22.689840Z\", \"updated_at\":\"2025-10-30T16:54:23.681022Z\", \"name\":\"test-pool-wait-2\", \"status\":\"scaling\", \"version\":\"1.34.1\", \"node_type\":\"pro2_xxs\", \"autoscaling\":false, \"size\":1, \"min_size\":1, \"max_size\":1, \"container_runtime\":\"containerd\", \"autohealing\":false, \"tags\":[], \"placement_group_id\":null, \"kubelet_args\":{}, \"upgrade_policy\":{\"max_unavailable\":1, \"max_surge\":0}, \"zone\":\"fr-par-1\", \"root_volume_type\":\"sbs_5k\", \"root_volume_size\":20000000000, \"public_ip_disabled\":false, \"new_images_enabled\":true, \"security_group_id\":\"4ef16f7a-478c-4b72-b932-982f4b04974b\"}"
-    headers:
-      Content-Length:
-      - "717"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:23 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 229da5f7-ba93-4213-a304-178e36d924c1
-    status: 200 OK
-    code: 200
-    duration: 39.365702ms
-- id: 110
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/b0c262ac-e3c4-4a41-9b7c-fac43b180e81
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 717
-    body: "{\"region\":\"fr-par\", \"id\":\"b0c262ac-e3c4-4a41-9b7c-fac43b180e81\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:52:22.689840Z\", \"updated_at\":\"2025-10-30T16:54:23.681022Z\", \"name\":\"test-pool-wait-2\", \"status\":\"scaling\", \"version\":\"1.34.1\", \"node_type\":\"pro2_xxs\", \"autoscaling\":false, \"size\":1, \"min_size\":1, \"max_size\":1, \"container_runtime\":\"containerd\", \"autohealing\":false, \"tags\":[], \"placement_group_id\":null, \"kubelet_args\":{}, \"upgrade_policy\":{\"max_unavailable\":1, \"max_surge\":0}, \"zone\":\"fr-par-1\", \"root_volume_type\":\"sbs_5k\", \"root_volume_size\":20000000000, \"public_ip_disabled\":false, \"new_images_enabled\":true, \"security_group_id\":\"4ef16f7a-478c-4b72-b932-982f4b04974b\"}"
-    headers:
-      Content-Length:
-      - "717"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:23 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 21a8d2c8-163a-4326-bb9e-94ac944cab63
-    status: 200 OK
-    code: 200
-    duration: 24.396658ms
-- id: 111
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/b0c262ac-e3c4-4a41-9b7c-fac43b180e81
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 715
-    body: "{\"region\":\"fr-par\", \"id\":\"b0c262ac-e3c4-4a41-9b7c-fac43b180e81\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:52:22.689840Z\", \"updated_at\":\"2025-10-30T16:54:25.061752Z\", \"name\":\"test-pool-wait-2\", \"status\":\"ready\", \"version\":\"1.34.1\", \"node_type\":\"pro2_xxs\", \"autoscaling\":false, \"size\":1, \"min_size\":1, \"max_size\":1, \"container_runtime\":\"containerd\", \"autohealing\":false, \"tags\":[], \"placement_group_id\":null, \"kubelet_args\":{}, \"upgrade_policy\":{\"max_unavailable\":1, \"max_surge\":0}, \"zone\":\"fr-par-1\", \"root_volume_type\":\"sbs_5k\", \"root_volume_size\":20000000000, \"public_ip_disabled\":false, \"new_images_enabled\":true, \"security_group_id\":\"4ef16f7a-478c-4b72-b932-982f4b04974b\"}"
-    headers:
-      Content-Length:
-      - "715"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:28 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 8f63ffb1-be77-486d-a45a-2dc8b1f23975
-    status: 200 OK
-    code: 200
-    duration: 86.141001ms
-- id: 112
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/b0c262ac-e3c4-4a41-9b7c-fac43b180e81
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 715
-    body: "{\"region\":\"fr-par\", \"id\":\"b0c262ac-e3c4-4a41-9b7c-fac43b180e81\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:52:22.689840Z\", \"updated_at\":\"2025-10-30T16:54:25.061752Z\", \"name\":\"test-pool-wait-2\", \"status\":\"ready\", \"version\":\"1.34.1\", \"node_type\":\"pro2_xxs\", \"autoscaling\":false, \"size\":1, \"min_size\":1, \"max_size\":1, \"container_runtime\":\"containerd\", \"autohealing\":false, \"tags\":[], \"placement_group_id\":null, \"kubelet_args\":{}, \"upgrade_policy\":{\"max_unavailable\":1, \"max_surge\":0}, \"zone\":\"fr-par-1\", \"root_volume_type\":\"sbs_5k\", \"root_volume_size\":20000000000, \"public_ip_disabled\":false, \"new_images_enabled\":true, \"security_group_id\":\"4ef16f7a-478c-4b72-b932-982f4b04974b\"}"
-    headers:
-      Content-Length:
-      - "715"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:28 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 54563a94-6c16-45f7-9e74-09dc917a8480
-    status: 200 OK
-    code: 200
-    duration: 88.987724ms
-- id: 113
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    form:
-      order_by:
-      - created_at_asc
-      page:
-      - "1"
-      pool_id:
-      - b0c262ac-e3c4-4a41-9b7c-fac43b180e81
-      status:
-      - unknown
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75/nodes?order_by=created_at_asc&page=1&pool_id=b0c262ac-e3c4-4a41-9b7c-fac43b180e81&status=unknown
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1243
-    body: "{\"total_count\":2, \"nodes\":[{\"region\":\"fr-par\", \"id\":\"803259ac-2333-4048-8fec-ae14c9eff6df\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:52:23.157062Z\", \"updated_at\":\"2025-10-30T16:54:25.015233Z\", \"pool_id\":\"b0c262ac-e3c4-4a41-9b7c-fac43b180e81\", \"status\":\"ready\", \"conditions\":{\"DiskPressure\":\"False\", \"MemoryPressure\":\"False\", \"NetworkUnavailable\":\"False\", \"PIDPressure\":\"False\", \"Ready\":\"True\"}, \"name\":\"scw-test-pool-wait-test-pool-wait-2-803259ac23\", \"public_ip_v4\":\"51.158.65.45\", \"public_ip_v6\":null, \"provider_id\":\"scaleway://instance/fr-par-1/f94c2846-a5e6-44e2-823b-e4da6094250f\", \"error_message\":\"\"}, {\"region\":\"fr-par\", \"id\":\"0e5eed3b-53a4-46b8-9d82-8868a450287f\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:53:15.555152Z\", \"updated_at\":\"2025-10-30T16:54:24.729826Z\", \"pool_id\":\"b0c262ac-e3c4-4a41-9b7c-fac43b180e81\", \"status\":\"deleting\", \"conditions\":{\"DiskPressure\":\"False\", \"MemoryPressure\":\"False\", \"PIDPressure\":\"False\", \"Ready\":\"True\"}, \"name\":\"scw-test-pool-wait-test-pool-wait-2-0e5eed3b53\", \"public_ip_v4\":\"51.158.76.222\", \"public_ip_v6\":null, \"provider_id\":\"scaleway://instance/fr-par-1/4af5920e-5aa3-4430-89d0-50a5680db098\", \"error_message\":\"\"}]}"
-    headers:
-      Content-Length:
-      - "1243"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:28 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 7319d6b0-c8db-4304-bbc5-b4c5c8a01a21
-    status: 200 OK
-    code: 200
-    duration: 24.37636ms
-- id: 114
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1630
-    body: "{\"region\":\"fr-par\", \"id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:01.607119Z\", \"updated_at\":\"2025-10-30T16:50:36.155897Z\", \"type\":\"kapsule\", \"name\":\"test-pool-wait\", \"description\":\"\", \"status\":\"ready\", \"version\":\"1.34.1\", \"cni\":\"calico\", \"tags\":[\"terraform-test\", \"scaleway_k8s_cluster\", \"minimal\"], \"cluster_url\":\"https://5114e066-aa93-4560-9be0-5ae445715a75.api.k8s.fr-par.scw.cloud:6443\", \"dns_wildcard\":\"*.5114e066-aa93-4560-9be0-5ae445715a75.nodes.k8s.fr-par.scw.cloud\", \"autoscaler_config\":{\"scale_down_disabled\":false, \"scale_down_delay_after_add\":\"10m\", \"estimator\":\"binpacking\", \"expander\":\"random\", \"ignore_daemonsets_utilization\":false, \"balance_similar_node_groups\":false, \"expendable_pods_priority_cutoff\":0, \"scale_down_unneeded_time\":\"10m\", \"scale_down_utilization_threshold\":0.5, \"max_graceful_termination_sec\":0}, \"auto_upgrade\":{\"enabled\":false, \"maintenance_window\":{\"start_hour\":0, \"day\":\"any\"}}, \"upgrade_available\":false, \"feature_gates\":[], \"admission_plugins\":[], \"open_id_connect_config\":{\"issuer_url\":\"\", \"client_id\":\"\", \"username_claim\":\"\", \"username_prefix\":\"\", \"groups_claim\":[], \"groups_prefix\":\"\", \"required_claim\":[]}, \"apiserver_cert_sans\":[], \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"commitment_ends_at\":\"2025-10-30T16:49:01.607128Z\", \"acl_available\":true, \"iam_nodes_group_id\":\"6c8f211e-8819-44e2-93ca-fda367c9ca2a\", \"new_images_enabled\":true, \"pod_cidr\":\"100.64.0.0/15\", \"service_cidr\":\"10.32.0.0/20\", \"service_dns_ip\":\"10.32.0.10\"}"
-    headers:
-      Content-Length:
-      - "1630"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:28 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 64795ded-ba00-42a0-8e92-e038a9e0c98b
-    status: 200 OK
-    code: 200
-    duration: 17.699899ms
-- id: 115
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    form:
-      order_by:
-      - created_at_desc
-      project_id:
-      - 105bdce1-64c0-48ab-899d-868455867ecf
-      resource_name:
-      - scw-test-pool-wait-test-pool-wait-2-803259ac23
-      resource_type:
-      - unknown_type
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=105bdce1-64c0-48ab-899d-868455867ecf&resource_name=scw-test-pool-wait-test-pool-wait-2-803259ac23&resource_type=unknown_type
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1122
-    body: "{\"total_count\":2, \"ips\":[{\"id\":\"35d11f02-76e3-4fe4-a39b-c2df537169d7\", \"address\":\"fd5f:519c:6d46:90dd:ab00:4e62:584d:4783/64\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_ipv6\":true, \"created_at\":\"2025-10-30T16:52:26.776899Z\", \"updated_at\":\"2025-10-30T16:52:26.776899Z\", \"source\":{\"subnet_id\":\"7493d1b7-5773-41c2-be8c-52e4ec098fc3\"}, \"resource\":{\"type\":\"instance_private_nic\", \"id\":\"6f4c43ec-ff56-4721-ab5d-fdf2a12b8f2e\", \"mac_address\":\"02:00:00:12:65:C5\", \"name\":\"scw-test-pool-wait-test-pool-wait-2-803259ac23\"}, \"tags\":[], \"reverses\":[], \"region\":\"fr-par\", \"zone\":null}, {\"id\":\"878dc0d8-d3e7-4ab9-b890-f5352063637c\", \"address\":\"172.18.20.4/22\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_ipv6\":false, \"created_at\":\"2025-10-30T16:52:26.654069Z\", \"updated_at\":\"2025-10-30T16:52:26.654069Z\", \"source\":{\"subnet_id\":\"da10d014-609b-48cc-9b9a-437dc31f4497\"}, \"resource\":{\"type\":\"instance_private_nic\", \"id\":\"6f4c43ec-ff56-4721-ab5d-fdf2a12b8f2e\", \"mac_address\":\"02:00:00:12:65:C5\", \"name\":\"scw-test-pool-wait-test-pool-wait-2-803259ac23\"}, \"tags\":[], \"reverses\":[], \"region\":\"fr-par\", \"zone\":null}]}"
-    headers:
-      Content-Length:
-      - "1122"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:28 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - a73725d2-4b76-4ac4-8d38-c92e5d3a1002
-    status: 200 OK
-    code: 200
-    duration: 29.683571ms
-- id: 116
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    form:
-      order_by:
-      - created_at_desc
-      project_id:
-      - 105bdce1-64c0-48ab-899d-868455867ecf
-      resource_name:
-      - scw-test-pool-wait-test-pool-wait-2-0e5eed3b53
-      resource_type:
-      - unknown_type
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=105bdce1-64c0-48ab-899d-868455867ecf&resource_name=scw-test-pool-wait-test-pool-wait-2-0e5eed3b53&resource_type=unknown_type
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1122
-    body: "{\"total_count\":2, \"ips\":[{\"id\":\"7e596df6-23ea-4a18-b40b-b04b6889b127\", \"address\":\"fd5f:519c:6d46:90dd:3968:9265:e922:7e76/64\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_ipv6\":true, \"created_at\":\"2025-10-30T16:53:19.349027Z\", \"updated_at\":\"2025-10-30T16:53:19.349027Z\", \"source\":{\"subnet_id\":\"7493d1b7-5773-41c2-be8c-52e4ec098fc3\"}, \"resource\":{\"type\":\"instance_private_nic\", \"id\":\"a3a5b239-815d-4735-b92e-16372f9e8741\", \"mac_address\":\"02:00:00:12:2E:F6\", \"name\":\"scw-test-pool-wait-test-pool-wait-2-0e5eed3b53\"}, \"tags\":[], \"reverses\":[], \"region\":\"fr-par\", \"zone\":null}, {\"id\":\"41cfcea9-5c9f-48bf-af2e-a1fe51acece8\", \"address\":\"172.18.20.5/22\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_ipv6\":false, \"created_at\":\"2025-10-30T16:53:19.175416Z\", \"updated_at\":\"2025-10-30T16:53:19.175416Z\", \"source\":{\"subnet_id\":\"da10d014-609b-48cc-9b9a-437dc31f4497\"}, \"resource\":{\"type\":\"instance_private_nic\", \"id\":\"a3a5b239-815d-4735-b92e-16372f9e8741\", \"mac_address\":\"02:00:00:12:2E:F6\", \"name\":\"scw-test-pool-wait-test-pool-wait-2-0e5eed3b53\"}, \"tags\":[], \"reverses\":[], \"region\":\"fr-par\", \"zone\":null}]}"
-    headers:
-      Content-Length:
-      - "1122"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:29 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 7f38b4ab-a2da-4de7-b440-04b3db7df960
-    status: 200 OK
-    code: 200
-    duration: 36.130641ms
-- id: 117
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1630
-    body: "{\"region\":\"fr-par\", \"id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:01.607119Z\", \"updated_at\":\"2025-10-30T16:50:36.155897Z\", \"type\":\"kapsule\", \"name\":\"test-pool-wait\", \"description\":\"\", \"status\":\"ready\", \"version\":\"1.34.1\", \"cni\":\"calico\", \"tags\":[\"terraform-test\", \"scaleway_k8s_cluster\", \"minimal\"], \"cluster_url\":\"https://5114e066-aa93-4560-9be0-5ae445715a75.api.k8s.fr-par.scw.cloud:6443\", \"dns_wildcard\":\"*.5114e066-aa93-4560-9be0-5ae445715a75.nodes.k8s.fr-par.scw.cloud\", \"autoscaler_config\":{\"scale_down_disabled\":false, \"scale_down_delay_after_add\":\"10m\", \"estimator\":\"binpacking\", \"expander\":\"random\", \"ignore_daemonsets_utilization\":false, \"balance_similar_node_groups\":false, \"expendable_pods_priority_cutoff\":0, \"scale_down_unneeded_time\":\"10m\", \"scale_down_utilization_threshold\":0.5, \"max_graceful_termination_sec\":0}, \"auto_upgrade\":{\"enabled\":false, \"maintenance_window\":{\"start_hour\":0, \"day\":\"any\"}}, \"upgrade_available\":false, \"feature_gates\":[], \"admission_plugins\":[], \"open_id_connect_config\":{\"issuer_url\":\"\", \"client_id\":\"\", \"username_claim\":\"\", \"username_prefix\":\"\", \"groups_claim\":[], \"groups_prefix\":\"\", \"required_claim\":[]}, \"apiserver_cert_sans\":[], \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"commitment_ends_at\":\"2025-10-30T16:49:01.607128Z\", \"acl_available\":true, \"iam_nodes_group_id\":\"6c8f211e-8819-44e2-93ca-fda367c9ca2a\", \"new_images_enabled\":true, \"pod_cidr\":\"100.64.0.0/15\", \"service_cidr\":\"10.32.0.0/20\", \"service_dns_ip\":\"10.32.0.10\"}"
-    headers:
-      Content-Length:
-      - "1630"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:29 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 1a350574-4276-45b3-93bd-3f8668228ecc
-    status: 200 OK
-    code: 200
-    duration: 21.906024ms
-- id: 118
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/b0c262ac-e3c4-4a41-9b7c-fac43b180e81
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 715
-    body: "{\"region\":\"fr-par\", \"id\":\"b0c262ac-e3c4-4a41-9b7c-fac43b180e81\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:52:22.689840Z\", \"updated_at\":\"2025-10-30T16:54:25.061752Z\", \"name\":\"test-pool-wait-2\", \"status\":\"ready\", \"version\":\"1.34.1\", \"node_type\":\"pro2_xxs\", \"autoscaling\":false, \"size\":1, \"min_size\":1, \"max_size\":1, \"container_runtime\":\"containerd\", \"autohealing\":false, \"tags\":[], \"placement_group_id\":null, \"kubelet_args\":{}, \"upgrade_policy\":{\"max_unavailable\":1, \"max_surge\":0}, \"zone\":\"fr-par-1\", \"root_volume_type\":\"sbs_5k\", \"root_volume_size\":20000000000, \"public_ip_disabled\":false, \"new_images_enabled\":true, \"security_group_id\":\"4ef16f7a-478c-4b72-b932-982f4b04974b\"}"
-    headers:
-      Content-Length:
-      - "715"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:29 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 9e94267c-6cb2-4a8b-a219-d00a1cc98a92
-    status: 200 OK
-    code: 200
-    duration: 19.294302ms
-- id: 119
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/1a7a1e1e-2b33-478e-8f1a-faa0303a1c43
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 419
-    body: "{\"id\":\"1a7a1e1e-2b33-478e-8f1a-faa0303a1c43\", \"name\":\"tf-vpc-confident-bose\", \"tags\":[], \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:00.136298Z\", \"updated_at\":\"2025-10-30T16:49:00.136298Z\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_default\":false, \"private_network_count\":1, \"routing_enabled\":true, \"custom_routes_propagation_enabled\":true, \"region\":\"fr-par\"}"
-    headers:
-      Content-Length:
-      - "419"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:29 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - f3e62cf2-3c3c-41ab-b009-e7e1897874f9
-    status: 200 OK
-    code: 200
-    duration: 28.599506ms
-- id: 120
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/363e7214-8a98-40d0-9357-9e4026c21b76
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1084
-    body: "{\"id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"name\":\"test-pool-wait\", \"tags\":[], \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:00.384609Z\", \"updated_at\":\"2025-10-30T16:49:00.384609Z\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"subnets\":[{\"id\":\"da10d014-609b-48cc-9b9a-437dc31f4497\", \"created_at\":\"2025-10-30T16:49:00.384609Z\", \"updated_at\":\"2025-10-30T16:49:00.384609Z\", \"subnet\":\"172.18.20.0/22\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"vpc_id\":\"1a7a1e1e-2b33-478e-8f1a-faa0303a1c43\"}, {\"id\":\"7493d1b7-5773-41c2-be8c-52e4ec098fc3\", \"created_at\":\"2025-10-30T16:49:00.384609Z\", \"updated_at\":\"2025-10-30T16:49:00.384609Z\", \"subnet\":\"fd5f:519c:6d46:90dd::/64\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"vpc_id\":\"1a7a1e1e-2b33-478e-8f1a-faa0303a1c43\"}], \"vpc_id\":\"1a7a1e1e-2b33-478e-8f1a-faa0303a1c43\", \"dhcp_enabled\":true, \"default_route_propagation_enabled\":false, \"region\":\"fr-par\"}"
-    headers:
-      Content-Length:
-      - "1084"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:29 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 9d5c42eb-40a5-4c44-a813-f6951de136a2
-    status: 200 OK
-    code: 200
-    duration: 24.432656ms
-- id: 121
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1630
-    body: "{\"region\":\"fr-par\", \"id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:01.607119Z\", \"updated_at\":\"2025-10-30T16:50:36.155897Z\", \"type\":\"kapsule\", \"name\":\"test-pool-wait\", \"description\":\"\", \"status\":\"ready\", \"version\":\"1.34.1\", \"cni\":\"calico\", \"tags\":[\"terraform-test\", \"scaleway_k8s_cluster\", \"minimal\"], \"cluster_url\":\"https://5114e066-aa93-4560-9be0-5ae445715a75.api.k8s.fr-par.scw.cloud:6443\", \"dns_wildcard\":\"*.5114e066-aa93-4560-9be0-5ae445715a75.nodes.k8s.fr-par.scw.cloud\", \"autoscaler_config\":{\"scale_down_disabled\":false, \"scale_down_delay_after_add\":\"10m\", \"estimator\":\"binpacking\", \"expander\":\"random\", \"ignore_daemonsets_utilization\":false, \"balance_similar_node_groups\":false, \"expendable_pods_priority_cutoff\":0, \"scale_down_unneeded_time\":\"10m\", \"scale_down_utilization_threshold\":0.5, \"max_graceful_termination_sec\":0}, \"auto_upgrade\":{\"enabled\":false, \"maintenance_window\":{\"start_hour\":0, \"day\":\"any\"}}, \"upgrade_available\":false, \"feature_gates\":[], \"admission_plugins\":[], \"open_id_connect_config\":{\"issuer_url\":\"\", \"client_id\":\"\", \"username_claim\":\"\", \"username_prefix\":\"\", \"groups_claim\":[], \"groups_prefix\":\"\", \"required_claim\":[]}, \"apiserver_cert_sans\":[], \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"commitment_ends_at\":\"2025-10-30T16:49:01.607128Z\", \"acl_available\":true, \"iam_nodes_group_id\":\"6c8f211e-8819-44e2-93ca-fda367c9ca2a\", \"new_images_enabled\":true, \"pod_cidr\":\"100.64.0.0/15\", \"service_cidr\":\"10.32.0.0/20\", \"service_dns_ip\":\"10.32.0.10\"}"
-    headers:
-      Content-Length:
-      - "1630"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:29 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - f68bc5db-60b7-4165-891a-7e90af527846
-    status: 200 OK
-    code: 200
-    duration: 27.070406ms
-- id: 122
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75/kubeconfig
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1654
-    body: "{\"name\":\"kubeconfig\", \"content_type\":\"application/octet-stream\", \"content\":\"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVSllSRU5EUVZGSFowRjNTVUpCWjBsQ1FVUkJTMEpuWjNGb2EycFBVRkZSUkVGcVFWWk5VazEzUlZGWlJGWlJVVVJGZDNCeVpGZEtiR050Tld3S1pFZFdlazFDTkZoRVZFa3hUVlJCZVU5VVJUSk9SR3QzVFZadldFUlVUVEZOVkVGNVQxUkZNazVFYTNkTlZtOTNSbFJGVkUxQ1JVZEJNVlZGUVhoTlN3cGhNMVpwV2xoS2RWcFlVbXhqZWtKYVRVSk5SMEo1Y1VkVFRUUTVRV2RGUjBORGNVZFRUVFE1UVhkRlNFRXdTVUZDVFhsNllqUkdTbVozWTFOM01tZEZDbEppVFRkVFZpOUpiM0ZXU21oWWVIbGxObHB1UkZOWlZ6WmxRbU4yV2tJM1RXVnVMMWxPYm5wM2F6QkpRazF2VDFkUFRXeHRlVGxJWVU5NE1XVkxaSFlLTUVRNE9XZDVZV3BSYWtKQlRVRTBSMEV4VldSRWQwVkNMM2RSUlVGM1NVTndSRUZRUW1kT1ZraFNUVUpCWmpoRlFsUkJSRUZSU0M5TlFqQkhRVEZWWkFwRVoxRlhRa0pTVTFsU1NtTm9UV1l3V0U5YWNtUkJhV1JMYkdOUWEyTklZeTlVUVV0Q1oyZHhhR3RxVDFCUlVVUkJaMDVLUVVSQ1IwRnBSVUY1Ym0xd0NqbFpkWG80VWpGVWFtNDBiV2RqYWpaV2QycFVTM2gzUm5KS1VrdFZTVVpIUTFwR2VsbEtWVU5KVVVSSWRERkNXalpHYUZrdlVUWlRabloxTVhCNmJEWUtNWG80VkhCMlNIQkxVa0pIY1RscmNVVlJOa3hPZHowOUNpMHRMUzB0UlU1RUlFTkZVbFJKUmtsRFFWUkZMUzB0TFMwSwogICAgc2VydmVyOiBodHRwczovLzUxMTRlMDY2LWFhOTMtNDU2MC05YmUwLTVhZTQ0NTcxNWE3NS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wtd2FpdAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXdhaXQiCiAgICB1c2VyOiB0ZXN0LXBvb2wtd2FpdC1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC13YWl0CmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXdhaXQtYWRtaW4KICB1c2VyOgogICAgdG9rZW46IGttQTQ5c2F6N1V4dVJSOHZ1UzIxMWpxN2NzVzNobFF1QzQ3QjRla3BobjE3UXBMcVRiVGJGelVO\"}"
-    headers:
-      Content-Length:
-      - "1654"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:29 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 9c9f2163-2ec7-4812-a332-50243f9b73d5
-    status: 200 OK
-    code: 200
-    duration: 99.252409ms
-- id: 123
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/b0c262ac-e3c4-4a41-9b7c-fac43b180e81
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 715
-    body: "{\"region\":\"fr-par\", \"id\":\"b0c262ac-e3c4-4a41-9b7c-fac43b180e81\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:52:22.689840Z\", \"updated_at\":\"2025-10-30T16:54:25.061752Z\", \"name\":\"test-pool-wait-2\", \"status\":\"ready\", \"version\":\"1.34.1\", \"node_type\":\"pro2_xxs\", \"autoscaling\":false, \"size\":1, \"min_size\":1, \"max_size\":1, \"container_runtime\":\"containerd\", \"autohealing\":false, \"tags\":[], \"placement_group_id\":null, \"kubelet_args\":{}, \"upgrade_policy\":{\"max_unavailable\":1, \"max_surge\":0}, \"zone\":\"fr-par-1\", \"root_volume_type\":\"sbs_5k\", \"root_volume_size\":20000000000, \"public_ip_disabled\":false, \"new_images_enabled\":true, \"security_group_id\":\"4ef16f7a-478c-4b72-b932-982f4b04974b\"}"
-    headers:
-      Content-Length:
-      - "715"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:29 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - f7d19069-fe73-42da-b8fa-ef69ac7fce4a
-    status: 200 OK
-    code: 200
-    duration: 18.938664ms
-- id: 124
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/034a502a-1d52-470d-84bd-4a8edd935ba3
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 713
-    body: "{\"region\":\"fr-par\", \"id\":\"034a502a-1d52-470d-84bd-4a8edd935ba3\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:49:07.243810Z\", \"updated_at\":\"2025-10-30T16:52:20.261969Z\", \"name\":\"test-pool-wait\", \"status\":\"ready\", \"version\":\"1.34.1\", \"node_type\":\"pro2_xxs\", \"autoscaling\":false, \"size\":1, \"min_size\":1, \"max_size\":1, \"container_runtime\":\"containerd\", \"autohealing\":false, \"tags\":[], \"placement_group_id\":null, \"kubelet_args\":{}, \"upgrade_policy\":{\"max_unavailable\":1, \"max_surge\":0}, \"zone\":\"fr-par-1\", \"root_volume_type\":\"sbs_5k\", \"root_volume_size\":20000000000, \"public_ip_disabled\":false, \"new_images_enabled\":true, \"security_group_id\":\"4ef16f7a-478c-4b72-b932-982f4b04974b\"}"
-    headers:
-      Content-Length:
-      - "713"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:29 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 32db3bf6-27ad-4a62-910d-08ba6ef75a8c
-    status: 200 OK
-    code: 200
-    duration: 23.264593ms
-- id: 125
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    form:
-      order_by:
-      - created_at_asc
-      page:
-      - "1"
-      pool_id:
-      - 034a502a-1d52-470d-84bd-4a8edd935ba3
-      status:
-      - unknown
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75/nodes?order_by=created_at_asc&page=1&pool_id=034a502a-1d52-470d-84bd-4a8edd935ba3&status=unknown
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 648
-    body: "{\"total_count\":1, \"nodes\":[{\"region\":\"fr-par\", \"id\":\"3e073c76-a98f-4e6b-ad3c-7a6ca77e15fd\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:51:15.736647Z\", \"updated_at\":\"2025-10-30T16:54:24.994372Z\", \"pool_id\":\"034a502a-1d52-470d-84bd-4a8edd935ba3\", \"status\":\"ready\", \"conditions\":{\"DiskPressure\":\"False\", \"MemoryPressure\":\"False\", \"NetworkUnavailable\":\"False\", \"PIDPressure\":\"False\", \"Ready\":\"True\"}, \"name\":\"scw-test-pool-wait-test-pool-wait-3e073c76a98f\", \"public_ip_v4\":\"51.158.97.50\", \"public_ip_v6\":null, \"provider_id\":\"scaleway://instance/fr-par-1/6ba8f808-ce5f-4e0a-b30e-a83f7f79f945\", \"error_message\":\"\"}]}"
-    headers:
-      Content-Length:
-      - "648"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:29 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 42d02c0a-dc22-4feb-b7a8-d362becfd958
-    status: 200 OK
-    code: 200
-    duration: 22.39432ms
-- id: 126
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    form:
-      order_by:
-      - created_at_asc
-      page:
-      - "1"
-      pool_id:
-      - b0c262ac-e3c4-4a41-9b7c-fac43b180e81
-      status:
-      - unknown
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75/nodes?order_by=created_at_asc&page=1&pool_id=b0c262ac-e3c4-4a41-9b7c-fac43b180e81&status=unknown
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1243
-    body: "{\"total_count\":2, \"nodes\":[{\"region\":\"fr-par\", \"id\":\"803259ac-2333-4048-8fec-ae14c9eff6df\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:52:23.157062Z\", \"updated_at\":\"2025-10-30T16:54:25.015233Z\", \"pool_id\":\"b0c262ac-e3c4-4a41-9b7c-fac43b180e81\", \"status\":\"ready\", \"conditions\":{\"DiskPressure\":\"False\", \"MemoryPressure\":\"False\", \"NetworkUnavailable\":\"False\", \"PIDPressure\":\"False\", \"Ready\":\"True\"}, \"name\":\"scw-test-pool-wait-test-pool-wait-2-803259ac23\", \"public_ip_v4\":\"51.158.65.45\", \"public_ip_v6\":null, \"provider_id\":\"scaleway://instance/fr-par-1/f94c2846-a5e6-44e2-823b-e4da6094250f\", \"error_message\":\"\"}, {\"region\":\"fr-par\", \"id\":\"0e5eed3b-53a4-46b8-9d82-8868a450287f\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:53:15.555152Z\", \"updated_at\":\"2025-10-30T16:54:24.729826Z\", \"pool_id\":\"b0c262ac-e3c4-4a41-9b7c-fac43b180e81\", \"status\":\"deleting\", \"conditions\":{\"DiskPressure\":\"False\", \"MemoryPressure\":\"False\", \"PIDPressure\":\"False\", \"Ready\":\"True\"}, \"name\":\"scw-test-pool-wait-test-pool-wait-2-0e5eed3b53\", \"public_ip_v4\":\"51.158.76.222\", \"public_ip_v6\":null, \"provider_id\":\"scaleway://instance/fr-par-1/4af5920e-5aa3-4430-89d0-50a5680db098\", \"error_message\":\"\"}]}"
-    headers:
-      Content-Length:
-      - "1243"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:29 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - fa3c4a6a-c517-44e4-b66a-38db853bd48d
-    status: 200 OK
-    code: 200
-    duration: 32.602058ms
-- id: 127
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1630
-    body: "{\"region\":\"fr-par\", \"id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:01.607119Z\", \"updated_at\":\"2025-10-30T16:50:36.155897Z\", \"type\":\"kapsule\", \"name\":\"test-pool-wait\", \"description\":\"\", \"status\":\"ready\", \"version\":\"1.34.1\", \"cni\":\"calico\", \"tags\":[\"terraform-test\", \"scaleway_k8s_cluster\", \"minimal\"], \"cluster_url\":\"https://5114e066-aa93-4560-9be0-5ae445715a75.api.k8s.fr-par.scw.cloud:6443\", \"dns_wildcard\":\"*.5114e066-aa93-4560-9be0-5ae445715a75.nodes.k8s.fr-par.scw.cloud\", \"autoscaler_config\":{\"scale_down_disabled\":false, \"scale_down_delay_after_add\":\"10m\", \"estimator\":\"binpacking\", \"expander\":\"random\", \"ignore_daemonsets_utilization\":false, \"balance_similar_node_groups\":false, \"expendable_pods_priority_cutoff\":0, \"scale_down_unneeded_time\":\"10m\", \"scale_down_utilization_threshold\":0.5, \"max_graceful_termination_sec\":0}, \"auto_upgrade\":{\"enabled\":false, \"maintenance_window\":{\"start_hour\":0, \"day\":\"any\"}}, \"upgrade_available\":false, \"feature_gates\":[], \"admission_plugins\":[], \"open_id_connect_config\":{\"issuer_url\":\"\", \"client_id\":\"\", \"username_claim\":\"\", \"username_prefix\":\"\", \"groups_claim\":[], \"groups_prefix\":\"\", \"required_claim\":[]}, \"apiserver_cert_sans\":[], \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"commitment_ends_at\":\"2025-10-30T16:49:01.607128Z\", \"acl_available\":true, \"iam_nodes_group_id\":\"6c8f211e-8819-44e2-93ca-fda367c9ca2a\", \"new_images_enabled\":true, \"pod_cidr\":\"100.64.0.0/15\", \"service_cidr\":\"10.32.0.0/20\", \"service_dns_ip\":\"10.32.0.10\"}"
-    headers:
-      Content-Length:
-      - "1630"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:29 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - e43a6778-4477-4e97-a9b1-25b6ffabdf27
-    status: 200 OK
-    code: 200
-    duration: 23.208559ms
-- id: 128
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1630
-    body: "{\"region\":\"fr-par\", \"id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:01.607119Z\", \"updated_at\":\"2025-10-30T16:50:36.155897Z\", \"type\":\"kapsule\", \"name\":\"test-pool-wait\", \"description\":\"\", \"status\":\"ready\", \"version\":\"1.34.1\", \"cni\":\"calico\", \"tags\":[\"terraform-test\", \"scaleway_k8s_cluster\", \"minimal\"], \"cluster_url\":\"https://5114e066-aa93-4560-9be0-5ae445715a75.api.k8s.fr-par.scw.cloud:6443\", \"dns_wildcard\":\"*.5114e066-aa93-4560-9be0-5ae445715a75.nodes.k8s.fr-par.scw.cloud\", \"autoscaler_config\":{\"scale_down_disabled\":false, \"scale_down_delay_after_add\":\"10m\", \"estimator\":\"binpacking\", \"expander\":\"random\", \"ignore_daemonsets_utilization\":false, \"balance_similar_node_groups\":false, \"expendable_pods_priority_cutoff\":0, \"scale_down_unneeded_time\":\"10m\", \"scale_down_utilization_threshold\":0.5, \"max_graceful_termination_sec\":0}, \"auto_upgrade\":{\"enabled\":false, \"maintenance_window\":{\"start_hour\":0, \"day\":\"any\"}}, \"upgrade_available\":false, \"feature_gates\":[], \"admission_plugins\":[], \"open_id_connect_config\":{\"issuer_url\":\"\", \"client_id\":\"\", \"username_claim\":\"\", \"username_prefix\":\"\", \"groups_claim\":[], \"groups_prefix\":\"\", \"required_claim\":[]}, \"apiserver_cert_sans\":[], \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"commitment_ends_at\":\"2025-10-30T16:49:01.607128Z\", \"acl_available\":true, \"iam_nodes_group_id\":\"6c8f211e-8819-44e2-93ca-fda367c9ca2a\", \"new_images_enabled\":true, \"pod_cidr\":\"100.64.0.0/15\", \"service_cidr\":\"10.32.0.0/20\", \"service_dns_ip\":\"10.32.0.10\"}"
-    headers:
-      Content-Length:
-      - "1630"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:29 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - e681d7ec-ff19-47e3-ab19-f819d0de3f14
-    status: 200 OK
-    code: 200
-    duration: 30.393133ms
-- id: 129
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    form:
-      order_by:
-      - created_at_desc
-      project_id:
-      - 105bdce1-64c0-48ab-899d-868455867ecf
-      resource_name:
-      - scw-test-pool-wait-test-pool-wait-3e073c76a98f
-      resource_type:
-      - unknown_type
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=105bdce1-64c0-48ab-899d-868455867ecf&resource_name=scw-test-pool-wait-test-pool-wait-3e073c76a98f&resource_type=unknown_type
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1122
-    body: "{\"total_count\":2, \"ips\":[{\"id\":\"54c6f7a2-4ca0-43bb-bc9a-b4a3905c0487\", \"address\":\"fd5f:519c:6d46:90dd:c183:ab7b:59b9:fc92/64\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_ipv6\":true, \"created_at\":\"2025-10-30T16:51:19.698188Z\", \"updated_at\":\"2025-10-30T16:51:19.698188Z\", \"source\":{\"subnet_id\":\"7493d1b7-5773-41c2-be8c-52e4ec098fc3\"}, \"resource\":{\"type\":\"instance_private_nic\", \"id\":\"45715cb9-7532-4c78-93a4-2fef3fa3b71a\", \"mac_address\":\"02:00:00:1D:E4:BA\", \"name\":\"scw-test-pool-wait-test-pool-wait-3e073c76a98f\"}, \"tags\":[], \"reverses\":[], \"region\":\"fr-par\", \"zone\":null}, {\"id\":\"ddc7378f-48eb-4ae3-af3e-4d5ee60054c4\", \"address\":\"172.18.20.3/22\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_ipv6\":false, \"created_at\":\"2025-10-30T16:51:19.565119Z\", \"updated_at\":\"2025-10-30T16:51:19.565119Z\", \"source\":{\"subnet_id\":\"da10d014-609b-48cc-9b9a-437dc31f4497\"}, \"resource\":{\"type\":\"instance_private_nic\", \"id\":\"45715cb9-7532-4c78-93a4-2fef3fa3b71a\", \"mac_address\":\"02:00:00:1D:E4:BA\", \"name\":\"scw-test-pool-wait-test-pool-wait-3e073c76a98f\"}, \"tags\":[], \"reverses\":[], \"region\":\"fr-par\", \"zone\":null}]}"
-    headers:
-      Content-Length:
-      - "1122"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:29 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 85a6087c-8bb3-4321-8d83-33f3e5ad9e74
-    status: 200 OK
-    code: 200
-    duration: 29.693239ms
-- id: 130
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    form:
-      order_by:
-      - created_at_desc
-      project_id:
-      - 105bdce1-64c0-48ab-899d-868455867ecf
-      resource_name:
-      - scw-test-pool-wait-test-pool-wait-2-803259ac23
-      resource_type:
-      - unknown_type
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=105bdce1-64c0-48ab-899d-868455867ecf&resource_name=scw-test-pool-wait-test-pool-wait-2-803259ac23&resource_type=unknown_type
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1122
-    body: "{\"total_count\":2, \"ips\":[{\"id\":\"35d11f02-76e3-4fe4-a39b-c2df537169d7\", \"address\":\"fd5f:519c:6d46:90dd:ab00:4e62:584d:4783/64\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_ipv6\":true, \"created_at\":\"2025-10-30T16:52:26.776899Z\", \"updated_at\":\"2025-10-30T16:52:26.776899Z\", \"source\":{\"subnet_id\":\"7493d1b7-5773-41c2-be8c-52e4ec098fc3\"}, \"resource\":{\"type\":\"instance_private_nic\", \"id\":\"6f4c43ec-ff56-4721-ab5d-fdf2a12b8f2e\", \"mac_address\":\"02:00:00:12:65:C5\", \"name\":\"scw-test-pool-wait-test-pool-wait-2-803259ac23\"}, \"tags\":[], \"reverses\":[], \"region\":\"fr-par\", \"zone\":null}, {\"id\":\"878dc0d8-d3e7-4ab9-b890-f5352063637c\", \"address\":\"172.18.20.4/22\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_ipv6\":false, \"created_at\":\"2025-10-30T16:52:26.654069Z\", \"updated_at\":\"2025-10-30T16:52:26.654069Z\", \"source\":{\"subnet_id\":\"da10d014-609b-48cc-9b9a-437dc31f4497\"}, \"resource\":{\"type\":\"instance_private_nic\", \"id\":\"6f4c43ec-ff56-4721-ab5d-fdf2a12b8f2e\", \"mac_address\":\"02:00:00:12:65:C5\", \"name\":\"scw-test-pool-wait-test-pool-wait-2-803259ac23\"}, \"tags\":[], \"reverses\":[], \"region\":\"fr-par\", \"zone\":null}]}"
-    headers:
-      Content-Length:
-      - "1122"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:29 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 1836cb09-21e7-4272-9b24-1a2d044cf203
-    status: 200 OK
-    code: 200
-    duration: 34.630386ms
-- id: 131
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    form:
-      order_by:
-      - created_at_desc
-      project_id:
-      - 105bdce1-64c0-48ab-899d-868455867ecf
-      resource_name:
-      - scw-test-pool-wait-test-pool-wait-2-0e5eed3b53
-      resource_type:
-      - unknown_type
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=105bdce1-64c0-48ab-899d-868455867ecf&resource_name=scw-test-pool-wait-test-pool-wait-2-0e5eed3b53&resource_type=unknown_type
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1122
-    body: "{\"total_count\":2, \"ips\":[{\"id\":\"7e596df6-23ea-4a18-b40b-b04b6889b127\", \"address\":\"fd5f:519c:6d46:90dd:3968:9265:e922:7e76/64\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_ipv6\":true, \"created_at\":\"2025-10-30T16:53:19.349027Z\", \"updated_at\":\"2025-10-30T16:53:19.349027Z\", \"source\":{\"subnet_id\":\"7493d1b7-5773-41c2-be8c-52e4ec098fc3\"}, \"resource\":{\"type\":\"instance_private_nic\", \"id\":\"a3a5b239-815d-4735-b92e-16372f9e8741\", \"mac_address\":\"02:00:00:12:2E:F6\", \"name\":\"scw-test-pool-wait-test-pool-wait-2-0e5eed3b53\"}, \"tags\":[], \"reverses\":[], \"region\":\"fr-par\", \"zone\":null}, {\"id\":\"41cfcea9-5c9f-48bf-af2e-a1fe51acece8\", \"address\":\"172.18.20.5/22\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_ipv6\":false, \"created_at\":\"2025-10-30T16:53:19.175416Z\", \"updated_at\":\"2025-10-30T16:53:19.175416Z\", \"source\":{\"subnet_id\":\"da10d014-609b-48cc-9b9a-437dc31f4497\"}, \"resource\":{\"type\":\"instance_private_nic\", \"id\":\"a3a5b239-815d-4735-b92e-16372f9e8741\", \"mac_address\":\"02:00:00:12:2E:F6\", \"name\":\"scw-test-pool-wait-test-pool-wait-2-0e5eed3b53\"}, \"tags\":[], \"reverses\":[], \"region\":\"fr-par\", \"zone\":null}]}"
-    headers:
-      Content-Length:
-      - "1122"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:29 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - ff914719-a506-4c06-a2c9-2a9f60588692
-    status: 200 OK
-    code: 200
-    duration: 30.270462ms
-- id: 132
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/1a7a1e1e-2b33-478e-8f1a-faa0303a1c43
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 419
-    body: "{\"id\":\"1a7a1e1e-2b33-478e-8f1a-faa0303a1c43\", \"name\":\"tf-vpc-confident-bose\", \"tags\":[], \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:00.136298Z\", \"updated_at\":\"2025-10-30T16:49:00.136298Z\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_default\":false, \"private_network_count\":1, \"routing_enabled\":true, \"custom_routes_propagation_enabled\":true, \"region\":\"fr-par\"}"
-    headers:
-      Content-Length:
-      - "419"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:29 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - fa9e3f8b-0d64-414f-95db-2dc93e54de41
-    status: 200 OK
-    code: 200
-    duration: 28.651153ms
-- id: 133
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/363e7214-8a98-40d0-9357-9e4026c21b76
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1084
-    body: "{\"id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"name\":\"test-pool-wait\", \"tags\":[], \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:00.384609Z\", \"updated_at\":\"2025-10-30T16:49:00.384609Z\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"subnets\":[{\"id\":\"da10d014-609b-48cc-9b9a-437dc31f4497\", \"created_at\":\"2025-10-30T16:49:00.384609Z\", \"updated_at\":\"2025-10-30T16:49:00.384609Z\", \"subnet\":\"172.18.20.0/22\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"vpc_id\":\"1a7a1e1e-2b33-478e-8f1a-faa0303a1c43\"}, {\"id\":\"7493d1b7-5773-41c2-be8c-52e4ec098fc3\", \"created_at\":\"2025-10-30T16:49:00.384609Z\", \"updated_at\":\"2025-10-30T16:49:00.384609Z\", \"subnet\":\"fd5f:519c:6d46:90dd::/64\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"vpc_id\":\"1a7a1e1e-2b33-478e-8f1a-faa0303a1c43\"}], \"vpc_id\":\"1a7a1e1e-2b33-478e-8f1a-faa0303a1c43\", \"dhcp_enabled\":true, \"default_route_propagation_enabled\":false, \"region\":\"fr-par\"}"
-    headers:
-      Content-Length:
-      - "1084"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:29 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 70605d89-3232-48e5-b64d-8318c504b090
-    status: 200 OK
-    code: 200
-    duration: 22.426861ms
-- id: 134
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1630
-    body: "{\"region\":\"fr-par\", \"id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:01.607119Z\", \"updated_at\":\"2025-10-30T16:50:36.155897Z\", \"type\":\"kapsule\", \"name\":\"test-pool-wait\", \"description\":\"\", \"status\":\"ready\", \"version\":\"1.34.1\", \"cni\":\"calico\", \"tags\":[\"terraform-test\", \"scaleway_k8s_cluster\", \"minimal\"], \"cluster_url\":\"https://5114e066-aa93-4560-9be0-5ae445715a75.api.k8s.fr-par.scw.cloud:6443\", \"dns_wildcard\":\"*.5114e066-aa93-4560-9be0-5ae445715a75.nodes.k8s.fr-par.scw.cloud\", \"autoscaler_config\":{\"scale_down_disabled\":false, \"scale_down_delay_after_add\":\"10m\", \"estimator\":\"binpacking\", \"expander\":\"random\", \"ignore_daemonsets_utilization\":false, \"balance_similar_node_groups\":false, \"expendable_pods_priority_cutoff\":0, \"scale_down_unneeded_time\":\"10m\", \"scale_down_utilization_threshold\":0.5, \"max_graceful_termination_sec\":0}, \"auto_upgrade\":{\"enabled\":false, \"maintenance_window\":{\"start_hour\":0, \"day\":\"any\"}}, \"upgrade_available\":false, \"feature_gates\":[], \"admission_plugins\":[], \"open_id_connect_config\":{\"issuer_url\":\"\", \"client_id\":\"\", \"username_claim\":\"\", \"username_prefix\":\"\", \"groups_claim\":[], \"groups_prefix\":\"\", \"required_claim\":[]}, \"apiserver_cert_sans\":[], \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"commitment_ends_at\":\"2025-10-30T16:49:01.607128Z\", \"acl_available\":true, \"iam_nodes_group_id\":\"6c8f211e-8819-44e2-93ca-fda367c9ca2a\", \"new_images_enabled\":true, \"pod_cidr\":\"100.64.0.0/15\", \"service_cidr\":\"10.32.0.0/20\", \"service_dns_ip\":\"10.32.0.10\"}"
-    headers:
-      Content-Length:
-      - "1630"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:29 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 2c792be7-5412-48cc-97d2-151843afef39
-    status: 200 OK
-    code: 200
-    duration: 36.672037ms
-- id: 135
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/b0c262ac-e3c4-4a41-9b7c-fac43b180e81
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 715
-    body: "{\"region\":\"fr-par\", \"id\":\"b0c262ac-e3c4-4a41-9b7c-fac43b180e81\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:52:22.689840Z\", \"updated_at\":\"2025-10-30T16:54:25.061752Z\", \"name\":\"test-pool-wait-2\", \"status\":\"ready\", \"version\":\"1.34.1\", \"node_type\":\"pro2_xxs\", \"autoscaling\":false, \"size\":1, \"min_size\":1, \"max_size\":1, \"container_runtime\":\"containerd\", \"autohealing\":false, \"tags\":[], \"placement_group_id\":null, \"kubelet_args\":{}, \"upgrade_policy\":{\"max_unavailable\":1, \"max_surge\":0}, \"zone\":\"fr-par-1\", \"root_volume_type\":\"sbs_5k\", \"root_volume_size\":20000000000, \"public_ip_disabled\":false, \"new_images_enabled\":true, \"security_group_id\":\"4ef16f7a-478c-4b72-b932-982f4b04974b\"}"
-    headers:
-      Content-Length:
-      - "715"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:29 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 9b559406-9069-4ae9-8d2a-1891ecdf7f78
-    status: 200 OK
-    code: 200
-    duration: 100.172025ms
-- id: 136
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    form:
-      order_by:
-      - created_at_asc
-      page:
-      - "1"
-      pool_id:
-      - b0c262ac-e3c4-4a41-9b7c-fac43b180e81
-      status:
-      - unknown
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75/nodes?order_by=created_at_asc&page=1&pool_id=b0c262ac-e3c4-4a41-9b7c-fac43b180e81&status=unknown
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1243
-    body: "{\"total_count\":2, \"nodes\":[{\"region\":\"fr-par\", \"id\":\"803259ac-2333-4048-8fec-ae14c9eff6df\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:52:23.157062Z\", \"updated_at\":\"2025-10-30T16:54:25.015233Z\", \"pool_id\":\"b0c262ac-e3c4-4a41-9b7c-fac43b180e81\", \"status\":\"ready\", \"conditions\":{\"DiskPressure\":\"False\", \"MemoryPressure\":\"False\", \"NetworkUnavailable\":\"False\", \"PIDPressure\":\"False\", \"Ready\":\"True\"}, \"name\":\"scw-test-pool-wait-test-pool-wait-2-803259ac23\", \"public_ip_v4\":\"51.158.65.45\", \"public_ip_v6\":null, \"provider_id\":\"scaleway://instance/fr-par-1/f94c2846-a5e6-44e2-823b-e4da6094250f\", \"error_message\":\"\"}, {\"region\":\"fr-par\", \"id\":\"0e5eed3b-53a4-46b8-9d82-8868a450287f\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:53:15.555152Z\", \"updated_at\":\"2025-10-30T16:54:24.729826Z\", \"pool_id\":\"b0c262ac-e3c4-4a41-9b7c-fac43b180e81\", \"status\":\"deleting\", \"conditions\":{\"DiskPressure\":\"False\", \"MemoryPressure\":\"False\", \"PIDPressure\":\"False\", \"Ready\":\"True\"}, \"name\":\"scw-test-pool-wait-test-pool-wait-2-0e5eed3b53\", \"public_ip_v4\":\"51.158.76.222\", \"public_ip_v6\":null, \"provider_id\":\"scaleway://instance/fr-par-1/4af5920e-5aa3-4430-89d0-50a5680db098\", \"error_message\":\"\"}]}"
-    headers:
-      Content-Length:
-      - "1243"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:29 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 1128ca4d-2738-48ab-896f-35b729c43a5c
-    status: 200 OK
-    code: 200
-    duration: 27.337037ms
-- id: 137
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75/kubeconfig
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1654
-    body: "{\"name\":\"kubeconfig\", \"content_type\":\"application/octet-stream\", \"content\":\"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVSllSRU5EUVZGSFowRjNTVUpCWjBsQ1FVUkJTMEpuWjNGb2EycFBVRkZSUkVGcVFWWk5VazEzUlZGWlJGWlJVVVJGZDNCeVpGZEtiR050Tld3S1pFZFdlazFDTkZoRVZFa3hUVlJCZVU5VVJUSk9SR3QzVFZadldFUlVUVEZOVkVGNVQxUkZNazVFYTNkTlZtOTNSbFJGVkUxQ1JVZEJNVlZGUVhoTlN3cGhNMVpwV2xoS2RWcFlVbXhqZWtKYVRVSk5SMEo1Y1VkVFRUUTVRV2RGUjBORGNVZFRUVFE1UVhkRlNFRXdTVUZDVFhsNllqUkdTbVozWTFOM01tZEZDbEppVFRkVFZpOUpiM0ZXU21oWWVIbGxObHB1UkZOWlZ6WmxRbU4yV2tJM1RXVnVMMWxPYm5wM2F6QkpRazF2VDFkUFRXeHRlVGxJWVU5NE1XVkxaSFlLTUVRNE9XZDVZV3BSYWtKQlRVRTBSMEV4VldSRWQwVkNMM2RSUlVGM1NVTndSRUZRUW1kT1ZraFNUVUpCWmpoRlFsUkJSRUZSU0M5TlFqQkhRVEZWWkFwRVoxRlhRa0pTVTFsU1NtTm9UV1l3V0U5YWNtUkJhV1JMYkdOUWEyTklZeTlVUVV0Q1oyZHhhR3RxVDFCUlVVUkJaMDVLUVVSQ1IwRnBSVUY1Ym0xd0NqbFpkWG80VWpGVWFtNDBiV2RqYWpaV2QycFVTM2gzUm5KS1VrdFZTVVpIUTFwR2VsbEtWVU5KVVVSSWRERkNXalpHYUZrdlVUWlRabloxTVhCNmJEWUtNWG80VkhCMlNIQkxVa0pIY1RscmNVVlJOa3hPZHowOUNpMHRMUzB0UlU1RUlFTkZVbFJKUmtsRFFWUkZMUzB0TFMwSwogICAgc2VydmVyOiBodHRwczovLzUxMTRlMDY2LWFhOTMtNDU2MC05YmUwLTVhZTQ0NTcxNWE3NS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wtd2FpdAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXdhaXQiCiAgICB1c2VyOiB0ZXN0LXBvb2wtd2FpdC1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC13YWl0CmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXdhaXQtYWRtaW4KICB1c2VyOgogICAgdG9rZW46IGttQTQ5c2F6N1V4dVJSOHZ1UzIxMWpxN2NzVzNobFF1QzQ3QjRla3BobjE3UXBMcVRiVGJGelVO\"}"
-    headers:
-      Content-Length:
-      - "1654"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:29 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 5a804e1b-958d-4d0d-91c6-6660f32204e9
-    status: 200 OK
-    code: 200
-    duration: 44.204284ms
-- id: 138
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1630
-    body: "{\"region\":\"fr-par\", \"id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:01.607119Z\", \"updated_at\":\"2025-10-30T16:50:36.155897Z\", \"type\":\"kapsule\", \"name\":\"test-pool-wait\", \"description\":\"\", \"status\":\"ready\", \"version\":\"1.34.1\", \"cni\":\"calico\", \"tags\":[\"terraform-test\", \"scaleway_k8s_cluster\", \"minimal\"], \"cluster_url\":\"https://5114e066-aa93-4560-9be0-5ae445715a75.api.k8s.fr-par.scw.cloud:6443\", \"dns_wildcard\":\"*.5114e066-aa93-4560-9be0-5ae445715a75.nodes.k8s.fr-par.scw.cloud\", \"autoscaler_config\":{\"scale_down_disabled\":false, \"scale_down_delay_after_add\":\"10m\", \"estimator\":\"binpacking\", \"expander\":\"random\", \"ignore_daemonsets_utilization\":false, \"balance_similar_node_groups\":false, \"expendable_pods_priority_cutoff\":0, \"scale_down_unneeded_time\":\"10m\", \"scale_down_utilization_threshold\":0.5, \"max_graceful_termination_sec\":0}, \"auto_upgrade\":{\"enabled\":false, \"maintenance_window\":{\"start_hour\":0, \"day\":\"any\"}}, \"upgrade_available\":false, \"feature_gates\":[], \"admission_plugins\":[], \"open_id_connect_config\":{\"issuer_url\":\"\", \"client_id\":\"\", \"username_claim\":\"\", \"username_prefix\":\"\", \"groups_claim\":[], \"groups_prefix\":\"\", \"required_claim\":[]}, \"apiserver_cert_sans\":[], \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"commitment_ends_at\":\"2025-10-30T16:49:01.607128Z\", \"acl_available\":true, \"iam_nodes_group_id\":\"6c8f211e-8819-44e2-93ca-fda367c9ca2a\", \"new_images_enabled\":true, \"pod_cidr\":\"100.64.0.0/15\", \"service_cidr\":\"10.32.0.0/20\", \"service_dns_ip\":\"10.32.0.10\"}"
-    headers:
-      Content-Length:
-      - "1630"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:29 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 2c640dca-0440-4849-bdbd-2631b3efeb39
-    status: 200 OK
-    code: 200
-    duration: 21.772743ms
-- id: 139
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/034a502a-1d52-470d-84bd-4a8edd935ba3
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 713
-    body: "{\"region\":\"fr-par\", \"id\":\"034a502a-1d52-470d-84bd-4a8edd935ba3\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:49:07.243810Z\", \"updated_at\":\"2025-10-30T16:52:20.261969Z\", \"name\":\"test-pool-wait\", \"status\":\"ready\", \"version\":\"1.34.1\", \"node_type\":\"pro2_xxs\", \"autoscaling\":false, \"size\":1, \"min_size\":1, \"max_size\":1, \"container_runtime\":\"containerd\", \"autohealing\":false, \"tags\":[], \"placement_group_id\":null, \"kubelet_args\":{}, \"upgrade_policy\":{\"max_unavailable\":1, \"max_surge\":0}, \"zone\":\"fr-par-1\", \"root_volume_type\":\"sbs_5k\", \"root_volume_size\":20000000000, \"public_ip_disabled\":false, \"new_images_enabled\":true, \"security_group_id\":\"4ef16f7a-478c-4b72-b932-982f4b04974b\"}"
-    headers:
-      Content-Length:
-      - "713"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:29 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 6fe672b0-1632-4ad0-bfaf-d5510d6959d9
-    status: 200 OK
-    code: 200
-    duration: 28.666662ms
-- id: 140
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    form:
-      order_by:
-      - created_at_desc
-      project_id:
-      - 105bdce1-64c0-48ab-899d-868455867ecf
-      resource_name:
-      - scw-test-pool-wait-test-pool-wait-2-803259ac23
-      resource_type:
-      - unknown_type
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=105bdce1-64c0-48ab-899d-868455867ecf&resource_name=scw-test-pool-wait-test-pool-wait-2-803259ac23&resource_type=unknown_type
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1122
-    body: "{\"total_count\":2, \"ips\":[{\"id\":\"35d11f02-76e3-4fe4-a39b-c2df537169d7\", \"address\":\"fd5f:519c:6d46:90dd:ab00:4e62:584d:4783/64\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_ipv6\":true, \"created_at\":\"2025-10-30T16:52:26.776899Z\", \"updated_at\":\"2025-10-30T16:52:26.776899Z\", \"source\":{\"subnet_id\":\"7493d1b7-5773-41c2-be8c-52e4ec098fc3\"}, \"resource\":{\"type\":\"instance_private_nic\", \"id\":\"6f4c43ec-ff56-4721-ab5d-fdf2a12b8f2e\", \"mac_address\":\"02:00:00:12:65:C5\", \"name\":\"scw-test-pool-wait-test-pool-wait-2-803259ac23\"}, \"tags\":[], \"reverses\":[], \"region\":\"fr-par\", \"zone\":null}, {\"id\":\"878dc0d8-d3e7-4ab9-b890-f5352063637c\", \"address\":\"172.18.20.4/22\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_ipv6\":false, \"created_at\":\"2025-10-30T16:52:26.654069Z\", \"updated_at\":\"2025-10-30T16:52:26.654069Z\", \"source\":{\"subnet_id\":\"da10d014-609b-48cc-9b9a-437dc31f4497\"}, \"resource\":{\"type\":\"instance_private_nic\", \"id\":\"6f4c43ec-ff56-4721-ab5d-fdf2a12b8f2e\", \"mac_address\":\"02:00:00:12:65:C5\", \"name\":\"scw-test-pool-wait-test-pool-wait-2-803259ac23\"}, \"tags\":[], \"reverses\":[], \"region\":\"fr-par\", \"zone\":null}]}"
-    headers:
-      Content-Length:
-      - "1122"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:30 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - d721dbbc-f92e-4d57-9877-fe5660b769dd
-    status: 200 OK
-    code: 200
-    duration: 37.103236ms
-- id: 141
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    form:
-      order_by:
-      - created_at_desc
-      project_id:
-      - 105bdce1-64c0-48ab-899d-868455867ecf
-      resource_name:
-      - scw-test-pool-wait-test-pool-wait-2-0e5eed3b53
-      resource_type:
-      - unknown_type
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=105bdce1-64c0-48ab-899d-868455867ecf&resource_name=scw-test-pool-wait-test-pool-wait-2-0e5eed3b53&resource_type=unknown_type
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1122
-    body: "{\"total_count\":2, \"ips\":[{\"id\":\"7e596df6-23ea-4a18-b40b-b04b6889b127\", \"address\":\"fd5f:519c:6d46:90dd:3968:9265:e922:7e76/64\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_ipv6\":true, \"created_at\":\"2025-10-30T16:53:19.349027Z\", \"updated_at\":\"2025-10-30T16:53:19.349027Z\", \"source\":{\"subnet_id\":\"7493d1b7-5773-41c2-be8c-52e4ec098fc3\"}, \"resource\":{\"type\":\"instance_private_nic\", \"id\":\"a3a5b239-815d-4735-b92e-16372f9e8741\", \"mac_address\":\"02:00:00:12:2E:F6\", \"name\":\"scw-test-pool-wait-test-pool-wait-2-0e5eed3b53\"}, \"tags\":[], \"reverses\":[], \"region\":\"fr-par\", \"zone\":null}, {\"id\":\"41cfcea9-5c9f-48bf-af2e-a1fe51acece8\", \"address\":\"172.18.20.5/22\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_ipv6\":false, \"created_at\":\"2025-10-30T16:53:19.175416Z\", \"updated_at\":\"2025-10-30T16:53:19.175416Z\", \"source\":{\"subnet_id\":\"da10d014-609b-48cc-9b9a-437dc31f4497\"}, \"resource\":{\"type\":\"instance_private_nic\", \"id\":\"a3a5b239-815d-4735-b92e-16372f9e8741\", \"mac_address\":\"02:00:00:12:2E:F6\", \"name\":\"scw-test-pool-wait-test-pool-wait-2-0e5eed3b53\"}, \"tags\":[], \"reverses\":[], \"region\":\"fr-par\", \"zone\":null}]}"
-    headers:
-      Content-Length:
-      - "1122"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:30 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - d41a3626-5a8d-41b8-8b56-bd8f2d7b5810
-    status: 200 OK
-    code: 200
-    duration: 23.638074ms
-- id: 142
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    form:
-      order_by:
-      - created_at_asc
-      page:
-      - "1"
-      pool_id:
-      - 034a502a-1d52-470d-84bd-4a8edd935ba3
-      status:
-      - unknown
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75/nodes?order_by=created_at_asc&page=1&pool_id=034a502a-1d52-470d-84bd-4a8edd935ba3&status=unknown
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 648
-    body: "{\"total_count\":1, \"nodes\":[{\"region\":\"fr-par\", \"id\":\"3e073c76-a98f-4e6b-ad3c-7a6ca77e15fd\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:51:15.736647Z\", \"updated_at\":\"2025-10-30T16:54:24.994372Z\", \"pool_id\":\"034a502a-1d52-470d-84bd-4a8edd935ba3\", \"status\":\"ready\", \"conditions\":{\"DiskPressure\":\"False\", \"MemoryPressure\":\"False\", \"NetworkUnavailable\":\"False\", \"PIDPressure\":\"False\", \"Ready\":\"True\"}, \"name\":\"scw-test-pool-wait-test-pool-wait-3e073c76a98f\", \"public_ip_v4\":\"51.158.97.50\", \"public_ip_v6\":null, \"provider_id\":\"scaleway://instance/fr-par-1/6ba8f808-ce5f-4e0a-b30e-a83f7f79f945\", \"error_message\":\"\"}]}"
-    headers:
-      Content-Length:
-      - "648"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:30 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 73033e48-f2a0-4059-83ff-2d5db00ecfcf
-    status: 200 OK
-    code: 200
-    duration: 88.160172ms
-- id: 143
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1630
-    body: "{\"region\":\"fr-par\", \"id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:01.607119Z\", \"updated_at\":\"2025-10-30T16:50:36.155897Z\", \"type\":\"kapsule\", \"name\":\"test-pool-wait\", \"description\":\"\", \"status\":\"ready\", \"version\":\"1.34.1\", \"cni\":\"calico\", \"tags\":[\"terraform-test\", \"scaleway_k8s_cluster\", \"minimal\"], \"cluster_url\":\"https://5114e066-aa93-4560-9be0-5ae445715a75.api.k8s.fr-par.scw.cloud:6443\", \"dns_wildcard\":\"*.5114e066-aa93-4560-9be0-5ae445715a75.nodes.k8s.fr-par.scw.cloud\", \"autoscaler_config\":{\"scale_down_disabled\":false, \"scale_down_delay_after_add\":\"10m\", \"estimator\":\"binpacking\", \"expander\":\"random\", \"ignore_daemonsets_utilization\":false, \"balance_similar_node_groups\":false, \"expendable_pods_priority_cutoff\":0, \"scale_down_unneeded_time\":\"10m\", \"scale_down_utilization_threshold\":0.5, \"max_graceful_termination_sec\":0}, \"auto_upgrade\":{\"enabled\":false, \"maintenance_window\":{\"start_hour\":0, \"day\":\"any\"}}, \"upgrade_available\":false, \"feature_gates\":[], \"admission_plugins\":[], \"open_id_connect_config\":{\"issuer_url\":\"\", \"client_id\":\"\", \"username_claim\":\"\", \"username_prefix\":\"\", \"groups_claim\":[], \"groups_prefix\":\"\", \"required_claim\":[]}, \"apiserver_cert_sans\":[], \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"commitment_ends_at\":\"2025-10-30T16:49:01.607128Z\", \"acl_available\":true, \"iam_nodes_group_id\":\"6c8f211e-8819-44e2-93ca-fda367c9ca2a\", \"new_images_enabled\":true, \"pod_cidr\":\"100.64.0.0/15\", \"service_cidr\":\"10.32.0.0/20\", \"service_dns_ip\":\"10.32.0.10\"}"
-    headers:
-      Content-Length:
-      - "1630"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:30 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - f4c49d6d-3fac-44af-b038-c5af687d87a4
-    status: 200 OK
-    code: 200
-    duration: 17.022137ms
-- id: 144
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    form:
-      order_by:
-      - created_at_desc
-      project_id:
-      - 105bdce1-64c0-48ab-899d-868455867ecf
-      resource_name:
-      - scw-test-pool-wait-test-pool-wait-3e073c76a98f
-      resource_type:
-      - unknown_type
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=105bdce1-64c0-48ab-899d-868455867ecf&resource_name=scw-test-pool-wait-test-pool-wait-3e073c76a98f&resource_type=unknown_type
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1122
-    body: "{\"total_count\":2, \"ips\":[{\"id\":\"54c6f7a2-4ca0-43bb-bc9a-b4a3905c0487\", \"address\":\"fd5f:519c:6d46:90dd:c183:ab7b:59b9:fc92/64\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_ipv6\":true, \"created_at\":\"2025-10-30T16:51:19.698188Z\", \"updated_at\":\"2025-10-30T16:51:19.698188Z\", \"source\":{\"subnet_id\":\"7493d1b7-5773-41c2-be8c-52e4ec098fc3\"}, \"resource\":{\"type\":\"instance_private_nic\", \"id\":\"45715cb9-7532-4c78-93a4-2fef3fa3b71a\", \"mac_address\":\"02:00:00:1D:E4:BA\", \"name\":\"scw-test-pool-wait-test-pool-wait-3e073c76a98f\"}, \"tags\":[], \"reverses\":[], \"region\":\"fr-par\", \"zone\":null}, {\"id\":\"ddc7378f-48eb-4ae3-af3e-4d5ee60054c4\", \"address\":\"172.18.20.3/22\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_ipv6\":false, \"created_at\":\"2025-10-30T16:51:19.565119Z\", \"updated_at\":\"2025-10-30T16:51:19.565119Z\", \"source\":{\"subnet_id\":\"da10d014-609b-48cc-9b9a-437dc31f4497\"}, \"resource\":{\"type\":\"instance_private_nic\", \"id\":\"45715cb9-7532-4c78-93a4-2fef3fa3b71a\", \"mac_address\":\"02:00:00:1D:E4:BA\", \"name\":\"scw-test-pool-wait-test-pool-wait-3e073c76a98f\"}, \"tags\":[], \"reverses\":[], \"region\":\"fr-par\", \"zone\":null}]}"
-    headers:
-      Content-Length:
-      - "1122"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:30 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 527c7d2e-d28b-42cf-b24e-99ae7427f088
-    status: 200 OK
-    code: 200
-    duration: 32.987611ms
-- id: 145
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/b0c262ac-e3c4-4a41-9b7c-fac43b180e81
-    method: DELETE
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 718
-    body: "{\"region\":\"fr-par\", \"id\":\"b0c262ac-e3c4-4a41-9b7c-fac43b180e81\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:52:22.689840Z\", \"updated_at\":\"2025-10-30T16:54:30.293530Z\", \"name\":\"test-pool-wait-2\", \"status\":\"deleting\", \"version\":\"1.34.1\", \"node_type\":\"pro2_xxs\", \"autoscaling\":false, \"size\":1, \"min_size\":1, \"max_size\":1, \"container_runtime\":\"containerd\", \"autohealing\":false, \"tags\":[], \"placement_group_id\":null, \"kubelet_args\":{}, \"upgrade_policy\":{\"max_unavailable\":1, \"max_surge\":0}, \"zone\":\"fr-par-1\", \"root_volume_type\":\"sbs_5k\", \"root_volume_size\":20000000000, \"public_ip_disabled\":false, \"new_images_enabled\":true, \"security_group_id\":\"4ef16f7a-478c-4b72-b932-982f4b04974b\"}"
-    headers:
-      Content-Length:
-      - "718"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:30 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 585135ea-b5bc-4d91-b92c-b9c76ccd854f
-    status: 200 OK
-    code: 200
-    duration: 52.957683ms
-- id: 146
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/b0c262ac-e3c4-4a41-9b7c-fac43b180e81
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 718
-    body: "{\"region\":\"fr-par\", \"id\":\"b0c262ac-e3c4-4a41-9b7c-fac43b180e81\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:52:22.689840Z\", \"updated_at\":\"2025-10-30T16:54:30.293530Z\", \"name\":\"test-pool-wait-2\", \"status\":\"deleting\", \"version\":\"1.34.1\", \"node_type\":\"pro2_xxs\", \"autoscaling\":false, \"size\":1, \"min_size\":1, \"max_size\":1, \"container_runtime\":\"containerd\", \"autohealing\":false, \"tags\":[], \"placement_group_id\":null, \"kubelet_args\":{}, \"upgrade_policy\":{\"max_unavailable\":1, \"max_surge\":0}, \"zone\":\"fr-par-1\", \"root_volume_type\":\"sbs_5k\", \"root_volume_size\":20000000000, \"public_ip_disabled\":false, \"new_images_enabled\":true, \"security_group_id\":\"4ef16f7a-478c-4b72-b932-982f4b04974b\"}"
-    headers:
-      Content-Length:
-      - "718"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:54:30 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 05df9156-410f-4e0c-bea5-710ce0f28fa2
-    status: 200 OK
-    code: 200
-    duration: 26.263231ms
-- id: 147
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/b0c262ac-e3c4-4a41-9b7c-fac43b180e81
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 125
-    body: "{\"message\":\"resource is not found\",\"resource\":\"pool\",\"resource_id\":\"b0c262ac-e3c4-4a41-9b7c-fac43b180e81\",\"type\":\"not_found\"}"
-    headers:
-      Content-Length:
-      - "125"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:55:36 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - d36e233d-3974-4b68-b93d-e26d43e81d3f
-    status: 404 Not Found
-    code: 404
-    duration: 19.281267ms
-- id: 148
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1630
-    body: "{\"region\":\"fr-par\", \"id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:01.607119Z\", \"updated_at\":\"2025-10-30T16:50:36.155897Z\", \"type\":\"kapsule\", \"name\":\"test-pool-wait\", \"description\":\"\", \"status\":\"ready\", \"version\":\"1.34.1\", \"cni\":\"calico\", \"tags\":[\"terraform-test\", \"scaleway_k8s_cluster\", \"minimal\"], \"cluster_url\":\"https://5114e066-aa93-4560-9be0-5ae445715a75.api.k8s.fr-par.scw.cloud:6443\", \"dns_wildcard\":\"*.5114e066-aa93-4560-9be0-5ae445715a75.nodes.k8s.fr-par.scw.cloud\", \"autoscaler_config\":{\"scale_down_disabled\":false, \"scale_down_delay_after_add\":\"10m\", \"estimator\":\"binpacking\", \"expander\":\"random\", \"ignore_daemonsets_utilization\":false, \"balance_similar_node_groups\":false, \"expendable_pods_priority_cutoff\":0, \"scale_down_unneeded_time\":\"10m\", \"scale_down_utilization_threshold\":0.5, \"max_graceful_termination_sec\":0}, \"auto_upgrade\":{\"enabled\":false, \"maintenance_window\":{\"start_hour\":0, \"day\":\"any\"}}, \"upgrade_available\":false, \"feature_gates\":[], \"admission_plugins\":[], \"open_id_connect_config\":{\"issuer_url\":\"\", \"client_id\":\"\", \"username_claim\":\"\", \"username_prefix\":\"\", \"groups_claim\":[], \"groups_prefix\":\"\", \"required_claim\":[]}, \"apiserver_cert_sans\":[], \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"commitment_ends_at\":\"2025-10-30T16:49:01.607128Z\", \"acl_available\":true, \"iam_nodes_group_id\":\"6c8f211e-8819-44e2-93ca-fda367c9ca2a\", \"new_images_enabled\":true, \"pod_cidr\":\"100.64.0.0/15\", \"service_cidr\":\"10.32.0.0/20\", \"service_dns_ip\":\"10.32.0.10\"}"
-    headers:
-      Content-Length:
-      - "1630"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:55:36 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 416f98b0-3d8a-4ac9-b689-ce673c2cedf0
-    status: 200 OK
-    code: 200
-    duration: 87.010404ms
-- id: 149
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/1a7a1e1e-2b33-478e-8f1a-faa0303a1c43
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 419
-    body: "{\"id\":\"1a7a1e1e-2b33-478e-8f1a-faa0303a1c43\", \"name\":\"tf-vpc-confident-bose\", \"tags\":[], \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:00.136298Z\", \"updated_at\":\"2025-10-30T16:49:00.136298Z\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_default\":false, \"private_network_count\":1, \"routing_enabled\":true, \"custom_routes_propagation_enabled\":true, \"region\":\"fr-par\"}"
-    headers:
-      Content-Length:
-      - "419"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:55:36 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 2b0b81ad-ee14-4b13-b317-e428aff7a10f
-    status: 200 OK
-    code: 200
-    duration: 26.484516ms
-- id: 150
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/363e7214-8a98-40d0-9357-9e4026c21b76
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1084
-    body: "{\"id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"name\":\"test-pool-wait\", \"tags\":[], \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:00.384609Z\", \"updated_at\":\"2025-10-30T16:49:00.384609Z\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"subnets\":[{\"id\":\"da10d014-609b-48cc-9b9a-437dc31f4497\", \"created_at\":\"2025-10-30T16:49:00.384609Z\", \"updated_at\":\"2025-10-30T16:49:00.384609Z\", \"subnet\":\"172.18.20.0/22\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"vpc_id\":\"1a7a1e1e-2b33-478e-8f1a-faa0303a1c43\"}, {\"id\":\"7493d1b7-5773-41c2-be8c-52e4ec098fc3\", \"created_at\":\"2025-10-30T16:49:00.384609Z\", \"updated_at\":\"2025-10-30T16:49:00.384609Z\", \"subnet\":\"fd5f:519c:6d46:90dd::/64\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"vpc_id\":\"1a7a1e1e-2b33-478e-8f1a-faa0303a1c43\"}], \"vpc_id\":\"1a7a1e1e-2b33-478e-8f1a-faa0303a1c43\", \"dhcp_enabled\":true, \"default_route_propagation_enabled\":false, \"region\":\"fr-par\"}"
-    headers:
-      Content-Length:
-      - "1084"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:55:36 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 98df14e0-a32f-4071-9444-558e781e443f
-    status: 200 OK
-    code: 200
-    duration: 31.051519ms
-- id: 151
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1630
-    body: "{\"region\":\"fr-par\", \"id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:01.607119Z\", \"updated_at\":\"2025-10-30T16:50:36.155897Z\", \"type\":\"kapsule\", \"name\":\"test-pool-wait\", \"description\":\"\", \"status\":\"ready\", \"version\":\"1.34.1\", \"cni\":\"calico\", \"tags\":[\"terraform-test\", \"scaleway_k8s_cluster\", \"minimal\"], \"cluster_url\":\"https://5114e066-aa93-4560-9be0-5ae445715a75.api.k8s.fr-par.scw.cloud:6443\", \"dns_wildcard\":\"*.5114e066-aa93-4560-9be0-5ae445715a75.nodes.k8s.fr-par.scw.cloud\", \"autoscaler_config\":{\"scale_down_disabled\":false, \"scale_down_delay_after_add\":\"10m\", \"estimator\":\"binpacking\", \"expander\":\"random\", \"ignore_daemonsets_utilization\":false, \"balance_similar_node_groups\":false, \"expendable_pods_priority_cutoff\":0, \"scale_down_unneeded_time\":\"10m\", \"scale_down_utilization_threshold\":0.5, \"max_graceful_termination_sec\":0}, \"auto_upgrade\":{\"enabled\":false, \"maintenance_window\":{\"start_hour\":0, \"day\":\"any\"}}, \"upgrade_available\":false, \"feature_gates\":[], \"admission_plugins\":[], \"open_id_connect_config\":{\"issuer_url\":\"\", \"client_id\":\"\", \"username_claim\":\"\", \"username_prefix\":\"\", \"groups_claim\":[], \"groups_prefix\":\"\", \"required_claim\":[]}, \"apiserver_cert_sans\":[], \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"commitment_ends_at\":\"2025-10-30T16:49:01.607128Z\", \"acl_available\":true, \"iam_nodes_group_id\":\"6c8f211e-8819-44e2-93ca-fda367c9ca2a\", \"new_images_enabled\":true, \"pod_cidr\":\"100.64.0.0/15\", \"service_cidr\":\"10.32.0.0/20\", \"service_dns_ip\":\"10.32.0.10\"}"
-    headers:
-      Content-Length:
-      - "1630"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:55:36 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 3eed7e9b-9d15-417d-838f-83178a20794d
-    status: 200 OK
-    code: 200
-    duration: 23.11938ms
-- id: 152
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75/kubeconfig
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1654
-    body: "{\"name\":\"kubeconfig\", \"content_type\":\"application/octet-stream\", \"content\":\"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVSllSRU5EUVZGSFowRjNTVUpCWjBsQ1FVUkJTMEpuWjNGb2EycFBVRkZSUkVGcVFWWk5VazEzUlZGWlJGWlJVVVJGZDNCeVpGZEtiR050Tld3S1pFZFdlazFDTkZoRVZFa3hUVlJCZVU5VVJUSk9SR3QzVFZadldFUlVUVEZOVkVGNVQxUkZNazVFYTNkTlZtOTNSbFJGVkUxQ1JVZEJNVlZGUVhoTlN3cGhNMVpwV2xoS2RWcFlVbXhqZWtKYVRVSk5SMEo1Y1VkVFRUUTVRV2RGUjBORGNVZFRUVFE1UVhkRlNFRXdTVUZDVFhsNllqUkdTbVozWTFOM01tZEZDbEppVFRkVFZpOUpiM0ZXU21oWWVIbGxObHB1UkZOWlZ6WmxRbU4yV2tJM1RXVnVMMWxPYm5wM2F6QkpRazF2VDFkUFRXeHRlVGxJWVU5NE1XVkxaSFlLTUVRNE9XZDVZV3BSYWtKQlRVRTBSMEV4VldSRWQwVkNMM2RSUlVGM1NVTndSRUZRUW1kT1ZraFNUVUpCWmpoRlFsUkJSRUZSU0M5TlFqQkhRVEZWWkFwRVoxRlhRa0pTVTFsU1NtTm9UV1l3V0U5YWNtUkJhV1JMYkdOUWEyTklZeTlVUVV0Q1oyZHhhR3RxVDFCUlVVUkJaMDVLUVVSQ1IwRnBSVUY1Ym0xd0NqbFpkWG80VWpGVWFtNDBiV2RqYWpaV2QycFVTM2gzUm5KS1VrdFZTVVpIUTFwR2VsbEtWVU5KVVVSSWRERkNXalpHYUZrdlVUWlRabloxTVhCNmJEWUtNWG80VkhCMlNIQkxVa0pIY1RscmNVVlJOa3hPZHowOUNpMHRMUzB0UlU1RUlFTkZVbFJKUmtsRFFWUkZMUzB0TFMwSwogICAgc2VydmVyOiBodHRwczovLzUxMTRlMDY2LWFhOTMtNDU2MC05YmUwLTVhZTQ0NTcxNWE3NS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wtd2FpdAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXdhaXQiCiAgICB1c2VyOiB0ZXN0LXBvb2wtd2FpdC1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC13YWl0CmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXdhaXQtYWRtaW4KICB1c2VyOgogICAgdG9rZW46IGttQTQ5c2F6N1V4dVJSOHZ1UzIxMWpxN2NzVzNobFF1QzQ3QjRla3BobjE3UXBMcVRiVGJGelVO\"}"
-    headers:
-      Content-Length:
-      - "1654"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:55:37 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - f865cd8e-819f-4a6f-993e-4dcd48bda06f
-    status: 200 OK
-    code: 200
-    duration: 86.881641ms
-- id: 153
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/034a502a-1d52-470d-84bd-4a8edd935ba3
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 713
-    body: "{\"region\":\"fr-par\", \"id\":\"034a502a-1d52-470d-84bd-4a8edd935ba3\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:49:07.243810Z\", \"updated_at\":\"2025-10-30T16:52:20.261969Z\", \"name\":\"test-pool-wait\", \"status\":\"ready\", \"version\":\"1.34.1\", \"node_type\":\"pro2_xxs\", \"autoscaling\":false, \"size\":1, \"min_size\":1, \"max_size\":1, \"container_runtime\":\"containerd\", \"autohealing\":false, \"tags\":[], \"placement_group_id\":null, \"kubelet_args\":{}, \"upgrade_policy\":{\"max_unavailable\":1, \"max_surge\":0}, \"zone\":\"fr-par-1\", \"root_volume_type\":\"sbs_5k\", \"root_volume_size\":20000000000, \"public_ip_disabled\":false, \"new_images_enabled\":true, \"security_group_id\":\"4ef16f7a-478c-4b72-b932-982f4b04974b\"}"
-    headers:
-      Content-Length:
-      - "713"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:55:37 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - a4727956-e425-48b6-ab17-23e393813926
-    status: 200 OK
-    code: 200
-    duration: 29.076431ms
-- id: 154
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    form:
-      order_by:
-      - created_at_asc
-      page:
-      - "1"
-      pool_id:
-      - 034a502a-1d52-470d-84bd-4a8edd935ba3
-      status:
-      - unknown
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75/nodes?order_by=created_at_asc&page=1&pool_id=034a502a-1d52-470d-84bd-4a8edd935ba3&status=unknown
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 648
-    body: "{\"total_count\":1, \"nodes\":[{\"region\":\"fr-par\", \"id\":\"3e073c76-a98f-4e6b-ad3c-7a6ca77e15fd\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:51:15.736647Z\", \"updated_at\":\"2025-10-30T16:55:12.378766Z\", \"pool_id\":\"034a502a-1d52-470d-84bd-4a8edd935ba3\", \"status\":\"ready\", \"conditions\":{\"DiskPressure\":\"False\", \"MemoryPressure\":\"False\", \"NetworkUnavailable\":\"False\", \"PIDPressure\":\"False\", \"Ready\":\"True\"}, \"name\":\"scw-test-pool-wait-test-pool-wait-3e073c76a98f\", \"public_ip_v4\":\"51.158.97.50\", \"public_ip_v6\":null, \"provider_id\":\"scaleway://instance/fr-par-1/6ba8f808-ce5f-4e0a-b30e-a83f7f79f945\", \"error_message\":\"\"}]}"
-    headers:
-      Content-Length:
-      - "648"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:55:37 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 7438863e-5750-4791-9b3b-de927d7d64ad
-    status: 200 OK
-    code: 200
-    duration: 85.760899ms
-- id: 155
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1630
-    body: "{\"region\":\"fr-par\", \"id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:01.607119Z\", \"updated_at\":\"2025-10-30T16:50:36.155897Z\", \"type\":\"kapsule\", \"name\":\"test-pool-wait\", \"description\":\"\", \"status\":\"ready\", \"version\":\"1.34.1\", \"cni\":\"calico\", \"tags\":[\"terraform-test\", \"scaleway_k8s_cluster\", \"minimal\"], \"cluster_url\":\"https://5114e066-aa93-4560-9be0-5ae445715a75.api.k8s.fr-par.scw.cloud:6443\", \"dns_wildcard\":\"*.5114e066-aa93-4560-9be0-5ae445715a75.nodes.k8s.fr-par.scw.cloud\", \"autoscaler_config\":{\"scale_down_disabled\":false, \"scale_down_delay_after_add\":\"10m\", \"estimator\":\"binpacking\", \"expander\":\"random\", \"ignore_daemonsets_utilization\":false, \"balance_similar_node_groups\":false, \"expendable_pods_priority_cutoff\":0, \"scale_down_unneeded_time\":\"10m\", \"scale_down_utilization_threshold\":0.5, \"max_graceful_termination_sec\":0}, \"auto_upgrade\":{\"enabled\":false, \"maintenance_window\":{\"start_hour\":0, \"day\":\"any\"}}, \"upgrade_available\":false, \"feature_gates\":[], \"admission_plugins\":[], \"open_id_connect_config\":{\"issuer_url\":\"\", \"client_id\":\"\", \"username_claim\":\"\", \"username_prefix\":\"\", \"groups_claim\":[], \"groups_prefix\":\"\", \"required_claim\":[]}, \"apiserver_cert_sans\":[], \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"commitment_ends_at\":\"2025-10-30T16:49:01.607128Z\", \"acl_available\":true, \"iam_nodes_group_id\":\"6c8f211e-8819-44e2-93ca-fda367c9ca2a\", \"new_images_enabled\":true, \"pod_cidr\":\"100.64.0.0/15\", \"service_cidr\":\"10.32.0.0/20\", \"service_dns_ip\":\"10.32.0.10\"}"
-    headers:
-      Content-Length:
-      - "1630"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:55:37 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - c420d5d4-e1fa-4513-9a7a-39a7e162b2f1
-    status: 200 OK
-    code: 200
-    duration: 24.900774ms
-- id: 156
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    form:
-      order_by:
-      - created_at_desc
-      project_id:
-      - 105bdce1-64c0-48ab-899d-868455867ecf
-      resource_name:
-      - scw-test-pool-wait-test-pool-wait-3e073c76a98f
-      resource_type:
-      - unknown_type
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=105bdce1-64c0-48ab-899d-868455867ecf&resource_name=scw-test-pool-wait-test-pool-wait-3e073c76a98f&resource_type=unknown_type
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1122
-    body: "{\"total_count\":2, \"ips\":[{\"id\":\"54c6f7a2-4ca0-43bb-bc9a-b4a3905c0487\", \"address\":\"fd5f:519c:6d46:90dd:c183:ab7b:59b9:fc92/64\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_ipv6\":true, \"created_at\":\"2025-10-30T16:51:19.698188Z\", \"updated_at\":\"2025-10-30T16:51:19.698188Z\", \"source\":{\"subnet_id\":\"7493d1b7-5773-41c2-be8c-52e4ec098fc3\"}, \"resource\":{\"type\":\"instance_private_nic\", \"id\":\"45715cb9-7532-4c78-93a4-2fef3fa3b71a\", \"mac_address\":\"02:00:00:1D:E4:BA\", \"name\":\"scw-test-pool-wait-test-pool-wait-3e073c76a98f\"}, \"tags\":[], \"reverses\":[], \"region\":\"fr-par\", \"zone\":null}, {\"id\":\"ddc7378f-48eb-4ae3-af3e-4d5ee60054c4\", \"address\":\"172.18.20.3/22\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"is_ipv6\":false, \"created_at\":\"2025-10-30T16:51:19.565119Z\", \"updated_at\":\"2025-10-30T16:51:19.565119Z\", \"source\":{\"subnet_id\":\"da10d014-609b-48cc-9b9a-437dc31f4497\"}, \"resource\":{\"type\":\"instance_private_nic\", \"id\":\"45715cb9-7532-4c78-93a4-2fef3fa3b71a\", \"mac_address\":\"02:00:00:1D:E4:BA\", \"name\":\"scw-test-pool-wait-test-pool-wait-3e073c76a98f\"}, \"tags\":[], \"reverses\":[], \"region\":\"fr-par\", \"zone\":null}]}"
-    headers:
-      Content-Length:
-      - "1122"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:55:37 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - c7fc2d8e-b1a0-41d9-af4c-02c5a2d24b77
-    status: 200 OK
-    code: 200
-    duration: 34.261573ms
-- id: 157
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/034a502a-1d52-470d-84bd-4a8edd935ba3
-    method: DELETE
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 716
-    body: "{\"region\":\"fr-par\", \"id\":\"034a502a-1d52-470d-84bd-4a8edd935ba3\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:49:07.243810Z\", \"updated_at\":\"2025-10-30T16:55:37.494697Z\", \"name\":\"test-pool-wait\", \"status\":\"deleting\", \"version\":\"1.34.1\", \"node_type\":\"pro2_xxs\", \"autoscaling\":false, \"size\":1, \"min_size\":1, \"max_size\":1, \"container_runtime\":\"containerd\", \"autohealing\":false, \"tags\":[], \"placement_group_id\":null, \"kubelet_args\":{}, \"upgrade_policy\":{\"max_unavailable\":1, \"max_surge\":0}, \"zone\":\"fr-par-1\", \"root_volume_type\":\"sbs_5k\", \"root_volume_size\":20000000000, \"public_ip_disabled\":false, \"new_images_enabled\":true, \"security_group_id\":\"4ef16f7a-478c-4b72-b932-982f4b04974b\"}"
-    headers:
-      Content-Length:
-      - "716"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:55:37 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 5de39d56-2a4a-494e-8cb4-3a7e7ddb56bd
-    status: 200 OK
-    code: 200
-    duration: 53.97945ms
-- id: 158
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/034a502a-1d52-470d-84bd-4a8edd935ba3
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 716
-    body: "{\"region\":\"fr-par\", \"id\":\"034a502a-1d52-470d-84bd-4a8edd935ba3\", \"cluster_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"created_at\":\"2025-10-30T16:49:07.243810Z\", \"updated_at\":\"2025-10-30T16:55:37.494697Z\", \"name\":\"test-pool-wait\", \"status\":\"deleting\", \"version\":\"1.34.1\", \"node_type\":\"pro2_xxs\", \"autoscaling\":false, \"size\":1, \"min_size\":1, \"max_size\":1, \"container_runtime\":\"containerd\", \"autohealing\":false, \"tags\":[], \"placement_group_id\":null, \"kubelet_args\":{}, \"upgrade_policy\":{\"max_unavailable\":1, \"max_surge\":0}, \"zone\":\"fr-par-1\", \"root_volume_type\":\"sbs_5k\", \"root_volume_size\":20000000000, \"public_ip_disabled\":false, \"new_images_enabled\":true, \"security_group_id\":\"4ef16f7a-478c-4b72-b932-982f4b04974b\"}"
-    headers:
-      Content-Length:
-      - "716"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:55:37 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - c791ade2-b379-42c0-ae24-30ae33a684d6
-    status: 200 OK
-    code: 200
-    duration: 24.265743ms
-- id: 159
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/034a502a-1d52-470d-84bd-4a8edd935ba3
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 125
-    body: "{\"message\":\"resource is not found\",\"resource\":\"pool\",\"resource_id\":\"034a502a-1d52-470d-84bd-4a8edd935ba3\",\"type\":\"not_found\"}"
-    headers:
-      Content-Length:
-      - "125"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:59:57 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 11a8aa32-e4fe-40e9-afd7-d32e1098588a
-    status: 404 Not Found
-    code: 404
-    duration: 36.491288ms
-- id: 160
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    form:
-      with_additional_resources:
-      - "false"
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75?with_additional_resources=false
-    method: DELETE
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1634
-    body: "{\"region\":\"fr-par\", \"id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:01.607119Z\", \"updated_at\":\"2025-10-30T16:59:57.587481Z\", \"type\":\"kapsule\", \"name\":\"test-pool-wait\", \"description\":\"\", \"status\":\"deleting\", \"version\":\"1.34.1\", \"cni\":\"calico\", \"tags\":[\"terraform-test\", \"scaleway_k8s_cluster\", \"minimal\"], \"cluster_url\":\"https://5114e066-aa93-4560-9be0-5ae445715a75.api.k8s.fr-par.scw.cloud:6443\", \"dns_wildcard\":\"*.5114e066-aa93-4560-9be0-5ae445715a75.nodes.k8s.fr-par.scw.cloud\", \"autoscaler_config\":{\"scale_down_disabled\":false, \"scale_down_delay_after_add\":\"10m\", \"estimator\":\"binpacking\", \"expander\":\"random\", \"ignore_daemonsets_utilization\":false, \"balance_similar_node_groups\":false, \"expendable_pods_priority_cutoff\":0, \"scale_down_unneeded_time\":\"10m\", \"scale_down_utilization_threshold\":0.5, \"max_graceful_termination_sec\":0}, \"auto_upgrade\":{\"enabled\":false, \"maintenance_window\":{\"start_hour\":0, \"day\":\"any\"}}, \"upgrade_available\":false, \"feature_gates\":[], \"admission_plugins\":[], \"open_id_connect_config\":{\"issuer_url\":\"\", \"client_id\":\"\", \"username_claim\":\"\", \"username_prefix\":\"\", \"groups_claim\":[], \"groups_prefix\":\"\", \"required_claim\":[]}, \"apiserver_cert_sans\":[], \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"commitment_ends_at\":\"2025-10-30T16:49:01.607128Z\", \"acl_available\":true, \"iam_nodes_group_id\":\"6c8f211e-8819-44e2-93ca-fda367c9ca2a\", \"new_images_enabled\":false, \"pod_cidr\":\"100.64.0.0/15\", \"service_cidr\":\"10.32.0.0/20\", \"service_dns_ip\":\"10.32.0.10\"}"
-    headers:
-      Content-Length:
-      - "1634"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:59:57 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 0168103f-a0bd-4a14-876e-e08b1dc6ac26
-    status: 200 OK
-    code: 200
-    duration: 147.899732ms
-- id: 161
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 1633
-    body: "{\"region\":\"fr-par\", \"id\":\"5114e066-aa93-4560-9be0-5ae445715a75\", \"organization_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"project_id\":\"105bdce1-64c0-48ab-899d-868455867ecf\", \"created_at\":\"2025-10-30T16:49:01.607119Z\", \"updated_at\":\"2025-10-30T16:59:57.587481Z\", \"type\":\"kapsule\", \"name\":\"test-pool-wait\", \"description\":\"\", \"status\":\"deleting\", \"version\":\"1.34.1\", \"cni\":\"calico\", \"tags\":[\"terraform-test\", \"scaleway_k8s_cluster\", \"minimal\"], \"cluster_url\":\"https://5114e066-aa93-4560-9be0-5ae445715a75.api.k8s.fr-par.scw.cloud:6443\", \"dns_wildcard\":\"*.5114e066-aa93-4560-9be0-5ae445715a75.nodes.k8s.fr-par.scw.cloud\", \"autoscaler_config\":{\"scale_down_disabled\":false, \"scale_down_delay_after_add\":\"10m\", \"estimator\":\"binpacking\", \"expander\":\"random\", \"ignore_daemonsets_utilization\":false, \"balance_similar_node_groups\":false, \"expendable_pods_priority_cutoff\":0, \"scale_down_unneeded_time\":\"10m\", \"scale_down_utilization_threshold\":0.5, \"max_graceful_termination_sec\":0}, \"auto_upgrade\":{\"enabled\":false, \"maintenance_window\":{\"start_hour\":0, \"day\":\"any\"}}, \"upgrade_available\":false, \"feature_gates\":[], \"admission_plugins\":[], \"open_id_connect_config\":{\"issuer_url\":\"\", \"client_id\":\"\", \"username_claim\":\"\", \"username_prefix\":\"\", \"groups_claim\":[], \"groups_prefix\":\"\", \"required_claim\":[]}, \"apiserver_cert_sans\":[], \"private_network_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\", \"commitment_ends_at\":\"2025-10-30T16:49:01.607128Z\", \"acl_available\":true, \"iam_nodes_group_id\":\"6c8f211e-8819-44e2-93ca-fda367c9ca2a\", \"new_images_enabled\":true, \"pod_cidr\":\"100.64.0.0/15\", \"service_cidr\":\"10.32.0.0/20\", \"service_dns_ip\":\"10.32.0.10\"}"
-    headers:
-      Content-Length:
-      - "1633"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 16:59:57 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 3b86500c-77d5-46af-9326-2fb7ac96e206
-    status: 200 OK
-    code: 200
-    duration: 100.040048ms
-- id: 162
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 128
-    body: "{\"message\":\"resource is not found\",\"resource\":\"cluster\",\"resource_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\",\"type\":\"not_found\"}"
-    headers:
-      Content-Length:
-      - "128"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 17:00:12 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 48cf239e-edf3-431f-a972-e7387691bf08
-    status: 404 Not Found
-    code: 404
-    duration: 18.401737ms
-- id: 163
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/363e7214-8a98-40d0-9357-9e4026c21b76
-    method: DELETE
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 0
-    body: ""
-    headers:
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 17:00:14 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 8db7b7fc-1f86-4ebc-a3af-a86e67850881
-    status: 204 No Content
-    code: 204
-    duration: 1.082171416s
-- id: 164
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/1a7a1e1e-2b33-478e-8f1a-faa0303a1c43
-    method: DELETE
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 0
-    body: ""
-    headers:
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 17:00:14 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 54bb300f-053d-43cf-aedd-cc3832dffd28
-    status: 204 No Content
-    code: 204
-    duration: 104.628209ms
-- id: 165
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/034a502a-1d52-470d-84bd-4a8edd935ba3
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 125
-    body: "{\"message\":\"resource is not found\",\"resource\":\"pool\",\"resource_id\":\"034a502a-1d52-470d-84bd-4a8edd935ba3\",\"type\":\"not_found\"}"
-    headers:
-      Content-Length:
-      - "125"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 17:00:14 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - edbfecae-c16e-4f04-9946-68466c2a20b0
-    status: 404 Not Found
-    code: 404
-    duration: 30.696542ms
-- id: 166
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5114e066-aa93-4560-9be0-5ae445715a75
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 128
-    body: "{\"message\":\"resource is not found\",\"resource\":\"cluster\",\"resource_id\":\"5114e066-aa93-4560-9be0-5ae445715a75\",\"type\":\"not_found\"}"
-    headers:
-      Content-Length:
-      - "128"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 17:00:14 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - 8c4b86ad-5725-4bb7-8134-0207ebac9938
-    status: 404 Not Found
-    code: 404
-    duration: 25.348265ms
-- id: 167
-  request:
-    proto: HTTP/1.1
-    proto_major: 1
-    proto_minor: 1
-    content_length: 0
-    host: api.scaleway.com
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/363e7214-8a98-40d0-9357-9e4026c21b76
-    method: GET
-  response:
-    proto: HTTP/2.0
-    proto_major: 2
-    proto_minor: 0
-    content_length: 136
-    body: "{\"message\":\"resource is not found\",\"resource\":\"private_network\",\"resource_id\":\"363e7214-8a98-40d0-9357-9e4026c21b76\",\"type\":\"not_found\"}"
-    headers:
-      Content-Length:
-      - "136"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 30 Oct 2025 17:00:14 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      X-Request-Id:
-      - b8a73f90-ff2b-440e-bfb7-d7b6c855521f
-    status: 404 Not Found
-    code: 404
-    duration: 36.30609ms
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/versions
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 4482
+        body: '{"versions":[{"region":"fr-par", "name":"1.35.2", "label":"Kubernetes 1.35.2", "available_cnis":["cilium", "cilium_native", "calico", "kilo", "none"], "available_container_runtimes":["containerd"], "available_feature_gates":["HPAScaleToZero", "CPUManagerPolicyAlphaOptions", "MutatingAdmissionPolicy"], "available_admission_plugins":["AlwaysPullImages", "PodNodeSelector", "PodTolerationRestriction"], "available_kubelet_args":{"containerLogMaxFiles":"uint16", "containerLogMaxSize":"quantity", "cpuCFSQuota":"bool", "cpuCFSQuotaPeriod":"duration", "cpuManagerPolicy":"enum:none|static", "cpuManagerPolicyOptions":"map[string]string", "enableDebuggingHandlers":"bool", "evictionHard":"map[string]string", "evictionMinimumReclaim":"map[string]string", "imageGCHighThresholdPercent":"uint32", "imageGCLowThresholdPercent":"uint32", "maxParallelImagePulls":"int32", "maxPods":"uint16", "registryBurst":"int32", "registryPullQPS":"int32", "serializeImagePulls":"bool"}, "deprecated_at":"2027-01-19T00:00:00Z", "end_of_life_at":"2027-03-19T00:00:00Z", "released_at":"2026-01-19T00:00:00Z"}, {"region":"fr-par", "name":"1.34.5", "label":"Kubernetes 1.34.5", "available_cnis":["cilium", "cilium_native", "calico", "kilo", "none"], "available_container_runtimes":["containerd"], "available_feature_gates":["HPAScaleToZero", "CPUManagerPolicyAlphaOptions", "ImageVolume", "MutatingAdmissionPolicy"], "available_admission_plugins":["AlwaysPullImages", "PodNodeSelector", "PodTolerationRestriction"], "available_kubelet_args":{"containerLogMaxFiles":"uint16", "containerLogMaxSize":"quantity", "cpuCFSQuota":"bool", "cpuCFSQuotaPeriod":"duration", "cpuManagerPolicy":"enum:none|static", "cpuManagerPolicyOptions":"map[string]string", "enableDebuggingHandlers":"bool", "evictionHard":"map[string]string", "evictionMinimumReclaim":"map[string]string", "imageGCHighThresholdPercent":"uint32", "imageGCLowThresholdPercent":"uint32", "maxParallelImagePulls":"int32", "maxPods":"uint16", "registryBurst":"int32", "registryPullQPS":"int32", "serializeImagePulls":"bool"}, "deprecated_at":"2026-09-29T00:00:00Z", "end_of_life_at":"2026-11-29T00:00:00Z", "released_at":"2025-09-29T00:00:00Z"}, {"region":"fr-par", "name":"1.33.9", "label":"Kubernetes 1.33.9", "available_cnis":["cilium", "calico", "kilo", "none"], "available_container_runtimes":["containerd"], "available_feature_gates":["HPAScaleToZero", "DRAAdminAccess", "DynamicResourceAllocation", "PodLevelResources", "CPUManagerPolicyAlphaOptions", "ImageVolume"], "available_admission_plugins":["AlwaysPullImages", "PodNodeSelector", "PodTolerationRestriction"], "available_kubelet_args":{"containerLogMaxFiles":"uint16", "containerLogMaxSize":"quantity", "cpuCFSQuota":"bool", "cpuCFSQuotaPeriod":"duration", "cpuManagerPolicy":"enum:none|static", "cpuManagerPolicyOptions":"map[string]string", "enableDebuggingHandlers":"bool", "evictionHard":"map[string]string", "evictionMinimumReclaim":"map[string]string", "imageGCHighThresholdPercent":"uint32", "imageGCLowThresholdPercent":"uint32", "maxParallelImagePulls":"int32", "maxPods":"uint16", "registryBurst":"int32", "registryPullQPS":"int32", "serializeImagePulls":"bool"}, "deprecated_at":"2026-09-04T00:00:00Z", "end_of_life_at":"2026-11-04T00:00:00Z", "released_at":"2025-09-04T00:00:00Z"}, {"region":"fr-par", "name":"1.32.13", "label":"Kubernetes 1.32.13", "available_cnis":["cilium", "calico", "kilo", "none"], "available_container_runtimes":["containerd"], "available_feature_gates":["HPAScaleToZero", "InPlacePodVerticalScaling", "SidecarContainers", "DRAAdminAccess", "DRAResourceClaimDeviceStatus", "DynamicResourceAllocation", "PodLevelResources", "CPUManagerPolicyAlphaOptions", "ImageVolume"], "available_admission_plugins":["AlwaysPullImages", "PodNodeSelector", "PodTolerationRestriction"], "available_kubelet_args":{"containerLogMaxFiles":"uint16", "containerLogMaxSize":"quantity", "cpuCFSQuota":"bool", "cpuCFSQuotaPeriod":"duration", "cpuManagerPolicy":"enum:none|static", "cpuManagerPolicyOptions":"map[string]string", "enableDebuggingHandlers":"bool", "evictionHard":"map[string]string", "evictionMinimumReclaim":"map[string]string", "imageGCHighThresholdPercent":"uint32", "imageGCLowThresholdPercent":"uint32", "maxParallelImagePulls":"int32", "maxPods":"uint16", "registryBurst":"int32", "registryPullQPS":"int32", "serializeImagePulls":"bool"}, "deprecated_at":"2026-03-24T00:00:00Z", "end_of_life_at":"2026-06-24T00:00:00Z", "released_at":"2025-03-24T00:00:00Z"}]}'
+        headers:
+            Content-Length:
+                - "4482"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:53:19 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - afd3bdb0-5008-4e55-bfc1-b5052e54773c
+        status: 200 OK
+        code: 200
+        duration: 20.460087ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 129
+        host: api.scaleway.com
+        body: '{"name":"tf-vpc-affectionate-proskuriakova","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"enable_routing":false}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 431
+        body: '{"id":"45317da4-924e-4fd3-b4ca-e93215bc5849", "name":"tf-vpc-affectionate-proskuriakova", "tags":[], "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:12.102781Z", "updated_at":"2026-03-30T12:54:12.102781Z", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_default":false, "private_network_count":0, "routing_enabled":true, "custom_routes_propagation_enabled":true, "region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "431"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:54:12 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 91bd390f-f5ff-48c6-955e-2c55f481c863
+        status: 200 OK
+        code: 200
+        duration: 49.34198ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/45317da4-924e-4fd3-b4ca-e93215bc5849
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 431
+        body: '{"id":"45317da4-924e-4fd3-b4ca-e93215bc5849", "name":"tf-vpc-affectionate-proskuriakova", "tags":[], "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:12.102781Z", "updated_at":"2026-03-30T12:54:12.102781Z", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_default":false, "private_network_count":0, "routing_enabled":true, "custom_routes_propagation_enabled":true, "region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "431"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:54:12 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - c4d6e826-33a1-4597-b2ba-c159a44291ec
+        status: 200 OK
+        code: 200
+        duration: 32.027506ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 192
+        host: api.scaleway.com
+        body: '{"name":"test-pool-wait","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"subnets":null,"vpc_id":"45317da4-924e-4fd3-b4ca-e93215bc5849","default_route_propagation_enabled":false}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1084
+        body: '{"id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "name":"test-pool-wait", "tags":[], "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:12.204171Z", "updated_at":"2026-03-30T12:54:12.204171Z", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "subnets":[{"id":"ae63fffc-03c5-47e1-bfb2-170301d26f53", "created_at":"2026-03-30T12:54:12.204171Z", "updated_at":"2026-03-30T12:54:12.204171Z", "subnet":"172.16.72.0/22", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "vpc_id":"45317da4-924e-4fd3-b4ca-e93215bc5849"}, {"id":"b18788e5-4872-494d-a7bb-0ba98125d9e4", "created_at":"2026-03-30T12:54:12.204171Z", "updated_at":"2026-03-30T12:54:12.204171Z", "subnet":"fd63:256c:45f7:bc7e::/64", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "vpc_id":"45317da4-924e-4fd3-b4ca-e93215bc5849"}], "vpc_id":"45317da4-924e-4fd3-b4ca-e93215bc5849", "dhcp_enabled":true, "default_route_propagation_enabled":false, "region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1084"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:54:12 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 9fecca41-cf90-427a-a7c5-409ab1dbfc18
+        status: 200 OK
+        code: 200
+        duration: 643.081481ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/97585af2-c151-4ad5-9778-fa88d5af8bba
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1084
+        body: '{"id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "name":"test-pool-wait", "tags":[], "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:12.204171Z", "updated_at":"2026-03-30T12:54:12.204171Z", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "subnets":[{"id":"ae63fffc-03c5-47e1-bfb2-170301d26f53", "created_at":"2026-03-30T12:54:12.204171Z", "updated_at":"2026-03-30T12:54:12.204171Z", "subnet":"172.16.72.0/22", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "vpc_id":"45317da4-924e-4fd3-b4ca-e93215bc5849"}, {"id":"b18788e5-4872-494d-a7bb-0ba98125d9e4", "created_at":"2026-03-30T12:54:12.204171Z", "updated_at":"2026-03-30T12:54:12.204171Z", "subnet":"fd63:256c:45f7:bc7e::/64", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "vpc_id":"45317da4-924e-4fd3-b4ca-e93215bc5849"}], "vpc_id":"45317da4-924e-4fd3-b4ca-e93215bc5849", "dhcp_enabled":true, "default_route_propagation_enabled":false, "region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1084"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:54:12 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 61a63914-0f18-491c-a298-b3b5624df08c
+        status: 200 OK
+        code: 200
+        duration: 26.102296ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 695
+        host: api.scaleway.com
+        body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-pool-wait","description":"","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"version":"1.35.2","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":[],"admission_plugins":[],"apiserver_cert_sans":[],"private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba"}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1570
+        body: '{"region":"fr-par", "id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:13.060726Z", "updated_at":"2026-03-30T12:54:13.060726Z", "type":"kapsule", "name":"test-pool-wait", "description":"", "status":"creating", "version":"1.35.2", "cni":"calico", "tags":["terraform-test", "scaleway_k8s_cluster", "minimal"], "cluster_url":"https://3b418478-2d8b-4fc7-87c3-f551ebb22f53.api.k8s.fr-par.scw.cloud:6443", "dns_wildcard":"*.3b418478-2d8b-4fc7-87c3-f551ebb22f53.nodes.k8s.fr-par.scw.cloud", "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m", "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false, "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":0, "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":0}, "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}}, "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"", "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[], "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "commitment_ends_at":"2026-03-30T12:54:13.060733Z", "acl_available":true, "iam_nodes_group_id":"", "pod_cidr":"100.64.0.0/15", "service_cidr":"10.32.0.0/20", "service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1570"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:54:13 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 248b7707-4622-4750-a646-d918cc924191
+        status: 200 OK
+        code: 200
+        duration: 243.523119ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1570
+        body: '{"region":"fr-par", "id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:13.060726Z", "updated_at":"2026-03-30T12:54:13.060726Z", "type":"kapsule", "name":"test-pool-wait", "description":"", "status":"creating", "version":"1.35.2", "cni":"calico", "tags":["terraform-test", "scaleway_k8s_cluster", "minimal"], "cluster_url":"https://3b418478-2d8b-4fc7-87c3-f551ebb22f53.api.k8s.fr-par.scw.cloud:6443", "dns_wildcard":"*.3b418478-2d8b-4fc7-87c3-f551ebb22f53.nodes.k8s.fr-par.scw.cloud", "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m", "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false, "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":0, "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":0}, "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}}, "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"", "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[], "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "commitment_ends_at":"2026-03-30T12:54:13.060733Z", "acl_available":true, "iam_nodes_group_id":"", "pod_cidr":"100.64.0.0/15", "service_cidr":"10.32.0.0/20", "service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1570"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:54:13 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 1c8ea8c4-747b-4a2a-b461-e6238bbb79f7
+        status: 200 OK
+        code: 200
+        duration: 33.867879ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1611
+        body: '{"region":"fr-par", "id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:13.060726Z", "updated_at":"2026-03-30T12:54:13.488208Z", "type":"kapsule", "name":"test-pool-wait", "description":"", "status":"pool_required", "version":"1.35.2", "cni":"calico", "tags":["terraform-test", "scaleway_k8s_cluster", "minimal"], "cluster_url":"https://3b418478-2d8b-4fc7-87c3-f551ebb22f53.api.k8s.fr-par.scw.cloud:6443", "dns_wildcard":"*.3b418478-2d8b-4fc7-87c3-f551ebb22f53.nodes.k8s.fr-par.scw.cloud", "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m", "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false, "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":0, "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":0}, "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}}, "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"", "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[], "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "commitment_ends_at":"2026-03-30T12:54:13.060733Z", "acl_available":true, "iam_nodes_group_id":"997eeeb9-fb5b-471b-8ba1-33cf150f3ca6", "pod_cidr":"100.64.0.0/15", "service_cidr":"10.32.0.0/20", "service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1611"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:54:18 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - b528f99b-d03b-4a86-a696-556c7e37f327
+        status: 200 OK
+        code: 200
+        duration: 40.632445ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_asc
+            page:
+                - "1"
+            status:
+                - unknown
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53/pools?order_by=created_at_asc&page=1&status=unknown
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 29
+        body: '{"total_count":0, "pools":[]}'
+        headers:
+            Content-Length:
+                - "29"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:54:18 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - d875a176-6a1f-43d6-a56d-5a61aed4efe6
+        status: 200 OK
+        code: 200
+        duration: 20.641939ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1611
+        body: '{"region":"fr-par", "id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:13.060726Z", "updated_at":"2026-03-30T12:54:13.488208Z", "type":"kapsule", "name":"test-pool-wait", "description":"", "status":"pool_required", "version":"1.35.2", "cni":"calico", "tags":["terraform-test", "scaleway_k8s_cluster", "minimal"], "cluster_url":"https://3b418478-2d8b-4fc7-87c3-f551ebb22f53.api.k8s.fr-par.scw.cloud:6443", "dns_wildcard":"*.3b418478-2d8b-4fc7-87c3-f551ebb22f53.nodes.k8s.fr-par.scw.cloud", "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m", "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false, "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":0, "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":0}, "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}}, "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"", "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[], "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "commitment_ends_at":"2026-03-30T12:54:13.060733Z", "acl_available":true, "iam_nodes_group_id":"997eeeb9-fb5b-471b-8ba1-33cf150f3ca6", "pod_cidr":"100.64.0.0/15", "service_cidr":"10.32.0.0/20", "service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1611"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:54:18 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 7bf66a88-7b3e-4ab5-8a29-a4df65bffed8
+        status: 200 OK
+        code: 200
+        duration: 35.222392ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53/kubeconfig
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1650
+        body: '{"name":"kubeconfig", "content_type":"application/octet-stream", "content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVSlhla05EUVZGSFowRjNTVUpCWjBsQ1FVUkJTMEpuWjNGb2EycFBVRkZSUkVGcVFWWk5VazEzUlZGWlJGWlJVVVJGZDNCeVpGZEtiR050Tld3S1pFZFdlazFDTkZoRVZFa3lUVVJOZVU5VVJYbE9WRkY0VFRGdldFUlVUVEpOUkUxNVQxUkZlVTVVVVhoTk1XOTNSbFJGVkUxQ1JVZEJNVlZGUVhoTlN3cGhNMVpwV2xoS2RWcFlVbXhqZWtKYVRVSk5SMEo1Y1VkVFRUUTVRV2RGUjBORGNVZFRUVFE1UVhkRlNFRXdTVUZDVHpWNk0wd3ZPRGRTUmpGT1dXTjFDbEJNY1RSbmN6UkhTWHBxY1hSU1pHNWpWbTFyYjNwTk1qUjVXRzlzTmtoTlp6SXpMekowYVdSeVQwUjNlVmN2WlV4Wk1sWldLMkZ4Y2poWmRteDJUaXNLVDJaM2FVNHlSMnBSYWtKQlRVRTBSMEV4VldSRWQwVkNMM2RSUlVGM1NVTndSRUZRUW1kT1ZraFNUVUpCWmpoRlFsUkJSRUZSU0M5TlFqQkhRVEZWWkFwRVoxRlhRa0pSWjJWNk0zRlRaR0VyVUZWc2VrODFRa051TlZScVRsa3JTWGg2UVV0Q1oyZHhhR3RxVDFCUlVVUkJaMDVKUVVSQ1JrRnBSVUZ0S3pneENuWkZWREptVW13d00yRlljSFZ1ZG5kMlNXc3hiMEY1VFRFd1ZuQm9lRXgwYUVOaGRVNVVSVU5KU0cxNVRWUmxMM2s1YTI5UFZHdGtiazlOTDJrMkwxZ0tSRzVyUnpNeldpc3JaMVJxV2xwWmJXNDJORVVLTFMwdExTMUZUa1FnUTBWU1ZFbEdTVU5CVkVVdExTMHRMUW89CiAgICBzZXJ2ZXI6IGh0dHBzOi8vM2I0MTg0NzgtMmQ4Yi00ZmM3LTg3YzMtZjU1MWViYjIyZjUzLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC13YWl0CiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXBvb2wtd2FpdCIKICAgIHVzZXI6IHRlc3QtcG9vbC13YWl0LWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXdhaXQKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXBvb2wtd2FpdC1hZG1pbgogIHVzZXI6CiAgICB0b2tlbjogNkxOdk9jQ3VWdWFJMEpqd3JleGNVYjZNc3J4T2ZMM2Jhd1llUmN0b0ZpTjJDVFo0d1pESVlrNEg="}'
+        headers:
+            Content-Length:
+                - "1650"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:54:18 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - acbf5f35-4a91-4004-9e38-9db6ab66ca45
+        status: 200 OK
+        code: 200
+        duration: 38.32277ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 41245
+        body: '{"servers": {"BASIC2-A16C-32G": {"alt_names": [], "arch": "arm64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 150.89, "hourly_price": 0.2067, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 503316480, "end_of_service": false}, "BASIC2-A16C-64G": {"alt_names": [], "arch": "arm64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 201.19, "hourly_price": 0.2756, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 503316480, "end_of_service": false}, "BASIC2-A2C-4G": {"alt_names": [], "arch": "arm64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 16.79, "hourly_price": 0.023, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 83886080, "end_of_service": false}, "BASIC2-A2C-8G": {"alt_names": [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 25.19, "hourly_price": 0.0345, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 83886080, "end_of_service": false}, "BASIC2-A4C-16G": {"alt_names": [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 50.3, "hourly_price": 0.0689, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 125829120, "end_of_service": false}, "BASIC2-A4C-8G": {"alt_names": [], "arch": "arm64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 37.74, "hourly_price": 0.0517, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 125829120, "end_of_service": false}, "BASIC2-A8C-16G": {"alt_names": [], "arch": "arm64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 75.48, "hourly_price": 0.1034, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 251658240, "end_of_service": false}, "BASIC2-A8C-32G": {"alt_names": [], "arch": "arm64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 100.59, "hourly_price": 0.1378, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 251658240, "end_of_service": false}, "BASIC3-X16C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 240.9, "hourly_price": 0.33, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]}, "block_bandwidth": 1048576000, "end_of_service": false}, "BASIC3-X16C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 321.2, "hourly_price": 0.44, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]}, "block_bandwidth": 1048576000, "end_of_service": false}, "BASIC3-X2C-4G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 26.791, "hourly_price": 0.0367, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth": 350000000, "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth": 350000000}]}, "block_bandwidth": 131072000, "end_of_service": false}, "BASIC3-X2C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 40.15, "hourly_price": 0.055, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth": 350000000, "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth": 350000000}]}, "block_bandwidth": 131072000, "end_of_service": false}, "BASIC3-X4C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 80.3, "hourly_price": 0.11, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth": 700000000, "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth": 700000000}]}, "block_bandwidth": 262144000, "end_of_service": false}, "BASIC3-X4C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 53.509, "hourly_price": 0.0733, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth": 700000000, "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth": 700000000}]}, "block_bandwidth": 262144000, "end_of_service": false}, "BASIC3-X8C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 120.45, "hourly_price": 0.165, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]}, "block_bandwidth": 524288000, "end_of_service": false}, "BASIC3-X8C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 160.6, "hourly_price": 0.22, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]}, "block_bandwidth": 524288000, "end_of_service": false}, "COMPUTE3-X16C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 320000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 341.786, "hourly_price": 0.4682, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 4000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 4000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "COMPUTE3-X2C-4G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 40000000000, "scratch_storage_max_volumes_count": 1, "monthly_price": 42.705, "hourly_price": 0.0585, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "COMPUTE3-X32C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 640000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 683.499, "hourly_price": 0.9363, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 8000000000, "sum_internet_bandwidth": 8000000000, "interfaces": [{"internal_bandwidth": 8000000000, "internet_bandwidth": 8000000000}]}, "block_bandwidth": 1000341504, "end_of_service": false}, "COMPUTE3-X48C-96G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 103079215104, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 960000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1019.81, "hourly_price": 1.397, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "COMPUTE3-X4C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 80000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 85.41, "hourly_price": 0.117, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "COMPUTE3-X64C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 1280000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1366.998, "hourly_price": 1.8726, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "COMPUTE3-X8C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 160000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 170.893, "hourly_price": 0.2341, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "COMPUTE3-X96C-192G": {"alt_names": [], "arch": "x86_64", "ncpus": 96, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 1280000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 2039.62, "hourly_price": 2.794, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "COPARM1-16C-64G": {"alt_names": [], "arch": "arm64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 252.14, "hourly_price": 0.3454, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 671088640, "end_of_service": false}, "COPARM1-2C-8G": {"alt_names": [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 31.1, "hourly_price": 0.0426, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 83886080, "end_of_service": false}, "COPARM1-32C-128G": {"alt_names": [], "arch": "arm64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 506.26, "hourly_price": 0.6935, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 1342177280, "end_of_service": false}, "COPARM1-4C-16G": {"alt_names": [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 62.56, "hourly_price": 0.0857, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 167772160, "end_of_service": false}, "COPARM1-8C-32G": {"alt_names": [], "arch": "arm64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 125.85, "hourly_price": 0.1724, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 335544320, "end_of_service": false}, "DEV1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 80000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 30.66, "hourly_price": 0.042, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 209715200, "end_of_service": false}, "DEV1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 3, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 40000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 14.454, "hourly_price": 0.0198, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 300000000, "sum_internet_bandwidth": 300000000, "interfaces": [{"internal_bandwidth": 300000000, "internet_bandwidth": 300000000}]}, "block_bandwidth": 157286400, "end_of_service": false}, "DEV1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 20000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 6.424, "hourly_price": 0.0088, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 104857600, "end_of_service": false}, "DEV1-XL": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 12884901888, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 120000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 46.5734, "hourly_price": 0.06378, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 262144000, "end_of_service": false}, "GP1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 554.07, "hourly_price": 0.759, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]}, "block_bandwidth": 1073741824, "end_of_service": false}, "GP1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 274.48, "hourly_price": 0.376, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "GP1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 300000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 136.51, "hourly_price": 0.187, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 524288000, "end_of_service": false}, "GP1-XL": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1197.93, "hourly_price": 1.641, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]}, "block_bandwidth": 2147483648, "end_of_service": false}, "GP1-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 150000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 66.43, "hourly_price": 0.091, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 314572800, "end_of_service": false}, "L4-1-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 51539607552, "gpu": 1, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 547.5, "hourly_price": 0.75, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 2500000000, "sum_internet_bandwidth": 2500000000, "interfaces": [{"internal_bandwidth": 2500000000, "internet_bandwidth": 2500000000}]}, "block_bandwidth": 1048576000, "end_of_service": false}, "L4-2-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 103079215104, "gpu": 2, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1095.0, "hourly_price": 1.5, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]}, "block_bandwidth": 1572864000, "end_of_service": false}, "L4-4-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 206158430208, "gpu": 4, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 2190.0, "hourly_price": 3.0, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]}, "block_bandwidth": 2621440000, "end_of_service": false}, "L4-8-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 412316860416, "gpu": 8, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 4380.0, "hourly_price": 6.0, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 20000000000, "sum_internet_bandwidth": 20000000000, "interfaces": [{"internal_bandwidth": 20000000000, "internet_bandwidth": 20000000000}]}, "block_bandwidth": 5242880000, "end_of_service": false}, "MEMORY3-X16C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 320000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 601.0, "hourly_price": 0.824, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 4000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 4000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "MEMORY3-X2C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 40000000000, "scratch_storage_max_volumes_count": 1, "monthly_price": 75.0, "hourly_price": 0.103, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "MEMORY3-X32C-256G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 640000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 1203.0, "hourly_price": 1.648, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 8000000000, "sum_internet_bandwidth": 8000000000, "interfaces": [{"internal_bandwidth": 8000000000, "internet_bandwidth": 8000000000}]}, "block_bandwidth": 1000341504, "end_of_service": false}, "MEMORY3-X48C-384G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 412316860416, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 960000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1804.0, "hourly_price": 2.472, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "MEMORY3-X4C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 80000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 150.0, "hourly_price": 0.206, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "MEMORY3-X8C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 160000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 300.0, "hourly_price": 0.412, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "PLAY2-MICRO": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 39.42, "hourly_price": 0.054, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 167772160, "end_of_service": false}, "PLAY2-NANO": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 19.71, "hourly_price": 0.027, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 83886080, "end_of_service": false}}}'
+        headers:
+            Content-Length:
+                - "41245"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:54:18 GMT
+            Link:
+                - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=3&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 06f237a0-678c-4d31-b569-a64725538eb5
+            X-Total-Count:
+                - "112"
+        status: 200 OK
+        code: 200
+        duration: 38.073893ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "2"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 40884
+        body: '{"servers": {"PLAY2-PICO": {"alt_names": [], "arch": "x86_64", "ncpus": 1, "ram": 2147483648, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 10.22, "hourly_price": 0.014, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]}, "block_bandwidth": 41943040, "end_of_service": false}, "POP2-16C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 430.7, "hourly_price": 0.59, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-16C-64G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1063.391, "hourly_price": 1.4567, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-2C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 53.66, "hourly_price": 0.0735, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-2C-8G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 133.079, "hourly_price": 0.1823, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-32C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 861.4, "hourly_price": 1.18, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-32C-128G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 2126.709, "hourly_price": 2.9133, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-48C-192G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1274.4, "hourly_price": 1.77, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-4C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 107.31, "hourly_price": 0.147, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-4C-16G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 265.501, "hourly_price": 0.3637, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-64C-256G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1715.5, "hourly_price": 2.35, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-8C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 211.7, "hourly_price": 0.29, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-8C-32G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 528.009, "hourly_price": 0.7233, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HC-16C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 310.69, "hourly_price": 0.4256, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-HC-2C-4G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 38.84, "hourly_price": 0.0532, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HC-32C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 621.38, "hourly_price": 0.8512, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HC-48C-96G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 103079215104, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 914.4, "hourly_price": 1.27, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HC-4C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 77.67, "hourly_price": 0.1064, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HC-64C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1242.75, "hourly_price": 1.7024, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HC-8C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 155.34, "hourly_price": 0.2128, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HM-16C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 601.52, "hourly_price": 0.824, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-HM-2C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 75.19, "hourly_price": 0.103, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HM-32C-256G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1203.04, "hourly_price": 1.648, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HM-48C-384G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 412316860416, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1778.4, "hourly_price": 2.47, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HM-4C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 150.38, "hourly_price": 0.206, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HM-64C-512G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 549755813888, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 2406.08, "hourly_price": 3.296, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HM-8C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 300.76, "hourly_price": 0.412, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HN-10": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 530.29, "hourly_price": 0.7264, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HN-3": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 186.49, "hourly_price": 0.2554, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HN-5": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 330.29, "hourly_price": 0.4524, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "PRO2-L": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 640.21, "hourly_price": 0.877, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6000000000, "sum_internet_bandwidth": 6000000000, "interfaces": [{"internal_bandwidth": 6000000000, "internet_bandwidth": 6000000000}]}, "block_bandwidth": 2097152000, "end_of_service": false}, "PRO2-M": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 319.74, "hourly_price": 0.438, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]}, "block_bandwidth": 1048576000, "end_of_service": false}, "PRO2-S": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 159.87, "hourly_price": 0.219, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]}, "block_bandwidth": 524288000, "end_of_service": false}, "PRO2-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 80.3, "hourly_price": 0.11, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth": 700000000, "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth": 700000000}]}, "block_bandwidth": 262144000, "end_of_service": false}, "PRO2-XXS": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 40.15, "hourly_price": 0.055, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth": 350000000, "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth": 350000000}]}, "block_bandwidth": 131072000, "end_of_service": false}, "RENDER-S": {"alt_names": [], "arch": "x86_64", "ncpus": 10, "ram": 45097156608, "gpu": 1, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "P100", "gpu_memory": 17179869184}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 400000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 891.33, "hourly_price": 1.221, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 2000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth": 2000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 2147483648, "end_of_service": false}, "STANDARD2-A16C-64G": {"alt_names": [], "arch": "arm64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 367.8324, "hourly_price": 0.5039, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "STANDARD2-A2C-8G": {"alt_names": [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 42.7525, "hourly_price": 0.0586, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "STANDARD2-A32C-128G": {"alt_names": [], "arch": "arm64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 735.7269, "hourly_price": 1.0078, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5033164800, "end_of_service": false}, "STANDARD2-A48C-192G": {"alt_names": [], "arch": "arm64", "ncpus": 48, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1103.5593, "hourly_price": 1.5117, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5033164800, "end_of_service": false}, "STANDARD2-A4C-16G": {"alt_names": [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 85.5049, "hourly_price": 0.1171, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "STANDARD2-A64C-256G": {"alt_names": [], "arch": "arm64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1470.366, "hourly_price": 2.0142, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5033164800, "end_of_service": false}, "STANDARD2-A8C-32G": {"alt_names": [], "arch": "arm64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 171.0098, "hourly_price": 0.2343, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "STANDARD3-X16C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 320000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 430.0, "hourly_price": 0.59, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 4000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 4000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "STANDARD3-X2C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 40000000000, "scratch_storage_max_volumes_count": 1, "monthly_price": 54.0, "hourly_price": 0.074, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "STANDARD3-X32C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 640000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 861.0, "hourly_price": 1.18, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 8000000000, "sum_internet_bandwidth": 8000000000, "interfaces": [{"internal_bandwidth": 8000000000, "internet_bandwidth": 8000000000}]}, "block_bandwidth": 1000341504, "end_of_service": false}, "STANDARD3-X48C-192G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 960000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1292.1, "hourly_price": 1.77, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "STANDARD3-X4C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 80000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 107.0, "hourly_price": 0.147, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "STANDARD3-X64C-256G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 1280000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1715.0, "hourly_price": 2.35, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "STANDARD3-X8C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 160000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 211.0, "hourly_price": 0.29, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}}}'
+        headers:
+            Content-Length:
+                - "40884"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:54:18 GMT
+            Link:
+                - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>; rel="previous",</products/servers?page=3&per_page=50&>; rel="next",</products/servers?page=3&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 1d5d5791-910a-42d1-bd79-75340e76bb96
+            X-Total-Count:
+                - "112"
+        status: 200 OK
+        code: 200
+        duration: 37.282037ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "3"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 10027
+        body: '{"servers": {"STARDUST1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 1, "ram": 1073741824, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 10000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 0.1095, "hourly_price": 0.00015, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]}, "block_bandwidth": 52428800, "end_of_service": false}, "START1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 26.864, "hourly_price": 0.0368, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "START1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 100000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 14.162, "hourly_price": 0.0194, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 300000000, "sum_internet_bandwidth": 300000000, "interfaces": [{"internal_bandwidth": 300000000, "internet_bandwidth": 300000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "START1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 50000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 7.738, "hourly_price": 0.0106, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "START1-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 1, "ram": 1073741824, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 25000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 4.526, "hourly_price": 0.0062, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "VC1L": {"alt_names": ["X64-8GB"], "arch": "x86_64", "ncpus": 6, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 18.0164, "hourly_price": 0.02468, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "VC1M": {"alt_names": ["X64-4GB"], "arch": "x86_64", "ncpus": 4, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 100000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 11.3515, "hourly_price": 0.01555, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "VC1S": {"alt_names": ["X64-2GB"], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 50000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 6.2926, "hourly_price": 0.00862, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "X64-120GB": {"alt_names": [], "arch": "x86_64", "ncpus": 12, "ram": 128849018880, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 800000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 310.7902, "hourly_price": 0.42574, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 1000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "X64-15GB": {"alt_names": [], "arch": "x86_64", "ncpus": 6, "ram": 16106127360, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 44.0336, "hourly_price": 0.06032, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 250000000, "sum_internet_bandwidth": 250000000, "interfaces": [{"internal_bandwidth": 250000000, "internet_bandwidth": 250000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "X64-30GB": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 32212254720, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 400000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 86.9138, "hourly_price": 0.11906, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "X64-60GB": {"alt_names": [], "arch": "x86_64", "ncpus": 10, "ram": 64424509440, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 700000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 155.49, "hourly_price": 0.213, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 1000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 41943040, "end_of_service": true}}}'
+        headers:
+            Content-Length:
+                - "10027"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:54:18 GMT
+            Link:
+                - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=2&per_page=50&>; rel="previous",</products/servers?page=3&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 18dc2153-7c47-4310-88a3-cade51e83ace
+            X-Total-Count:
+                - "112"
+        status: 200 OK
+        code: 200
+        duration: 47.332399ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1611
+        body: '{"region":"fr-par", "id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:13.060726Z", "updated_at":"2026-03-30T12:54:13.488208Z", "type":"kapsule", "name":"test-pool-wait", "description":"", "status":"pool_required", "version":"1.35.2", "cni":"calico", "tags":["terraform-test", "scaleway_k8s_cluster", "minimal"], "cluster_url":"https://3b418478-2d8b-4fc7-87c3-f551ebb22f53.api.k8s.fr-par.scw.cloud:6443", "dns_wildcard":"*.3b418478-2d8b-4fc7-87c3-f551ebb22f53.nodes.k8s.fr-par.scw.cloud", "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m", "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false, "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":0, "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":0}, "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}}, "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"", "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[], "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "commitment_ends_at":"2026-03-30T12:54:13.060733Z", "acl_available":true, "iam_nodes_group_id":"997eeeb9-fb5b-471b-8ba1-33cf150f3ca6", "pod_cidr":"100.64.0.0/15", "service_cidr":"10.32.0.0/20", "service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1611"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:54:18 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 0c96569a-2770-4d48-8256-e25c3401962d
+        status: 200 OK
+        code: 200
+        duration: 23.868464ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 320
+        host: api.scaleway.com
+        body: '{"name":"test-pool-wait","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"kubelet_args":{},"zone":"fr-par-1","root_volume_type":"default_volume_type","public_ip_disabled":false,"labels":null,"taints":null,"startup_taints":null}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53/pools
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 735
+        body: '{"region":"fr-par", "id":"aef8b176-85f1-4ac9-80c5-5632257daa82", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:54:18.475205Z", "updated_at":"2026-03-30T12:54:18.475205Z", "name":"test-pool-wait", "status":"scaling", "version":"1.35.2", "node_type":"pro2_xxs", "autoscaling":false, "size":1, "min_size":1, "max_size":1, "container_runtime":"containerd", "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{}, "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"sbs_5k", "root_volume_size":20000000000, "public_ip_disabled":false, "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b", "labels":{}, "taints":[], "startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "735"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:54:18 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 52c95a80-6b56-4f4f-9c35-8d757c65b1ed
+        status: 200 OK
+        code: 200
+        duration: 101.451073ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aef8b176-85f1-4ac9-80c5-5632257daa82
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 735
+        body: '{"region":"fr-par", "id":"aef8b176-85f1-4ac9-80c5-5632257daa82", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:54:18.475205Z", "updated_at":"2026-03-30T12:54:18.475205Z", "name":"test-pool-wait", "status":"scaling", "version":"1.35.2", "node_type":"pro2_xxs", "autoscaling":false, "size":1, "min_size":1, "max_size":1, "container_runtime":"containerd", "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{}, "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"sbs_5k", "root_volume_size":20000000000, "public_ip_disabled":false, "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b", "labels":{}, "taints":[], "startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "735"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:54:18 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - cf4af50a-fa50-4030-80ce-1f6d49972c85
+        status: 200 OK
+        code: 200
+        duration: 19.393566ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aef8b176-85f1-4ac9-80c5-5632257daa82
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 733
+        body: '{"region":"fr-par", "id":"aef8b176-85f1-4ac9-80c5-5632257daa82", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:54:18.475205Z", "updated_at":"2026-03-30T12:56:27.984394Z", "name":"test-pool-wait", "status":"ready", "version":"1.35.2", "node_type":"pro2_xxs", "autoscaling":false, "size":1, "min_size":1, "max_size":1, "container_runtime":"containerd", "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{}, "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"sbs_5k", "root_volume_size":20000000000, "public_ip_disabled":false, "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b", "labels":{}, "taints":[], "startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "733"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:56:29 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 710ac7c4-505b-437c-bcac-3fa645c5d8a1
+        status: 200 OK
+        code: 200
+        duration: 34.37785ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1603
+        body: '{"region":"fr-par", "id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:13.060726Z", "updated_at":"2026-03-30T12:55:41.789306Z", "type":"kapsule", "name":"test-pool-wait", "description":"", "status":"ready", "version":"1.35.2", "cni":"calico", "tags":["terraform-test", "scaleway_k8s_cluster", "minimal"], "cluster_url":"https://3b418478-2d8b-4fc7-87c3-f551ebb22f53.api.k8s.fr-par.scw.cloud:6443", "dns_wildcard":"*.3b418478-2d8b-4fc7-87c3-f551ebb22f53.nodes.k8s.fr-par.scw.cloud", "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m", "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false, "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":0, "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":0}, "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}}, "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"", "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[], "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "commitment_ends_at":"2026-03-30T12:54:13.060733Z", "acl_available":true, "iam_nodes_group_id":"997eeeb9-fb5b-471b-8ba1-33cf150f3ca6", "pod_cidr":"100.64.0.0/15", "service_cidr":"10.32.0.0/20", "service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1603"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:56:29 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - c2f0f2e5-9403-4404-af99-e4c858da4227
+        status: 200 OK
+        code: 200
+        duration: 21.997364ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aef8b176-85f1-4ac9-80c5-5632257daa82
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 733
+        body: '{"region":"fr-par", "id":"aef8b176-85f1-4ac9-80c5-5632257daa82", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:54:18.475205Z", "updated_at":"2026-03-30T12:56:27.984394Z", "name":"test-pool-wait", "status":"ready", "version":"1.35.2", "node_type":"pro2_xxs", "autoscaling":false, "size":1, "min_size":1, "max_size":1, "container_runtime":"containerd", "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{}, "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"sbs_5k", "root_volume_size":20000000000, "public_ip_disabled":false, "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b", "labels":{}, "taints":[], "startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "733"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:56:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 9bd2c79a-a1e1-458a-945f-eeb75dedd124
+        status: 200 OK
+        code: 200
+        duration: 31.496682ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_asc
+            page:
+                - "1"
+            pool_id:
+                - aef8b176-85f1-4ac9-80c5-5632257daa82
+            status:
+                - unknown
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53/nodes?order_by=created_at_asc&page=1&pool_id=aef8b176-85f1-4ac9-80c5-5632257daa82&status=unknown
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 619
+        body: '{"total_count":1, "nodes":[{"region":"fr-par", "id":"f02a58a1-5b25-41c1-948d-dfe4d877c500", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:55:42.710952Z", "updated_at":"2026-03-30T12:56:27.964785Z", "pool_id":"aef8b176-85f1-4ac9-80c5-5632257daa82", "status":"ready", "conditions":{"DiskPressure":"False", "MemoryPressure":"False", "PIDPressure":"False", "Ready":"True"}, "name":"scw-test-pool-wait-test-pool-wait-f02a58a15b25", "public_ip_v4":"51.158.97.194", "public_ip_v6":null, "provider_id":"scaleway://instance/fr-par-1/5a65da2a-aa5f-45b7-a8cf-e1dc0465f407", "error_message":""}]}'
+        headers:
+            Content-Length:
+                - "619"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:56:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 7e5b4909-df6a-42a4-99cd-1ae4d43df8ac
+        status: 200 OK
+        code: 200
+        duration: 32.643004ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1603
+        body: '{"region":"fr-par", "id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:13.060726Z", "updated_at":"2026-03-30T12:55:41.789306Z", "type":"kapsule", "name":"test-pool-wait", "description":"", "status":"ready", "version":"1.35.2", "cni":"calico", "tags":["terraform-test", "scaleway_k8s_cluster", "minimal"], "cluster_url":"https://3b418478-2d8b-4fc7-87c3-f551ebb22f53.api.k8s.fr-par.scw.cloud:6443", "dns_wildcard":"*.3b418478-2d8b-4fc7-87c3-f551ebb22f53.nodes.k8s.fr-par.scw.cloud", "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m", "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false, "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":0, "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":0}, "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}}, "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"", "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[], "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "commitment_ends_at":"2026-03-30T12:54:13.060733Z", "acl_available":true, "iam_nodes_group_id":"997eeeb9-fb5b-471b-8ba1-33cf150f3ca6", "pod_cidr":"100.64.0.0/15", "service_cidr":"10.32.0.0/20", "service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1603"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:56:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 969f8eec-6567-4a68-9730-ddd76ca1dd1c
+        status: 200 OK
+        code: 200
+        duration: 26.504243ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_desc
+            project_id:
+                - fa1e3217-dc80-42ac-85c3-3f034b78b552
+            resource_name:
+                - scw-test-pool-wait-test-pool-wait-f02a58a15b25
+            resource_type:
+                - unknown_type
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=fa1e3217-dc80-42ac-85c3-3f034b78b552&resource_name=scw-test-pool-wait-test-pool-wait-f02a58a15b25&resource_type=unknown_type
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1121
+        body: '{"total_count":2, "ips":[{"id":"7a65b835-044c-4996-a22b-5715ea76a553", "address":"fd63:256c:45f7:bc7e:4f61:41e:1ed2:7ab4/64", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_ipv6":true, "created_at":"2026-03-30T12:55:45.022856Z", "updated_at":"2026-03-30T12:55:45.022856Z", "source":{"subnet_id":"b18788e5-4872-494d-a7bb-0ba98125d9e4"}, "resource":{"type":"instance_private_nic", "id":"aa4dd472-9b34-45a8-bed3-592e94180874", "mac_address":"02:00:00:1B:24:BE", "name":"scw-test-pool-wait-test-pool-wait-f02a58a15b25"}, "tags":[], "reverses":[], "region":"fr-par", "zone":null}, {"id":"ff1cbc09-c270-4fb8-9808-8f2232e772f8", "address":"172.16.72.3/22", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_ipv6":false, "created_at":"2026-03-30T12:55:44.890521Z", "updated_at":"2026-03-30T12:55:44.890521Z", "source":{"subnet_id":"ae63fffc-03c5-47e1-bfb2-170301d26f53"}, "resource":{"type":"instance_private_nic", "id":"aa4dd472-9b34-45a8-bed3-592e94180874", "mac_address":"02:00:00:1B:24:BE", "name":"scw-test-pool-wait-test-pool-wait-f02a58a15b25"}, "tags":[], "reverses":[], "region":"fr-par", "zone":null}]}'
+        headers:
+            Content-Length:
+                - "1121"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:56:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 8e4ce74e-a37a-48d8-b930-91ec8d45b054
+        status: 200 OK
+        code: 200
+        duration: 33.257387ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1603
+        body: '{"region":"fr-par", "id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:13.060726Z", "updated_at":"2026-03-30T12:55:41.789306Z", "type":"kapsule", "name":"test-pool-wait", "description":"", "status":"ready", "version":"1.35.2", "cni":"calico", "tags":["terraform-test", "scaleway_k8s_cluster", "minimal"], "cluster_url":"https://3b418478-2d8b-4fc7-87c3-f551ebb22f53.api.k8s.fr-par.scw.cloud:6443", "dns_wildcard":"*.3b418478-2d8b-4fc7-87c3-f551ebb22f53.nodes.k8s.fr-par.scw.cloud", "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m", "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false, "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":0, "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":0}, "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}}, "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"", "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[], "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "commitment_ends_at":"2026-03-30T12:54:13.060733Z", "acl_available":true, "iam_nodes_group_id":"997eeeb9-fb5b-471b-8ba1-33cf150f3ca6", "pod_cidr":"100.64.0.0/15", "service_cidr":"10.32.0.0/20", "service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1603"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:56:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 869a9598-d1b6-48bb-933a-d30e54559881
+        status: 200 OK
+        code: 200
+        duration: 31.609284ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aef8b176-85f1-4ac9-80c5-5632257daa82
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 733
+        body: '{"region":"fr-par", "id":"aef8b176-85f1-4ac9-80c5-5632257daa82", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:54:18.475205Z", "updated_at":"2026-03-30T12:56:27.984394Z", "name":"test-pool-wait", "status":"ready", "version":"1.35.2", "node_type":"pro2_xxs", "autoscaling":false, "size":1, "min_size":1, "max_size":1, "container_runtime":"containerd", "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{}, "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"sbs_5k", "root_volume_size":20000000000, "public_ip_disabled":false, "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b", "labels":{}, "taints":[], "startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "733"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:56:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 12d6c07c-7e40-4631-8b58-202819b14597
+        status: 200 OK
+        code: 200
+        duration: 30.605019ms
+    - id: 25
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/45317da4-924e-4fd3-b4ca-e93215bc5849
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 431
+        body: '{"id":"45317da4-924e-4fd3-b4ca-e93215bc5849", "name":"tf-vpc-affectionate-proskuriakova", "tags":[], "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:12.102781Z", "updated_at":"2026-03-30T12:54:12.102781Z", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_default":false, "private_network_count":1, "routing_enabled":true, "custom_routes_propagation_enabled":true, "region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "431"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:56:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 8635a59a-ad0d-42d1-a8fe-df070873d2f1
+        status: 200 OK
+        code: 200
+        duration: 31.230302ms
+    - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/97585af2-c151-4ad5-9778-fa88d5af8bba
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1084
+        body: '{"id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "name":"test-pool-wait", "tags":[], "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:12.204171Z", "updated_at":"2026-03-30T12:54:12.204171Z", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "subnets":[{"id":"ae63fffc-03c5-47e1-bfb2-170301d26f53", "created_at":"2026-03-30T12:54:12.204171Z", "updated_at":"2026-03-30T12:54:12.204171Z", "subnet":"172.16.72.0/22", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "vpc_id":"45317da4-924e-4fd3-b4ca-e93215bc5849"}, {"id":"b18788e5-4872-494d-a7bb-0ba98125d9e4", "created_at":"2026-03-30T12:54:12.204171Z", "updated_at":"2026-03-30T12:54:12.204171Z", "subnet":"fd63:256c:45f7:bc7e::/64", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "vpc_id":"45317da4-924e-4fd3-b4ca-e93215bc5849"}], "vpc_id":"45317da4-924e-4fd3-b4ca-e93215bc5849", "dhcp_enabled":true, "default_route_propagation_enabled":false, "region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1084"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:56:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - a2b75346-3028-4f2b-af06-ebf634394982
+        status: 200 OK
+        code: 200
+        duration: 26.786362ms
+    - id: 27
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1603
+        body: '{"region":"fr-par", "id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:13.060726Z", "updated_at":"2026-03-30T12:55:41.789306Z", "type":"kapsule", "name":"test-pool-wait", "description":"", "status":"ready", "version":"1.35.2", "cni":"calico", "tags":["terraform-test", "scaleway_k8s_cluster", "minimal"], "cluster_url":"https://3b418478-2d8b-4fc7-87c3-f551ebb22f53.api.k8s.fr-par.scw.cloud:6443", "dns_wildcard":"*.3b418478-2d8b-4fc7-87c3-f551ebb22f53.nodes.k8s.fr-par.scw.cloud", "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m", "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false, "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":0, "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":0}, "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}}, "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"", "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[], "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "commitment_ends_at":"2026-03-30T12:54:13.060733Z", "acl_available":true, "iam_nodes_group_id":"997eeeb9-fb5b-471b-8ba1-33cf150f3ca6", "pod_cidr":"100.64.0.0/15", "service_cidr":"10.32.0.0/20", "service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1603"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:56:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - b3b3486c-44f1-4c54-9c6f-cd67c2f9aed7
+        status: 200 OK
+        code: 200
+        duration: 21.596672ms
+    - id: 28
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53/kubeconfig
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1650
+        body: '{"name":"kubeconfig", "content_type":"application/octet-stream", "content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVSlhla05EUVZGSFowRjNTVUpCWjBsQ1FVUkJTMEpuWjNGb2EycFBVRkZSUkVGcVFWWk5VazEzUlZGWlJGWlJVVVJGZDNCeVpGZEtiR050Tld3S1pFZFdlazFDTkZoRVZFa3lUVVJOZVU5VVJYbE9WRkY0VFRGdldFUlVUVEpOUkUxNVQxUkZlVTVVVVhoTk1XOTNSbFJGVkUxQ1JVZEJNVlZGUVhoTlN3cGhNMVpwV2xoS2RWcFlVbXhqZWtKYVRVSk5SMEo1Y1VkVFRUUTVRV2RGUjBORGNVZFRUVFE1UVhkRlNFRXdTVUZDVHpWNk0wd3ZPRGRTUmpGT1dXTjFDbEJNY1RSbmN6UkhTWHBxY1hSU1pHNWpWbTFyYjNwTk1qUjVXRzlzTmtoTlp6SXpMekowYVdSeVQwUjNlVmN2WlV4Wk1sWldLMkZ4Y2poWmRteDJUaXNLVDJaM2FVNHlSMnBSYWtKQlRVRTBSMEV4VldSRWQwVkNMM2RSUlVGM1NVTndSRUZRUW1kT1ZraFNUVUpCWmpoRlFsUkJSRUZSU0M5TlFqQkhRVEZWWkFwRVoxRlhRa0pSWjJWNk0zRlRaR0VyVUZWc2VrODFRa051TlZScVRsa3JTWGg2UVV0Q1oyZHhhR3RxVDFCUlVVUkJaMDVKUVVSQ1JrRnBSVUZ0S3pneENuWkZWREptVW13d00yRlljSFZ1ZG5kMlNXc3hiMEY1VFRFd1ZuQm9lRXgwYUVOaGRVNVVSVU5KU0cxNVRWUmxMM2s1YTI5UFZHdGtiazlOTDJrMkwxZ0tSRzVyUnpNeldpc3JaMVJxV2xwWmJXNDJORVVLTFMwdExTMUZUa1FnUTBWU1ZFbEdTVU5CVkVVdExTMHRMUW89CiAgICBzZXJ2ZXI6IGh0dHBzOi8vM2I0MTg0NzgtMmQ4Yi00ZmM3LTg3YzMtZjU1MWViYjIyZjUzLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC13YWl0CiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXBvb2wtd2FpdCIKICAgIHVzZXI6IHRlc3QtcG9vbC13YWl0LWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXdhaXQKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXBvb2wtd2FpdC1hZG1pbgogIHVzZXI6CiAgICB0b2tlbjogNkxOdk9jQ3VWdWFJMEpqd3JleGNVYjZNc3J4T2ZMM2Jhd1llUmN0b0ZpTjJDVFo0d1pESVlrNEg="}'
+        headers:
+            Content-Length:
+                - "1650"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:56:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 671d9e9c-2081-4289-b39f-c951bd7d469a
+        status: 200 OK
+        code: 200
+        duration: 33.970034ms
+    - id: 29
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aef8b176-85f1-4ac9-80c5-5632257daa82
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 733
+        body: '{"region":"fr-par", "id":"aef8b176-85f1-4ac9-80c5-5632257daa82", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:54:18.475205Z", "updated_at":"2026-03-30T12:56:27.984394Z", "name":"test-pool-wait", "status":"ready", "version":"1.35.2", "node_type":"pro2_xxs", "autoscaling":false, "size":1, "min_size":1, "max_size":1, "container_runtime":"containerd", "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{}, "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"sbs_5k", "root_volume_size":20000000000, "public_ip_disabled":false, "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b", "labels":{}, "taints":[], "startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "733"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:56:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 27fc4ac9-1d40-4e89-9139-2a208c948d22
+        status: 200 OK
+        code: 200
+        duration: 22.485841ms
+    - id: 30
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_asc
+            page:
+                - "1"
+            pool_id:
+                - aef8b176-85f1-4ac9-80c5-5632257daa82
+            status:
+                - unknown
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53/nodes?order_by=created_at_asc&page=1&pool_id=aef8b176-85f1-4ac9-80c5-5632257daa82&status=unknown
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 619
+        body: '{"total_count":1, "nodes":[{"region":"fr-par", "id":"f02a58a1-5b25-41c1-948d-dfe4d877c500", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:55:42.710952Z", "updated_at":"2026-03-30T12:56:27.964785Z", "pool_id":"aef8b176-85f1-4ac9-80c5-5632257daa82", "status":"ready", "conditions":{"DiskPressure":"False", "MemoryPressure":"False", "PIDPressure":"False", "Ready":"True"}, "name":"scw-test-pool-wait-test-pool-wait-f02a58a15b25", "public_ip_v4":"51.158.97.194", "public_ip_v6":null, "provider_id":"scaleway://instance/fr-par-1/5a65da2a-aa5f-45b7-a8cf-e1dc0465f407", "error_message":""}]}'
+        headers:
+            Content-Length:
+                - "619"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:56:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 2f25e785-c004-4ccb-be4c-457da3aa358f
+        status: 200 OK
+        code: 200
+        duration: 22.50138ms
+    - id: 31
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1603
+        body: '{"region":"fr-par", "id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:13.060726Z", "updated_at":"2026-03-30T12:55:41.789306Z", "type":"kapsule", "name":"test-pool-wait", "description":"", "status":"ready", "version":"1.35.2", "cni":"calico", "tags":["terraform-test", "scaleway_k8s_cluster", "minimal"], "cluster_url":"https://3b418478-2d8b-4fc7-87c3-f551ebb22f53.api.k8s.fr-par.scw.cloud:6443", "dns_wildcard":"*.3b418478-2d8b-4fc7-87c3-f551ebb22f53.nodes.k8s.fr-par.scw.cloud", "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m", "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false, "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":0, "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":0}, "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}}, "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"", "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[], "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "commitment_ends_at":"2026-03-30T12:54:13.060733Z", "acl_available":true, "iam_nodes_group_id":"997eeeb9-fb5b-471b-8ba1-33cf150f3ca6", "pod_cidr":"100.64.0.0/15", "service_cidr":"10.32.0.0/20", "service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1603"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:56:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 593c980b-f58c-4599-9c20-a62e2671de84
+        status: 200 OK
+        code: 200
+        duration: 29.30071ms
+    - id: 32
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_desc
+            project_id:
+                - fa1e3217-dc80-42ac-85c3-3f034b78b552
+            resource_name:
+                - scw-test-pool-wait-test-pool-wait-f02a58a15b25
+            resource_type:
+                - unknown_type
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=fa1e3217-dc80-42ac-85c3-3f034b78b552&resource_name=scw-test-pool-wait-test-pool-wait-f02a58a15b25&resource_type=unknown_type
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1121
+        body: '{"total_count":2, "ips":[{"id":"7a65b835-044c-4996-a22b-5715ea76a553", "address":"fd63:256c:45f7:bc7e:4f61:41e:1ed2:7ab4/64", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_ipv6":true, "created_at":"2026-03-30T12:55:45.022856Z", "updated_at":"2026-03-30T12:55:45.022856Z", "source":{"subnet_id":"b18788e5-4872-494d-a7bb-0ba98125d9e4"}, "resource":{"type":"instance_private_nic", "id":"aa4dd472-9b34-45a8-bed3-592e94180874", "mac_address":"02:00:00:1B:24:BE", "name":"scw-test-pool-wait-test-pool-wait-f02a58a15b25"}, "tags":[], "reverses":[], "region":"fr-par", "zone":null}, {"id":"ff1cbc09-c270-4fb8-9808-8f2232e772f8", "address":"172.16.72.3/22", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_ipv6":false, "created_at":"2026-03-30T12:55:44.890521Z", "updated_at":"2026-03-30T12:55:44.890521Z", "source":{"subnet_id":"ae63fffc-03c5-47e1-bfb2-170301d26f53"}, "resource":{"type":"instance_private_nic", "id":"aa4dd472-9b34-45a8-bed3-592e94180874", "mac_address":"02:00:00:1B:24:BE", "name":"scw-test-pool-wait-test-pool-wait-f02a58a15b25"}, "tags":[], "reverses":[], "region":"fr-par", "zone":null}]}'
+        headers:
+            Content-Length:
+                - "1121"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:56:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - ce118bc0-61b0-4943-bc49-ede8247f3d00
+        status: 200 OK
+        code: 200
+        duration: 25.58083ms
+    - id: 33
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/45317da4-924e-4fd3-b4ca-e93215bc5849
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 431
+        body: '{"id":"45317da4-924e-4fd3-b4ca-e93215bc5849", "name":"tf-vpc-affectionate-proskuriakova", "tags":[], "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:12.102781Z", "updated_at":"2026-03-30T12:54:12.102781Z", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_default":false, "private_network_count":1, "routing_enabled":true, "custom_routes_propagation_enabled":true, "region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "431"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:56:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - f6822e9e-7485-45b1-a18f-cef353ec1b0c
+        status: 200 OK
+        code: 200
+        duration: 27.371901ms
+    - id: 34
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/97585af2-c151-4ad5-9778-fa88d5af8bba
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1084
+        body: '{"id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "name":"test-pool-wait", "tags":[], "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:12.204171Z", "updated_at":"2026-03-30T12:54:12.204171Z", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "subnets":[{"id":"ae63fffc-03c5-47e1-bfb2-170301d26f53", "created_at":"2026-03-30T12:54:12.204171Z", "updated_at":"2026-03-30T12:54:12.204171Z", "subnet":"172.16.72.0/22", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "vpc_id":"45317da4-924e-4fd3-b4ca-e93215bc5849"}, {"id":"b18788e5-4872-494d-a7bb-0ba98125d9e4", "created_at":"2026-03-30T12:54:12.204171Z", "updated_at":"2026-03-30T12:54:12.204171Z", "subnet":"fd63:256c:45f7:bc7e::/64", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "vpc_id":"45317da4-924e-4fd3-b4ca-e93215bc5849"}], "vpc_id":"45317da4-924e-4fd3-b4ca-e93215bc5849", "dhcp_enabled":true, "default_route_propagation_enabled":false, "region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1084"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:56:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 3baaada0-cc86-4bf5-bd58-84de7f90a4b6
+        status: 200 OK
+        code: 200
+        duration: 26.480538ms
+    - id: 35
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1603
+        body: '{"region":"fr-par", "id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:13.060726Z", "updated_at":"2026-03-30T12:55:41.789306Z", "type":"kapsule", "name":"test-pool-wait", "description":"", "status":"ready", "version":"1.35.2", "cni":"calico", "tags":["terraform-test", "scaleway_k8s_cluster", "minimal"], "cluster_url":"https://3b418478-2d8b-4fc7-87c3-f551ebb22f53.api.k8s.fr-par.scw.cloud:6443", "dns_wildcard":"*.3b418478-2d8b-4fc7-87c3-f551ebb22f53.nodes.k8s.fr-par.scw.cloud", "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m", "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false, "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":0, "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":0}, "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}}, "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"", "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[], "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "commitment_ends_at":"2026-03-30T12:54:13.060733Z", "acl_available":true, "iam_nodes_group_id":"997eeeb9-fb5b-471b-8ba1-33cf150f3ca6", "pod_cidr":"100.64.0.0/15", "service_cidr":"10.32.0.0/20", "service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1603"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:56:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 519535c3-d7e4-4315-9664-94e6577b5b19
+        status: 200 OK
+        code: 200
+        duration: 23.445582ms
+    - id: 36
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53/kubeconfig
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1650
+        body: '{"name":"kubeconfig", "content_type":"application/octet-stream", "content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVSlhla05EUVZGSFowRjNTVUpCWjBsQ1FVUkJTMEpuWjNGb2EycFBVRkZSUkVGcVFWWk5VazEzUlZGWlJGWlJVVVJGZDNCeVpGZEtiR050Tld3S1pFZFdlazFDTkZoRVZFa3lUVVJOZVU5VVJYbE9WRkY0VFRGdldFUlVUVEpOUkUxNVQxUkZlVTVVVVhoTk1XOTNSbFJGVkUxQ1JVZEJNVlZGUVhoTlN3cGhNMVpwV2xoS2RWcFlVbXhqZWtKYVRVSk5SMEo1Y1VkVFRUUTVRV2RGUjBORGNVZFRUVFE1UVhkRlNFRXdTVUZDVHpWNk0wd3ZPRGRTUmpGT1dXTjFDbEJNY1RSbmN6UkhTWHBxY1hSU1pHNWpWbTFyYjNwTk1qUjVXRzlzTmtoTlp6SXpMekowYVdSeVQwUjNlVmN2WlV4Wk1sWldLMkZ4Y2poWmRteDJUaXNLVDJaM2FVNHlSMnBSYWtKQlRVRTBSMEV4VldSRWQwVkNMM2RSUlVGM1NVTndSRUZRUW1kT1ZraFNUVUpCWmpoRlFsUkJSRUZSU0M5TlFqQkhRVEZWWkFwRVoxRlhRa0pSWjJWNk0zRlRaR0VyVUZWc2VrODFRa051TlZScVRsa3JTWGg2UVV0Q1oyZHhhR3RxVDFCUlVVUkJaMDVKUVVSQ1JrRnBSVUZ0S3pneENuWkZWREptVW13d00yRlljSFZ1ZG5kMlNXc3hiMEY1VFRFd1ZuQm9lRXgwYUVOaGRVNVVSVU5KU0cxNVRWUmxMM2s1YTI5UFZHdGtiazlOTDJrMkwxZ0tSRzVyUnpNeldpc3JaMVJxV2xwWmJXNDJORVVLTFMwdExTMUZUa1FnUTBWU1ZFbEdTVU5CVkVVdExTMHRMUW89CiAgICBzZXJ2ZXI6IGh0dHBzOi8vM2I0MTg0NzgtMmQ4Yi00ZmM3LTg3YzMtZjU1MWViYjIyZjUzLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC13YWl0CiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXBvb2wtd2FpdCIKICAgIHVzZXI6IHRlc3QtcG9vbC13YWl0LWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXdhaXQKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXBvb2wtd2FpdC1hZG1pbgogIHVzZXI6CiAgICB0b2tlbjogNkxOdk9jQ3VWdWFJMEpqd3JleGNVYjZNc3J4T2ZMM2Jhd1llUmN0b0ZpTjJDVFo0d1pESVlrNEg="}'
+        headers:
+            Content-Length:
+                - "1650"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:56:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 4735e875-ea61-471f-936f-87dba8849291
+        status: 200 OK
+        code: 200
+        duration: 22.499196ms
+    - id: 37
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aef8b176-85f1-4ac9-80c5-5632257daa82
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 733
+        body: '{"region":"fr-par", "id":"aef8b176-85f1-4ac9-80c5-5632257daa82", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:54:18.475205Z", "updated_at":"2026-03-30T12:56:27.984394Z", "name":"test-pool-wait", "status":"ready", "version":"1.35.2", "node_type":"pro2_xxs", "autoscaling":false, "size":1, "min_size":1, "max_size":1, "container_runtime":"containerd", "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{}, "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"sbs_5k", "root_volume_size":20000000000, "public_ip_disabled":false, "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b", "labels":{}, "taints":[], "startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "733"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:56:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 5e1f1a2c-0dc9-48e8-bcd6-52827407e9a5
+        status: 200 OK
+        code: 200
+        duration: 22.896832ms
+    - id: 38
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_asc
+            page:
+                - "1"
+            pool_id:
+                - aef8b176-85f1-4ac9-80c5-5632257daa82
+            status:
+                - unknown
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53/nodes?order_by=created_at_asc&page=1&pool_id=aef8b176-85f1-4ac9-80c5-5632257daa82&status=unknown
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 619
+        body: '{"total_count":1, "nodes":[{"region":"fr-par", "id":"f02a58a1-5b25-41c1-948d-dfe4d877c500", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:55:42.710952Z", "updated_at":"2026-03-30T12:56:27.964785Z", "pool_id":"aef8b176-85f1-4ac9-80c5-5632257daa82", "status":"ready", "conditions":{"DiskPressure":"False", "MemoryPressure":"False", "PIDPressure":"False", "Ready":"True"}, "name":"scw-test-pool-wait-test-pool-wait-f02a58a15b25", "public_ip_v4":"51.158.97.194", "public_ip_v6":null, "provider_id":"scaleway://instance/fr-par-1/5a65da2a-aa5f-45b7-a8cf-e1dc0465f407", "error_message":""}]}'
+        headers:
+            Content-Length:
+                - "619"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:56:30 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 89656b44-ad09-4732-b2ab-9d019e7fdd46
+        status: 200 OK
+        code: 200
+        duration: 23.046633ms
+    - id: 39
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1603
+        body: '{"region":"fr-par", "id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:13.060726Z", "updated_at":"2026-03-30T12:55:41.789306Z", "type":"kapsule", "name":"test-pool-wait", "description":"", "status":"ready", "version":"1.35.2", "cni":"calico", "tags":["terraform-test", "scaleway_k8s_cluster", "minimal"], "cluster_url":"https://3b418478-2d8b-4fc7-87c3-f551ebb22f53.api.k8s.fr-par.scw.cloud:6443", "dns_wildcard":"*.3b418478-2d8b-4fc7-87c3-f551ebb22f53.nodes.k8s.fr-par.scw.cloud", "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m", "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false, "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":0, "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":0}, "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}}, "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"", "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[], "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "commitment_ends_at":"2026-03-30T12:54:13.060733Z", "acl_available":true, "iam_nodes_group_id":"997eeeb9-fb5b-471b-8ba1-33cf150f3ca6", "pod_cidr":"100.64.0.0/15", "service_cidr":"10.32.0.0/20", "service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1603"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:56:31 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - e6e3dd9e-d8d1-43a5-8501-5e4722e0c12e
+        status: 200 OK
+        code: 200
+        duration: 28.673654ms
+    - id: 40
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_desc
+            project_id:
+                - fa1e3217-dc80-42ac-85c3-3f034b78b552
+            resource_name:
+                - scw-test-pool-wait-test-pool-wait-f02a58a15b25
+            resource_type:
+                - unknown_type
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=fa1e3217-dc80-42ac-85c3-3f034b78b552&resource_name=scw-test-pool-wait-test-pool-wait-f02a58a15b25&resource_type=unknown_type
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1121
+        body: '{"total_count":2, "ips":[{"id":"7a65b835-044c-4996-a22b-5715ea76a553", "address":"fd63:256c:45f7:bc7e:4f61:41e:1ed2:7ab4/64", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_ipv6":true, "created_at":"2026-03-30T12:55:45.022856Z", "updated_at":"2026-03-30T12:55:45.022856Z", "source":{"subnet_id":"b18788e5-4872-494d-a7bb-0ba98125d9e4"}, "resource":{"type":"instance_private_nic", "id":"aa4dd472-9b34-45a8-bed3-592e94180874", "mac_address":"02:00:00:1B:24:BE", "name":"scw-test-pool-wait-test-pool-wait-f02a58a15b25"}, "tags":[], "reverses":[], "region":"fr-par", "zone":null}, {"id":"ff1cbc09-c270-4fb8-9808-8f2232e772f8", "address":"172.16.72.3/22", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_ipv6":false, "created_at":"2026-03-30T12:55:44.890521Z", "updated_at":"2026-03-30T12:55:44.890521Z", "source":{"subnet_id":"ae63fffc-03c5-47e1-bfb2-170301d26f53"}, "resource":{"type":"instance_private_nic", "id":"aa4dd472-9b34-45a8-bed3-592e94180874", "mac_address":"02:00:00:1B:24:BE", "name":"scw-test-pool-wait-test-pool-wait-f02a58a15b25"}, "tags":[], "reverses":[], "region":"fr-par", "zone":null}]}'
+        headers:
+            Content-Length:
+                - "1121"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:56:31 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 233a1f12-f504-432b-b855-166dd08d63a8
+        status: 200 OK
+        code: 200
+        duration: 27.321536ms
+    - id: 41
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 41245
+        body: '{"servers": {"BASIC2-A16C-32G": {"alt_names": [], "arch": "arm64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 150.89, "hourly_price": 0.2067, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 503316480, "end_of_service": false}, "BASIC2-A16C-64G": {"alt_names": [], "arch": "arm64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 201.19, "hourly_price": 0.2756, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 503316480, "end_of_service": false}, "BASIC2-A2C-4G": {"alt_names": [], "arch": "arm64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 16.79, "hourly_price": 0.023, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 83886080, "end_of_service": false}, "BASIC2-A2C-8G": {"alt_names": [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 25.19, "hourly_price": 0.0345, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 83886080, "end_of_service": false}, "BASIC2-A4C-16G": {"alt_names": [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 50.3, "hourly_price": 0.0689, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 125829120, "end_of_service": false}, "BASIC2-A4C-8G": {"alt_names": [], "arch": "arm64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 37.74, "hourly_price": 0.0517, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 125829120, "end_of_service": false}, "BASIC2-A8C-16G": {"alt_names": [], "arch": "arm64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 75.48, "hourly_price": 0.1034, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 251658240, "end_of_service": false}, "BASIC2-A8C-32G": {"alt_names": [], "arch": "arm64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 100.59, "hourly_price": 0.1378, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 251658240, "end_of_service": false}, "BASIC3-X16C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 240.9, "hourly_price": 0.33, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]}, "block_bandwidth": 1048576000, "end_of_service": false}, "BASIC3-X16C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 321.2, "hourly_price": 0.44, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]}, "block_bandwidth": 1048576000, "end_of_service": false}, "BASIC3-X2C-4G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 26.791, "hourly_price": 0.0367, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth": 350000000, "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth": 350000000}]}, "block_bandwidth": 131072000, "end_of_service": false}, "BASIC3-X2C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 40.15, "hourly_price": 0.055, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth": 350000000, "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth": 350000000}]}, "block_bandwidth": 131072000, "end_of_service": false}, "BASIC3-X4C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 80.3, "hourly_price": 0.11, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth": 700000000, "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth": 700000000}]}, "block_bandwidth": 262144000, "end_of_service": false}, "BASIC3-X4C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 53.509, "hourly_price": 0.0733, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth": 700000000, "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth": 700000000}]}, "block_bandwidth": 262144000, "end_of_service": false}, "BASIC3-X8C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 120.45, "hourly_price": 0.165, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]}, "block_bandwidth": 524288000, "end_of_service": false}, "BASIC3-X8C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 160.6, "hourly_price": 0.22, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]}, "block_bandwidth": 524288000, "end_of_service": false}, "COMPUTE3-X16C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 320000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 341.786, "hourly_price": 0.4682, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 4000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 4000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "COMPUTE3-X2C-4G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 40000000000, "scratch_storage_max_volumes_count": 1, "monthly_price": 42.705, "hourly_price": 0.0585, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "COMPUTE3-X32C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 640000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 683.499, "hourly_price": 0.9363, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 8000000000, "sum_internet_bandwidth": 8000000000, "interfaces": [{"internal_bandwidth": 8000000000, "internet_bandwidth": 8000000000}]}, "block_bandwidth": 1000341504, "end_of_service": false}, "COMPUTE3-X48C-96G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 103079215104, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 960000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1019.81, "hourly_price": 1.397, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "COMPUTE3-X4C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 80000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 85.41, "hourly_price": 0.117, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "COMPUTE3-X64C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 1280000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1366.998, "hourly_price": 1.8726, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "COMPUTE3-X8C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 160000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 170.893, "hourly_price": 0.2341, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "COMPUTE3-X96C-192G": {"alt_names": [], "arch": "x86_64", "ncpus": 96, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 1280000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 2039.62, "hourly_price": 2.794, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "COPARM1-16C-64G": {"alt_names": [], "arch": "arm64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 252.14, "hourly_price": 0.3454, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 671088640, "end_of_service": false}, "COPARM1-2C-8G": {"alt_names": [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 31.1, "hourly_price": 0.0426, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 83886080, "end_of_service": false}, "COPARM1-32C-128G": {"alt_names": [], "arch": "arm64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 506.26, "hourly_price": 0.6935, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 1342177280, "end_of_service": false}, "COPARM1-4C-16G": {"alt_names": [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 62.56, "hourly_price": 0.0857, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 167772160, "end_of_service": false}, "COPARM1-8C-32G": {"alt_names": [], "arch": "arm64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 125.85, "hourly_price": 0.1724, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 335544320, "end_of_service": false}, "DEV1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 80000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 30.66, "hourly_price": 0.042, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 209715200, "end_of_service": false}, "DEV1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 3, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 40000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 14.454, "hourly_price": 0.0198, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 300000000, "sum_internet_bandwidth": 300000000, "interfaces": [{"internal_bandwidth": 300000000, "internet_bandwidth": 300000000}]}, "block_bandwidth": 157286400, "end_of_service": false}, "DEV1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 20000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 6.424, "hourly_price": 0.0088, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 104857600, "end_of_service": false}, "DEV1-XL": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 12884901888, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 120000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 46.5734, "hourly_price": 0.06378, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 262144000, "end_of_service": false}, "GP1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 554.07, "hourly_price": 0.759, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]}, "block_bandwidth": 1073741824, "end_of_service": false}, "GP1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 274.48, "hourly_price": 0.376, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "GP1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 300000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 136.51, "hourly_price": 0.187, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 524288000, "end_of_service": false}, "GP1-XL": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1197.93, "hourly_price": 1.641, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]}, "block_bandwidth": 2147483648, "end_of_service": false}, "GP1-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 150000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 66.43, "hourly_price": 0.091, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 314572800, "end_of_service": false}, "L4-1-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 51539607552, "gpu": 1, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 547.5, "hourly_price": 0.75, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 2500000000, "sum_internet_bandwidth": 2500000000, "interfaces": [{"internal_bandwidth": 2500000000, "internet_bandwidth": 2500000000}]}, "block_bandwidth": 1048576000, "end_of_service": false}, "L4-2-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 103079215104, "gpu": 2, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1095.0, "hourly_price": 1.5, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]}, "block_bandwidth": 1572864000, "end_of_service": false}, "L4-4-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 206158430208, "gpu": 4, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 2190.0, "hourly_price": 3.0, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]}, "block_bandwidth": 2621440000, "end_of_service": false}, "L4-8-24G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 412316860416, "gpu": 8, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 4380.0, "hourly_price": 6.0, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 20000000000, "sum_internet_bandwidth": 20000000000, "interfaces": [{"internal_bandwidth": 20000000000, "internet_bandwidth": 20000000000}]}, "block_bandwidth": 5242880000, "end_of_service": false}, "MEMORY3-X16C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 320000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 601.0, "hourly_price": 0.824, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 4000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 4000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "MEMORY3-X2C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 40000000000, "scratch_storage_max_volumes_count": 1, "monthly_price": 75.0, "hourly_price": 0.103, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "MEMORY3-X32C-256G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 640000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 1203.0, "hourly_price": 1.648, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 8000000000, "sum_internet_bandwidth": 8000000000, "interfaces": [{"internal_bandwidth": 8000000000, "internet_bandwidth": 8000000000}]}, "block_bandwidth": 1000341504, "end_of_service": false}, "MEMORY3-X48C-384G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 412316860416, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 960000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1804.0, "hourly_price": 2.472, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "MEMORY3-X4C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 80000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 150.0, "hourly_price": 0.206, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "MEMORY3-X8C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 160000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 300.0, "hourly_price": 0.412, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "PLAY2-MICRO": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 39.42, "hourly_price": 0.054, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 167772160, "end_of_service": false}, "PLAY2-NANO": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 19.71, "hourly_price": 0.027, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 83886080, "end_of_service": false}}}'
+        headers:
+            Content-Length:
+                - "41245"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:56:31 GMT
+            Link:
+                - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=3&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 7e4ee234-41ce-4b57-a6d1-5a296116c00c
+            X-Total-Count:
+                - "112"
+        status: 200 OK
+        code: 200
+        duration: 65.58612ms
+    - id: 42
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "2"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 40884
+        body: '{"servers": {"PLAY2-PICO": {"alt_names": [], "arch": "x86_64", "ncpus": 1, "ram": 2147483648, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 10.22, "hourly_price": 0.014, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]}, "block_bandwidth": 41943040, "end_of_service": false}, "POP2-16C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 430.7, "hourly_price": 0.59, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-16C-64G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1063.391, "hourly_price": 1.4567, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-2C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 53.66, "hourly_price": 0.0735, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-2C-8G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 133.079, "hourly_price": 0.1823, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-32C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 861.4, "hourly_price": 1.18, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-32C-128G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 2126.709, "hourly_price": 2.9133, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-48C-192G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1274.4, "hourly_price": 1.77, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-4C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 107.31, "hourly_price": 0.147, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-4C-16G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 265.501, "hourly_price": 0.3637, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-64C-256G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1715.5, "hourly_price": 2.35, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-8C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 211.7, "hourly_price": 0.29, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-8C-32G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 528.009, "hourly_price": 0.7233, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HC-16C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 310.69, "hourly_price": 0.4256, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-HC-2C-4G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 38.84, "hourly_price": 0.0532, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HC-32C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 621.38, "hourly_price": 0.8512, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HC-48C-96G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 103079215104, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 914.4, "hourly_price": 1.27, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HC-4C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 77.67, "hourly_price": 0.1064, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HC-64C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1242.75, "hourly_price": 1.7024, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HC-8C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 155.34, "hourly_price": 0.2128, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HM-16C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 601.52, "hourly_price": 0.824, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-HM-2C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 75.19, "hourly_price": 0.103, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HM-32C-256G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1203.04, "hourly_price": 1.648, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HM-48C-384G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 412316860416, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1778.4, "hourly_price": 2.47, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HM-4C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 150.38, "hourly_price": 0.206, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HM-64C-512G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 549755813888, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 2406.08, "hourly_price": 3.296, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HM-8C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 300.76, "hourly_price": 0.412, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HN-10": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 530.29, "hourly_price": 0.7264, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HN-3": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 186.49, "hourly_price": 0.2554, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HN-5": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 330.29, "hourly_price": 0.4524, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "PRO2-L": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 640.21, "hourly_price": 0.877, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6000000000, "sum_internet_bandwidth": 6000000000, "interfaces": [{"internal_bandwidth": 6000000000, "internet_bandwidth": 6000000000}]}, "block_bandwidth": 2097152000, "end_of_service": false}, "PRO2-M": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 319.74, "hourly_price": 0.438, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]}, "block_bandwidth": 1048576000, "end_of_service": false}, "PRO2-S": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 159.87, "hourly_price": 0.219, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]}, "block_bandwidth": 524288000, "end_of_service": false}, "PRO2-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 80.3, "hourly_price": 0.11, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth": 700000000, "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth": 700000000}]}, "block_bandwidth": 262144000, "end_of_service": false}, "PRO2-XXS": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 40.15, "hourly_price": 0.055, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth": 350000000, "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth": 350000000}]}, "block_bandwidth": 131072000, "end_of_service": false}, "RENDER-S": {"alt_names": [], "arch": "x86_64", "ncpus": 10, "ram": 45097156608, "gpu": 1, "gpu_info": {"gpu_manufacturer": "NVIDIA", "gpu_name": "P100", "gpu_memory": 17179869184}, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 400000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 891.33, "hourly_price": 1.221, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 2000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth": 2000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 2147483648, "end_of_service": false}, "STANDARD2-A16C-64G": {"alt_names": [], "arch": "arm64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 367.8324, "hourly_price": 0.5039, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200, "end_of_service": false}, "STANDARD2-A2C-8G": {"alt_names": [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 42.7525, "hourly_price": 0.0586, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 419430400, "end_of_service": false}, "STANDARD2-A32C-128G": {"alt_names": [], "arch": "arm64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 735.7269, "hourly_price": 1.0078, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5033164800, "end_of_service": false}, "STANDARD2-A48C-192G": {"alt_names": [], "arch": "arm64", "ncpus": 48, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1103.5593, "hourly_price": 1.5117, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5033164800, "end_of_service": false}, "STANDARD2-A4C-16G": {"alt_names": [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 85.5049, "hourly_price": 0.1171, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]}, "block_bandwidth": 838860800, "end_of_service": false}, "STANDARD2-A64C-256G": {"alt_names": [], "arch": "arm64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 1470.366, "hourly_price": 2.0142, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5033164800, "end_of_service": false}, "STANDARD2-A8C-32G": {"alt_names": [], "arch": "arm64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 171.0098, "hourly_price": 0.2343, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600, "end_of_service": false}, "STANDARD3-X16C-64G": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 320000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 430.0, "hourly_price": 0.59, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 4000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 4000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "STANDARD3-X2C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 40000000000, "scratch_storage_max_volumes_count": 1, "monthly_price": 54.0, "hourly_price": 0.074, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "STANDARD3-X32C-128G": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 640000000000, "scratch_storage_max_volumes_count": 4, "monthly_price": 861.0, "hourly_price": 1.18, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 8000000000, "sum_internet_bandwidth": 8000000000, "interfaces": [{"internal_bandwidth": 8000000000, "internet_bandwidth": 8000000000}]}, "block_bandwidth": 1000341504, "end_of_service": false}, "STANDARD3-X48C-192G": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 960000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1292.1, "hourly_price": 1.77, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "STANDARD3-X4C-16G": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 80000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 107.0, "hourly_price": 0.147, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}, "STANDARD3-X64C-256G": {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 1280000000000, "scratch_storage_max_volumes_count": 8, "monthly_price": 1715.0, "hourly_price": 2.35, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 16000000000, "sum_internet_bandwidth": 16000000000, "interfaces": [{"internal_bandwidth": 16000000000, "internet_bandwidth": 16000000000}]}, "block_bandwidth": 1999634432, "end_of_service": false}, "STANDARD3-X8C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": 160000000000, "scratch_storage_max_volumes_count": 2, "monthly_price": 211.0, "hourly_price": 0.29, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 4000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth": 4000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 500170752, "end_of_service": false}}}'
+        headers:
+            Content-Length:
+                - "40884"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:56:31 GMT
+            Link:
+                - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>; rel="previous",</products/servers?page=3&per_page=50&>; rel="next",</products/servers?page=3&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 72bbcdfd-abb0-4542-87c7-763c594ed1fc
+            X-Total-Count:
+                - "112"
+        status: 200 OK
+        code: 200
+        duration: 133.547188ms
+    - id: 43
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "3"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 10027
+        body: '{"servers": {"STARDUST1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 1, "ram": 1073741824, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 10000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 0.1095, "hourly_price": 0.00015, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]}, "block_bandwidth": 52428800, "end_of_service": false}, "START1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 26.864, "hourly_price": 0.0368, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "START1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 100000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 14.162, "hourly_price": 0.0194, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 300000000, "sum_internet_bandwidth": 300000000, "interfaces": [{"internal_bandwidth": 300000000, "internet_bandwidth": 300000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "START1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 50000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 7.738, "hourly_price": 0.0106, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "START1-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 1, "ram": 1073741824, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 25000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 4.526, "hourly_price": 0.0062, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "VC1L": {"alt_names": ["X64-8GB"], "arch": "x86_64", "ncpus": 6, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 18.0164, "hourly_price": 0.02468, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "VC1M": {"alt_names": ["X64-4GB"], "arch": "x86_64", "ncpus": 4, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 100000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 11.3515, "hourly_price": 0.01555, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "VC1S": {"alt_names": ["X64-2GB"], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 50000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 6.2926, "hourly_price": 0.00862, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "X64-120GB": {"alt_names": [], "arch": "x86_64", "ncpus": 12, "ram": 128849018880, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 800000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 310.7902, "hourly_price": 0.42574, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 1000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "X64-15GB": {"alt_names": [], "arch": "x86_64", "ncpus": 6, "ram": 16106127360, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 44.0336, "hourly_price": 0.06032, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 250000000, "sum_internet_bandwidth": 250000000, "interfaces": [{"internal_bandwidth": 250000000, "internet_bandwidth": 250000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "X64-30GB": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 32212254720, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 400000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 86.9138, "hourly_price": 0.11906, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 41943040, "end_of_service": true}, "X64-60GB": {"alt_names": [], "arch": "x86_64", "ncpus": 10, "ram": 64424509440, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 700000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": 0, "scratch_storage_max_volumes_count": 0, "monthly_price": 155.49, "hourly_price": 0.213, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth": 1000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 41943040, "end_of_service": true}}}'
+        headers:
+            Content-Length:
+                - "10027"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:56:31 GMT
+            Link:
+                - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=2&per_page=50&>; rel="previous",</products/servers?page=3&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 17f72676-3f9c-4e13-bf22-519724b51fbc
+            X-Total-Count:
+                - "112"
+        status: 200 OK
+        code: 200
+        duration: 69.164245ms
+    - id: 44
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1603
+        body: '{"region":"fr-par", "id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:13.060726Z", "updated_at":"2026-03-30T12:55:41.789306Z", "type":"kapsule", "name":"test-pool-wait", "description":"", "status":"ready", "version":"1.35.2", "cni":"calico", "tags":["terraform-test", "scaleway_k8s_cluster", "minimal"], "cluster_url":"https://3b418478-2d8b-4fc7-87c3-f551ebb22f53.api.k8s.fr-par.scw.cloud:6443", "dns_wildcard":"*.3b418478-2d8b-4fc7-87c3-f551ebb22f53.nodes.k8s.fr-par.scw.cloud", "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m", "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false, "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":0, "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":0}, "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}}, "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"", "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[], "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "commitment_ends_at":"2026-03-30T12:54:13.060733Z", "acl_available":true, "iam_nodes_group_id":"997eeeb9-fb5b-471b-8ba1-33cf150f3ca6", "pod_cidr":"100.64.0.0/15", "service_cidr":"10.32.0.0/20", "service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1603"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:56:31 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - bc5bfa7f-6575-402f-b218-a0a9bf8055b0
+        status: 200 OK
+        code: 200
+        duration: 20.065789ms
+    - id: 45
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 322
+        host: api.scaleway.com
+        body: '{"name":"test-pool-wait-2","node_type":"pro2_xxs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"kubelet_args":{},"zone":"fr-par-1","root_volume_type":"default_volume_type","public_ip_disabled":false,"labels":null,"taints":null,"startup_taints":null}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53/pools
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 737
+        body: '{"region":"fr-par", "id":"9e6791ab-321a-4ea7-9b53-f600e6b9a39d", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:56:31.542980Z", "updated_at":"2026-03-30T12:56:31.542980Z", "name":"test-pool-wait-2", "status":"scaling", "version":"1.35.2", "node_type":"pro2_xxs", "autoscaling":false, "size":1, "min_size":1, "max_size":1, "container_runtime":"containerd", "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{}, "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"sbs_5k", "root_volume_size":20000000000, "public_ip_disabled":false, "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b", "labels":{}, "taints":[], "startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "737"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:56:31 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - b75a05a1-419c-4f4c-ad55-3bc25f05ffc1
+        status: 200 OK
+        code: 200
+        duration: 106.325289ms
+    - id: 46
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9e6791ab-321a-4ea7-9b53-f600e6b9a39d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 737
+        body: '{"region":"fr-par", "id":"9e6791ab-321a-4ea7-9b53-f600e6b9a39d", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:56:31.542980Z", "updated_at":"2026-03-30T12:56:31.542980Z", "name":"test-pool-wait-2", "status":"scaling", "version":"1.35.2", "node_type":"pro2_xxs", "autoscaling":false, "size":1, "min_size":1, "max_size":1, "container_runtime":"containerd", "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{}, "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"sbs_5k", "root_volume_size":20000000000, "public_ip_disabled":false, "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b", "labels":{}, "taints":[], "startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "737"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:56:31 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - b9025fd6-497c-448b-85ec-91c32133849b
+        status: 200 OK
+        code: 200
+        duration: 43.194025ms
+    - id: 47
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9e6791ab-321a-4ea7-9b53-f600e6b9a39d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 735
+        body: '{"region":"fr-par", "id":"9e6791ab-321a-4ea7-9b53-f600e6b9a39d", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:56:31.542980Z", "updated_at":"2026-03-30T12:57:21.329097Z", "name":"test-pool-wait-2", "status":"ready", "version":"1.35.2", "node_type":"pro2_xxs", "autoscaling":false, "size":1, "min_size":1, "max_size":1, "container_runtime":"containerd", "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{}, "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"sbs_5k", "root_volume_size":20000000000, "public_ip_disabled":false, "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b", "labels":{}, "taints":[], "startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "735"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:57:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 2d1a79af-b916-46ca-8255-311087c40e5d
+        status: 200 OK
+        code: 200
+        duration: 32.751318ms
+    - id: 48
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1603
+        body: '{"region":"fr-par", "id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:13.060726Z", "updated_at":"2026-03-30T12:55:41.789306Z", "type":"kapsule", "name":"test-pool-wait", "description":"", "status":"ready", "version":"1.35.2", "cni":"calico", "tags":["terraform-test", "scaleway_k8s_cluster", "minimal"], "cluster_url":"https://3b418478-2d8b-4fc7-87c3-f551ebb22f53.api.k8s.fr-par.scw.cloud:6443", "dns_wildcard":"*.3b418478-2d8b-4fc7-87c3-f551ebb22f53.nodes.k8s.fr-par.scw.cloud", "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m", "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false, "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":0, "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":0}, "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}}, "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"", "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[], "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "commitment_ends_at":"2026-03-30T12:54:13.060733Z", "acl_available":true, "iam_nodes_group_id":"997eeeb9-fb5b-471b-8ba1-33cf150f3ca6", "pod_cidr":"100.64.0.0/15", "service_cidr":"10.32.0.0/20", "service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1603"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:57:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 6e264093-768d-4e9e-b8e2-fabe566f5d8c
+        status: 200 OK
+        code: 200
+        duration: 20.946953ms
+    - id: 49
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9e6791ab-321a-4ea7-9b53-f600e6b9a39d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 735
+        body: '{"region":"fr-par", "id":"9e6791ab-321a-4ea7-9b53-f600e6b9a39d", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:56:31.542980Z", "updated_at":"2026-03-30T12:57:21.329097Z", "name":"test-pool-wait-2", "status":"ready", "version":"1.35.2", "node_type":"pro2_xxs", "autoscaling":false, "size":1, "min_size":1, "max_size":1, "container_runtime":"containerd", "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{}, "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"sbs_5k", "root_volume_size":20000000000, "public_ip_disabled":false, "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b", "labels":{}, "taints":[], "startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "735"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:57:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - e4438969-19a2-4672-9f6c-5ecbbda01d9e
+        status: 200 OK
+        code: 200
+        duration: 19.211857ms
+    - id: 50
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_asc
+            page:
+                - "1"
+            pool_id:
+                - 9e6791ab-321a-4ea7-9b53-f600e6b9a39d
+            status:
+                - unknown
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53/nodes?order_by=created_at_asc&page=1&pool_id=9e6791ab-321a-4ea7-9b53-f600e6b9a39d&status=unknown
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 619
+        body: '{"total_count":1, "nodes":[{"region":"fr-par", "id":"9a2bb294-ae27-460e-b3b4-0d7d59769218", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:56:31.814706Z", "updated_at":"2026-03-30T12:57:21.319209Z", "pool_id":"9e6791ab-321a-4ea7-9b53-f600e6b9a39d", "status":"ready", "conditions":{"DiskPressure":"False", "MemoryPressure":"False", "PIDPressure":"False", "Ready":"True"}, "name":"scw-test-pool-wait-test-pool-wait-2-9a2bb294ae", "public_ip_v4":"51.15.232.167", "public_ip_v6":null, "provider_id":"scaleway://instance/fr-par-1/d5e63ca1-4ce2-440e-b55d-becd8f830797", "error_message":""}]}'
+        headers:
+            Content-Length:
+                - "619"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:57:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - ad1d6f80-b26a-46a1-a003-5b26bea8d46f
+        status: 200 OK
+        code: 200
+        duration: 27.955587ms
+    - id: 51
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1603
+        body: '{"region":"fr-par", "id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:13.060726Z", "updated_at":"2026-03-30T12:55:41.789306Z", "type":"kapsule", "name":"test-pool-wait", "description":"", "status":"ready", "version":"1.35.2", "cni":"calico", "tags":["terraform-test", "scaleway_k8s_cluster", "minimal"], "cluster_url":"https://3b418478-2d8b-4fc7-87c3-f551ebb22f53.api.k8s.fr-par.scw.cloud:6443", "dns_wildcard":"*.3b418478-2d8b-4fc7-87c3-f551ebb22f53.nodes.k8s.fr-par.scw.cloud", "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m", "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false, "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":0, "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":0}, "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}}, "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"", "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[], "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "commitment_ends_at":"2026-03-30T12:54:13.060733Z", "acl_available":true, "iam_nodes_group_id":"997eeeb9-fb5b-471b-8ba1-33cf150f3ca6", "pod_cidr":"100.64.0.0/15", "service_cidr":"10.32.0.0/20", "service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1603"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:57:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 47909421-fec2-4342-a81d-b37daab17171
+        status: 200 OK
+        code: 200
+        duration: 21.564452ms
+    - id: 52
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_desc
+            project_id:
+                - fa1e3217-dc80-42ac-85c3-3f034b78b552
+            resource_name:
+                - scw-test-pool-wait-test-pool-wait-2-9a2bb294ae
+            resource_type:
+                - unknown_type
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=fa1e3217-dc80-42ac-85c3-3f034b78b552&resource_name=scw-test-pool-wait-test-pool-wait-2-9a2bb294ae&resource_type=unknown_type
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1122
+        body: '{"total_count":2, "ips":[{"id":"75b3496a-ca81-4973-865a-4dc5d2529d87", "address":"fd63:256c:45f7:bc7e:6fe5:edb8:a736:809e/64", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_ipv6":true, "created_at":"2026-03-30T12:56:34.289056Z", "updated_at":"2026-03-30T12:56:34.289056Z", "source":{"subnet_id":"b18788e5-4872-494d-a7bb-0ba98125d9e4"}, "resource":{"type":"instance_private_nic", "id":"cbaad5fe-1d2e-40ef-8e6b-6b409ccab201", "mac_address":"02:00:00:12:4D:A4", "name":"scw-test-pool-wait-test-pool-wait-2-9a2bb294ae"}, "tags":[], "reverses":[], "region":"fr-par", "zone":null}, {"id":"03c33497-a15d-45bb-986e-9a6ad6191de2", "address":"172.16.72.4/22", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_ipv6":false, "created_at":"2026-03-30T12:56:34.167958Z", "updated_at":"2026-03-30T12:56:34.167958Z", "source":{"subnet_id":"ae63fffc-03c5-47e1-bfb2-170301d26f53"}, "resource":{"type":"instance_private_nic", "id":"cbaad5fe-1d2e-40ef-8e6b-6b409ccab201", "mac_address":"02:00:00:12:4D:A4", "name":"scw-test-pool-wait-test-pool-wait-2-9a2bb294ae"}, "tags":[], "reverses":[], "region":"fr-par", "zone":null}]}'
+        headers:
+            Content-Length:
+                - "1122"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:57:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - ecc43716-8c7c-41e0-8dc3-642b3fcaeed3
+        status: 200 OK
+        code: 200
+        duration: 30.458775ms
+    - id: 53
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1603
+        body: '{"region":"fr-par", "id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:13.060726Z", "updated_at":"2026-03-30T12:55:41.789306Z", "type":"kapsule", "name":"test-pool-wait", "description":"", "status":"ready", "version":"1.35.2", "cni":"calico", "tags":["terraform-test", "scaleway_k8s_cluster", "minimal"], "cluster_url":"https://3b418478-2d8b-4fc7-87c3-f551ebb22f53.api.k8s.fr-par.scw.cloud:6443", "dns_wildcard":"*.3b418478-2d8b-4fc7-87c3-f551ebb22f53.nodes.k8s.fr-par.scw.cloud", "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m", "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false, "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":0, "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":0}, "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}}, "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"", "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[], "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "commitment_ends_at":"2026-03-30T12:54:13.060733Z", "acl_available":true, "iam_nodes_group_id":"997eeeb9-fb5b-471b-8ba1-33cf150f3ca6", "pod_cidr":"100.64.0.0/15", "service_cidr":"10.32.0.0/20", "service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1603"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:57:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 90fdfa55-6750-487d-b501-9cba063a0f8a
+        status: 200 OK
+        code: 200
+        duration: 37.333127ms
+    - id: 54
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9e6791ab-321a-4ea7-9b53-f600e6b9a39d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 735
+        body: '{"region":"fr-par", "id":"9e6791ab-321a-4ea7-9b53-f600e6b9a39d", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:56:31.542980Z", "updated_at":"2026-03-30T12:57:21.329097Z", "name":"test-pool-wait-2", "status":"ready", "version":"1.35.2", "node_type":"pro2_xxs", "autoscaling":false, "size":1, "min_size":1, "max_size":1, "container_runtime":"containerd", "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{}, "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"sbs_5k", "root_volume_size":20000000000, "public_ip_disabled":false, "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b", "labels":{}, "taints":[], "startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "735"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:57:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - aa824b2f-3600-4df4-bd83-7daf211f1801
+        status: 200 OK
+        code: 200
+        duration: 21.191943ms
+    - id: 55
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/45317da4-924e-4fd3-b4ca-e93215bc5849
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 431
+        body: '{"id":"45317da4-924e-4fd3-b4ca-e93215bc5849", "name":"tf-vpc-affectionate-proskuriakova", "tags":[], "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:12.102781Z", "updated_at":"2026-03-30T12:54:12.102781Z", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_default":false, "private_network_count":1, "routing_enabled":true, "custom_routes_propagation_enabled":true, "region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "431"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:57:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - e90063f0-5bc1-42fd-923f-9a29bf7db90f
+        status: 200 OK
+        code: 200
+        duration: 31.616007ms
+    - id: 56
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/97585af2-c151-4ad5-9778-fa88d5af8bba
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1084
+        body: '{"id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "name":"test-pool-wait", "tags":[], "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:12.204171Z", "updated_at":"2026-03-30T12:54:12.204171Z", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "subnets":[{"id":"ae63fffc-03c5-47e1-bfb2-170301d26f53", "created_at":"2026-03-30T12:54:12.204171Z", "updated_at":"2026-03-30T12:54:12.204171Z", "subnet":"172.16.72.0/22", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "vpc_id":"45317da4-924e-4fd3-b4ca-e93215bc5849"}, {"id":"b18788e5-4872-494d-a7bb-0ba98125d9e4", "created_at":"2026-03-30T12:54:12.204171Z", "updated_at":"2026-03-30T12:54:12.204171Z", "subnet":"fd63:256c:45f7:bc7e::/64", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "vpc_id":"45317da4-924e-4fd3-b4ca-e93215bc5849"}], "vpc_id":"45317da4-924e-4fd3-b4ca-e93215bc5849", "dhcp_enabled":true, "default_route_propagation_enabled":false, "region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1084"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:57:22 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 225c23e3-ff06-49a2-8402-a289c9c8e3c4
+        status: 200 OK
+        code: 200
+        duration: 28.703571ms
+    - id: 57
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1603
+        body: '{"region":"fr-par", "id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:13.060726Z", "updated_at":"2026-03-30T12:55:41.789306Z", "type":"kapsule", "name":"test-pool-wait", "description":"", "status":"ready", "version":"1.35.2", "cni":"calico", "tags":["terraform-test", "scaleway_k8s_cluster", "minimal"], "cluster_url":"https://3b418478-2d8b-4fc7-87c3-f551ebb22f53.api.k8s.fr-par.scw.cloud:6443", "dns_wildcard":"*.3b418478-2d8b-4fc7-87c3-f551ebb22f53.nodes.k8s.fr-par.scw.cloud", "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m", "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false, "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":0, "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":0}, "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}}, "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"", "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[], "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "commitment_ends_at":"2026-03-30T12:54:13.060733Z", "acl_available":true, "iam_nodes_group_id":"997eeeb9-fb5b-471b-8ba1-33cf150f3ca6", "pod_cidr":"100.64.0.0/15", "service_cidr":"10.32.0.0/20", "service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1603"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:57:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 4fb3a093-07f2-4e3a-a306-394fa5a83c80
+        status: 200 OK
+        code: 200
+        duration: 28.935456ms
+    - id: 58
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53/kubeconfig
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1650
+        body: '{"name":"kubeconfig", "content_type":"application/octet-stream", "content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVSlhla05EUVZGSFowRjNTVUpCWjBsQ1FVUkJTMEpuWjNGb2EycFBVRkZSUkVGcVFWWk5VazEzUlZGWlJGWlJVVVJGZDNCeVpGZEtiR050Tld3S1pFZFdlazFDTkZoRVZFa3lUVVJOZVU5VVJYbE9WRkY0VFRGdldFUlVUVEpOUkUxNVQxUkZlVTVVVVhoTk1XOTNSbFJGVkUxQ1JVZEJNVlZGUVhoTlN3cGhNMVpwV2xoS2RWcFlVbXhqZWtKYVRVSk5SMEo1Y1VkVFRUUTVRV2RGUjBORGNVZFRUVFE1UVhkRlNFRXdTVUZDVHpWNk0wd3ZPRGRTUmpGT1dXTjFDbEJNY1RSbmN6UkhTWHBxY1hSU1pHNWpWbTFyYjNwTk1qUjVXRzlzTmtoTlp6SXpMekowYVdSeVQwUjNlVmN2WlV4Wk1sWldLMkZ4Y2poWmRteDJUaXNLVDJaM2FVNHlSMnBSYWtKQlRVRTBSMEV4VldSRWQwVkNMM2RSUlVGM1NVTndSRUZRUW1kT1ZraFNUVUpCWmpoRlFsUkJSRUZSU0M5TlFqQkhRVEZWWkFwRVoxRlhRa0pSWjJWNk0zRlRaR0VyVUZWc2VrODFRa051TlZScVRsa3JTWGg2UVV0Q1oyZHhhR3RxVDFCUlVVUkJaMDVKUVVSQ1JrRnBSVUZ0S3pneENuWkZWREptVW13d00yRlljSFZ1ZG5kMlNXc3hiMEY1VFRFd1ZuQm9lRXgwYUVOaGRVNVVSVU5KU0cxNVRWUmxMM2s1YTI5UFZHdGtiazlOTDJrMkwxZ0tSRzVyUnpNeldpc3JaMVJxV2xwWmJXNDJORVVLTFMwdExTMUZUa1FnUTBWU1ZFbEdTVU5CVkVVdExTMHRMUW89CiAgICBzZXJ2ZXI6IGh0dHBzOi8vM2I0MTg0NzgtMmQ4Yi00ZmM3LTg3YzMtZjU1MWViYjIyZjUzLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC13YWl0CiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXBvb2wtd2FpdCIKICAgIHVzZXI6IHRlc3QtcG9vbC13YWl0LWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXdhaXQKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXBvb2wtd2FpdC1hZG1pbgogIHVzZXI6CiAgICB0b2tlbjogNkxOdk9jQ3VWdWFJMEpqd3JleGNVYjZNc3J4T2ZMM2Jhd1llUmN0b0ZpTjJDVFo0d1pESVlrNEg="}'
+        headers:
+            Content-Length:
+                - "1650"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:57:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 5857a1c8-42e1-42c8-8c3d-1eb0acce094d
+        status: 200 OK
+        code: 200
+        duration: 44.956043ms
+    - id: 59
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9e6791ab-321a-4ea7-9b53-f600e6b9a39d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 735
+        body: '{"region":"fr-par", "id":"9e6791ab-321a-4ea7-9b53-f600e6b9a39d", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:56:31.542980Z", "updated_at":"2026-03-30T12:57:21.329097Z", "name":"test-pool-wait-2", "status":"ready", "version":"1.35.2", "node_type":"pro2_xxs", "autoscaling":false, "size":1, "min_size":1, "max_size":1, "container_runtime":"containerd", "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{}, "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"sbs_5k", "root_volume_size":20000000000, "public_ip_disabled":false, "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b", "labels":{}, "taints":[], "startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "735"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:57:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - eef17feb-fba9-4085-877e-71e6d1f6be1c
+        status: 200 OK
+        code: 200
+        duration: 19.958859ms
+    - id: 60
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aef8b176-85f1-4ac9-80c5-5632257daa82
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 733
+        body: '{"region":"fr-par", "id":"aef8b176-85f1-4ac9-80c5-5632257daa82", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:54:18.475205Z", "updated_at":"2026-03-30T12:56:27.984394Z", "name":"test-pool-wait", "status":"ready", "version":"1.35.2", "node_type":"pro2_xxs", "autoscaling":false, "size":1, "min_size":1, "max_size":1, "container_runtime":"containerd", "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{}, "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"sbs_5k", "root_volume_size":20000000000, "public_ip_disabled":false, "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b", "labels":{}, "taints":[], "startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "733"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:57:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 98db3299-1b55-4c67-b130-553ea479fd21
+        status: 200 OK
+        code: 200
+        duration: 22.746671ms
+    - id: 61
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_asc
+            page:
+                - "1"
+            pool_id:
+                - 9e6791ab-321a-4ea7-9b53-f600e6b9a39d
+            status:
+                - unknown
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53/nodes?order_by=created_at_asc&page=1&pool_id=9e6791ab-321a-4ea7-9b53-f600e6b9a39d&status=unknown
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 619
+        body: '{"total_count":1, "nodes":[{"region":"fr-par", "id":"9a2bb294-ae27-460e-b3b4-0d7d59769218", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:56:31.814706Z", "updated_at":"2026-03-30T12:57:21.319209Z", "pool_id":"9e6791ab-321a-4ea7-9b53-f600e6b9a39d", "status":"ready", "conditions":{"DiskPressure":"False", "MemoryPressure":"False", "PIDPressure":"False", "Ready":"True"}, "name":"scw-test-pool-wait-test-pool-wait-2-9a2bb294ae", "public_ip_v4":"51.15.232.167", "public_ip_v6":null, "provider_id":"scaleway://instance/fr-par-1/d5e63ca1-4ce2-440e-b55d-becd8f830797", "error_message":""}]}'
+        headers:
+            Content-Length:
+                - "619"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:57:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - cfe952ad-8bb9-4598-901a-5fed260dffc7
+        status: 200 OK
+        code: 200
+        duration: 23.088693ms
+    - id: 62
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_asc
+            page:
+                - "1"
+            pool_id:
+                - aef8b176-85f1-4ac9-80c5-5632257daa82
+            status:
+                - unknown
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53/nodes?order_by=created_at_asc&page=1&pool_id=aef8b176-85f1-4ac9-80c5-5632257daa82&status=unknown
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 649
+        body: '{"total_count":1, "nodes":[{"region":"fr-par", "id":"f02a58a1-5b25-41c1-948d-dfe4d877c500", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:55:42.710952Z", "updated_at":"2026-03-30T12:57:21.299287Z", "pool_id":"aef8b176-85f1-4ac9-80c5-5632257daa82", "status":"ready", "conditions":{"DiskPressure":"False", "MemoryPressure":"False", "NetworkUnavailable":"False", "PIDPressure":"False", "Ready":"True"}, "name":"scw-test-pool-wait-test-pool-wait-f02a58a15b25", "public_ip_v4":"51.158.97.194", "public_ip_v6":null, "provider_id":"scaleway://instance/fr-par-1/5a65da2a-aa5f-45b7-a8cf-e1dc0465f407", "error_message":""}]}'
+        headers:
+            Content-Length:
+                - "649"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:57:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 81dd697c-0dc0-4a27-9023-f105b1c30976
+        status: 200 OK
+        code: 200
+        duration: 29.685003ms
+    - id: 63
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1603
+        body: '{"region":"fr-par", "id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:13.060726Z", "updated_at":"2026-03-30T12:55:41.789306Z", "type":"kapsule", "name":"test-pool-wait", "description":"", "status":"ready", "version":"1.35.2", "cni":"calico", "tags":["terraform-test", "scaleway_k8s_cluster", "minimal"], "cluster_url":"https://3b418478-2d8b-4fc7-87c3-f551ebb22f53.api.k8s.fr-par.scw.cloud:6443", "dns_wildcard":"*.3b418478-2d8b-4fc7-87c3-f551ebb22f53.nodes.k8s.fr-par.scw.cloud", "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m", "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false, "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":0, "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":0}, "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}}, "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"", "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[], "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "commitment_ends_at":"2026-03-30T12:54:13.060733Z", "acl_available":true, "iam_nodes_group_id":"997eeeb9-fb5b-471b-8ba1-33cf150f3ca6", "pod_cidr":"100.64.0.0/15", "service_cidr":"10.32.0.0/20", "service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1603"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:57:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 26818873-e247-4390-b9fa-28a6b35b8ee5
+        status: 200 OK
+        code: 200
+        duration: 27.705317ms
+    - id: 64
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1603
+        body: '{"region":"fr-par", "id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:13.060726Z", "updated_at":"2026-03-30T12:55:41.789306Z", "type":"kapsule", "name":"test-pool-wait", "description":"", "status":"ready", "version":"1.35.2", "cni":"calico", "tags":["terraform-test", "scaleway_k8s_cluster", "minimal"], "cluster_url":"https://3b418478-2d8b-4fc7-87c3-f551ebb22f53.api.k8s.fr-par.scw.cloud:6443", "dns_wildcard":"*.3b418478-2d8b-4fc7-87c3-f551ebb22f53.nodes.k8s.fr-par.scw.cloud", "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m", "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false, "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":0, "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":0}, "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}}, "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"", "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[], "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "commitment_ends_at":"2026-03-30T12:54:13.060733Z", "acl_available":true, "iam_nodes_group_id":"997eeeb9-fb5b-471b-8ba1-33cf150f3ca6", "pod_cidr":"100.64.0.0/15", "service_cidr":"10.32.0.0/20", "service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1603"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:57:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 4ba8d4ed-101e-49a1-a06c-034e45bb3368
+        status: 200 OK
+        code: 200
+        duration: 21.311347ms
+    - id: 65
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_desc
+            project_id:
+                - fa1e3217-dc80-42ac-85c3-3f034b78b552
+            resource_name:
+                - scw-test-pool-wait-test-pool-wait-f02a58a15b25
+            resource_type:
+                - unknown_type
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=fa1e3217-dc80-42ac-85c3-3f034b78b552&resource_name=scw-test-pool-wait-test-pool-wait-f02a58a15b25&resource_type=unknown_type
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1121
+        body: '{"total_count":2, "ips":[{"id":"7a65b835-044c-4996-a22b-5715ea76a553", "address":"fd63:256c:45f7:bc7e:4f61:41e:1ed2:7ab4/64", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_ipv6":true, "created_at":"2026-03-30T12:55:45.022856Z", "updated_at":"2026-03-30T12:55:45.022856Z", "source":{"subnet_id":"b18788e5-4872-494d-a7bb-0ba98125d9e4"}, "resource":{"type":"instance_private_nic", "id":"aa4dd472-9b34-45a8-bed3-592e94180874", "mac_address":"02:00:00:1B:24:BE", "name":"scw-test-pool-wait-test-pool-wait-f02a58a15b25"}, "tags":[], "reverses":[], "region":"fr-par", "zone":null}, {"id":"ff1cbc09-c270-4fb8-9808-8f2232e772f8", "address":"172.16.72.3/22", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_ipv6":false, "created_at":"2026-03-30T12:55:44.890521Z", "updated_at":"2026-03-30T12:55:44.890521Z", "source":{"subnet_id":"ae63fffc-03c5-47e1-bfb2-170301d26f53"}, "resource":{"type":"instance_private_nic", "id":"aa4dd472-9b34-45a8-bed3-592e94180874", "mac_address":"02:00:00:1B:24:BE", "name":"scw-test-pool-wait-test-pool-wait-f02a58a15b25"}, "tags":[], "reverses":[], "region":"fr-par", "zone":null}]}'
+        headers:
+            Content-Length:
+                - "1121"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:57:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 08fad7e3-5315-4fc4-a274-e6d3ca706df2
+        status: 200 OK
+        code: 200
+        duration: 48.283458ms
+    - id: 66
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_desc
+            project_id:
+                - fa1e3217-dc80-42ac-85c3-3f034b78b552
+            resource_name:
+                - scw-test-pool-wait-test-pool-wait-2-9a2bb294ae
+            resource_type:
+                - unknown_type
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=fa1e3217-dc80-42ac-85c3-3f034b78b552&resource_name=scw-test-pool-wait-test-pool-wait-2-9a2bb294ae&resource_type=unknown_type
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1122
+        body: '{"total_count":2, "ips":[{"id":"75b3496a-ca81-4973-865a-4dc5d2529d87", "address":"fd63:256c:45f7:bc7e:6fe5:edb8:a736:809e/64", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_ipv6":true, "created_at":"2026-03-30T12:56:34.289056Z", "updated_at":"2026-03-30T12:56:34.289056Z", "source":{"subnet_id":"b18788e5-4872-494d-a7bb-0ba98125d9e4"}, "resource":{"type":"instance_private_nic", "id":"cbaad5fe-1d2e-40ef-8e6b-6b409ccab201", "mac_address":"02:00:00:12:4D:A4", "name":"scw-test-pool-wait-test-pool-wait-2-9a2bb294ae"}, "tags":[], "reverses":[], "region":"fr-par", "zone":null}, {"id":"03c33497-a15d-45bb-986e-9a6ad6191de2", "address":"172.16.72.4/22", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_ipv6":false, "created_at":"2026-03-30T12:56:34.167958Z", "updated_at":"2026-03-30T12:56:34.167958Z", "source":{"subnet_id":"ae63fffc-03c5-47e1-bfb2-170301d26f53"}, "resource":{"type":"instance_private_nic", "id":"cbaad5fe-1d2e-40ef-8e6b-6b409ccab201", "mac_address":"02:00:00:12:4D:A4", "name":"scw-test-pool-wait-test-pool-wait-2-9a2bb294ae"}, "tags":[], "reverses":[], "region":"fr-par", "zone":null}]}'
+        headers:
+            Content-Length:
+                - "1122"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:57:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 68c6cf5a-81a6-48ea-bd26-9429f10a6fa9
+        status: 200 OK
+        code: 200
+        duration: 51.097178ms
+    - id: 67
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/45317da4-924e-4fd3-b4ca-e93215bc5849
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 431
+        body: '{"id":"45317da4-924e-4fd3-b4ca-e93215bc5849", "name":"tf-vpc-affectionate-proskuriakova", "tags":[], "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:12.102781Z", "updated_at":"2026-03-30T12:54:12.102781Z", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_default":false, "private_network_count":1, "routing_enabled":true, "custom_routes_propagation_enabled":true, "region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "431"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:57:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - ebe8dfa5-389c-4ba9-aacd-abc9a9532500
+        status: 200 OK
+        code: 200
+        duration: 31.953781ms
+    - id: 68
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/97585af2-c151-4ad5-9778-fa88d5af8bba
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1084
+        body: '{"id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "name":"test-pool-wait", "tags":[], "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:12.204171Z", "updated_at":"2026-03-30T12:54:12.204171Z", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "subnets":[{"id":"ae63fffc-03c5-47e1-bfb2-170301d26f53", "created_at":"2026-03-30T12:54:12.204171Z", "updated_at":"2026-03-30T12:54:12.204171Z", "subnet":"172.16.72.0/22", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "vpc_id":"45317da4-924e-4fd3-b4ca-e93215bc5849"}, {"id":"b18788e5-4872-494d-a7bb-0ba98125d9e4", "created_at":"2026-03-30T12:54:12.204171Z", "updated_at":"2026-03-30T12:54:12.204171Z", "subnet":"fd63:256c:45f7:bc7e::/64", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "vpc_id":"45317da4-924e-4fd3-b4ca-e93215bc5849"}], "vpc_id":"45317da4-924e-4fd3-b4ca-e93215bc5849", "dhcp_enabled":true, "default_route_propagation_enabled":false, "region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1084"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:57:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - fcc54240-83b4-4b09-91a2-a887fc43d9a4
+        status: 200 OK
+        code: 200
+        duration: 27.330143ms
+    - id: 69
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1603
+        body: '{"region":"fr-par", "id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:13.060726Z", "updated_at":"2026-03-30T12:55:41.789306Z", "type":"kapsule", "name":"test-pool-wait", "description":"", "status":"ready", "version":"1.35.2", "cni":"calico", "tags":["terraform-test", "scaleway_k8s_cluster", "minimal"], "cluster_url":"https://3b418478-2d8b-4fc7-87c3-f551ebb22f53.api.k8s.fr-par.scw.cloud:6443", "dns_wildcard":"*.3b418478-2d8b-4fc7-87c3-f551ebb22f53.nodes.k8s.fr-par.scw.cloud", "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m", "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false, "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":0, "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":0}, "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}}, "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"", "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[], "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "commitment_ends_at":"2026-03-30T12:54:13.060733Z", "acl_available":true, "iam_nodes_group_id":"997eeeb9-fb5b-471b-8ba1-33cf150f3ca6", "pod_cidr":"100.64.0.0/15", "service_cidr":"10.32.0.0/20", "service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1603"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:57:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 689e4761-9887-417a-ac6e-dd4fdd2fab7f
+        status: 200 OK
+        code: 200
+        duration: 25.890702ms
+    - id: 70
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53/kubeconfig
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1650
+        body: '{"name":"kubeconfig", "content_type":"application/octet-stream", "content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVSlhla05EUVZGSFowRjNTVUpCWjBsQ1FVUkJTMEpuWjNGb2EycFBVRkZSUkVGcVFWWk5VazEzUlZGWlJGWlJVVVJGZDNCeVpGZEtiR050Tld3S1pFZFdlazFDTkZoRVZFa3lUVVJOZVU5VVJYbE9WRkY0VFRGdldFUlVUVEpOUkUxNVQxUkZlVTVVVVhoTk1XOTNSbFJGVkUxQ1JVZEJNVlZGUVhoTlN3cGhNMVpwV2xoS2RWcFlVbXhqZWtKYVRVSk5SMEo1Y1VkVFRUUTVRV2RGUjBORGNVZFRUVFE1UVhkRlNFRXdTVUZDVHpWNk0wd3ZPRGRTUmpGT1dXTjFDbEJNY1RSbmN6UkhTWHBxY1hSU1pHNWpWbTFyYjNwTk1qUjVXRzlzTmtoTlp6SXpMekowYVdSeVQwUjNlVmN2WlV4Wk1sWldLMkZ4Y2poWmRteDJUaXNLVDJaM2FVNHlSMnBSYWtKQlRVRTBSMEV4VldSRWQwVkNMM2RSUlVGM1NVTndSRUZRUW1kT1ZraFNUVUpCWmpoRlFsUkJSRUZSU0M5TlFqQkhRVEZWWkFwRVoxRlhRa0pSWjJWNk0zRlRaR0VyVUZWc2VrODFRa051TlZScVRsa3JTWGg2UVV0Q1oyZHhhR3RxVDFCUlVVUkJaMDVKUVVSQ1JrRnBSVUZ0S3pneENuWkZWREptVW13d00yRlljSFZ1ZG5kMlNXc3hiMEY1VFRFd1ZuQm9lRXgwYUVOaGRVNVVSVU5KU0cxNVRWUmxMM2s1YTI5UFZHdGtiazlOTDJrMkwxZ0tSRzVyUnpNeldpc3JaMVJxV2xwWmJXNDJORVVLTFMwdExTMUZUa1FnUTBWU1ZFbEdTVU5CVkVVdExTMHRMUW89CiAgICBzZXJ2ZXI6IGh0dHBzOi8vM2I0MTg0NzgtMmQ4Yi00ZmM3LTg3YzMtZjU1MWViYjIyZjUzLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC13YWl0CiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXBvb2wtd2FpdCIKICAgIHVzZXI6IHRlc3QtcG9vbC13YWl0LWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXdhaXQKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXBvb2wtd2FpdC1hZG1pbgogIHVzZXI6CiAgICB0b2tlbjogNkxOdk9jQ3VWdWFJMEpqd3JleGNVYjZNc3J4T2ZMM2Jhd1llUmN0b0ZpTjJDVFo0d1pESVlrNEg="}'
+        headers:
+            Content-Length:
+                - "1650"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:57:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - d57217f3-c17e-40b0-a47f-21c582306554
+        status: 200 OK
+        code: 200
+        duration: 43.514348ms
+    - id: 71
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aef8b176-85f1-4ac9-80c5-5632257daa82
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 733
+        body: '{"region":"fr-par", "id":"aef8b176-85f1-4ac9-80c5-5632257daa82", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:54:18.475205Z", "updated_at":"2026-03-30T12:56:27.984394Z", "name":"test-pool-wait", "status":"ready", "version":"1.35.2", "node_type":"pro2_xxs", "autoscaling":false, "size":1, "min_size":1, "max_size":1, "container_runtime":"containerd", "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{}, "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"sbs_5k", "root_volume_size":20000000000, "public_ip_disabled":false, "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b", "labels":{}, "taints":[], "startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "733"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:57:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 6dc4fa95-b0d2-4cde-86a6-43f44a5e287b
+        status: 200 OK
+        code: 200
+        duration: 23.80103ms
+    - id: 72
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9e6791ab-321a-4ea7-9b53-f600e6b9a39d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 735
+        body: '{"region":"fr-par", "id":"9e6791ab-321a-4ea7-9b53-f600e6b9a39d", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:56:31.542980Z", "updated_at":"2026-03-30T12:57:21.329097Z", "name":"test-pool-wait-2", "status":"ready", "version":"1.35.2", "node_type":"pro2_xxs", "autoscaling":false, "size":1, "min_size":1, "max_size":1, "container_runtime":"containerd", "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{}, "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"sbs_5k", "root_volume_size":20000000000, "public_ip_disabled":false, "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b", "labels":{}, "taints":[], "startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "735"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:57:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 490744fc-926e-4cf6-9b83-e1c0afb1a7c0
+        status: 200 OK
+        code: 200
+        duration: 34.105599ms
+    - id: 73
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_asc
+            page:
+                - "1"
+            pool_id:
+                - aef8b176-85f1-4ac9-80c5-5632257daa82
+            status:
+                - unknown
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53/nodes?order_by=created_at_asc&page=1&pool_id=aef8b176-85f1-4ac9-80c5-5632257daa82&status=unknown
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 649
+        body: '{"total_count":1, "nodes":[{"region":"fr-par", "id":"f02a58a1-5b25-41c1-948d-dfe4d877c500", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:55:42.710952Z", "updated_at":"2026-03-30T12:57:21.299287Z", "pool_id":"aef8b176-85f1-4ac9-80c5-5632257daa82", "status":"ready", "conditions":{"DiskPressure":"False", "MemoryPressure":"False", "NetworkUnavailable":"False", "PIDPressure":"False", "Ready":"True"}, "name":"scw-test-pool-wait-test-pool-wait-f02a58a15b25", "public_ip_v4":"51.158.97.194", "public_ip_v6":null, "provider_id":"scaleway://instance/fr-par-1/5a65da2a-aa5f-45b7-a8cf-e1dc0465f407", "error_message":""}]}'
+        headers:
+            Content-Length:
+                - "649"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:57:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 57fc0c59-eed4-4d11-9c33-947f4cdf2d27
+        status: 200 OK
+        code: 200
+        duration: 31.174198ms
+    - id: 74
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_asc
+            page:
+                - "1"
+            pool_id:
+                - 9e6791ab-321a-4ea7-9b53-f600e6b9a39d
+            status:
+                - unknown
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53/nodes?order_by=created_at_asc&page=1&pool_id=9e6791ab-321a-4ea7-9b53-f600e6b9a39d&status=unknown
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 619
+        body: '{"total_count":1, "nodes":[{"region":"fr-par", "id":"9a2bb294-ae27-460e-b3b4-0d7d59769218", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:56:31.814706Z", "updated_at":"2026-03-30T12:57:21.319209Z", "pool_id":"9e6791ab-321a-4ea7-9b53-f600e6b9a39d", "status":"ready", "conditions":{"DiskPressure":"False", "MemoryPressure":"False", "PIDPressure":"False", "Ready":"True"}, "name":"scw-test-pool-wait-test-pool-wait-2-9a2bb294ae", "public_ip_v4":"51.15.232.167", "public_ip_v6":null, "provider_id":"scaleway://instance/fr-par-1/d5e63ca1-4ce2-440e-b55d-becd8f830797", "error_message":""}]}'
+        headers:
+            Content-Length:
+                - "619"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:57:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 5bce4e62-1fe4-470f-a0fa-e43a7960c940
+        status: 200 OK
+        code: 200
+        duration: 25.553008ms
+    - id: 75
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1603
+        body: '{"region":"fr-par", "id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:13.060726Z", "updated_at":"2026-03-30T12:55:41.789306Z", "type":"kapsule", "name":"test-pool-wait", "description":"", "status":"ready", "version":"1.35.2", "cni":"calico", "tags":["terraform-test", "scaleway_k8s_cluster", "minimal"], "cluster_url":"https://3b418478-2d8b-4fc7-87c3-f551ebb22f53.api.k8s.fr-par.scw.cloud:6443", "dns_wildcard":"*.3b418478-2d8b-4fc7-87c3-f551ebb22f53.nodes.k8s.fr-par.scw.cloud", "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m", "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false, "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":0, "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":0}, "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}}, "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"", "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[], "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "commitment_ends_at":"2026-03-30T12:54:13.060733Z", "acl_available":true, "iam_nodes_group_id":"997eeeb9-fb5b-471b-8ba1-33cf150f3ca6", "pod_cidr":"100.64.0.0/15", "service_cidr":"10.32.0.0/20", "service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1603"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:57:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - be1b66fe-58e2-46cf-9b20-420b94ed5881
+        status: 200 OK
+        code: 200
+        duration: 25.146525ms
+    - id: 76
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1603
+        body: '{"region":"fr-par", "id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:13.060726Z", "updated_at":"2026-03-30T12:55:41.789306Z", "type":"kapsule", "name":"test-pool-wait", "description":"", "status":"ready", "version":"1.35.2", "cni":"calico", "tags":["terraform-test", "scaleway_k8s_cluster", "minimal"], "cluster_url":"https://3b418478-2d8b-4fc7-87c3-f551ebb22f53.api.k8s.fr-par.scw.cloud:6443", "dns_wildcard":"*.3b418478-2d8b-4fc7-87c3-f551ebb22f53.nodes.k8s.fr-par.scw.cloud", "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m", "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false, "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":0, "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":0}, "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}}, "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"", "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[], "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "commitment_ends_at":"2026-03-30T12:54:13.060733Z", "acl_available":true, "iam_nodes_group_id":"997eeeb9-fb5b-471b-8ba1-33cf150f3ca6", "pod_cidr":"100.64.0.0/15", "service_cidr":"10.32.0.0/20", "service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1603"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:57:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 5f4a9092-62a6-4275-a56d-fbf84be13ac0
+        status: 200 OK
+        code: 200
+        duration: 23.638835ms
+    - id: 77
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_desc
+            project_id:
+                - fa1e3217-dc80-42ac-85c3-3f034b78b552
+            resource_name:
+                - scw-test-pool-wait-test-pool-wait-f02a58a15b25
+            resource_type:
+                - unknown_type
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=fa1e3217-dc80-42ac-85c3-3f034b78b552&resource_name=scw-test-pool-wait-test-pool-wait-f02a58a15b25&resource_type=unknown_type
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1121
+        body: '{"total_count":2, "ips":[{"id":"7a65b835-044c-4996-a22b-5715ea76a553", "address":"fd63:256c:45f7:bc7e:4f61:41e:1ed2:7ab4/64", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_ipv6":true, "created_at":"2026-03-30T12:55:45.022856Z", "updated_at":"2026-03-30T12:55:45.022856Z", "source":{"subnet_id":"b18788e5-4872-494d-a7bb-0ba98125d9e4"}, "resource":{"type":"instance_private_nic", "id":"aa4dd472-9b34-45a8-bed3-592e94180874", "mac_address":"02:00:00:1B:24:BE", "name":"scw-test-pool-wait-test-pool-wait-f02a58a15b25"}, "tags":[], "reverses":[], "region":"fr-par", "zone":null}, {"id":"ff1cbc09-c270-4fb8-9808-8f2232e772f8", "address":"172.16.72.3/22", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_ipv6":false, "created_at":"2026-03-30T12:55:44.890521Z", "updated_at":"2026-03-30T12:55:44.890521Z", "source":{"subnet_id":"ae63fffc-03c5-47e1-bfb2-170301d26f53"}, "resource":{"type":"instance_private_nic", "id":"aa4dd472-9b34-45a8-bed3-592e94180874", "mac_address":"02:00:00:1B:24:BE", "name":"scw-test-pool-wait-test-pool-wait-f02a58a15b25"}, "tags":[], "reverses":[], "region":"fr-par", "zone":null}]}'
+        headers:
+            Content-Length:
+                - "1121"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:57:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 585c0870-67ac-4f2b-b69e-ec39cfbca35a
+        status: 200 OK
+        code: 200
+        duration: 24.268477ms
+    - id: 78
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_desc
+            project_id:
+                - fa1e3217-dc80-42ac-85c3-3f034b78b552
+            resource_name:
+                - scw-test-pool-wait-test-pool-wait-2-9a2bb294ae
+            resource_type:
+                - unknown_type
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=fa1e3217-dc80-42ac-85c3-3f034b78b552&resource_name=scw-test-pool-wait-test-pool-wait-2-9a2bb294ae&resource_type=unknown_type
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1122
+        body: '{"total_count":2, "ips":[{"id":"75b3496a-ca81-4973-865a-4dc5d2529d87", "address":"fd63:256c:45f7:bc7e:6fe5:edb8:a736:809e/64", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_ipv6":true, "created_at":"2026-03-30T12:56:34.289056Z", "updated_at":"2026-03-30T12:56:34.289056Z", "source":{"subnet_id":"b18788e5-4872-494d-a7bb-0ba98125d9e4"}, "resource":{"type":"instance_private_nic", "id":"cbaad5fe-1d2e-40ef-8e6b-6b409ccab201", "mac_address":"02:00:00:12:4D:A4", "name":"scw-test-pool-wait-test-pool-wait-2-9a2bb294ae"}, "tags":[], "reverses":[], "region":"fr-par", "zone":null}, {"id":"03c33497-a15d-45bb-986e-9a6ad6191de2", "address":"172.16.72.4/22", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_ipv6":false, "created_at":"2026-03-30T12:56:34.167958Z", "updated_at":"2026-03-30T12:56:34.167958Z", "source":{"subnet_id":"ae63fffc-03c5-47e1-bfb2-170301d26f53"}, "resource":{"type":"instance_private_nic", "id":"cbaad5fe-1d2e-40ef-8e6b-6b409ccab201", "mac_address":"02:00:00:12:4D:A4", "name":"scw-test-pool-wait-test-pool-wait-2-9a2bb294ae"}, "tags":[], "reverses":[], "region":"fr-par", "zone":null}]}'
+        headers:
+            Content-Length:
+                - "1122"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:57:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - ee0501a8-e76e-4224-a86d-a12e4cf761ec
+        status: 200 OK
+        code: 200
+        duration: 33.891157ms
+    - id: 79
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1603
+        body: '{"region":"fr-par", "id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:13.060726Z", "updated_at":"2026-03-30T12:55:41.789306Z", "type":"kapsule", "name":"test-pool-wait", "description":"", "status":"ready", "version":"1.35.2", "cni":"calico", "tags":["terraform-test", "scaleway_k8s_cluster", "minimal"], "cluster_url":"https://3b418478-2d8b-4fc7-87c3-f551ebb22f53.api.k8s.fr-par.scw.cloud:6443", "dns_wildcard":"*.3b418478-2d8b-4fc7-87c3-f551ebb22f53.nodes.k8s.fr-par.scw.cloud", "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m", "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false, "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":0, "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":0}, "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}}, "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"", "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[], "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "commitment_ends_at":"2026-03-30T12:54:13.060733Z", "acl_available":true, "iam_nodes_group_id":"997eeeb9-fb5b-471b-8ba1-33cf150f3ca6", "pod_cidr":"100.64.0.0/15", "service_cidr":"10.32.0.0/20", "service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1603"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:57:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - d60a02d9-7ba4-4861-8f04-463451d693a2
+        status: 200 OK
+        code: 200
+        duration: 33.128055ms
+    - id: 80
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 82
+        host: api.scaleway.com
+        body: '{"size":2,"max_size":2,"upgrade_policy":{"max_unavailable":null,"max_surge":null}}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9e6791ab-321a-4ea7-9b53-f600e6b9a39d
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 737
+        body: '{"region":"fr-par", "id":"9e6791ab-321a-4ea7-9b53-f600e6b9a39d", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:56:31.542980Z", "updated_at":"2026-03-30T12:57:23.816013Z", "name":"test-pool-wait-2", "status":"scaling", "version":"1.35.2", "node_type":"pro2_xxs", "autoscaling":false, "size":2, "min_size":1, "max_size":2, "container_runtime":"containerd", "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{}, "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"sbs_5k", "root_volume_size":20000000000, "public_ip_disabled":false, "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b", "labels":{}, "taints":[], "startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "737"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:57:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 9aa94f5c-46a4-4709-9e2b-30b26a3ac539
+        status: 200 OK
+        code: 200
+        duration: 52.271934ms
+    - id: 81
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9e6791ab-321a-4ea7-9b53-f600e6b9a39d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 737
+        body: '{"region":"fr-par", "id":"9e6791ab-321a-4ea7-9b53-f600e6b9a39d", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:56:31.542980Z", "updated_at":"2026-03-30T12:57:23.816013Z", "name":"test-pool-wait-2", "status":"scaling", "version":"1.35.2", "node_type":"pro2_xxs", "autoscaling":false, "size":2, "min_size":1, "max_size":2, "container_runtime":"containerd", "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{}, "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"sbs_5k", "root_volume_size":20000000000, "public_ip_disabled":false, "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b", "labels":{}, "taints":[], "startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "737"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:57:23 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - fae83448-7a8e-4dc6-b0ef-f0c7e8eabe2e
+        status: 200 OK
+        code: 200
+        duration: 23.238334ms
+    - id: 82
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9e6791ab-321a-4ea7-9b53-f600e6b9a39d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 735
+        body: '{"region":"fr-par", "id":"9e6791ab-321a-4ea7-9b53-f600e6b9a39d", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:56:31.542980Z", "updated_at":"2026-03-30T12:58:43.576826Z", "name":"test-pool-wait-2", "status":"ready", "version":"1.35.2", "node_type":"pro2_xxs", "autoscaling":false, "size":2, "min_size":1, "max_size":2, "container_runtime":"containerd", "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{}, "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"sbs_5k", "root_volume_size":20000000000, "public_ip_disabled":false, "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b", "labels":{}, "taints":[], "startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "735"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:44 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - c86e96e9-dd8c-4607-aad9-0d861b097c43
+        status: 200 OK
+        code: 200
+        duration: 31.448774ms
+    - id: 83
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9e6791ab-321a-4ea7-9b53-f600e6b9a39d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 735
+        body: '{"region":"fr-par", "id":"9e6791ab-321a-4ea7-9b53-f600e6b9a39d", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:56:31.542980Z", "updated_at":"2026-03-30T12:58:43.576826Z", "name":"test-pool-wait-2", "status":"ready", "version":"1.35.2", "node_type":"pro2_xxs", "autoscaling":false, "size":2, "min_size":1, "max_size":2, "container_runtime":"containerd", "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{}, "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"sbs_5k", "root_volume_size":20000000000, "public_ip_disabled":false, "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b", "labels":{}, "taints":[], "startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "735"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:44 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 568f957b-0638-42d2-a109-a9465eeebe9a
+        status: 200 OK
+        code: 200
+        duration: 36.863827ms
+    - id: 84
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_asc
+            page:
+                - "1"
+            pool_id:
+                - 9e6791ab-321a-4ea7-9b53-f600e6b9a39d
+            status:
+                - unknown
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53/nodes?order_by=created_at_asc&page=1&pool_id=9e6791ab-321a-4ea7-9b53-f600e6b9a39d&status=unknown
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1240
+        body: '{"total_count":2, "nodes":[{"region":"fr-par", "id":"9a2bb294-ae27-460e-b3b4-0d7d59769218", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:56:31.814706Z", "updated_at":"2026-03-30T12:58:43.566810Z", "pool_id":"9e6791ab-321a-4ea7-9b53-f600e6b9a39d", "status":"ready", "conditions":{"DiskPressure":"False", "MemoryPressure":"False", "NetworkUnavailable":"False", "PIDPressure":"False", "Ready":"True"}, "name":"scw-test-pool-wait-test-pool-wait-2-9a2bb294ae", "public_ip_v4":"51.15.232.167", "public_ip_v6":null, "provider_id":"scaleway://instance/fr-par-1/d5e63ca1-4ce2-440e-b55d-becd8f830797", "error_message":""}, {"region":"fr-par", "id":"00f6377f-4855-45b1-8b8f-950b5885aa13", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:57:24.069214Z", "updated_at":"2026-03-30T12:58:43.556023Z", "pool_id":"9e6791ab-321a-4ea7-9b53-f600e6b9a39d", "status":"ready", "conditions":{"DiskPressure":"False", "MemoryPressure":"False", "PIDPressure":"False", "Ready":"True"}, "name":"scw-test-pool-wait-test-pool-wait-2-00f6377f48", "public_ip_v4":"51.15.201.66", "public_ip_v6":null, "provider_id":"scaleway://instance/fr-par-1/6ff84171-28f0-4d81-83b7-2d20641b4c0e", "error_message":""}]}'
+        headers:
+            Content-Length:
+                - "1240"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:44 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - b84d52f1-c4ed-4156-949d-4d60e3463019
+        status: 200 OK
+        code: 200
+        duration: 27.220839ms
+    - id: 85
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1603
+        body: '{"region":"fr-par", "id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:13.060726Z", "updated_at":"2026-03-30T12:55:41.789306Z", "type":"kapsule", "name":"test-pool-wait", "description":"", "status":"ready", "version":"1.35.2", "cni":"calico", "tags":["terraform-test", "scaleway_k8s_cluster", "minimal"], "cluster_url":"https://3b418478-2d8b-4fc7-87c3-f551ebb22f53.api.k8s.fr-par.scw.cloud:6443", "dns_wildcard":"*.3b418478-2d8b-4fc7-87c3-f551ebb22f53.nodes.k8s.fr-par.scw.cloud", "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m", "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false, "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":0, "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":0}, "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}}, "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"", "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[], "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "commitment_ends_at":"2026-03-30T12:54:13.060733Z", "acl_available":true, "iam_nodes_group_id":"997eeeb9-fb5b-471b-8ba1-33cf150f3ca6", "pod_cidr":"100.64.0.0/15", "service_cidr":"10.32.0.0/20", "service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1603"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:44 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 83dc033a-5747-453f-89c2-98f136af2fa3
+        status: 200 OK
+        code: 200
+        duration: 24.535318ms
+    - id: 86
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_desc
+            project_id:
+                - fa1e3217-dc80-42ac-85c3-3f034b78b552
+            resource_name:
+                - scw-test-pool-wait-test-pool-wait-2-9a2bb294ae
+            resource_type:
+                - unknown_type
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=fa1e3217-dc80-42ac-85c3-3f034b78b552&resource_name=scw-test-pool-wait-test-pool-wait-2-9a2bb294ae&resource_type=unknown_type
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1122
+        body: '{"total_count":2, "ips":[{"id":"75b3496a-ca81-4973-865a-4dc5d2529d87", "address":"fd63:256c:45f7:bc7e:6fe5:edb8:a736:809e/64", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_ipv6":true, "created_at":"2026-03-30T12:56:34.289056Z", "updated_at":"2026-03-30T12:56:34.289056Z", "source":{"subnet_id":"b18788e5-4872-494d-a7bb-0ba98125d9e4"}, "resource":{"type":"instance_private_nic", "id":"cbaad5fe-1d2e-40ef-8e6b-6b409ccab201", "mac_address":"02:00:00:12:4D:A4", "name":"scw-test-pool-wait-test-pool-wait-2-9a2bb294ae"}, "tags":[], "reverses":[], "region":"fr-par", "zone":null}, {"id":"03c33497-a15d-45bb-986e-9a6ad6191de2", "address":"172.16.72.4/22", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_ipv6":false, "created_at":"2026-03-30T12:56:34.167958Z", "updated_at":"2026-03-30T12:56:34.167958Z", "source":{"subnet_id":"ae63fffc-03c5-47e1-bfb2-170301d26f53"}, "resource":{"type":"instance_private_nic", "id":"cbaad5fe-1d2e-40ef-8e6b-6b409ccab201", "mac_address":"02:00:00:12:4D:A4", "name":"scw-test-pool-wait-test-pool-wait-2-9a2bb294ae"}, "tags":[], "reverses":[], "region":"fr-par", "zone":null}]}'
+        headers:
+            Content-Length:
+                - "1122"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:44 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 7c70690e-cfc1-4fad-81ab-6f3883a7c916
+        status: 200 OK
+        code: 200
+        duration: 23.862095ms
+    - id: 87
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_desc
+            project_id:
+                - fa1e3217-dc80-42ac-85c3-3f034b78b552
+            resource_name:
+                - scw-test-pool-wait-test-pool-wait-2-00f6377f48
+            resource_type:
+                - unknown_type
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=fa1e3217-dc80-42ac-85c3-3f034b78b552&resource_name=scw-test-pool-wait-test-pool-wait-2-00f6377f48&resource_type=unknown_type
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1122
+        body: '{"total_count":2, "ips":[{"id":"e1da6015-0634-4fa0-8ae0-f4d6b6f6a21f", "address":"fd63:256c:45f7:bc7e:7155:5e2e:87ee:2354/64", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_ipv6":true, "created_at":"2026-03-30T12:57:26.282082Z", "updated_at":"2026-03-30T12:57:26.282082Z", "source":{"subnet_id":"b18788e5-4872-494d-a7bb-0ba98125d9e4"}, "resource":{"type":"instance_private_nic", "id":"c8158951-a6dc-4e60-9e9a-d4a959853a7a", "mac_address":"02:00:00:1E:DF:CC", "name":"scw-test-pool-wait-test-pool-wait-2-00f6377f48"}, "tags":[], "reverses":[], "region":"fr-par", "zone":null}, {"id":"cee553a5-62ab-471c-b4a2-25570903bf19", "address":"172.16.72.5/22", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_ipv6":false, "created_at":"2026-03-30T12:57:26.188417Z", "updated_at":"2026-03-30T12:57:26.188417Z", "source":{"subnet_id":"ae63fffc-03c5-47e1-bfb2-170301d26f53"}, "resource":{"type":"instance_private_nic", "id":"c8158951-a6dc-4e60-9e9a-d4a959853a7a", "mac_address":"02:00:00:1E:DF:CC", "name":"scw-test-pool-wait-test-pool-wait-2-00f6377f48"}, "tags":[], "reverses":[], "region":"fr-par", "zone":null}]}'
+        headers:
+            Content-Length:
+                - "1122"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:44 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 21f72075-efff-481b-bb85-0b65e081bd44
+        status: 200 OK
+        code: 200
+        duration: 27.790759ms
+    - id: 88
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1603
+        body: '{"region":"fr-par", "id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:13.060726Z", "updated_at":"2026-03-30T12:55:41.789306Z", "type":"kapsule", "name":"test-pool-wait", "description":"", "status":"ready", "version":"1.35.2", "cni":"calico", "tags":["terraform-test", "scaleway_k8s_cluster", "minimal"], "cluster_url":"https://3b418478-2d8b-4fc7-87c3-f551ebb22f53.api.k8s.fr-par.scw.cloud:6443", "dns_wildcard":"*.3b418478-2d8b-4fc7-87c3-f551ebb22f53.nodes.k8s.fr-par.scw.cloud", "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m", "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false, "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":0, "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":0}, "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}}, "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"", "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[], "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "commitment_ends_at":"2026-03-30T12:54:13.060733Z", "acl_available":true, "iam_nodes_group_id":"997eeeb9-fb5b-471b-8ba1-33cf150f3ca6", "pod_cidr":"100.64.0.0/15", "service_cidr":"10.32.0.0/20", "service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1603"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:44 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 2721e960-9b44-4bcc-8aba-5ac67e64312a
+        status: 200 OK
+        code: 200
+        duration: 21.021905ms
+    - id: 89
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9e6791ab-321a-4ea7-9b53-f600e6b9a39d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 735
+        body: '{"region":"fr-par", "id":"9e6791ab-321a-4ea7-9b53-f600e6b9a39d", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:56:31.542980Z", "updated_at":"2026-03-30T12:58:43.576826Z", "name":"test-pool-wait-2", "status":"ready", "version":"1.35.2", "node_type":"pro2_xxs", "autoscaling":false, "size":2, "min_size":1, "max_size":2, "container_runtime":"containerd", "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{}, "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"sbs_5k", "root_volume_size":20000000000, "public_ip_disabled":false, "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b", "labels":{}, "taints":[], "startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "735"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:44 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 186b673f-823b-4833-9b64-bc99a8f3bc46
+        status: 200 OK
+        code: 200
+        duration: 23.616905ms
+    - id: 90
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/45317da4-924e-4fd3-b4ca-e93215bc5849
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 431
+        body: '{"id":"45317da4-924e-4fd3-b4ca-e93215bc5849", "name":"tf-vpc-affectionate-proskuriakova", "tags":[], "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:12.102781Z", "updated_at":"2026-03-30T12:54:12.102781Z", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_default":false, "private_network_count":1, "routing_enabled":true, "custom_routes_propagation_enabled":true, "region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "431"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:44 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 75d3e4f8-3a75-4521-bd77-f0566fd3eef0
+        status: 200 OK
+        code: 200
+        duration: 31.233911ms
+    - id: 91
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/97585af2-c151-4ad5-9778-fa88d5af8bba
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1084
+        body: '{"id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "name":"test-pool-wait", "tags":[], "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:12.204171Z", "updated_at":"2026-03-30T12:54:12.204171Z", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "subnets":[{"id":"ae63fffc-03c5-47e1-bfb2-170301d26f53", "created_at":"2026-03-30T12:54:12.204171Z", "updated_at":"2026-03-30T12:54:12.204171Z", "subnet":"172.16.72.0/22", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "vpc_id":"45317da4-924e-4fd3-b4ca-e93215bc5849"}, {"id":"b18788e5-4872-494d-a7bb-0ba98125d9e4", "created_at":"2026-03-30T12:54:12.204171Z", "updated_at":"2026-03-30T12:54:12.204171Z", "subnet":"fd63:256c:45f7:bc7e::/64", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "vpc_id":"45317da4-924e-4fd3-b4ca-e93215bc5849"}], "vpc_id":"45317da4-924e-4fd3-b4ca-e93215bc5849", "dhcp_enabled":true, "default_route_propagation_enabled":false, "region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1084"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 84e0c2bd-b5d7-4e73-b120-0e768e4ac162
+        status: 200 OK
+        code: 200
+        duration: 24.124668ms
+    - id: 92
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1603
+        body: '{"region":"fr-par", "id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:13.060726Z", "updated_at":"2026-03-30T12:55:41.789306Z", "type":"kapsule", "name":"test-pool-wait", "description":"", "status":"ready", "version":"1.35.2", "cni":"calico", "tags":["terraform-test", "scaleway_k8s_cluster", "minimal"], "cluster_url":"https://3b418478-2d8b-4fc7-87c3-f551ebb22f53.api.k8s.fr-par.scw.cloud:6443", "dns_wildcard":"*.3b418478-2d8b-4fc7-87c3-f551ebb22f53.nodes.k8s.fr-par.scw.cloud", "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m", "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false, "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":0, "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":0}, "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}}, "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"", "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[], "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "commitment_ends_at":"2026-03-30T12:54:13.060733Z", "acl_available":true, "iam_nodes_group_id":"997eeeb9-fb5b-471b-8ba1-33cf150f3ca6", "pod_cidr":"100.64.0.0/15", "service_cidr":"10.32.0.0/20", "service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1603"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - a359673b-604f-44b4-bfa9-7e6a6aa93699
+        status: 200 OK
+        code: 200
+        duration: 21.146127ms
+    - id: 93
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53/kubeconfig
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1650
+        body: '{"name":"kubeconfig", "content_type":"application/octet-stream", "content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVSlhla05EUVZGSFowRjNTVUpCWjBsQ1FVUkJTMEpuWjNGb2EycFBVRkZSUkVGcVFWWk5VazEzUlZGWlJGWlJVVVJGZDNCeVpGZEtiR050Tld3S1pFZFdlazFDTkZoRVZFa3lUVVJOZVU5VVJYbE9WRkY0VFRGdldFUlVUVEpOUkUxNVQxUkZlVTVVVVhoTk1XOTNSbFJGVkUxQ1JVZEJNVlZGUVhoTlN3cGhNMVpwV2xoS2RWcFlVbXhqZWtKYVRVSk5SMEo1Y1VkVFRUUTVRV2RGUjBORGNVZFRUVFE1UVhkRlNFRXdTVUZDVHpWNk0wd3ZPRGRTUmpGT1dXTjFDbEJNY1RSbmN6UkhTWHBxY1hSU1pHNWpWbTFyYjNwTk1qUjVXRzlzTmtoTlp6SXpMekowYVdSeVQwUjNlVmN2WlV4Wk1sWldLMkZ4Y2poWmRteDJUaXNLVDJaM2FVNHlSMnBSYWtKQlRVRTBSMEV4VldSRWQwVkNMM2RSUlVGM1NVTndSRUZRUW1kT1ZraFNUVUpCWmpoRlFsUkJSRUZSU0M5TlFqQkhRVEZWWkFwRVoxRlhRa0pSWjJWNk0zRlRaR0VyVUZWc2VrODFRa051TlZScVRsa3JTWGg2UVV0Q1oyZHhhR3RxVDFCUlVVUkJaMDVKUVVSQ1JrRnBSVUZ0S3pneENuWkZWREptVW13d00yRlljSFZ1ZG5kMlNXc3hiMEY1VFRFd1ZuQm9lRXgwYUVOaGRVNVVSVU5KU0cxNVRWUmxMM2s1YTI5UFZHdGtiazlOTDJrMkwxZ0tSRzVyUnpNeldpc3JaMVJxV2xwWmJXNDJORVVLTFMwdExTMUZUa1FnUTBWU1ZFbEdTVU5CVkVVdExTMHRMUW89CiAgICBzZXJ2ZXI6IGh0dHBzOi8vM2I0MTg0NzgtMmQ4Yi00ZmM3LTg3YzMtZjU1MWViYjIyZjUzLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC13YWl0CiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXBvb2wtd2FpdCIKICAgIHVzZXI6IHRlc3QtcG9vbC13YWl0LWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXdhaXQKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXBvb2wtd2FpdC1hZG1pbgogIHVzZXI6CiAgICB0b2tlbjogNkxOdk9jQ3VWdWFJMEpqd3JleGNVYjZNc3J4T2ZMM2Jhd1llUmN0b0ZpTjJDVFo0d1pESVlrNEg="}'
+        headers:
+            Content-Length:
+                - "1650"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 54d0617c-83d9-42ed-a349-d5ebc529f5b4
+        status: 200 OK
+        code: 200
+        duration: 46.325646ms
+    - id: 94
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9e6791ab-321a-4ea7-9b53-f600e6b9a39d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 735
+        body: '{"region":"fr-par", "id":"9e6791ab-321a-4ea7-9b53-f600e6b9a39d", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:56:31.542980Z", "updated_at":"2026-03-30T12:58:43.576826Z", "name":"test-pool-wait-2", "status":"ready", "version":"1.35.2", "node_type":"pro2_xxs", "autoscaling":false, "size":2, "min_size":1, "max_size":2, "container_runtime":"containerd", "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{}, "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"sbs_5k", "root_volume_size":20000000000, "public_ip_disabled":false, "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b", "labels":{}, "taints":[], "startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "735"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - da5e5786-16c5-411a-990c-46fd815c25dc
+        status: 200 OK
+        code: 200
+        duration: 25.419969ms
+    - id: 95
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aef8b176-85f1-4ac9-80c5-5632257daa82
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 733
+        body: '{"region":"fr-par", "id":"aef8b176-85f1-4ac9-80c5-5632257daa82", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:54:18.475205Z", "updated_at":"2026-03-30T12:56:27.984394Z", "name":"test-pool-wait", "status":"ready", "version":"1.35.2", "node_type":"pro2_xxs", "autoscaling":false, "size":1, "min_size":1, "max_size":1, "container_runtime":"containerd", "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{}, "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"sbs_5k", "root_volume_size":20000000000, "public_ip_disabled":false, "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b", "labels":{}, "taints":[], "startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "733"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 3cce00b5-af92-4103-922a-e262fca5e2db
+        status: 200 OK
+        code: 200
+        duration: 29.844133ms
+    - id: 96
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_asc
+            page:
+                - "1"
+            pool_id:
+                - 9e6791ab-321a-4ea7-9b53-f600e6b9a39d
+            status:
+                - unknown
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53/nodes?order_by=created_at_asc&page=1&pool_id=9e6791ab-321a-4ea7-9b53-f600e6b9a39d&status=unknown
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1240
+        body: '{"total_count":2, "nodes":[{"region":"fr-par", "id":"9a2bb294-ae27-460e-b3b4-0d7d59769218", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:56:31.814706Z", "updated_at":"2026-03-30T12:58:43.566810Z", "pool_id":"9e6791ab-321a-4ea7-9b53-f600e6b9a39d", "status":"ready", "conditions":{"DiskPressure":"False", "MemoryPressure":"False", "NetworkUnavailable":"False", "PIDPressure":"False", "Ready":"True"}, "name":"scw-test-pool-wait-test-pool-wait-2-9a2bb294ae", "public_ip_v4":"51.15.232.167", "public_ip_v6":null, "provider_id":"scaleway://instance/fr-par-1/d5e63ca1-4ce2-440e-b55d-becd8f830797", "error_message":""}, {"region":"fr-par", "id":"00f6377f-4855-45b1-8b8f-950b5885aa13", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:57:24.069214Z", "updated_at":"2026-03-30T12:58:43.556023Z", "pool_id":"9e6791ab-321a-4ea7-9b53-f600e6b9a39d", "status":"ready", "conditions":{"DiskPressure":"False", "MemoryPressure":"False", "PIDPressure":"False", "Ready":"True"}, "name":"scw-test-pool-wait-test-pool-wait-2-00f6377f48", "public_ip_v4":"51.15.201.66", "public_ip_v6":null, "provider_id":"scaleway://instance/fr-par-1/6ff84171-28f0-4d81-83b7-2d20641b4c0e", "error_message":""}]}'
+        headers:
+            Content-Length:
+                - "1240"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 71548ea8-c89b-479f-abf7-c2fb594512db
+        status: 200 OK
+        code: 200
+        duration: 23.282227ms
+    - id: 97
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_asc
+            page:
+                - "1"
+            pool_id:
+                - aef8b176-85f1-4ac9-80c5-5632257daa82
+            status:
+                - unknown
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53/nodes?order_by=created_at_asc&page=1&pool_id=aef8b176-85f1-4ac9-80c5-5632257daa82&status=unknown
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 649
+        body: '{"total_count":1, "nodes":[{"region":"fr-par", "id":"f02a58a1-5b25-41c1-948d-dfe4d877c500", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:55:42.710952Z", "updated_at":"2026-03-30T12:58:43.539627Z", "pool_id":"aef8b176-85f1-4ac9-80c5-5632257daa82", "status":"ready", "conditions":{"DiskPressure":"False", "MemoryPressure":"False", "NetworkUnavailable":"False", "PIDPressure":"False", "Ready":"True"}, "name":"scw-test-pool-wait-test-pool-wait-f02a58a15b25", "public_ip_v4":"51.158.97.194", "public_ip_v6":null, "provider_id":"scaleway://instance/fr-par-1/5a65da2a-aa5f-45b7-a8cf-e1dc0465f407", "error_message":""}]}'
+        headers:
+            Content-Length:
+                - "649"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 0df08f55-9655-4e9c-86b2-1d5d6a1757f1
+        status: 200 OK
+        code: 200
+        duration: 33.03448ms
+    - id: 98
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1603
+        body: '{"region":"fr-par", "id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:13.060726Z", "updated_at":"2026-03-30T12:55:41.789306Z", "type":"kapsule", "name":"test-pool-wait", "description":"", "status":"ready", "version":"1.35.2", "cni":"calico", "tags":["terraform-test", "scaleway_k8s_cluster", "minimal"], "cluster_url":"https://3b418478-2d8b-4fc7-87c3-f551ebb22f53.api.k8s.fr-par.scw.cloud:6443", "dns_wildcard":"*.3b418478-2d8b-4fc7-87c3-f551ebb22f53.nodes.k8s.fr-par.scw.cloud", "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m", "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false, "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":0, "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":0}, "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}}, "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"", "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[], "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "commitment_ends_at":"2026-03-30T12:54:13.060733Z", "acl_available":true, "iam_nodes_group_id":"997eeeb9-fb5b-471b-8ba1-33cf150f3ca6", "pod_cidr":"100.64.0.0/15", "service_cidr":"10.32.0.0/20", "service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1603"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 5e3b5f72-319f-4efd-b61d-e737bd510beb
+        status: 200 OK
+        code: 200
+        duration: 21.689137ms
+    - id: 99
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1603
+        body: '{"region":"fr-par", "id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:13.060726Z", "updated_at":"2026-03-30T12:55:41.789306Z", "type":"kapsule", "name":"test-pool-wait", "description":"", "status":"ready", "version":"1.35.2", "cni":"calico", "tags":["terraform-test", "scaleway_k8s_cluster", "minimal"], "cluster_url":"https://3b418478-2d8b-4fc7-87c3-f551ebb22f53.api.k8s.fr-par.scw.cloud:6443", "dns_wildcard":"*.3b418478-2d8b-4fc7-87c3-f551ebb22f53.nodes.k8s.fr-par.scw.cloud", "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m", "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false, "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":0, "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":0}, "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}}, "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"", "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[], "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "commitment_ends_at":"2026-03-30T12:54:13.060733Z", "acl_available":true, "iam_nodes_group_id":"997eeeb9-fb5b-471b-8ba1-33cf150f3ca6", "pod_cidr":"100.64.0.0/15", "service_cidr":"10.32.0.0/20", "service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1603"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - d186acfd-b773-492b-a6c5-487565bf6e9b
+        status: 200 OK
+        code: 200
+        duration: 24.755362ms
+    - id: 100
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_desc
+            project_id:
+                - fa1e3217-dc80-42ac-85c3-3f034b78b552
+            resource_name:
+                - scw-test-pool-wait-test-pool-wait-2-9a2bb294ae
+            resource_type:
+                - unknown_type
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=fa1e3217-dc80-42ac-85c3-3f034b78b552&resource_name=scw-test-pool-wait-test-pool-wait-2-9a2bb294ae&resource_type=unknown_type
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1122
+        body: '{"total_count":2, "ips":[{"id":"75b3496a-ca81-4973-865a-4dc5d2529d87", "address":"fd63:256c:45f7:bc7e:6fe5:edb8:a736:809e/64", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_ipv6":true, "created_at":"2026-03-30T12:56:34.289056Z", "updated_at":"2026-03-30T12:56:34.289056Z", "source":{"subnet_id":"b18788e5-4872-494d-a7bb-0ba98125d9e4"}, "resource":{"type":"instance_private_nic", "id":"cbaad5fe-1d2e-40ef-8e6b-6b409ccab201", "mac_address":"02:00:00:12:4D:A4", "name":"scw-test-pool-wait-test-pool-wait-2-9a2bb294ae"}, "tags":[], "reverses":[], "region":"fr-par", "zone":null}, {"id":"03c33497-a15d-45bb-986e-9a6ad6191de2", "address":"172.16.72.4/22", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_ipv6":false, "created_at":"2026-03-30T12:56:34.167958Z", "updated_at":"2026-03-30T12:56:34.167958Z", "source":{"subnet_id":"ae63fffc-03c5-47e1-bfb2-170301d26f53"}, "resource":{"type":"instance_private_nic", "id":"cbaad5fe-1d2e-40ef-8e6b-6b409ccab201", "mac_address":"02:00:00:12:4D:A4", "name":"scw-test-pool-wait-test-pool-wait-2-9a2bb294ae"}, "tags":[], "reverses":[], "region":"fr-par", "zone":null}]}'
+        headers:
+            Content-Length:
+                - "1122"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 918e8328-ba2e-4bc6-a130-05589090967b
+        status: 200 OK
+        code: 200
+        duration: 24.495624ms
+    - id: 101
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_desc
+            project_id:
+                - fa1e3217-dc80-42ac-85c3-3f034b78b552
+            resource_name:
+                - scw-test-pool-wait-test-pool-wait-2-00f6377f48
+            resource_type:
+                - unknown_type
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=fa1e3217-dc80-42ac-85c3-3f034b78b552&resource_name=scw-test-pool-wait-test-pool-wait-2-00f6377f48&resource_type=unknown_type
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1122
+        body: '{"total_count":2, "ips":[{"id":"e1da6015-0634-4fa0-8ae0-f4d6b6f6a21f", "address":"fd63:256c:45f7:bc7e:7155:5e2e:87ee:2354/64", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_ipv6":true, "created_at":"2026-03-30T12:57:26.282082Z", "updated_at":"2026-03-30T12:57:26.282082Z", "source":{"subnet_id":"b18788e5-4872-494d-a7bb-0ba98125d9e4"}, "resource":{"type":"instance_private_nic", "id":"c8158951-a6dc-4e60-9e9a-d4a959853a7a", "mac_address":"02:00:00:1E:DF:CC", "name":"scw-test-pool-wait-test-pool-wait-2-00f6377f48"}, "tags":[], "reverses":[], "region":"fr-par", "zone":null}, {"id":"cee553a5-62ab-471c-b4a2-25570903bf19", "address":"172.16.72.5/22", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_ipv6":false, "created_at":"2026-03-30T12:57:26.188417Z", "updated_at":"2026-03-30T12:57:26.188417Z", "source":{"subnet_id":"ae63fffc-03c5-47e1-bfb2-170301d26f53"}, "resource":{"type":"instance_private_nic", "id":"c8158951-a6dc-4e60-9e9a-d4a959853a7a", "mac_address":"02:00:00:1E:DF:CC", "name":"scw-test-pool-wait-test-pool-wait-2-00f6377f48"}, "tags":[], "reverses":[], "region":"fr-par", "zone":null}]}'
+        headers:
+            Content-Length:
+                - "1122"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 79d725c9-c1e8-4683-bfd3-c9ea9af858bb
+        status: 200 OK
+        code: 200
+        duration: 25.59084ms
+    - id: 102
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_desc
+            project_id:
+                - fa1e3217-dc80-42ac-85c3-3f034b78b552
+            resource_name:
+                - scw-test-pool-wait-test-pool-wait-f02a58a15b25
+            resource_type:
+                - unknown_type
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=fa1e3217-dc80-42ac-85c3-3f034b78b552&resource_name=scw-test-pool-wait-test-pool-wait-f02a58a15b25&resource_type=unknown_type
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1121
+        body: '{"total_count":2, "ips":[{"id":"7a65b835-044c-4996-a22b-5715ea76a553", "address":"fd63:256c:45f7:bc7e:4f61:41e:1ed2:7ab4/64", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_ipv6":true, "created_at":"2026-03-30T12:55:45.022856Z", "updated_at":"2026-03-30T12:55:45.022856Z", "source":{"subnet_id":"b18788e5-4872-494d-a7bb-0ba98125d9e4"}, "resource":{"type":"instance_private_nic", "id":"aa4dd472-9b34-45a8-bed3-592e94180874", "mac_address":"02:00:00:1B:24:BE", "name":"scw-test-pool-wait-test-pool-wait-f02a58a15b25"}, "tags":[], "reverses":[], "region":"fr-par", "zone":null}, {"id":"ff1cbc09-c270-4fb8-9808-8f2232e772f8", "address":"172.16.72.3/22", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_ipv6":false, "created_at":"2026-03-30T12:55:44.890521Z", "updated_at":"2026-03-30T12:55:44.890521Z", "source":{"subnet_id":"ae63fffc-03c5-47e1-bfb2-170301d26f53"}, "resource":{"type":"instance_private_nic", "id":"aa4dd472-9b34-45a8-bed3-592e94180874", "mac_address":"02:00:00:1B:24:BE", "name":"scw-test-pool-wait-test-pool-wait-f02a58a15b25"}, "tags":[], "reverses":[], "region":"fr-par", "zone":null}]}'
+        headers:
+            Content-Length:
+                - "1121"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 9908eb87-9fc7-470c-93ef-d34d0097745f
+        status: 200 OK
+        code: 200
+        duration: 33.051061ms
+    - id: 103
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/45317da4-924e-4fd3-b4ca-e93215bc5849
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 431
+        body: '{"id":"45317da4-924e-4fd3-b4ca-e93215bc5849", "name":"tf-vpc-affectionate-proskuriakova", "tags":[], "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:12.102781Z", "updated_at":"2026-03-30T12:54:12.102781Z", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_default":false, "private_network_count":1, "routing_enabled":true, "custom_routes_propagation_enabled":true, "region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "431"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 2118ba2f-01f3-434f-901b-e3099a02e562
+        status: 200 OK
+        code: 200
+        duration: 27.364308ms
+    - id: 104
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/97585af2-c151-4ad5-9778-fa88d5af8bba
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1084
+        body: '{"id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "name":"test-pool-wait", "tags":[], "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:12.204171Z", "updated_at":"2026-03-30T12:54:12.204171Z", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "subnets":[{"id":"ae63fffc-03c5-47e1-bfb2-170301d26f53", "created_at":"2026-03-30T12:54:12.204171Z", "updated_at":"2026-03-30T12:54:12.204171Z", "subnet":"172.16.72.0/22", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "vpc_id":"45317da4-924e-4fd3-b4ca-e93215bc5849"}, {"id":"b18788e5-4872-494d-a7bb-0ba98125d9e4", "created_at":"2026-03-30T12:54:12.204171Z", "updated_at":"2026-03-30T12:54:12.204171Z", "subnet":"fd63:256c:45f7:bc7e::/64", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "vpc_id":"45317da4-924e-4fd3-b4ca-e93215bc5849"}], "vpc_id":"45317da4-924e-4fd3-b4ca-e93215bc5849", "dhcp_enabled":true, "default_route_propagation_enabled":false, "region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1084"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 9bb2e789-43e4-4af5-9111-89607bdfc1f7
+        status: 200 OK
+        code: 200
+        duration: 33.743781ms
+    - id: 105
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1603
+        body: '{"region":"fr-par", "id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:13.060726Z", "updated_at":"2026-03-30T12:55:41.789306Z", "type":"kapsule", "name":"test-pool-wait", "description":"", "status":"ready", "version":"1.35.2", "cni":"calico", "tags":["terraform-test", "scaleway_k8s_cluster", "minimal"], "cluster_url":"https://3b418478-2d8b-4fc7-87c3-f551ebb22f53.api.k8s.fr-par.scw.cloud:6443", "dns_wildcard":"*.3b418478-2d8b-4fc7-87c3-f551ebb22f53.nodes.k8s.fr-par.scw.cloud", "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m", "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false, "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":0, "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":0}, "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}}, "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"", "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[], "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "commitment_ends_at":"2026-03-30T12:54:13.060733Z", "acl_available":true, "iam_nodes_group_id":"997eeeb9-fb5b-471b-8ba1-33cf150f3ca6", "pod_cidr":"100.64.0.0/15", "service_cidr":"10.32.0.0/20", "service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1603"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - a08dbe46-dd91-4f61-8557-ec2d48296b01
+        status: 200 OK
+        code: 200
+        duration: 21.935099ms
+    - id: 106
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53/kubeconfig
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1650
+        body: '{"name":"kubeconfig", "content_type":"application/octet-stream", "content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVSlhla05EUVZGSFowRjNTVUpCWjBsQ1FVUkJTMEpuWjNGb2EycFBVRkZSUkVGcVFWWk5VazEzUlZGWlJGWlJVVVJGZDNCeVpGZEtiR050Tld3S1pFZFdlazFDTkZoRVZFa3lUVVJOZVU5VVJYbE9WRkY0VFRGdldFUlVUVEpOUkUxNVQxUkZlVTVVVVhoTk1XOTNSbFJGVkUxQ1JVZEJNVlZGUVhoTlN3cGhNMVpwV2xoS2RWcFlVbXhqZWtKYVRVSk5SMEo1Y1VkVFRUUTVRV2RGUjBORGNVZFRUVFE1UVhkRlNFRXdTVUZDVHpWNk0wd3ZPRGRTUmpGT1dXTjFDbEJNY1RSbmN6UkhTWHBxY1hSU1pHNWpWbTFyYjNwTk1qUjVXRzlzTmtoTlp6SXpMekowYVdSeVQwUjNlVmN2WlV4Wk1sWldLMkZ4Y2poWmRteDJUaXNLVDJaM2FVNHlSMnBSYWtKQlRVRTBSMEV4VldSRWQwVkNMM2RSUlVGM1NVTndSRUZRUW1kT1ZraFNUVUpCWmpoRlFsUkJSRUZSU0M5TlFqQkhRVEZWWkFwRVoxRlhRa0pSWjJWNk0zRlRaR0VyVUZWc2VrODFRa051TlZScVRsa3JTWGg2UVV0Q1oyZHhhR3RxVDFCUlVVUkJaMDVKUVVSQ1JrRnBSVUZ0S3pneENuWkZWREptVW13d00yRlljSFZ1ZG5kMlNXc3hiMEY1VFRFd1ZuQm9lRXgwYUVOaGRVNVVSVU5KU0cxNVRWUmxMM2s1YTI5UFZHdGtiazlOTDJrMkwxZ0tSRzVyUnpNeldpc3JaMVJxV2xwWmJXNDJORVVLTFMwdExTMUZUa1FnUTBWU1ZFbEdTVU5CVkVVdExTMHRMUW89CiAgICBzZXJ2ZXI6IGh0dHBzOi8vM2I0MTg0NzgtMmQ4Yi00ZmM3LTg3YzMtZjU1MWViYjIyZjUzLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC13YWl0CiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXBvb2wtd2FpdCIKICAgIHVzZXI6IHRlc3QtcG9vbC13YWl0LWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXdhaXQKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXBvb2wtd2FpdC1hZG1pbgogIHVzZXI6CiAgICB0b2tlbjogNkxOdk9jQ3VWdWFJMEpqd3JleGNVYjZNc3J4T2ZMM2Jhd1llUmN0b0ZpTjJDVFo0d1pESVlrNEg="}'
+        headers:
+            Content-Length:
+                - "1650"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 3472f4ba-d473-45f4-b707-fddc34d1c92e
+        status: 200 OK
+        code: 200
+        duration: 38.214001ms
+    - id: 107
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aef8b176-85f1-4ac9-80c5-5632257daa82
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 733
+        body: '{"region":"fr-par", "id":"aef8b176-85f1-4ac9-80c5-5632257daa82", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:54:18.475205Z", "updated_at":"2026-03-30T12:56:27.984394Z", "name":"test-pool-wait", "status":"ready", "version":"1.35.2", "node_type":"pro2_xxs", "autoscaling":false, "size":1, "min_size":1, "max_size":1, "container_runtime":"containerd", "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{}, "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"sbs_5k", "root_volume_size":20000000000, "public_ip_disabled":false, "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b", "labels":{}, "taints":[], "startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "733"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - bcdb022a-457b-49ee-b544-d11d97d1000a
+        status: 200 OK
+        code: 200
+        duration: 28.631827ms
+    - id: 108
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9e6791ab-321a-4ea7-9b53-f600e6b9a39d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 735
+        body: '{"region":"fr-par", "id":"9e6791ab-321a-4ea7-9b53-f600e6b9a39d", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:56:31.542980Z", "updated_at":"2026-03-30T12:58:43.576826Z", "name":"test-pool-wait-2", "status":"ready", "version":"1.35.2", "node_type":"pro2_xxs", "autoscaling":false, "size":2, "min_size":1, "max_size":2, "container_runtime":"containerd", "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{}, "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"sbs_5k", "root_volume_size":20000000000, "public_ip_disabled":false, "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b", "labels":{}, "taints":[], "startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "735"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 8d337a5f-dbf6-4f03-9135-2f8134e77f96
+        status: 200 OK
+        code: 200
+        duration: 28.660551ms
+    - id: 109
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_asc
+            page:
+                - "1"
+            pool_id:
+                - aef8b176-85f1-4ac9-80c5-5632257daa82
+            status:
+                - unknown
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53/nodes?order_by=created_at_asc&page=1&pool_id=aef8b176-85f1-4ac9-80c5-5632257daa82&status=unknown
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 649
+        body: '{"total_count":1, "nodes":[{"region":"fr-par", "id":"f02a58a1-5b25-41c1-948d-dfe4d877c500", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:55:42.710952Z", "updated_at":"2026-03-30T12:58:43.539627Z", "pool_id":"aef8b176-85f1-4ac9-80c5-5632257daa82", "status":"ready", "conditions":{"DiskPressure":"False", "MemoryPressure":"False", "NetworkUnavailable":"False", "PIDPressure":"False", "Ready":"True"}, "name":"scw-test-pool-wait-test-pool-wait-f02a58a15b25", "public_ip_v4":"51.158.97.194", "public_ip_v6":null, "provider_id":"scaleway://instance/fr-par-1/5a65da2a-aa5f-45b7-a8cf-e1dc0465f407", "error_message":""}]}'
+        headers:
+            Content-Length:
+                - "649"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 56436643-cbc3-493b-8f2a-13fd76074edf
+        status: 200 OK
+        code: 200
+        duration: 41.612771ms
+    - id: 110
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_asc
+            page:
+                - "1"
+            pool_id:
+                - 9e6791ab-321a-4ea7-9b53-f600e6b9a39d
+            status:
+                - unknown
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53/nodes?order_by=created_at_asc&page=1&pool_id=9e6791ab-321a-4ea7-9b53-f600e6b9a39d&status=unknown
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1240
+        body: '{"total_count":2, "nodes":[{"region":"fr-par", "id":"9a2bb294-ae27-460e-b3b4-0d7d59769218", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:56:31.814706Z", "updated_at":"2026-03-30T12:58:43.566810Z", "pool_id":"9e6791ab-321a-4ea7-9b53-f600e6b9a39d", "status":"ready", "conditions":{"DiskPressure":"False", "MemoryPressure":"False", "NetworkUnavailable":"False", "PIDPressure":"False", "Ready":"True"}, "name":"scw-test-pool-wait-test-pool-wait-2-9a2bb294ae", "public_ip_v4":"51.15.232.167", "public_ip_v6":null, "provider_id":"scaleway://instance/fr-par-1/d5e63ca1-4ce2-440e-b55d-becd8f830797", "error_message":""}, {"region":"fr-par", "id":"00f6377f-4855-45b1-8b8f-950b5885aa13", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:57:24.069214Z", "updated_at":"2026-03-30T12:58:43.556023Z", "pool_id":"9e6791ab-321a-4ea7-9b53-f600e6b9a39d", "status":"ready", "conditions":{"DiskPressure":"False", "MemoryPressure":"False", "PIDPressure":"False", "Ready":"True"}, "name":"scw-test-pool-wait-test-pool-wait-2-00f6377f48", "public_ip_v4":"51.15.201.66", "public_ip_v6":null, "provider_id":"scaleway://instance/fr-par-1/6ff84171-28f0-4d81-83b7-2d20641b4c0e", "error_message":""}]}'
+        headers:
+            Content-Length:
+                - "1240"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 7ec01537-8e9f-4f23-b653-916e5284e5e8
+        status: 200 OK
+        code: 200
+        duration: 43.292903ms
+    - id: 111
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1603
+        body: '{"region":"fr-par", "id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:13.060726Z", "updated_at":"2026-03-30T12:55:41.789306Z", "type":"kapsule", "name":"test-pool-wait", "description":"", "status":"ready", "version":"1.35.2", "cni":"calico", "tags":["terraform-test", "scaleway_k8s_cluster", "minimal"], "cluster_url":"https://3b418478-2d8b-4fc7-87c3-f551ebb22f53.api.k8s.fr-par.scw.cloud:6443", "dns_wildcard":"*.3b418478-2d8b-4fc7-87c3-f551ebb22f53.nodes.k8s.fr-par.scw.cloud", "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m", "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false, "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":0, "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":0}, "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}}, "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"", "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[], "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "commitment_ends_at":"2026-03-30T12:54:13.060733Z", "acl_available":true, "iam_nodes_group_id":"997eeeb9-fb5b-471b-8ba1-33cf150f3ca6", "pod_cidr":"100.64.0.0/15", "service_cidr":"10.32.0.0/20", "service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1603"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 13fcef09-744d-41d3-a4c1-c9dd63384184
+        status: 200 OK
+        code: 200
+        duration: 21.357124ms
+    - id: 112
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1603
+        body: '{"region":"fr-par", "id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:13.060726Z", "updated_at":"2026-03-30T12:55:41.789306Z", "type":"kapsule", "name":"test-pool-wait", "description":"", "status":"ready", "version":"1.35.2", "cni":"calico", "tags":["terraform-test", "scaleway_k8s_cluster", "minimal"], "cluster_url":"https://3b418478-2d8b-4fc7-87c3-f551ebb22f53.api.k8s.fr-par.scw.cloud:6443", "dns_wildcard":"*.3b418478-2d8b-4fc7-87c3-f551ebb22f53.nodes.k8s.fr-par.scw.cloud", "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m", "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false, "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":0, "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":0}, "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}}, "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"", "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[], "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "commitment_ends_at":"2026-03-30T12:54:13.060733Z", "acl_available":true, "iam_nodes_group_id":"997eeeb9-fb5b-471b-8ba1-33cf150f3ca6", "pod_cidr":"100.64.0.0/15", "service_cidr":"10.32.0.0/20", "service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1603"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - be159644-1bd4-44bb-9087-260576311be5
+        status: 200 OK
+        code: 200
+        duration: 24.465127ms
+    - id: 113
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_desc
+            project_id:
+                - fa1e3217-dc80-42ac-85c3-3f034b78b552
+            resource_name:
+                - scw-test-pool-wait-test-pool-wait-2-9a2bb294ae
+            resource_type:
+                - unknown_type
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=fa1e3217-dc80-42ac-85c3-3f034b78b552&resource_name=scw-test-pool-wait-test-pool-wait-2-9a2bb294ae&resource_type=unknown_type
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1122
+        body: '{"total_count":2, "ips":[{"id":"75b3496a-ca81-4973-865a-4dc5d2529d87", "address":"fd63:256c:45f7:bc7e:6fe5:edb8:a736:809e/64", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_ipv6":true, "created_at":"2026-03-30T12:56:34.289056Z", "updated_at":"2026-03-30T12:56:34.289056Z", "source":{"subnet_id":"b18788e5-4872-494d-a7bb-0ba98125d9e4"}, "resource":{"type":"instance_private_nic", "id":"cbaad5fe-1d2e-40ef-8e6b-6b409ccab201", "mac_address":"02:00:00:12:4D:A4", "name":"scw-test-pool-wait-test-pool-wait-2-9a2bb294ae"}, "tags":[], "reverses":[], "region":"fr-par", "zone":null}, {"id":"03c33497-a15d-45bb-986e-9a6ad6191de2", "address":"172.16.72.4/22", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_ipv6":false, "created_at":"2026-03-30T12:56:34.167958Z", "updated_at":"2026-03-30T12:56:34.167958Z", "source":{"subnet_id":"ae63fffc-03c5-47e1-bfb2-170301d26f53"}, "resource":{"type":"instance_private_nic", "id":"cbaad5fe-1d2e-40ef-8e6b-6b409ccab201", "mac_address":"02:00:00:12:4D:A4", "name":"scw-test-pool-wait-test-pool-wait-2-9a2bb294ae"}, "tags":[], "reverses":[], "region":"fr-par", "zone":null}]}'
+        headers:
+            Content-Length:
+                - "1122"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - f8c59548-4d4c-4f14-9e43-0113a8537e08
+        status: 200 OK
+        code: 200
+        duration: 27.315727ms
+    - id: 114
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_desc
+            project_id:
+                - fa1e3217-dc80-42ac-85c3-3f034b78b552
+            resource_name:
+                - scw-test-pool-wait-test-pool-wait-f02a58a15b25
+            resource_type:
+                - unknown_type
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=fa1e3217-dc80-42ac-85c3-3f034b78b552&resource_name=scw-test-pool-wait-test-pool-wait-f02a58a15b25&resource_type=unknown_type
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1121
+        body: '{"total_count":2, "ips":[{"id":"7a65b835-044c-4996-a22b-5715ea76a553", "address":"fd63:256c:45f7:bc7e:4f61:41e:1ed2:7ab4/64", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_ipv6":true, "created_at":"2026-03-30T12:55:45.022856Z", "updated_at":"2026-03-30T12:55:45.022856Z", "source":{"subnet_id":"b18788e5-4872-494d-a7bb-0ba98125d9e4"}, "resource":{"type":"instance_private_nic", "id":"aa4dd472-9b34-45a8-bed3-592e94180874", "mac_address":"02:00:00:1B:24:BE", "name":"scw-test-pool-wait-test-pool-wait-f02a58a15b25"}, "tags":[], "reverses":[], "region":"fr-par", "zone":null}, {"id":"ff1cbc09-c270-4fb8-9808-8f2232e772f8", "address":"172.16.72.3/22", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_ipv6":false, "created_at":"2026-03-30T12:55:44.890521Z", "updated_at":"2026-03-30T12:55:44.890521Z", "source":{"subnet_id":"ae63fffc-03c5-47e1-bfb2-170301d26f53"}, "resource":{"type":"instance_private_nic", "id":"aa4dd472-9b34-45a8-bed3-592e94180874", "mac_address":"02:00:00:1B:24:BE", "name":"scw-test-pool-wait-test-pool-wait-f02a58a15b25"}, "tags":[], "reverses":[], "region":"fr-par", "zone":null}]}'
+        headers:
+            Content-Length:
+                - "1121"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 2ea76d2d-395c-42fd-98fa-b89f6c2c4e07
+        status: 200 OK
+        code: 200
+        duration: 35.573946ms
+    - id: 115
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_desc
+            project_id:
+                - fa1e3217-dc80-42ac-85c3-3f034b78b552
+            resource_name:
+                - scw-test-pool-wait-test-pool-wait-2-00f6377f48
+            resource_type:
+                - unknown_type
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=fa1e3217-dc80-42ac-85c3-3f034b78b552&resource_name=scw-test-pool-wait-test-pool-wait-2-00f6377f48&resource_type=unknown_type
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1122
+        body: '{"total_count":2, "ips":[{"id":"e1da6015-0634-4fa0-8ae0-f4d6b6f6a21f", "address":"fd63:256c:45f7:bc7e:7155:5e2e:87ee:2354/64", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_ipv6":true, "created_at":"2026-03-30T12:57:26.282082Z", "updated_at":"2026-03-30T12:57:26.282082Z", "source":{"subnet_id":"b18788e5-4872-494d-a7bb-0ba98125d9e4"}, "resource":{"type":"instance_private_nic", "id":"c8158951-a6dc-4e60-9e9a-d4a959853a7a", "mac_address":"02:00:00:1E:DF:CC", "name":"scw-test-pool-wait-test-pool-wait-2-00f6377f48"}, "tags":[], "reverses":[], "region":"fr-par", "zone":null}, {"id":"cee553a5-62ab-471c-b4a2-25570903bf19", "address":"172.16.72.5/22", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_ipv6":false, "created_at":"2026-03-30T12:57:26.188417Z", "updated_at":"2026-03-30T12:57:26.188417Z", "source":{"subnet_id":"ae63fffc-03c5-47e1-bfb2-170301d26f53"}, "resource":{"type":"instance_private_nic", "id":"c8158951-a6dc-4e60-9e9a-d4a959853a7a", "mac_address":"02:00:00:1E:DF:CC", "name":"scw-test-pool-wait-test-pool-wait-2-00f6377f48"}, "tags":[], "reverses":[], "region":"fr-par", "zone":null}]}'
+        headers:
+            Content-Length:
+                - "1122"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 883833da-8d27-4408-b4cc-088343d0be5a
+        status: 200 OK
+        code: 200
+        duration: 32.845956ms
+    - id: 116
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1603
+        body: '{"region":"fr-par", "id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:13.060726Z", "updated_at":"2026-03-30T12:55:41.789306Z", "type":"kapsule", "name":"test-pool-wait", "description":"", "status":"ready", "version":"1.35.2", "cni":"calico", "tags":["terraform-test", "scaleway_k8s_cluster", "minimal"], "cluster_url":"https://3b418478-2d8b-4fc7-87c3-f551ebb22f53.api.k8s.fr-par.scw.cloud:6443", "dns_wildcard":"*.3b418478-2d8b-4fc7-87c3-f551ebb22f53.nodes.k8s.fr-par.scw.cloud", "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m", "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false, "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":0, "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":0}, "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}}, "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"", "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[], "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "commitment_ends_at":"2026-03-30T12:54:13.060733Z", "acl_available":true, "iam_nodes_group_id":"997eeeb9-fb5b-471b-8ba1-33cf150f3ca6", "pod_cidr":"100.64.0.0/15", "service_cidr":"10.32.0.0/20", "service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1603"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 954ac21f-841b-4f74-b92a-1c9abfb31298
+        status: 200 OK
+        code: 200
+        duration: 25.104738ms
+    - id: 117
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 82
+        host: api.scaleway.com
+        body: '{"size":1,"max_size":1,"upgrade_policy":{"max_unavailable":null,"max_surge":null}}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9e6791ab-321a-4ea7-9b53-f600e6b9a39d
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 737
+        body: '{"region":"fr-par", "id":"9e6791ab-321a-4ea7-9b53-f600e6b9a39d", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:56:31.542980Z", "updated_at":"2026-03-30T12:58:45.838602Z", "name":"test-pool-wait-2", "status":"scaling", "version":"1.35.2", "node_type":"pro2_xxs", "autoscaling":false, "size":1, "min_size":1, "max_size":1, "container_runtime":"containerd", "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{}, "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"sbs_5k", "root_volume_size":20000000000, "public_ip_disabled":false, "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b", "labels":{}, "taints":[], "startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "737"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - a16c4b6e-935f-4491-81e5-1fe7266c2d50
+        status: 200 OK
+        code: 200
+        duration: 40.966447ms
+    - id: 118
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9e6791ab-321a-4ea7-9b53-f600e6b9a39d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 737
+        body: '{"region":"fr-par", "id":"9e6791ab-321a-4ea7-9b53-f600e6b9a39d", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:56:31.542980Z", "updated_at":"2026-03-30T12:58:45.838602Z", "name":"test-pool-wait-2", "status":"scaling", "version":"1.35.2", "node_type":"pro2_xxs", "autoscaling":false, "size":1, "min_size":1, "max_size":1, "container_runtime":"containerd", "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{}, "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"sbs_5k", "root_volume_size":20000000000, "public_ip_disabled":false, "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b", "labels":{}, "taints":[], "startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "737"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - b0adbba0-ba3c-4373-bc38-c5da32e13106
+        status: 200 OK
+        code: 200
+        duration: 22.571262ms
+    - id: 119
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9e6791ab-321a-4ea7-9b53-f600e6b9a39d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 735
+        body: '{"region":"fr-par", "id":"9e6791ab-321a-4ea7-9b53-f600e6b9a39d", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:56:31.542980Z", "updated_at":"2026-03-30T12:58:46.545438Z", "name":"test-pool-wait-2", "status":"ready", "version":"1.35.2", "node_type":"pro2_xxs", "autoscaling":false, "size":1, "min_size":1, "max_size":1, "container_runtime":"containerd", "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{}, "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"sbs_5k", "root_volume_size":20000000000, "public_ip_disabled":false, "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b", "labels":{}, "taints":[], "startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "735"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - ce7b4e76-215c-475f-b835-de17c9a8bfc0
+        status: 200 OK
+        code: 200
+        duration: 43.617964ms
+    - id: 120
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9e6791ab-321a-4ea7-9b53-f600e6b9a39d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 735
+        body: '{"region":"fr-par", "id":"9e6791ab-321a-4ea7-9b53-f600e6b9a39d", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:56:31.542980Z", "updated_at":"2026-03-30T12:58:46.545438Z", "name":"test-pool-wait-2", "status":"ready", "version":"1.35.2", "node_type":"pro2_xxs", "autoscaling":false, "size":1, "min_size":1, "max_size":1, "container_runtime":"containerd", "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{}, "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"sbs_5k", "root_volume_size":20000000000, "public_ip_disabled":false, "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b", "labels":{}, "taints":[], "startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "735"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 53615e48-59af-48a9-a918-bfab24c5270f
+        status: 200 OK
+        code: 200
+        duration: 24.041933ms
+    - id: 121
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_asc
+            page:
+                - "1"
+            pool_id:
+                - 9e6791ab-321a-4ea7-9b53-f600e6b9a39d
+            status:
+                - unknown
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53/nodes?order_by=created_at_asc&page=1&pool_id=9e6791ab-321a-4ea7-9b53-f600e6b9a39d&status=unknown
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1243
+        body: '{"total_count":2, "nodes":[{"region":"fr-par", "id":"9a2bb294-ae27-460e-b3b4-0d7d59769218", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:56:31.814706Z", "updated_at":"2026-03-30T12:58:46.486950Z", "pool_id":"9e6791ab-321a-4ea7-9b53-f600e6b9a39d", "status":"ready", "conditions":{"DiskPressure":"False", "MemoryPressure":"False", "NetworkUnavailable":"False", "PIDPressure":"False", "Ready":"True"}, "name":"scw-test-pool-wait-test-pool-wait-2-9a2bb294ae", "public_ip_v4":"51.15.232.167", "public_ip_v6":null, "provider_id":"scaleway://instance/fr-par-1/d5e63ca1-4ce2-440e-b55d-becd8f830797", "error_message":""}, {"region":"fr-par", "id":"00f6377f-4855-45b1-8b8f-950b5885aa13", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:57:24.069214Z", "updated_at":"2026-03-30T12:58:46.185085Z", "pool_id":"9e6791ab-321a-4ea7-9b53-f600e6b9a39d", "status":"deleting", "conditions":{"DiskPressure":"False", "MemoryPressure":"False", "PIDPressure":"False", "Ready":"True"}, "name":"scw-test-pool-wait-test-pool-wait-2-00f6377f48", "public_ip_v4":"51.15.201.66", "public_ip_v6":null, "provider_id":"scaleway://instance/fr-par-1/6ff84171-28f0-4d81-83b7-2d20641b4c0e", "error_message":""}]}'
+        headers:
+            Content-Length:
+                - "1243"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 4ee9b2e8-51cb-452f-88ed-67d86d733968
+        status: 200 OK
+        code: 200
+        duration: 38.612999ms
+    - id: 122
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1603
+        body: '{"region":"fr-par", "id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:13.060726Z", "updated_at":"2026-03-30T12:55:41.789306Z", "type":"kapsule", "name":"test-pool-wait", "description":"", "status":"ready", "version":"1.35.2", "cni":"calico", "tags":["terraform-test", "scaleway_k8s_cluster", "minimal"], "cluster_url":"https://3b418478-2d8b-4fc7-87c3-f551ebb22f53.api.k8s.fr-par.scw.cloud:6443", "dns_wildcard":"*.3b418478-2d8b-4fc7-87c3-f551ebb22f53.nodes.k8s.fr-par.scw.cloud", "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m", "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false, "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":0, "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":0}, "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}}, "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"", "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[], "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "commitment_ends_at":"2026-03-30T12:54:13.060733Z", "acl_available":true, "iam_nodes_group_id":"997eeeb9-fb5b-471b-8ba1-33cf150f3ca6", "pod_cidr":"100.64.0.0/15", "service_cidr":"10.32.0.0/20", "service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1603"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 1f8a4056-0e6a-4dd4-b482-3eec98df6836
+        status: 200 OK
+        code: 200
+        duration: 25.423145ms
+    - id: 123
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_desc
+            project_id:
+                - fa1e3217-dc80-42ac-85c3-3f034b78b552
+            resource_name:
+                - scw-test-pool-wait-test-pool-wait-2-9a2bb294ae
+            resource_type:
+                - unknown_type
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=fa1e3217-dc80-42ac-85c3-3f034b78b552&resource_name=scw-test-pool-wait-test-pool-wait-2-9a2bb294ae&resource_type=unknown_type
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1122
+        body: '{"total_count":2, "ips":[{"id":"75b3496a-ca81-4973-865a-4dc5d2529d87", "address":"fd63:256c:45f7:bc7e:6fe5:edb8:a736:809e/64", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_ipv6":true, "created_at":"2026-03-30T12:56:34.289056Z", "updated_at":"2026-03-30T12:56:34.289056Z", "source":{"subnet_id":"b18788e5-4872-494d-a7bb-0ba98125d9e4"}, "resource":{"type":"instance_private_nic", "id":"cbaad5fe-1d2e-40ef-8e6b-6b409ccab201", "mac_address":"02:00:00:12:4D:A4", "name":"scw-test-pool-wait-test-pool-wait-2-9a2bb294ae"}, "tags":[], "reverses":[], "region":"fr-par", "zone":null}, {"id":"03c33497-a15d-45bb-986e-9a6ad6191de2", "address":"172.16.72.4/22", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_ipv6":false, "created_at":"2026-03-30T12:56:34.167958Z", "updated_at":"2026-03-30T12:56:34.167958Z", "source":{"subnet_id":"ae63fffc-03c5-47e1-bfb2-170301d26f53"}, "resource":{"type":"instance_private_nic", "id":"cbaad5fe-1d2e-40ef-8e6b-6b409ccab201", "mac_address":"02:00:00:12:4D:A4", "name":"scw-test-pool-wait-test-pool-wait-2-9a2bb294ae"}, "tags":[], "reverses":[], "region":"fr-par", "zone":null}]}'
+        headers:
+            Content-Length:
+                - "1122"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - eabfa554-d7c9-4791-b2b4-97a0754cddc7
+        status: 200 OK
+        code: 200
+        duration: 135.692041ms
+    - id: 124
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_desc
+            project_id:
+                - fa1e3217-dc80-42ac-85c3-3f034b78b552
+            resource_name:
+                - scw-test-pool-wait-test-pool-wait-2-00f6377f48
+            resource_type:
+                - unknown_type
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=fa1e3217-dc80-42ac-85c3-3f034b78b552&resource_name=scw-test-pool-wait-test-pool-wait-2-00f6377f48&resource_type=unknown_type
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1122
+        body: '{"total_count":2, "ips":[{"id":"e1da6015-0634-4fa0-8ae0-f4d6b6f6a21f", "address":"fd63:256c:45f7:bc7e:7155:5e2e:87ee:2354/64", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_ipv6":true, "created_at":"2026-03-30T12:57:26.282082Z", "updated_at":"2026-03-30T12:57:26.282082Z", "source":{"subnet_id":"b18788e5-4872-494d-a7bb-0ba98125d9e4"}, "resource":{"type":"instance_private_nic", "id":"c8158951-a6dc-4e60-9e9a-d4a959853a7a", "mac_address":"02:00:00:1E:DF:CC", "name":"scw-test-pool-wait-test-pool-wait-2-00f6377f48"}, "tags":[], "reverses":[], "region":"fr-par", "zone":null}, {"id":"cee553a5-62ab-471c-b4a2-25570903bf19", "address":"172.16.72.5/22", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_ipv6":false, "created_at":"2026-03-30T12:57:26.188417Z", "updated_at":"2026-03-30T12:57:26.188417Z", "source":{"subnet_id":"ae63fffc-03c5-47e1-bfb2-170301d26f53"}, "resource":{"type":"instance_private_nic", "id":"c8158951-a6dc-4e60-9e9a-d4a959853a7a", "mac_address":"02:00:00:1E:DF:CC", "name":"scw-test-pool-wait-test-pool-wait-2-00f6377f48"}, "tags":[], "reverses":[], "region":"fr-par", "zone":null}]}'
+        headers:
+            Content-Length:
+                - "1122"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 78f434f9-85ca-4148-852a-e57f56ef8c35
+        status: 200 OK
+        code: 200
+        duration: 27.590333ms
+    - id: 125
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1603
+        body: '{"region":"fr-par", "id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:13.060726Z", "updated_at":"2026-03-30T12:55:41.789306Z", "type":"kapsule", "name":"test-pool-wait", "description":"", "status":"ready", "version":"1.35.2", "cni":"calico", "tags":["terraform-test", "scaleway_k8s_cluster", "minimal"], "cluster_url":"https://3b418478-2d8b-4fc7-87c3-f551ebb22f53.api.k8s.fr-par.scw.cloud:6443", "dns_wildcard":"*.3b418478-2d8b-4fc7-87c3-f551ebb22f53.nodes.k8s.fr-par.scw.cloud", "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m", "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false, "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":0, "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":0}, "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}}, "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"", "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[], "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "commitment_ends_at":"2026-03-30T12:54:13.060733Z", "acl_available":true, "iam_nodes_group_id":"997eeeb9-fb5b-471b-8ba1-33cf150f3ca6", "pod_cidr":"100.64.0.0/15", "service_cidr":"10.32.0.0/20", "service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1603"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 9021628e-72ee-48fd-97de-857af82e86f9
+        status: 200 OK
+        code: 200
+        duration: 25.53777ms
+    - id: 126
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9e6791ab-321a-4ea7-9b53-f600e6b9a39d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 735
+        body: '{"region":"fr-par", "id":"9e6791ab-321a-4ea7-9b53-f600e6b9a39d", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:56:31.542980Z", "updated_at":"2026-03-30T12:58:46.545438Z", "name":"test-pool-wait-2", "status":"ready", "version":"1.35.2", "node_type":"pro2_xxs", "autoscaling":false, "size":1, "min_size":1, "max_size":1, "container_runtime":"containerd", "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{}, "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"sbs_5k", "root_volume_size":20000000000, "public_ip_disabled":false, "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b", "labels":{}, "taints":[], "startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "735"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - bf72451f-efc7-4943-a4e6-153a9f47be81
+        status: 200 OK
+        code: 200
+        duration: 19.188925ms
+    - id: 127
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/45317da4-924e-4fd3-b4ca-e93215bc5849
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 431
+        body: '{"id":"45317da4-924e-4fd3-b4ca-e93215bc5849", "name":"tf-vpc-affectionate-proskuriakova", "tags":[], "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:12.102781Z", "updated_at":"2026-03-30T12:54:12.102781Z", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_default":false, "private_network_count":1, "routing_enabled":true, "custom_routes_propagation_enabled":true, "region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "431"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - de6c4aab-1d18-4c29-9518-a99731973f68
+        status: 200 OK
+        code: 200
+        duration: 26.954549ms
+    - id: 128
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/97585af2-c151-4ad5-9778-fa88d5af8bba
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1084
+        body: '{"id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "name":"test-pool-wait", "tags":[], "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:12.204171Z", "updated_at":"2026-03-30T12:54:12.204171Z", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "subnets":[{"id":"ae63fffc-03c5-47e1-bfb2-170301d26f53", "created_at":"2026-03-30T12:54:12.204171Z", "updated_at":"2026-03-30T12:54:12.204171Z", "subnet":"172.16.72.0/22", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "vpc_id":"45317da4-924e-4fd3-b4ca-e93215bc5849"}, {"id":"b18788e5-4872-494d-a7bb-0ba98125d9e4", "created_at":"2026-03-30T12:54:12.204171Z", "updated_at":"2026-03-30T12:54:12.204171Z", "subnet":"fd63:256c:45f7:bc7e::/64", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "vpc_id":"45317da4-924e-4fd3-b4ca-e93215bc5849"}], "vpc_id":"45317da4-924e-4fd3-b4ca-e93215bc5849", "dhcp_enabled":true, "default_route_propagation_enabled":false, "region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1084"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 2ad989c2-59a6-4915-9698-ab7d9db93873
+        status: 200 OK
+        code: 200
+        duration: 27.369759ms
+    - id: 129
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1603
+        body: '{"region":"fr-par", "id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:13.060726Z", "updated_at":"2026-03-30T12:55:41.789306Z", "type":"kapsule", "name":"test-pool-wait", "description":"", "status":"ready", "version":"1.35.2", "cni":"calico", "tags":["terraform-test", "scaleway_k8s_cluster", "minimal"], "cluster_url":"https://3b418478-2d8b-4fc7-87c3-f551ebb22f53.api.k8s.fr-par.scw.cloud:6443", "dns_wildcard":"*.3b418478-2d8b-4fc7-87c3-f551ebb22f53.nodes.k8s.fr-par.scw.cloud", "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m", "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false, "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":0, "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":0}, "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}}, "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"", "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[], "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "commitment_ends_at":"2026-03-30T12:54:13.060733Z", "acl_available":true, "iam_nodes_group_id":"997eeeb9-fb5b-471b-8ba1-33cf150f3ca6", "pod_cidr":"100.64.0.0/15", "service_cidr":"10.32.0.0/20", "service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1603"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 552b9daf-f9cd-49fe-bdd3-154c522be157
+        status: 200 OK
+        code: 200
+        duration: 24.923988ms
+    - id: 130
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53/kubeconfig
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1650
+        body: '{"name":"kubeconfig", "content_type":"application/octet-stream", "content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVSlhla05EUVZGSFowRjNTVUpCWjBsQ1FVUkJTMEpuWjNGb2EycFBVRkZSUkVGcVFWWk5VazEzUlZGWlJGWlJVVVJGZDNCeVpGZEtiR050Tld3S1pFZFdlazFDTkZoRVZFa3lUVVJOZVU5VVJYbE9WRkY0VFRGdldFUlVUVEpOUkUxNVQxUkZlVTVVVVhoTk1XOTNSbFJGVkUxQ1JVZEJNVlZGUVhoTlN3cGhNMVpwV2xoS2RWcFlVbXhqZWtKYVRVSk5SMEo1Y1VkVFRUUTVRV2RGUjBORGNVZFRUVFE1UVhkRlNFRXdTVUZDVHpWNk0wd3ZPRGRTUmpGT1dXTjFDbEJNY1RSbmN6UkhTWHBxY1hSU1pHNWpWbTFyYjNwTk1qUjVXRzlzTmtoTlp6SXpMekowYVdSeVQwUjNlVmN2WlV4Wk1sWldLMkZ4Y2poWmRteDJUaXNLVDJaM2FVNHlSMnBSYWtKQlRVRTBSMEV4VldSRWQwVkNMM2RSUlVGM1NVTndSRUZRUW1kT1ZraFNUVUpCWmpoRlFsUkJSRUZSU0M5TlFqQkhRVEZWWkFwRVoxRlhRa0pSWjJWNk0zRlRaR0VyVUZWc2VrODFRa051TlZScVRsa3JTWGg2UVV0Q1oyZHhhR3RxVDFCUlVVUkJaMDVKUVVSQ1JrRnBSVUZ0S3pneENuWkZWREptVW13d00yRlljSFZ1ZG5kMlNXc3hiMEY1VFRFd1ZuQm9lRXgwYUVOaGRVNVVSVU5KU0cxNVRWUmxMM2s1YTI5UFZHdGtiazlOTDJrMkwxZ0tSRzVyUnpNeldpc3JaMVJxV2xwWmJXNDJORVVLTFMwdExTMUZUa1FnUTBWU1ZFbEdTVU5CVkVVdExTMHRMUW89CiAgICBzZXJ2ZXI6IGh0dHBzOi8vM2I0MTg0NzgtMmQ4Yi00ZmM3LTg3YzMtZjU1MWViYjIyZjUzLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC13YWl0CiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXBvb2wtd2FpdCIKICAgIHVzZXI6IHRlc3QtcG9vbC13YWl0LWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXdhaXQKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXBvb2wtd2FpdC1hZG1pbgogIHVzZXI6CiAgICB0b2tlbjogNkxOdk9jQ3VWdWFJMEpqd3JleGNVYjZNc3J4T2ZMM2Jhd1llUmN0b0ZpTjJDVFo0d1pESVlrNEg="}'
+        headers:
+            Content-Length:
+                - "1650"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 3dfabe09-7414-415e-baac-e32d3467bd50
+        status: 200 OK
+        code: 200
+        duration: 41.332424ms
+    - id: 131
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9e6791ab-321a-4ea7-9b53-f600e6b9a39d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 735
+        body: '{"region":"fr-par", "id":"9e6791ab-321a-4ea7-9b53-f600e6b9a39d", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:56:31.542980Z", "updated_at":"2026-03-30T12:58:46.545438Z", "name":"test-pool-wait-2", "status":"ready", "version":"1.35.2", "node_type":"pro2_xxs", "autoscaling":false, "size":1, "min_size":1, "max_size":1, "container_runtime":"containerd", "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{}, "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"sbs_5k", "root_volume_size":20000000000, "public_ip_disabled":false, "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b", "labels":{}, "taints":[], "startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "735"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 4d732b04-1801-46fa-abd9-98ef8bff3079
+        status: 200 OK
+        code: 200
+        duration: 23.556362ms
+    - id: 132
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aef8b176-85f1-4ac9-80c5-5632257daa82
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 733
+        body: '{"region":"fr-par", "id":"aef8b176-85f1-4ac9-80c5-5632257daa82", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:54:18.475205Z", "updated_at":"2026-03-30T12:56:27.984394Z", "name":"test-pool-wait", "status":"ready", "version":"1.35.2", "node_type":"pro2_xxs", "autoscaling":false, "size":1, "min_size":1, "max_size":1, "container_runtime":"containerd", "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{}, "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"sbs_5k", "root_volume_size":20000000000, "public_ip_disabled":false, "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b", "labels":{}, "taints":[], "startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "733"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - e3b359bc-56c6-473f-b47b-1f393a4c739c
+        status: 200 OK
+        code: 200
+        duration: 23.870361ms
+    - id: 133
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_asc
+            page:
+                - "1"
+            pool_id:
+                - aef8b176-85f1-4ac9-80c5-5632257daa82
+            status:
+                - unknown
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53/nodes?order_by=created_at_asc&page=1&pool_id=aef8b176-85f1-4ac9-80c5-5632257daa82&status=unknown
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 649
+        body: '{"total_count":1, "nodes":[{"region":"fr-par", "id":"f02a58a1-5b25-41c1-948d-dfe4d877c500", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:55:42.710952Z", "updated_at":"2026-03-30T12:58:46.465638Z", "pool_id":"aef8b176-85f1-4ac9-80c5-5632257daa82", "status":"ready", "conditions":{"DiskPressure":"False", "MemoryPressure":"False", "NetworkUnavailable":"False", "PIDPressure":"False", "Ready":"True"}, "name":"scw-test-pool-wait-test-pool-wait-f02a58a15b25", "public_ip_v4":"51.158.97.194", "public_ip_v6":null, "provider_id":"scaleway://instance/fr-par-1/5a65da2a-aa5f-45b7-a8cf-e1dc0465f407", "error_message":""}]}'
+        headers:
+            Content-Length:
+                - "649"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - b23fa211-2f3f-497e-a461-50e145f00a68
+        status: 200 OK
+        code: 200
+        duration: 24.79732ms
+    - id: 134
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_asc
+            page:
+                - "1"
+            pool_id:
+                - 9e6791ab-321a-4ea7-9b53-f600e6b9a39d
+            status:
+                - unknown
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53/nodes?order_by=created_at_asc&page=1&pool_id=9e6791ab-321a-4ea7-9b53-f600e6b9a39d&status=unknown
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1243
+        body: '{"total_count":2, "nodes":[{"region":"fr-par", "id":"9a2bb294-ae27-460e-b3b4-0d7d59769218", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:56:31.814706Z", "updated_at":"2026-03-30T12:58:46.486950Z", "pool_id":"9e6791ab-321a-4ea7-9b53-f600e6b9a39d", "status":"ready", "conditions":{"DiskPressure":"False", "MemoryPressure":"False", "NetworkUnavailable":"False", "PIDPressure":"False", "Ready":"True"}, "name":"scw-test-pool-wait-test-pool-wait-2-9a2bb294ae", "public_ip_v4":"51.15.232.167", "public_ip_v6":null, "provider_id":"scaleway://instance/fr-par-1/d5e63ca1-4ce2-440e-b55d-becd8f830797", "error_message":""}, {"region":"fr-par", "id":"00f6377f-4855-45b1-8b8f-950b5885aa13", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:57:24.069214Z", "updated_at":"2026-03-30T12:58:46.185085Z", "pool_id":"9e6791ab-321a-4ea7-9b53-f600e6b9a39d", "status":"deleting", "conditions":{"DiskPressure":"False", "MemoryPressure":"False", "PIDPressure":"False", "Ready":"True"}, "name":"scw-test-pool-wait-test-pool-wait-2-00f6377f48", "public_ip_v4":"51.15.201.66", "public_ip_v6":null, "provider_id":"scaleway://instance/fr-par-1/6ff84171-28f0-4d81-83b7-2d20641b4c0e", "error_message":""}]}'
+        headers:
+            Content-Length:
+                - "1243"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - fd842f68-357f-46e4-a5c2-1a4e8cc8c5cc
+        status: 200 OK
+        code: 200
+        duration: 25.246373ms
+    - id: 135
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1603
+        body: '{"region":"fr-par", "id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:13.060726Z", "updated_at":"2026-03-30T12:55:41.789306Z", "type":"kapsule", "name":"test-pool-wait", "description":"", "status":"ready", "version":"1.35.2", "cni":"calico", "tags":["terraform-test", "scaleway_k8s_cluster", "minimal"], "cluster_url":"https://3b418478-2d8b-4fc7-87c3-f551ebb22f53.api.k8s.fr-par.scw.cloud:6443", "dns_wildcard":"*.3b418478-2d8b-4fc7-87c3-f551ebb22f53.nodes.k8s.fr-par.scw.cloud", "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m", "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false, "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":0, "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":0}, "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}}, "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"", "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[], "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "commitment_ends_at":"2026-03-30T12:54:13.060733Z", "acl_available":true, "iam_nodes_group_id":"997eeeb9-fb5b-471b-8ba1-33cf150f3ca6", "pod_cidr":"100.64.0.0/15", "service_cidr":"10.32.0.0/20", "service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1603"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 8814a4ae-955d-41de-b914-b97ad02a0110
+        status: 200 OK
+        code: 200
+        duration: 20.686585ms
+    - id: 136
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1603
+        body: '{"region":"fr-par", "id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:13.060726Z", "updated_at":"2026-03-30T12:55:41.789306Z", "type":"kapsule", "name":"test-pool-wait", "description":"", "status":"ready", "version":"1.35.2", "cni":"calico", "tags":["terraform-test", "scaleway_k8s_cluster", "minimal"], "cluster_url":"https://3b418478-2d8b-4fc7-87c3-f551ebb22f53.api.k8s.fr-par.scw.cloud:6443", "dns_wildcard":"*.3b418478-2d8b-4fc7-87c3-f551ebb22f53.nodes.k8s.fr-par.scw.cloud", "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m", "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false, "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":0, "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":0}, "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}}, "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"", "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[], "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "commitment_ends_at":"2026-03-30T12:54:13.060733Z", "acl_available":true, "iam_nodes_group_id":"997eeeb9-fb5b-471b-8ba1-33cf150f3ca6", "pod_cidr":"100.64.0.0/15", "service_cidr":"10.32.0.0/20", "service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1603"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - de445f52-ba5d-41d0-9c8f-c5f3f0d3dd60
+        status: 200 OK
+        code: 200
+        duration: 23.963536ms
+    - id: 137
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_desc
+            project_id:
+                - fa1e3217-dc80-42ac-85c3-3f034b78b552
+            resource_name:
+                - scw-test-pool-wait-test-pool-wait-f02a58a15b25
+            resource_type:
+                - unknown_type
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=fa1e3217-dc80-42ac-85c3-3f034b78b552&resource_name=scw-test-pool-wait-test-pool-wait-f02a58a15b25&resource_type=unknown_type
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1121
+        body: '{"total_count":2, "ips":[{"id":"7a65b835-044c-4996-a22b-5715ea76a553", "address":"fd63:256c:45f7:bc7e:4f61:41e:1ed2:7ab4/64", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_ipv6":true, "created_at":"2026-03-30T12:55:45.022856Z", "updated_at":"2026-03-30T12:55:45.022856Z", "source":{"subnet_id":"b18788e5-4872-494d-a7bb-0ba98125d9e4"}, "resource":{"type":"instance_private_nic", "id":"aa4dd472-9b34-45a8-bed3-592e94180874", "mac_address":"02:00:00:1B:24:BE", "name":"scw-test-pool-wait-test-pool-wait-f02a58a15b25"}, "tags":[], "reverses":[], "region":"fr-par", "zone":null}, {"id":"ff1cbc09-c270-4fb8-9808-8f2232e772f8", "address":"172.16.72.3/22", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_ipv6":false, "created_at":"2026-03-30T12:55:44.890521Z", "updated_at":"2026-03-30T12:55:44.890521Z", "source":{"subnet_id":"ae63fffc-03c5-47e1-bfb2-170301d26f53"}, "resource":{"type":"instance_private_nic", "id":"aa4dd472-9b34-45a8-bed3-592e94180874", "mac_address":"02:00:00:1B:24:BE", "name":"scw-test-pool-wait-test-pool-wait-f02a58a15b25"}, "tags":[], "reverses":[], "region":"fr-par", "zone":null}]}'
+        headers:
+            Content-Length:
+                - "1121"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - b5845ac3-f059-49b3-8fc4-6c9b8affd2d5
+        status: 200 OK
+        code: 200
+        duration: 28.956997ms
+    - id: 138
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_desc
+            project_id:
+                - fa1e3217-dc80-42ac-85c3-3f034b78b552
+            resource_name:
+                - scw-test-pool-wait-test-pool-wait-2-9a2bb294ae
+            resource_type:
+                - unknown_type
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=fa1e3217-dc80-42ac-85c3-3f034b78b552&resource_name=scw-test-pool-wait-test-pool-wait-2-9a2bb294ae&resource_type=unknown_type
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1122
+        body: '{"total_count":2, "ips":[{"id":"75b3496a-ca81-4973-865a-4dc5d2529d87", "address":"fd63:256c:45f7:bc7e:6fe5:edb8:a736:809e/64", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_ipv6":true, "created_at":"2026-03-30T12:56:34.289056Z", "updated_at":"2026-03-30T12:56:34.289056Z", "source":{"subnet_id":"b18788e5-4872-494d-a7bb-0ba98125d9e4"}, "resource":{"type":"instance_private_nic", "id":"cbaad5fe-1d2e-40ef-8e6b-6b409ccab201", "mac_address":"02:00:00:12:4D:A4", "name":"scw-test-pool-wait-test-pool-wait-2-9a2bb294ae"}, "tags":[], "reverses":[], "region":"fr-par", "zone":null}, {"id":"03c33497-a15d-45bb-986e-9a6ad6191de2", "address":"172.16.72.4/22", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_ipv6":false, "created_at":"2026-03-30T12:56:34.167958Z", "updated_at":"2026-03-30T12:56:34.167958Z", "source":{"subnet_id":"ae63fffc-03c5-47e1-bfb2-170301d26f53"}, "resource":{"type":"instance_private_nic", "id":"cbaad5fe-1d2e-40ef-8e6b-6b409ccab201", "mac_address":"02:00:00:12:4D:A4", "name":"scw-test-pool-wait-test-pool-wait-2-9a2bb294ae"}, "tags":[], "reverses":[], "region":"fr-par", "zone":null}]}'
+        headers:
+            Content-Length:
+                - "1122"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - e0049ee1-e6b5-488d-bf12-f39fb6e4f7f6
+        status: 200 OK
+        code: 200
+        duration: 26.74165ms
+    - id: 139
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_desc
+            project_id:
+                - fa1e3217-dc80-42ac-85c3-3f034b78b552
+            resource_name:
+                - scw-test-pool-wait-test-pool-wait-2-00f6377f48
+            resource_type:
+                - unknown_type
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=fa1e3217-dc80-42ac-85c3-3f034b78b552&resource_name=scw-test-pool-wait-test-pool-wait-2-00f6377f48&resource_type=unknown_type
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1122
+        body: '{"total_count":2, "ips":[{"id":"e1da6015-0634-4fa0-8ae0-f4d6b6f6a21f", "address":"fd63:256c:45f7:bc7e:7155:5e2e:87ee:2354/64", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_ipv6":true, "created_at":"2026-03-30T12:57:26.282082Z", "updated_at":"2026-03-30T12:57:26.282082Z", "source":{"subnet_id":"b18788e5-4872-494d-a7bb-0ba98125d9e4"}, "resource":{"type":"instance_private_nic", "id":"c8158951-a6dc-4e60-9e9a-d4a959853a7a", "mac_address":"02:00:00:1E:DF:CC", "name":"scw-test-pool-wait-test-pool-wait-2-00f6377f48"}, "tags":[], "reverses":[], "region":"fr-par", "zone":null}, {"id":"cee553a5-62ab-471c-b4a2-25570903bf19", "address":"172.16.72.5/22", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_ipv6":false, "created_at":"2026-03-30T12:57:26.188417Z", "updated_at":"2026-03-30T12:57:26.188417Z", "source":{"subnet_id":"ae63fffc-03c5-47e1-bfb2-170301d26f53"}, "resource":{"type":"instance_private_nic", "id":"c8158951-a6dc-4e60-9e9a-d4a959853a7a", "mac_address":"02:00:00:1E:DF:CC", "name":"scw-test-pool-wait-test-pool-wait-2-00f6377f48"}, "tags":[], "reverses":[], "region":"fr-par", "zone":null}]}'
+        headers:
+            Content-Length:
+                - "1122"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 05152304-68a1-478d-bff3-874597ffe668
+        status: 200 OK
+        code: 200
+        duration: 32.765265ms
+    - id: 140
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/45317da4-924e-4fd3-b4ca-e93215bc5849
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 431
+        body: '{"id":"45317da4-924e-4fd3-b4ca-e93215bc5849", "name":"tf-vpc-affectionate-proskuriakova", "tags":[], "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:12.102781Z", "updated_at":"2026-03-30T12:54:12.102781Z", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_default":false, "private_network_count":1, "routing_enabled":true, "custom_routes_propagation_enabled":true, "region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "431"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - d7cb2347-863e-46ef-833a-12ab40ba2238
+        status: 200 OK
+        code: 200
+        duration: 79.800382ms
+    - id: 141
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9e6791ab-321a-4ea7-9b53-f600e6b9a39d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 735
+        body: '{"region":"fr-par", "id":"9e6791ab-321a-4ea7-9b53-f600e6b9a39d", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:56:31.542980Z", "updated_at":"2026-03-30T12:58:46.545438Z", "name":"test-pool-wait-2", "status":"ready", "version":"1.35.2", "node_type":"pro2_xxs", "autoscaling":false, "size":1, "min_size":1, "max_size":1, "container_runtime":"containerd", "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{}, "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"sbs_5k", "root_volume_size":20000000000, "public_ip_disabled":false, "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b", "labels":{}, "taints":[], "startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "735"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 17cf1cda-6df9-42e1-afc7-057596a8a02b
+        status: 200 OK
+        code: 200
+        duration: 82.477998ms
+    - id: 142
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/97585af2-c151-4ad5-9778-fa88d5af8bba
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1084
+        body: '{"id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "name":"test-pool-wait", "tags":[], "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:12.204171Z", "updated_at":"2026-03-30T12:54:12.204171Z", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "subnets":[{"id":"ae63fffc-03c5-47e1-bfb2-170301d26f53", "created_at":"2026-03-30T12:54:12.204171Z", "updated_at":"2026-03-30T12:54:12.204171Z", "subnet":"172.16.72.0/22", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "vpc_id":"45317da4-924e-4fd3-b4ca-e93215bc5849"}, {"id":"b18788e5-4872-494d-a7bb-0ba98125d9e4", "created_at":"2026-03-30T12:54:12.204171Z", "updated_at":"2026-03-30T12:54:12.204171Z", "subnet":"fd63:256c:45f7:bc7e::/64", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "vpc_id":"45317da4-924e-4fd3-b4ca-e93215bc5849"}], "vpc_id":"45317da4-924e-4fd3-b4ca-e93215bc5849", "dhcp_enabled":true, "default_route_propagation_enabled":false, "region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1084"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 475a8e17-580c-4cad-81b3-0d8a9aab80d9
+        status: 200 OK
+        code: 200
+        duration: 20.782956ms
+    - id: 143
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_asc
+            page:
+                - "1"
+            pool_id:
+                - 9e6791ab-321a-4ea7-9b53-f600e6b9a39d
+            status:
+                - unknown
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53/nodes?order_by=created_at_asc&page=1&pool_id=9e6791ab-321a-4ea7-9b53-f600e6b9a39d&status=unknown
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1243
+        body: '{"total_count":2, "nodes":[{"region":"fr-par", "id":"9a2bb294-ae27-460e-b3b4-0d7d59769218", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:56:31.814706Z", "updated_at":"2026-03-30T12:58:46.486950Z", "pool_id":"9e6791ab-321a-4ea7-9b53-f600e6b9a39d", "status":"ready", "conditions":{"DiskPressure":"False", "MemoryPressure":"False", "NetworkUnavailable":"False", "PIDPressure":"False", "Ready":"True"}, "name":"scw-test-pool-wait-test-pool-wait-2-9a2bb294ae", "public_ip_v4":"51.15.232.167", "public_ip_v6":null, "provider_id":"scaleway://instance/fr-par-1/d5e63ca1-4ce2-440e-b55d-becd8f830797", "error_message":""}, {"region":"fr-par", "id":"00f6377f-4855-45b1-8b8f-950b5885aa13", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:57:24.069214Z", "updated_at":"2026-03-30T12:58:46.185085Z", "pool_id":"9e6791ab-321a-4ea7-9b53-f600e6b9a39d", "status":"deleting", "conditions":{"DiskPressure":"False", "MemoryPressure":"False", "PIDPressure":"False", "Ready":"True"}, "name":"scw-test-pool-wait-test-pool-wait-2-00f6377f48", "public_ip_v4":"51.15.201.66", "public_ip_v6":null, "provider_id":"scaleway://instance/fr-par-1/6ff84171-28f0-4d81-83b7-2d20641b4c0e", "error_message":""}]}'
+        headers:
+            Content-Length:
+                - "1243"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - f522530f-1b62-4868-b8bd-bbb426ea00a6
+        status: 200 OK
+        code: 200
+        duration: 53.990201ms
+    - id: 144
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1603
+        body: '{"region":"fr-par", "id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:13.060726Z", "updated_at":"2026-03-30T12:55:41.789306Z", "type":"kapsule", "name":"test-pool-wait", "description":"", "status":"ready", "version":"1.35.2", "cni":"calico", "tags":["terraform-test", "scaleway_k8s_cluster", "minimal"], "cluster_url":"https://3b418478-2d8b-4fc7-87c3-f551ebb22f53.api.k8s.fr-par.scw.cloud:6443", "dns_wildcard":"*.3b418478-2d8b-4fc7-87c3-f551ebb22f53.nodes.k8s.fr-par.scw.cloud", "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m", "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false, "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":0, "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":0}, "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}}, "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"", "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[], "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "commitment_ends_at":"2026-03-30T12:54:13.060733Z", "acl_available":true, "iam_nodes_group_id":"997eeeb9-fb5b-471b-8ba1-33cf150f3ca6", "pod_cidr":"100.64.0.0/15", "service_cidr":"10.32.0.0/20", "service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1603"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 26b3340f-78d0-4b90-ba0e-20e243139369
+        status: 200 OK
+        code: 200
+        duration: 24.659441ms
+    - id: 145
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53/kubeconfig
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1650
+        body: '{"name":"kubeconfig", "content_type":"application/octet-stream", "content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVSlhla05EUVZGSFowRjNTVUpCWjBsQ1FVUkJTMEpuWjNGb2EycFBVRkZSUkVGcVFWWk5VazEzUlZGWlJGWlJVVVJGZDNCeVpGZEtiR050Tld3S1pFZFdlazFDTkZoRVZFa3lUVVJOZVU5VVJYbE9WRkY0VFRGdldFUlVUVEpOUkUxNVQxUkZlVTVVVVhoTk1XOTNSbFJGVkUxQ1JVZEJNVlZGUVhoTlN3cGhNMVpwV2xoS2RWcFlVbXhqZWtKYVRVSk5SMEo1Y1VkVFRUUTVRV2RGUjBORGNVZFRUVFE1UVhkRlNFRXdTVUZDVHpWNk0wd3ZPRGRTUmpGT1dXTjFDbEJNY1RSbmN6UkhTWHBxY1hSU1pHNWpWbTFyYjNwTk1qUjVXRzlzTmtoTlp6SXpMekowYVdSeVQwUjNlVmN2WlV4Wk1sWldLMkZ4Y2poWmRteDJUaXNLVDJaM2FVNHlSMnBSYWtKQlRVRTBSMEV4VldSRWQwVkNMM2RSUlVGM1NVTndSRUZRUW1kT1ZraFNUVUpCWmpoRlFsUkJSRUZSU0M5TlFqQkhRVEZWWkFwRVoxRlhRa0pSWjJWNk0zRlRaR0VyVUZWc2VrODFRa051TlZScVRsa3JTWGg2UVV0Q1oyZHhhR3RxVDFCUlVVUkJaMDVKUVVSQ1JrRnBSVUZ0S3pneENuWkZWREptVW13d00yRlljSFZ1ZG5kMlNXc3hiMEY1VFRFd1ZuQm9lRXgwYUVOaGRVNVVSVU5KU0cxNVRWUmxMM2s1YTI5UFZHdGtiazlOTDJrMkwxZ0tSRzVyUnpNeldpc3JaMVJxV2xwWmJXNDJORVVLTFMwdExTMUZUa1FnUTBWU1ZFbEdTVU5CVkVVdExTMHRMUW89CiAgICBzZXJ2ZXI6IGh0dHBzOi8vM2I0MTg0NzgtMmQ4Yi00ZmM3LTg3YzMtZjU1MWViYjIyZjUzLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC13YWl0CiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXBvb2wtd2FpdCIKICAgIHVzZXI6IHRlc3QtcG9vbC13YWl0LWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXdhaXQKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXBvb2wtd2FpdC1hZG1pbgogIHVzZXI6CiAgICB0b2tlbjogNkxOdk9jQ3VWdWFJMEpqd3JleGNVYjZNc3J4T2ZMM2Jhd1llUmN0b0ZpTjJDVFo0d1pESVlrNEg="}'
+        headers:
+            Content-Length:
+                - "1650"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - ef33ba43-3bf3-40e1-9b15-85c2c0c86124
+        status: 200 OK
+        code: 200
+        duration: 24.979101ms
+    - id: 146
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1603
+        body: '{"region":"fr-par", "id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:13.060726Z", "updated_at":"2026-03-30T12:55:41.789306Z", "type":"kapsule", "name":"test-pool-wait", "description":"", "status":"ready", "version":"1.35.2", "cni":"calico", "tags":["terraform-test", "scaleway_k8s_cluster", "minimal"], "cluster_url":"https://3b418478-2d8b-4fc7-87c3-f551ebb22f53.api.k8s.fr-par.scw.cloud:6443", "dns_wildcard":"*.3b418478-2d8b-4fc7-87c3-f551ebb22f53.nodes.k8s.fr-par.scw.cloud", "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m", "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false, "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":0, "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":0}, "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}}, "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"", "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[], "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "commitment_ends_at":"2026-03-30T12:54:13.060733Z", "acl_available":true, "iam_nodes_group_id":"997eeeb9-fb5b-471b-8ba1-33cf150f3ca6", "pod_cidr":"100.64.0.0/15", "service_cidr":"10.32.0.0/20", "service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1603"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 2831e190-0ca7-4762-8e65-933f89489020
+        status: 200 OK
+        code: 200
+        duration: 28.677814ms
+    - id: 147
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aef8b176-85f1-4ac9-80c5-5632257daa82
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 733
+        body: '{"region":"fr-par", "id":"aef8b176-85f1-4ac9-80c5-5632257daa82", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:54:18.475205Z", "updated_at":"2026-03-30T12:56:27.984394Z", "name":"test-pool-wait", "status":"ready", "version":"1.35.2", "node_type":"pro2_xxs", "autoscaling":false, "size":1, "min_size":1, "max_size":1, "container_runtime":"containerd", "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{}, "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"sbs_5k", "root_volume_size":20000000000, "public_ip_disabled":false, "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b", "labels":{}, "taints":[], "startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "733"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 4fa58add-9333-48ee-8af8-0b4ca44e089e
+        status: 200 OK
+        code: 200
+        duration: 20.956391ms
+    - id: 148
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_desc
+            project_id:
+                - fa1e3217-dc80-42ac-85c3-3f034b78b552
+            resource_name:
+                - scw-test-pool-wait-test-pool-wait-2-9a2bb294ae
+            resource_type:
+                - unknown_type
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=fa1e3217-dc80-42ac-85c3-3f034b78b552&resource_name=scw-test-pool-wait-test-pool-wait-2-9a2bb294ae&resource_type=unknown_type
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1122
+        body: '{"total_count":2, "ips":[{"id":"75b3496a-ca81-4973-865a-4dc5d2529d87", "address":"fd63:256c:45f7:bc7e:6fe5:edb8:a736:809e/64", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_ipv6":true, "created_at":"2026-03-30T12:56:34.289056Z", "updated_at":"2026-03-30T12:56:34.289056Z", "source":{"subnet_id":"b18788e5-4872-494d-a7bb-0ba98125d9e4"}, "resource":{"type":"instance_private_nic", "id":"cbaad5fe-1d2e-40ef-8e6b-6b409ccab201", "mac_address":"02:00:00:12:4D:A4", "name":"scw-test-pool-wait-test-pool-wait-2-9a2bb294ae"}, "tags":[], "reverses":[], "region":"fr-par", "zone":null}, {"id":"03c33497-a15d-45bb-986e-9a6ad6191de2", "address":"172.16.72.4/22", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_ipv6":false, "created_at":"2026-03-30T12:56:34.167958Z", "updated_at":"2026-03-30T12:56:34.167958Z", "source":{"subnet_id":"ae63fffc-03c5-47e1-bfb2-170301d26f53"}, "resource":{"type":"instance_private_nic", "id":"cbaad5fe-1d2e-40ef-8e6b-6b409ccab201", "mac_address":"02:00:00:12:4D:A4", "name":"scw-test-pool-wait-test-pool-wait-2-9a2bb294ae"}, "tags":[], "reverses":[], "region":"fr-par", "zone":null}]}'
+        headers:
+            Content-Length:
+                - "1122"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - fe16a8d4-b31d-4b74-ba34-a98188b0b23a
+        status: 200 OK
+        code: 200
+        duration: 26.538498ms
+    - id: 149
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_asc
+            page:
+                - "1"
+            pool_id:
+                - aef8b176-85f1-4ac9-80c5-5632257daa82
+            status:
+                - unknown
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53/nodes?order_by=created_at_asc&page=1&pool_id=aef8b176-85f1-4ac9-80c5-5632257daa82&status=unknown
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 649
+        body: '{"total_count":1, "nodes":[{"region":"fr-par", "id":"f02a58a1-5b25-41c1-948d-dfe4d877c500", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:55:42.710952Z", "updated_at":"2026-03-30T12:58:46.465638Z", "pool_id":"aef8b176-85f1-4ac9-80c5-5632257daa82", "status":"ready", "conditions":{"DiskPressure":"False", "MemoryPressure":"False", "NetworkUnavailable":"False", "PIDPressure":"False", "Ready":"True"}, "name":"scw-test-pool-wait-test-pool-wait-f02a58a15b25", "public_ip_v4":"51.158.97.194", "public_ip_v6":null, "provider_id":"scaleway://instance/fr-par-1/5a65da2a-aa5f-45b7-a8cf-e1dc0465f407", "error_message":""}]}'
+        headers:
+            Content-Length:
+                - "649"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 8b565d90-f2ea-43d0-aafc-76925e3814f4
+        status: 200 OK
+        code: 200
+        duration: 25.172816ms
+    - id: 150
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_desc
+            project_id:
+                - fa1e3217-dc80-42ac-85c3-3f034b78b552
+            resource_name:
+                - scw-test-pool-wait-test-pool-wait-2-00f6377f48
+            resource_type:
+                - unknown_type
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=fa1e3217-dc80-42ac-85c3-3f034b78b552&resource_name=scw-test-pool-wait-test-pool-wait-2-00f6377f48&resource_type=unknown_type
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1122
+        body: '{"total_count":2, "ips":[{"id":"e1da6015-0634-4fa0-8ae0-f4d6b6f6a21f", "address":"fd63:256c:45f7:bc7e:7155:5e2e:87ee:2354/64", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_ipv6":true, "created_at":"2026-03-30T12:57:26.282082Z", "updated_at":"2026-03-30T12:57:26.282082Z", "source":{"subnet_id":"b18788e5-4872-494d-a7bb-0ba98125d9e4"}, "resource":{"type":"instance_private_nic", "id":"c8158951-a6dc-4e60-9e9a-d4a959853a7a", "mac_address":"02:00:00:1E:DF:CC", "name":"scw-test-pool-wait-test-pool-wait-2-00f6377f48"}, "tags":[], "reverses":[], "region":"fr-par", "zone":null}, {"id":"cee553a5-62ab-471c-b4a2-25570903bf19", "address":"172.16.72.5/22", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_ipv6":false, "created_at":"2026-03-30T12:57:26.188417Z", "updated_at":"2026-03-30T12:57:26.188417Z", "source":{"subnet_id":"ae63fffc-03c5-47e1-bfb2-170301d26f53"}, "resource":{"type":"instance_private_nic", "id":"c8158951-a6dc-4e60-9e9a-d4a959853a7a", "mac_address":"02:00:00:1E:DF:CC", "name":"scw-test-pool-wait-test-pool-wait-2-00f6377f48"}, "tags":[], "reverses":[], "region":"fr-par", "zone":null}]}'
+        headers:
+            Content-Length:
+                - "1122"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 93aae71e-1dd9-4e92-abb0-a7b78b9b1b28
+        status: 200 OK
+        code: 200
+        duration: 32.096039ms
+    - id: 151
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1603
+        body: '{"region":"fr-par", "id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:13.060726Z", "updated_at":"2026-03-30T12:55:41.789306Z", "type":"kapsule", "name":"test-pool-wait", "description":"", "status":"ready", "version":"1.35.2", "cni":"calico", "tags":["terraform-test", "scaleway_k8s_cluster", "minimal"], "cluster_url":"https://3b418478-2d8b-4fc7-87c3-f551ebb22f53.api.k8s.fr-par.scw.cloud:6443", "dns_wildcard":"*.3b418478-2d8b-4fc7-87c3-f551ebb22f53.nodes.k8s.fr-par.scw.cloud", "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m", "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false, "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":0, "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":0}, "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}}, "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"", "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[], "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "commitment_ends_at":"2026-03-30T12:54:13.060733Z", "acl_available":true, "iam_nodes_group_id":"997eeeb9-fb5b-471b-8ba1-33cf150f3ca6", "pod_cidr":"100.64.0.0/15", "service_cidr":"10.32.0.0/20", "service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1603"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 553106a1-5976-44bd-b2ac-efdfe6bc33c5
+        status: 200 OK
+        code: 200
+        duration: 21.86094ms
+    - id: 152
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_desc
+            project_id:
+                - fa1e3217-dc80-42ac-85c3-3f034b78b552
+            resource_name:
+                - scw-test-pool-wait-test-pool-wait-f02a58a15b25
+            resource_type:
+                - unknown_type
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=fa1e3217-dc80-42ac-85c3-3f034b78b552&resource_name=scw-test-pool-wait-test-pool-wait-f02a58a15b25&resource_type=unknown_type
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1121
+        body: '{"total_count":2, "ips":[{"id":"7a65b835-044c-4996-a22b-5715ea76a553", "address":"fd63:256c:45f7:bc7e:4f61:41e:1ed2:7ab4/64", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_ipv6":true, "created_at":"2026-03-30T12:55:45.022856Z", "updated_at":"2026-03-30T12:55:45.022856Z", "source":{"subnet_id":"b18788e5-4872-494d-a7bb-0ba98125d9e4"}, "resource":{"type":"instance_private_nic", "id":"aa4dd472-9b34-45a8-bed3-592e94180874", "mac_address":"02:00:00:1B:24:BE", "name":"scw-test-pool-wait-test-pool-wait-f02a58a15b25"}, "tags":[], "reverses":[], "region":"fr-par", "zone":null}, {"id":"ff1cbc09-c270-4fb8-9808-8f2232e772f8", "address":"172.16.72.3/22", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_ipv6":false, "created_at":"2026-03-30T12:55:44.890521Z", "updated_at":"2026-03-30T12:55:44.890521Z", "source":{"subnet_id":"ae63fffc-03c5-47e1-bfb2-170301d26f53"}, "resource":{"type":"instance_private_nic", "id":"aa4dd472-9b34-45a8-bed3-592e94180874", "mac_address":"02:00:00:1B:24:BE", "name":"scw-test-pool-wait-test-pool-wait-f02a58a15b25"}, "tags":[], "reverses":[], "region":"fr-par", "zone":null}]}'
+        headers:
+            Content-Length:
+                - "1121"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 535246ce-f5cd-405b-ba06-97236977fe35
+        status: 200 OK
+        code: 200
+        duration: 30.688968ms
+    - id: 153
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9e6791ab-321a-4ea7-9b53-f600e6b9a39d
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 738
+        body: '{"region":"fr-par", "id":"9e6791ab-321a-4ea7-9b53-f600e6b9a39d", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:56:31.542980Z", "updated_at":"2026-03-30T12:58:52.440987Z", "name":"test-pool-wait-2", "status":"deleting", "version":"1.35.2", "node_type":"pro2_xxs", "autoscaling":false, "size":1, "min_size":1, "max_size":1, "container_runtime":"containerd", "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{}, "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"sbs_5k", "root_volume_size":20000000000, "public_ip_disabled":false, "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b", "labels":{}, "taints":[], "startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "738"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 842ef648-d662-4f9a-ba5d-7367dd50a426
+        status: 200 OK
+        code: 200
+        duration: 43.956318ms
+    - id: 154
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9e6791ab-321a-4ea7-9b53-f600e6b9a39d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 738
+        body: '{"region":"fr-par", "id":"9e6791ab-321a-4ea7-9b53-f600e6b9a39d", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:56:31.542980Z", "updated_at":"2026-03-30T12:58:52.440987Z", "name":"test-pool-wait-2", "status":"deleting", "version":"1.35.2", "node_type":"pro2_xxs", "autoscaling":false, "size":1, "min_size":1, "max_size":1, "container_runtime":"containerd", "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{}, "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"sbs_5k", "root_volume_size":20000000000, "public_ip_disabled":false, "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b", "labels":{}, "taints":[], "startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "738"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 12:58:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 165ea683-fab3-4ffa-95fe-c5ed59e58fde
+        status: 200 OK
+        code: 200
+        duration: 18.768906ms
+    - id: 155
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9e6791ab-321a-4ea7-9b53-f600e6b9a39d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 125
+        body: '{"message":"resource is not found","resource":"pool","resource_id":"9e6791ab-321a-4ea7-9b53-f600e6b9a39d","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "125"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 13:00:07 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 18ded46c-5fc8-46ac-9c6d-26b16b4d7867
+        status: 404 Not Found
+        code: 404
+        duration: 27.055158ms
+    - id: 156
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1603
+        body: '{"region":"fr-par", "id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:13.060726Z", "updated_at":"2026-03-30T12:55:41.789306Z", "type":"kapsule", "name":"test-pool-wait", "description":"", "status":"ready", "version":"1.35.2", "cni":"calico", "tags":["terraform-test", "scaleway_k8s_cluster", "minimal"], "cluster_url":"https://3b418478-2d8b-4fc7-87c3-f551ebb22f53.api.k8s.fr-par.scw.cloud:6443", "dns_wildcard":"*.3b418478-2d8b-4fc7-87c3-f551ebb22f53.nodes.k8s.fr-par.scw.cloud", "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m", "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false, "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":0, "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":0}, "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}}, "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"", "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[], "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "commitment_ends_at":"2026-03-30T12:54:13.060733Z", "acl_available":true, "iam_nodes_group_id":"997eeeb9-fb5b-471b-8ba1-33cf150f3ca6", "pod_cidr":"100.64.0.0/15", "service_cidr":"10.32.0.0/20", "service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1603"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 13:00:07 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 2257f3b2-3536-4650-9b58-7bb978e605c3
+        status: 200 OK
+        code: 200
+        duration: 29.914244ms
+    - id: 157
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/45317da4-924e-4fd3-b4ca-e93215bc5849
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 431
+        body: '{"id":"45317da4-924e-4fd3-b4ca-e93215bc5849", "name":"tf-vpc-affectionate-proskuriakova", "tags":[], "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:12.102781Z", "updated_at":"2026-03-30T12:54:12.102781Z", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_default":false, "private_network_count":1, "routing_enabled":true, "custom_routes_propagation_enabled":true, "region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "431"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 13:00:08 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 3798bbf9-3c60-4f61-a57a-6fa64a2c4da4
+        status: 200 OK
+        code: 200
+        duration: 29.155501ms
+    - id: 158
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/97585af2-c151-4ad5-9778-fa88d5af8bba
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1084
+        body: '{"id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "name":"test-pool-wait", "tags":[], "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:12.204171Z", "updated_at":"2026-03-30T12:54:12.204171Z", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "subnets":[{"id":"ae63fffc-03c5-47e1-bfb2-170301d26f53", "created_at":"2026-03-30T12:54:12.204171Z", "updated_at":"2026-03-30T12:54:12.204171Z", "subnet":"172.16.72.0/22", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "vpc_id":"45317da4-924e-4fd3-b4ca-e93215bc5849"}, {"id":"b18788e5-4872-494d-a7bb-0ba98125d9e4", "created_at":"2026-03-30T12:54:12.204171Z", "updated_at":"2026-03-30T12:54:12.204171Z", "subnet":"fd63:256c:45f7:bc7e::/64", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "vpc_id":"45317da4-924e-4fd3-b4ca-e93215bc5849"}], "vpc_id":"45317da4-924e-4fd3-b4ca-e93215bc5849", "dhcp_enabled":true, "default_route_propagation_enabled":false, "region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "1084"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 13:00:08 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 9fa90764-fc4c-4b0e-ab3a-1bac08ad2260
+        status: 200 OK
+        code: 200
+        duration: 45.074598ms
+    - id: 159
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1603
+        body: '{"region":"fr-par", "id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:13.060726Z", "updated_at":"2026-03-30T12:55:41.789306Z", "type":"kapsule", "name":"test-pool-wait", "description":"", "status":"ready", "version":"1.35.2", "cni":"calico", "tags":["terraform-test", "scaleway_k8s_cluster", "minimal"], "cluster_url":"https://3b418478-2d8b-4fc7-87c3-f551ebb22f53.api.k8s.fr-par.scw.cloud:6443", "dns_wildcard":"*.3b418478-2d8b-4fc7-87c3-f551ebb22f53.nodes.k8s.fr-par.scw.cloud", "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m", "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false, "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":0, "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":0}, "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}}, "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"", "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[], "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "commitment_ends_at":"2026-03-30T12:54:13.060733Z", "acl_available":true, "iam_nodes_group_id":"997eeeb9-fb5b-471b-8ba1-33cf150f3ca6", "pod_cidr":"100.64.0.0/15", "service_cidr":"10.32.0.0/20", "service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1603"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 13:00:08 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - ad87718c-4253-4957-b24f-0e2036636220
+        status: 200 OK
+        code: 200
+        duration: 48.752792ms
+    - id: 160
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53/kubeconfig
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1650
+        body: '{"name":"kubeconfig", "content_type":"application/octet-stream", "content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVSlhla05EUVZGSFowRjNTVUpCWjBsQ1FVUkJTMEpuWjNGb2EycFBVRkZSUkVGcVFWWk5VazEzUlZGWlJGWlJVVVJGZDNCeVpGZEtiR050Tld3S1pFZFdlazFDTkZoRVZFa3lUVVJOZVU5VVJYbE9WRkY0VFRGdldFUlVUVEpOUkUxNVQxUkZlVTVVVVhoTk1XOTNSbFJGVkUxQ1JVZEJNVlZGUVhoTlN3cGhNMVpwV2xoS2RWcFlVbXhqZWtKYVRVSk5SMEo1Y1VkVFRUUTVRV2RGUjBORGNVZFRUVFE1UVhkRlNFRXdTVUZDVHpWNk0wd3ZPRGRTUmpGT1dXTjFDbEJNY1RSbmN6UkhTWHBxY1hSU1pHNWpWbTFyYjNwTk1qUjVXRzlzTmtoTlp6SXpMekowYVdSeVQwUjNlVmN2WlV4Wk1sWldLMkZ4Y2poWmRteDJUaXNLVDJaM2FVNHlSMnBSYWtKQlRVRTBSMEV4VldSRWQwVkNMM2RSUlVGM1NVTndSRUZRUW1kT1ZraFNUVUpCWmpoRlFsUkJSRUZSU0M5TlFqQkhRVEZWWkFwRVoxRlhRa0pSWjJWNk0zRlRaR0VyVUZWc2VrODFRa051TlZScVRsa3JTWGg2UVV0Q1oyZHhhR3RxVDFCUlVVUkJaMDVKUVVSQ1JrRnBSVUZ0S3pneENuWkZWREptVW13d00yRlljSFZ1ZG5kMlNXc3hiMEY1VFRFd1ZuQm9lRXgwYUVOaGRVNVVSVU5KU0cxNVRWUmxMM2s1YTI5UFZHdGtiazlOTDJrMkwxZ0tSRzVyUnpNeldpc3JaMVJxV2xwWmJXNDJORVVLTFMwdExTMUZUa1FnUTBWU1ZFbEdTVU5CVkVVdExTMHRMUW89CiAgICBzZXJ2ZXI6IGh0dHBzOi8vM2I0MTg0NzgtMmQ4Yi00ZmM3LTg3YzMtZjU1MWViYjIyZjUzLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC13YWl0CiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXBvb2wtd2FpdCIKICAgIHVzZXI6IHRlc3QtcG9vbC13YWl0LWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXdhaXQKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXBvb2wtd2FpdC1hZG1pbgogIHVzZXI6CiAgICB0b2tlbjogNkxOdk9jQ3VWdWFJMEpqd3JleGNVYjZNc3J4T2ZMM2Jhd1llUmN0b0ZpTjJDVFo0d1pESVlrNEg="}'
+        headers:
+            Content-Length:
+                - "1650"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 13:00:08 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 24f9ccfa-283a-4a66-b3b8-5abfa2dcffa9
+        status: 200 OK
+        code: 200
+        duration: 38.32454ms
+    - id: 161
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aef8b176-85f1-4ac9-80c5-5632257daa82
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 733
+        body: '{"region":"fr-par", "id":"aef8b176-85f1-4ac9-80c5-5632257daa82", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:54:18.475205Z", "updated_at":"2026-03-30T12:56:27.984394Z", "name":"test-pool-wait", "status":"ready", "version":"1.35.2", "node_type":"pro2_xxs", "autoscaling":false, "size":1, "min_size":1, "max_size":1, "container_runtime":"containerd", "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{}, "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"sbs_5k", "root_volume_size":20000000000, "public_ip_disabled":false, "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b", "labels":{}, "taints":[], "startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "733"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 13:00:08 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - b83bc7dd-9e53-4b28-ad21-ef99373f1300
+        status: 200 OK
+        code: 200
+        duration: 38.284835ms
+    - id: 162
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_asc
+            page:
+                - "1"
+            pool_id:
+                - aef8b176-85f1-4ac9-80c5-5632257daa82
+            status:
+                - unknown
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53/nodes?order_by=created_at_asc&page=1&pool_id=aef8b176-85f1-4ac9-80c5-5632257daa82&status=unknown
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 649
+        body: '{"total_count":1, "nodes":[{"region":"fr-par", "id":"f02a58a1-5b25-41c1-948d-dfe4d877c500", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:55:42.710952Z", "updated_at":"2026-03-30T12:58:52.730374Z", "pool_id":"aef8b176-85f1-4ac9-80c5-5632257daa82", "status":"ready", "conditions":{"DiskPressure":"False", "MemoryPressure":"False", "NetworkUnavailable":"False", "PIDPressure":"False", "Ready":"True"}, "name":"scw-test-pool-wait-test-pool-wait-f02a58a15b25", "public_ip_v4":"51.158.97.194", "public_ip_v6":null, "provider_id":"scaleway://instance/fr-par-1/5a65da2a-aa5f-45b7-a8cf-e1dc0465f407", "error_message":""}]}'
+        headers:
+            Content-Length:
+                - "649"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 13:00:08 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - cdaa9c0b-a1c7-43f7-86df-7368c6814406
+        status: 200 OK
+        code: 200
+        duration: 27.010875ms
+    - id: 163
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1603
+        body: '{"region":"fr-par", "id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:13.060726Z", "updated_at":"2026-03-30T12:55:41.789306Z", "type":"kapsule", "name":"test-pool-wait", "description":"", "status":"ready", "version":"1.35.2", "cni":"calico", "tags":["terraform-test", "scaleway_k8s_cluster", "minimal"], "cluster_url":"https://3b418478-2d8b-4fc7-87c3-f551ebb22f53.api.k8s.fr-par.scw.cloud:6443", "dns_wildcard":"*.3b418478-2d8b-4fc7-87c3-f551ebb22f53.nodes.k8s.fr-par.scw.cloud", "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m", "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false, "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":0, "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":0}, "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}}, "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"", "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[], "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "commitment_ends_at":"2026-03-30T12:54:13.060733Z", "acl_available":true, "iam_nodes_group_id":"997eeeb9-fb5b-471b-8ba1-33cf150f3ca6", "pod_cidr":"100.64.0.0/15", "service_cidr":"10.32.0.0/20", "service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1603"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 13:00:08 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - b1f315a5-fbb0-4cb8-959a-043e65c88093
+        status: 200 OK
+        code: 200
+        duration: 25.516931ms
+    - id: 164
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            order_by:
+                - created_at_desc
+            project_id:
+                - fa1e3217-dc80-42ac-85c3-3f034b78b552
+            resource_name:
+                - scw-test-pool-wait-test-pool-wait-f02a58a15b25
+            resource_type:
+                - unknown_type
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?order_by=created_at_desc&project_id=fa1e3217-dc80-42ac-85c3-3f034b78b552&resource_name=scw-test-pool-wait-test-pool-wait-f02a58a15b25&resource_type=unknown_type
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1121
+        body: '{"total_count":2, "ips":[{"id":"7a65b835-044c-4996-a22b-5715ea76a553", "address":"fd63:256c:45f7:bc7e:4f61:41e:1ed2:7ab4/64", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_ipv6":true, "created_at":"2026-03-30T12:55:45.022856Z", "updated_at":"2026-03-30T12:55:45.022856Z", "source":{"subnet_id":"b18788e5-4872-494d-a7bb-0ba98125d9e4"}, "resource":{"type":"instance_private_nic", "id":"aa4dd472-9b34-45a8-bed3-592e94180874", "mac_address":"02:00:00:1B:24:BE", "name":"scw-test-pool-wait-test-pool-wait-f02a58a15b25"}, "tags":[], "reverses":[], "region":"fr-par", "zone":null}, {"id":"ff1cbc09-c270-4fb8-9808-8f2232e772f8", "address":"172.16.72.3/22", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "is_ipv6":false, "created_at":"2026-03-30T12:55:44.890521Z", "updated_at":"2026-03-30T12:55:44.890521Z", "source":{"subnet_id":"ae63fffc-03c5-47e1-bfb2-170301d26f53"}, "resource":{"type":"instance_private_nic", "id":"aa4dd472-9b34-45a8-bed3-592e94180874", "mac_address":"02:00:00:1B:24:BE", "name":"scw-test-pool-wait-test-pool-wait-f02a58a15b25"}, "tags":[], "reverses":[], "region":"fr-par", "zone":null}]}'
+        headers:
+            Content-Length:
+                - "1121"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 13:00:08 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - f2ea85a2-f7ea-4c93-b969-7a5c6a2f3add
+        status: 200 OK
+        code: 200
+        duration: 35.578075ms
+    - id: 165
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aef8b176-85f1-4ac9-80c5-5632257daa82
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 736
+        body: '{"region":"fr-par", "id":"aef8b176-85f1-4ac9-80c5-5632257daa82", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:54:18.475205Z", "updated_at":"2026-03-30T13:00:08.590839Z", "name":"test-pool-wait", "status":"deleting", "version":"1.35.2", "node_type":"pro2_xxs", "autoscaling":false, "size":1, "min_size":1, "max_size":1, "container_runtime":"containerd", "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{}, "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"sbs_5k", "root_volume_size":20000000000, "public_ip_disabled":false, "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b", "labels":{}, "taints":[], "startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "736"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 13:00:08 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 03426d93-d3f8-429b-a21f-c1d32fd3e6f5
+        status: 200 OK
+        code: 200
+        duration: 82.989149ms
+    - id: 166
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aef8b176-85f1-4ac9-80c5-5632257daa82
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 736
+        body: '{"region":"fr-par", "id":"aef8b176-85f1-4ac9-80c5-5632257daa82", "cluster_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "created_at":"2026-03-30T12:54:18.475205Z", "updated_at":"2026-03-30T13:00:08.590839Z", "name":"test-pool-wait", "status":"deleting", "version":"1.35.2", "node_type":"pro2_xxs", "autoscaling":false, "size":1, "min_size":1, "max_size":1, "container_runtime":"containerd", "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{}, "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"sbs_5k", "root_volume_size":20000000000, "public_ip_disabled":false, "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b", "labels":{}, "taints":[], "startup_taints":[]}'
+        headers:
+            Content-Length:
+                - "736"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 13:00:08 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - f35899cf-9ce1-4951-86a0-d10ad09f5349
+        status: 200 OK
+        code: 200
+        duration: 24.995814ms
+    - id: 167
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aef8b176-85f1-4ac9-80c5-5632257daa82
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 125
+        body: '{"message":"resource is not found","resource":"pool","resource_id":"aef8b176-85f1-4ac9-80c5-5632257daa82","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "125"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 13:01:53 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - bf48382c-1322-41b6-ba21-c8a84f5c877e
+        status: 404 Not Found
+        code: 404
+        duration: 33.103456ms
+    - id: 168
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            with_additional_resources:
+                - "false"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53?with_additional_resources=false
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1606
+        body: '{"region":"fr-par", "id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:13.060726Z", "updated_at":"2026-03-30T13:01:53.935726Z", "type":"kapsule", "name":"test-pool-wait", "description":"", "status":"deleting", "version":"1.35.2", "cni":"calico", "tags":["terraform-test", "scaleway_k8s_cluster", "minimal"], "cluster_url":"https://3b418478-2d8b-4fc7-87c3-f551ebb22f53.api.k8s.fr-par.scw.cloud:6443", "dns_wildcard":"*.3b418478-2d8b-4fc7-87c3-f551ebb22f53.nodes.k8s.fr-par.scw.cloud", "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m", "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false, "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":0, "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":0}, "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}}, "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"", "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[], "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "commitment_ends_at":"2026-03-30T12:54:13.060733Z", "acl_available":true, "iam_nodes_group_id":"997eeeb9-fb5b-471b-8ba1-33cf150f3ca6", "pod_cidr":"100.64.0.0/15", "service_cidr":"10.32.0.0/20", "service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1606"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 13:01:54 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - ef068cd6-02b1-490d-9589-f7da0830c772
+        status: 200 OK
+        code: 200
+        duration: 101.666118ms
+    - id: 169
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 1606
+        body: '{"region":"fr-par", "id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2026-03-30T12:54:13.060726Z", "updated_at":"2026-03-30T13:01:53.935726Z", "type":"kapsule", "name":"test-pool-wait", "description":"", "status":"deleting", "version":"1.35.2", "cni":"calico", "tags":["terraform-test", "scaleway_k8s_cluster", "minimal"], "cluster_url":"https://3b418478-2d8b-4fc7-87c3-f551ebb22f53.api.k8s.fr-par.scw.cloud:6443", "dns_wildcard":"*.3b418478-2d8b-4fc7-87c3-f551ebb22f53.nodes.k8s.fr-par.scw.cloud", "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m", "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false, "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":0, "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":0}, "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}}, "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"", "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[], "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"97585af2-c151-4ad5-9778-fa88d5af8bba", "commitment_ends_at":"2026-03-30T12:54:13.060733Z", "acl_available":true, "iam_nodes_group_id":"997eeeb9-fb5b-471b-8ba1-33cf150f3ca6", "pod_cidr":"100.64.0.0/15", "service_cidr":"10.32.0.0/20", "service_dns_ip":"10.32.0.10"}'
+        headers:
+            Content-Length:
+                - "1606"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 13:01:54 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 8093022d-76a9-42b3-9bbe-4ec7e2a24c14
+        status: 200 OK
+        code: 200
+        duration: 88.31814ms
+    - id: 170
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 128
+        body: '{"message":"resource is not found","resource":"cluster","resource_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "128"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 13:01:59 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - ed5f68c5-e8ef-448c-ae00-474f271c9cfe
+        status: 404 Not Found
+        code: 404
+        duration: 25.410935ms
+    - id: 171
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/97585af2-c151-4ad5-9778-fa88d5af8bba
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 13:02:00 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 61b36b2d-d325-4fc6-ad8a-b86522bd4195
+        status: 204 No Content
+        code: 204
+        duration: 1.55691411s
+    - id: 172
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/45317da4-924e-4fd3-b4ca-e93215bc5849
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 13:02:01 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 5bd04f29-91e7-445c-b73b-5bcb16137230
+        status: 204 No Content
+        code: 204
+        duration: 463.594662ms
+    - id: 173
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aef8b176-85f1-4ac9-80c5-5632257daa82
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 125
+        body: '{"message":"resource is not found","resource":"pool","resource_id":"aef8b176-85f1-4ac9-80c5-5632257daa82","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "125"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 13:02:01 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 6f45e4d6-8f3a-425b-9c49-72d87a872b3c
+        status: 404 Not Found
+        code: 404
+        duration: 26.306138ms
+    - id: 174
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3b418478-2d8b-4fc7-87c3-f551ebb22f53
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 128
+        body: '{"message":"resource is not found","resource":"cluster","resource_id":"3b418478-2d8b-4fc7-87c3-f551ebb22f53","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "128"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 13:02:01 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 5c7a30ed-2648-42eb-913a-7a0d1eb39e16
+        status: 404 Not Found
+        code: 404
+        duration: 26.530142ms
+    - id: 175
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.0; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/97585af2-c151-4ad5-9778-fa88d5af8bba
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 136
+        body: '{"message":"resource is not found","resource":"private_network","resource_id":"97585af2-c151-4ad5-9778-fa88d5af8bba","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "136"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 30 Mar 2026 13:02:01 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge03)
+            X-Request-Id:
+                - 19a3369b-392f-459c-98f7-8c85b3ccfae2
+        status: 404 Not Found
+        code: 404
+        duration: 20.400276ms

--- a/templates/resources/k8s_pool.md.tmpl
+++ b/templates/resources/k8s_pool.md.tmpl
@@ -37,7 +37,7 @@ The following arguments are supported:
 
 ~> **Important:** This field will only be used at creation if autoscaling is enabled.
 
-- `min_size` - (Defaults to `1`) The minimum size of the pool, used by the autoscaling feature.
+- `min_size` - (Defaults to `1` if `size` > 0, or `0` otherwise) The minimum size of the pool, used by the autoscaling feature.
 
 - `max_size` - (Defaults to `size`) The maximum size of the pool, used by the autoscaling feature.
 
@@ -70,6 +70,8 @@ The following arguments are supported:
 - `root_volume_type` - (Optional) System volume type of the nodes composing the pool
 
 - `root_volume_size_in_gb` - (Optional) The size of the system volume of the nodes in gigabyte
+
+-> Note: The minimal volume size of a node is 20GB.
 
 - `zone` - (Defaults to [provider](../index.md#zone) `zone`) The [zone](../guides/regions_and_zones.md#regions) in which the pool should be created.
 


### PR DESCRIPTION
This PR adds validation for the following specs of a k8s pool:
- pool `root_volume_type` must be compatible with the type of storage supported by the `node_type`
- pool `root_volume_size` must be at least 20GB, and lower than the max capacity of the `node_type` when using local storage.
- pool `size` must be greater than 0 on mutualized clusters, except if the cluster already has at least another node on another pool. (So far the provider did not allow size 0 pools so we had to change the default value of `min_size`)

It also documents the recommended usage of the `create_before_destroy` lifecycle rule to reduce the impact of failures in a pool's update when the requested change requires the resource's replacement.