### PR TITLE
feat(object): add support for bucket `noncurrent_versions`

### DIFF
--- a/internal/services/object/bucket.go
+++ b/internal/services/object/bucket.go
@@ -439,15 +439,15 @@ func resourceBucketLifecycleUpdate(ctx context.Context, conn *s3.Client, d *sche
 
 		rule := s3Types.LifecycleRule{}
 
-		// Filter
-		rule.Filter = extractFilter(r, d)
-
 		// ID
 		if val, ok := r["id"].(string); ok && val != "" {
 			rule.ID = aws.String(val)
 		} else {
 			rule.ID = aws.String(id.PrefixedUniqueId("tf-scw-bucket-lifecycle-"))
 		}
+
+		// Filter
+		rule.Filter = extractFilter(r, d)
 
 		// Enabled
 		if val, ok := r["enabled"].(bool); ok && val {
@@ -534,15 +534,13 @@ func extractFilter(r map[string]any, resourceData *schema.ResourceData) *s3Types
 	filterElements := []any{prefix, tags, objectSizeGreaterThan, objectSizeLessThan}
 	fieldsCounter := 0
 	for _, e := range filterElements {
-		if isSet(e) {
-			fieldsCounter++
-		}
+		fieldsCounter += countFilters(e)
 	}
 
 	filter := &s3Types.LifecycleRuleFilter{}
 
 	if fieldsCounter == 1 {
-		// If a single filter field is set, just put it in "filter"
+		// If a single filter field is set, put it in "filter"
 		if len(tags) > 0 {
 			filter.Tag = &tags[0]
 		}
@@ -584,17 +582,27 @@ func extractFilter(r map[string]any, resourceData *schema.ResourceData) *s3Types
 	return filter
 }
 
-func isSet(i any) bool {
+// Return as many elements as represented by "i"
+// This function was designed around the need to count each tag as separate filters
+func countFilters(i any) int {
 	switch v := i.(type) {
 	case string:
-		return v != ""
+		if v != "" {
+			return 1
+		}
 	case *int64:
-		return v != nil
-	case []string:
-		return len(v) > 0 // This handles "v != nil" as well
+		if v != nil {
+			return 1
+		}
+	case []s3Types.Tag:
+		return len(v)
 	default:
-		return i != nil
+		if v != nil {
+			return 1
+		}
 	}
+
+	return 0
 }
 
 //gocyclo:ignore
@@ -771,7 +779,7 @@ func resourceObjectBucketRead(ctx context.Context, d *schema.ResourceData, m any
 				}
 			}
 
-			// expiration
+			// Expiration
 			if lifecycleRule.Expiration != nil {
 				e := make(map[string]any)
 				if lifecycleRule.Expiration.Days != nil {
@@ -780,7 +788,8 @@ func resourceObjectBucketRead(ctx context.Context, d *schema.ResourceData, m any
 
 				rule["expiration"] = []any{e}
 			}
-			//// transition
+
+			// Transition
 			if len(lifecycleRule.Transitions) > 0 {
 				transitions := make([]any, 0, len(lifecycleRule.Transitions))
 

--- a/internal/services/object/bucket.go
+++ b/internal/services/object/bucket.go
@@ -229,9 +229,10 @@ func bucketSchema() map[string]*schema.Schema {
 						},
 					},
 					"noncurrent_version_expiration": {
-						Type:     schema.TypeList,
-						MaxItems: 1,
-						Optional: true,
+						Type:        schema.TypeList,
+						MaxItems:    1,
+						Optional:    true,
+						Description: "Configuration block that specifies when noncurrent object versions expire",
 						Elem: &schema.Resource{
 							Schema: map[string]*schema.Schema{
 								"newer_noncurrent_versions": {
@@ -250,8 +251,9 @@ func bucketSchema() map[string]*schema.Schema {
 						},
 					},
 					"noncurrent_version_transition": {
-						Type:     schema.TypeSet,
-						Optional: true,
+						Type:        schema.TypeSet,
+						Optional:    true,
+						Description: "Set of configuration blocks that specify the transition rule for the lifecycle rule that describes when noncurrent objects transition to a specific storage class",
 						Elem: &schema.Resource{
 							Schema: map[string]*schema.Schema{
 								"newer_noncurrent_versions": {

--- a/internal/services/object/bucket.go
+++ b/internal/services/object/bucket.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -160,6 +161,16 @@ func bucketSchema() map[string]*schema.Schema {
 						Optional:    true,
 						Description: "The tags associated with the bucket lifecycle",
 					},
+					"object_size_greated_than": {
+						Type:        schema.TypeInt,
+						Optional:    true,
+						Description: "", // FIXME
+					},
+					"object_size_less_than": {
+						Type:        schema.TypeInt,
+						Optional:    true,
+						Description: "", // FIXME
+					},
 					"enabled": {
 						Type:        schema.TypeBool,
 						Required:    true,
@@ -175,13 +186,24 @@ func bucketSchema() map[string]*schema.Schema {
 						Optional:    true,
 						MaxItems:    1,
 						Description: "Specifies a period in the object's expire",
-						Elem: &schema.Resource{
+						Elem: &schema.Resource{ // FIXME: au moins un des trois
 							Schema: map[string]*schema.Schema{
+								"date": {
+									Type:         schema.TypeString,
+									Optional:     true,
+									ValidateFunc: validBucketLifecycleTimestamp,
+									Description:  "", // FIXME
+								},
 								"days": {
 									Type:         schema.TypeInt,
-									Required:     true,
+									Optional:     true,
 									ValidateFunc: validation.IntAtLeast(0),
 									Description:  "Specifies the number of days after object creation when the specific rule action takes effect",
+								},
+								"expired_object_delete_marker": {
+									Type:        schema.TypeBool,
+									Optional:    true,
+									Description: "", // FIXME
 								},
 							},
 						},
@@ -191,8 +213,14 @@ func bucketSchema() map[string]*schema.Schema {
 						Optional:    true,
 						Set:         transitionHash,
 						Description: "Define when objects transition to another storage class",
-						Elem: &schema.Resource{
+						Elem: &schema.Resource{ // FIXME: date or days mandatory
 							Schema: map[string]*schema.Schema{
+								"date": {
+									Type:         schema.TypeString,
+									Optional:     true,
+									ValidateFunc: validBucketLifecycleTimestamp,
+									Description:  "", // FIXME
+								},
 								"days": {
 									Type:         schema.TypeInt,
 									Optional:     true,
@@ -204,6 +232,53 @@ func bucketSchema() map[string]*schema.Schema {
 									Required:     true,
 									ValidateFunc: validation.StringInSlice(TransitionSCWStorageClassValues(), false),
 									Description:  "Specifies the Scaleway Object Storage class to which you want the object to transition",
+								},
+							},
+						},
+					},
+					"noncurrent_version_expiration": {
+						Type:     schema.TypeList,
+						MaxItems: 1,
+						Optional: true,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"newer_noncurrent_versions": {
+									Type:         schema.TypeInt,
+									Optional:     true,
+									ValidateFunc: validation.IntBetween(0, 100),
+									Description:  "", // FIXME
+								},
+								"noncurrent_days": {
+									Type:         schema.TypeInt,
+									Optional:     true,
+									ValidateFunc: validation.IntAtLeast(1),
+									Description:  "", // FIXME
+								},
+							},
+						},
+					},
+					"noncurrent_version_transition": {
+						Type:     schema.TypeSet,
+						Optional: true,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"newer_noncurrent_versions": {
+									Type:         schema.TypeInt,
+									Optional:     true,
+									ValidateFunc: validation.IntBetween(0, 100),
+									Description:  "", // FIXME
+								},
+								"noncurrent_days": {
+									Type:         schema.TypeInt,
+									Required:     true,
+									ValidateFunc: validation.IntAtLeast(1),
+									Description:  "", // FIXME
+								},
+								"storage_class": {
+									Type:         schema.TypeString,
+									Required:     true,
+									ValidateFunc: validation.StringInSlice(TransitionSCWStorageClassValues(), false),
+									Description:  "", // FIXME
 								},
 							},
 						},
@@ -779,4 +854,15 @@ func resourceS3BucketCorsUpdate(ctx context.Context, s3conn *s3.Client, d *schem
 	}
 
 	return nil
+}
+
+func validBucketLifecycleTimestamp(v any, k string) (ws []string, errors []error) {
+	value := v.(string)
+	_, err := time.Parse(time.RFC3339, fmt.Sprintf("%sT00:00:00Z", value))
+	if err != nil {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be parsed as RFC3339 Timestamp Format", value))
+	}
+
+	return
 }

--- a/internal/services/object/bucket.go
+++ b/internal/services/object/bucket.go
@@ -440,7 +440,7 @@ func resourceBucketLifecycleUpdate(ctx context.Context, conn *s3.Client, d *sche
 		rule := s3Types.LifecycleRule{}
 
 		// Filter
-		rule.Filter = extractFilter(r)
+		rule.Filter = extractFilter(r, d)
 
 		// ID
 		if val, ok := r["id"].(string); ok && val != "" {
@@ -517,11 +517,19 @@ func resourceBucketLifecycleUpdate(ctx context.Context, conn *s3.Client, d *sche
 	return nil
 }
 
-func extractFilter(r map[string]any) *s3Types.LifecycleRuleFilter {
+func extractFilter(r map[string]any, resourceData *schema.ResourceData) *s3Types.LifecycleRuleFilter {
 	prefix := r["prefix"].(string)
 	tags := ExpandObjectBucketTags(r["tags"])
-	objectSizeGreaterThan := r["object_size_greater_than"].(*int64)
-	objectSizeLessThan := r["object_size_less_than"].(*int64)
+
+	var objectSizeGreaterThan *int64
+	if v, ok := resourceData.GetOk("object_size_greater_than"); ok {
+		objectSizeGreaterThan = new(int64(v.(int)))
+	}
+
+	var objectSizeLessThan *int64
+	if v, ok := resourceData.GetOk("object_size_less_than"); ok {
+		objectSizeLessThan = new(int64(v.(int)))
+	}
 
 	filterElements := []any{prefix, tags, objectSizeGreaterThan, objectSizeLessThan}
 	fieldsCounter := 0

--- a/internal/services/object/bucket.go
+++ b/internal/services/object/bucket.go
@@ -32,7 +32,7 @@ func ResourceBucket() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 		SchemaFunc:    bucketSchema,
-		CustomizeDiff: validateLifecycle,
+		CustomizeDiff: validateBucket,
 	}
 }
 
@@ -300,6 +300,10 @@ func bucketSchema() map[string]*schema.Schema {
 	}
 }
 
+/*
+*** CREATE
+ */
+
 func resourceObjectBucketCreate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	bucketName := d.Get("name").(string)
 
@@ -348,6 +352,10 @@ func resourceObjectBucketCreate(ctx context.Context, d *schema.ResourceData, m a
 
 	return resourceObjectBucketUpdate(ctx, d, m)
 }
+
+/*
+*** UPDATE
+ */
 
 func resourceObjectBucketUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	s3Client, _, bucketName, err := s3ClientWithRegionAndName(ctx, d, m, d.Id())
@@ -475,6 +483,15 @@ func resourceBucketLifecycleUpdate(ctx context.Context, conn *s3.Client, d *sche
 				i.Days = aws.Int32(days)
 			}
 
+			if val, ok := e["date"].(string); ok && val != "" {
+				date, err := time.Parse("2006-01-02", val)
+				if err != nil {
+					return fmt.Errorf("error while parsing expiration date '%s': %w", val, err)
+				}
+
+				i.Date = aws.Time(date)
+			}
+
 			rule.Expiration = i
 		}
 
@@ -494,6 +511,15 @@ func resourceBucketLifecycleUpdate(ctx context.Context, conn *s3.Client, d *sche
 
 				if val, ok := transition["storage_class"].(string); ok && val != "" {
 					i.StorageClass = s3Types.TransitionStorageClass(val)
+				}
+
+				if val, ok := transition["date"].(string); ok && val != "" {
+					date, err := time.Parse(time.RFC3339, val)
+					if err != nil {
+						return fmt.Errorf("error while parsing transition date '%s': %w", date, err)
+					}
+
+					i.Date = aws.Time(date)
 				}
 
 				rule.Transitions = append(rule.Transitions, i)
@@ -604,6 +630,63 @@ func countFilters(i any) int {
 
 	return 0
 }
+
+func resourceObjectBucketVersioningUpdate(ctx context.Context, s3conn *s3.Client, d *schema.ResourceData) error {
+	v := d.Get("versioning").([]any)
+	bucketName := d.Get("name").(string)
+	vc := expandObjectBucketVersioning(v)
+
+	i := &s3.PutBucketVersioningInput{
+		Bucket:                  new(bucketName),
+		VersioningConfiguration: vc,
+	}
+	tflog.Debug(ctx, fmt.Sprintf("S3 put bucket versioning: %#v", i))
+
+	_, err := s3conn.PutBucketVersioning(ctx, i)
+	if err != nil {
+		return fmt.Errorf("error putting S3 versioning: %w", err)
+	}
+
+	return nil
+}
+
+func resourceS3BucketCorsUpdate(ctx context.Context, s3conn *s3.Client, d *schema.ResourceData) error {
+	bucketName := d.Get("name").(string)
+	rawCors := d.Get("cors_rule").([]any)
+
+	if len(rawCors) == 0 {
+		// Delete CORS
+		tflog.Debug(ctx, fmt.Sprintf("S3 bucket: %s, delete CORS", bucketName))
+
+		_, err := s3conn.DeleteBucketCors(ctx, &s3.DeleteBucketCorsInput{
+			Bucket: new(bucketName),
+		})
+		if err != nil {
+			return fmt.Errorf("error deleting S3 CORS: %w", err)
+		}
+	} else {
+		// Put CORS
+		rules := expandBucketCORS(ctx, rawCors, bucketName)
+		corsInput := &s3.PutBucketCorsInput{
+			Bucket: new(bucketName),
+			CORSConfiguration: &s3Types.CORSConfiguration{
+				CORSRules: rules,
+			},
+		}
+		tflog.Debug(ctx, fmt.Sprintf("S3 bucket: %s, put CORS: %#v", bucketName, corsInput))
+
+		_, err := s3conn.PutBucketCors(ctx, corsInput)
+		if err != nil {
+			return fmt.Errorf("error putting S3 CORS: %w", err)
+		}
+	}
+
+	return nil
+}
+
+/*
+*** READ
+ */
 
 //gocyclo:ignore
 func resourceObjectBucketRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
@@ -724,7 +807,23 @@ func resourceObjectBucketRead(ctx context.Context, d *schema.ResourceData, m any
 		}
 	}
 
+	lifecycleRules := resourceBucketLifecycleRulesRead(lifecycle, d)
+
+	if err := d.Set("lifecycle_rule", lifecycleRules); err != nil {
+		return append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  fmt.Sprintf("error setting lifecycle_rule: %s", err),
+		})
+	}
+
+	return diags
+}
+
+func resourceBucketLifecycleRulesRead(
+	lifecycle *s3.GetBucketLifecycleConfigurationOutput, d *schema.ResourceData,
+) []map[string]any {
 	lifecycleRules := make([]map[string]any, 0)
+
 	if lifecycle != nil && len(lifecycle.Rules) > 0 {
 		lifecycleRules = make([]map[string]any, 0, len(lifecycle.Rules))
 
@@ -775,7 +874,9 @@ func resourceObjectBucketRead(ctx context.Context, d *schema.ResourceData, m any
 			// AbortIncompleteMultipartUploadDays
 			if lifecycleRule.AbortIncompleteMultipartUpload != nil {
 				if lifecycleRule.AbortIncompleteMultipartUpload.DaysAfterInitiation != nil {
-					rule["abort_incomplete_multipart_upload_days"] = int(aws.ToInt32(lifecycleRule.AbortIncompleteMultipartUpload.DaysAfterInitiation))
+					rule["abort_incomplete_multipart_upload_days"] = int(aws.ToInt32(
+						lifecycleRule.AbortIncompleteMultipartUpload.DaysAfterInitiation,
+					))
 				}
 			}
 
@@ -784,6 +885,10 @@ func resourceObjectBucketRead(ctx context.Context, d *schema.ResourceData, m any
 				e := make(map[string]any)
 				if lifecycleRule.Expiration.Days != nil {
 					e["days"] = int(aws.ToInt32(lifecycleRule.Expiration.Days))
+				}
+
+				if lifecycleRule.Expiration.Date != nil {
+					e["date"] = aws.ToString(new(lifecycleRule.Expiration.Date.Format("2006-01-02")))
 				}
 
 				rule["expiration"] = []any{e}
@@ -797,6 +902,10 @@ func resourceObjectBucketRead(ctx context.Context, d *schema.ResourceData, m any
 					t := make(map[string]any)
 					if v.Days != nil {
 						t["days"] = int(aws.ToInt32(v.Days))
+					}
+
+					if v.Date != nil {
+						t["date"] = aws.ToString(new(v.Date.Format("2006-01-02")))
 					}
 
 					if v.StorageClass != "" {
@@ -813,15 +922,12 @@ func resourceObjectBucketRead(ctx context.Context, d *schema.ResourceData, m any
 		}
 	}
 
-	if err := d.Set("lifecycle_rule", lifecycleRules); err != nil {
-		return append(diags, diag.Diagnostic{
-			Severity: diag.Error,
-			Summary:  fmt.Sprintf("error setting lifecycle_rule: %s", err),
-		})
-	}
-
-	return diags
+	return lifecycleRules
 }
+
+/*
+*** DELETE
+ */
 
 func resourceObjectBucketDelete(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	s3Client, _, bucketName, err := s3ClientWithRegionAndName(ctx, d, m, d.Id())
@@ -861,58 +967,9 @@ func resourceObjectBucketDelete(ctx context.Context, d *schema.ResourceData, m a
 	return nil
 }
 
-func resourceObjectBucketVersioningUpdate(ctx context.Context, s3conn *s3.Client, d *schema.ResourceData) error {
-	v := d.Get("versioning").([]any)
-	bucketName := d.Get("name").(string)
-	vc := expandObjectBucketVersioning(v)
-
-	i := &s3.PutBucketVersioningInput{
-		Bucket:                  new(bucketName),
-		VersioningConfiguration: vc,
-	}
-	tflog.Debug(ctx, fmt.Sprintf("S3 put bucket versioning: %#v", i))
-
-	_, err := s3conn.PutBucketVersioning(ctx, i)
-	if err != nil {
-		return fmt.Errorf("error putting S3 versioning: %w", err)
-	}
-
-	return nil
-}
-
-func resourceS3BucketCorsUpdate(ctx context.Context, s3conn *s3.Client, d *schema.ResourceData) error {
-	bucketName := d.Get("name").(string)
-	rawCors := d.Get("cors_rule").([]any)
-
-	if len(rawCors) == 0 {
-		// Delete CORS
-		tflog.Debug(ctx, fmt.Sprintf("S3 bucket: %s, delete CORS", bucketName))
-
-		_, err := s3conn.DeleteBucketCors(ctx, &s3.DeleteBucketCorsInput{
-			Bucket: new(bucketName),
-		})
-		if err != nil {
-			return fmt.Errorf("error deleting S3 CORS: %w", err)
-		}
-	} else {
-		// Put CORS
-		rules := expandBucketCORS(ctx, rawCors, bucketName)
-		corsInput := &s3.PutBucketCorsInput{
-			Bucket: new(bucketName),
-			CORSConfiguration: &s3Types.CORSConfiguration{
-				CORSRules: rules,
-			},
-		}
-		tflog.Debug(ctx, fmt.Sprintf("S3 bucket: %s, put CORS: %#v", bucketName, corsInput))
-
-		_, err := s3conn.PutBucketCors(ctx, corsInput)
-		if err != nil {
-			return fmt.Errorf("error putting S3 CORS: %w", err)
-		}
-	}
-
-	return nil
-}
+/*
+*** VALIDATE
+ */
 
 func validBucketLifecycleTimestamp(v any, k string) (ws []string, errors []error) {
 	value := v.(string)
@@ -925,7 +982,7 @@ func validBucketLifecycleTimestamp(v any, k string) (ws []string, errors []error
 	return
 }
 
-func validateLifecycle(ctx context.Context, diff *schema.ResourceDiff, meta interface{}) error {
+func validateBucket(ctx context.Context, diff *schema.ResourceDiff, meta interface{}) error {
 	// Object lock and versioning
 	if diff.Get("object_lock_enabled").(bool) {
 		if diff.HasChange("versioning") && !diff.Get("versioning.0.enabled").(bool) {
@@ -933,6 +990,7 @@ func validateLifecycle(ctx context.Context, diff *schema.ResourceDiff, meta inte
 		}
 	}
 
+	// Lifecycle rules
 	ruleCount := diff.Get("lifecycle_rule.#").(int)
 
 	for i := range ruleCount {

--- a/internal/services/object/bucket.go
+++ b/internal/services/object/bucket.go
@@ -494,6 +494,10 @@ func resourceBucketLifecycleUpdate(ctx context.Context, conn *s3.Client, d *sche
 				i.Date = aws.Time(date)
 			}
 
+			if val, ok := e["expired_object_delete_marker"].(bool); ok {
+				i.ExpiredObjectDeleteMarker = aws.Bool(val)
+			}
+
 			rule.Expiration = i
 		}
 
@@ -891,6 +895,10 @@ func resourceBucketLifecycleRulesRead(
 
 				if lifecycleRule.Expiration.Date != nil {
 					e["date"] = aws.ToString(new(lifecycleRule.Expiration.Date.Format("2006-01-02")))
+				}
+
+				if lifecycleRule.Expiration.ExpiredObjectDeleteMarker != nil {
+					e["expired_object_delete_marker"] = aws.ToBool(lifecycleRule.Expiration.ExpiredObjectDeleteMarker)
 				}
 
 				rule["expiration"] = []any{e}

--- a/internal/services/object/bucket.go
+++ b/internal/services/object/bucket.go
@@ -949,10 +949,9 @@ func validateLifecycle(ctx context.Context, diff *schema.ResourceDiff, meta inte
 			transitionSet := v.(*schema.Set)
 			for _, transitionRaw := range transitionSet.List() {
 				transition := transitionRaw.(map[string]interface{})
-				if err := validateLifecycleTransition(transition, i); err != nil {
+				if err := validateLifecycleTransition(transition); err != nil {
 					return err
 				}
-
 			}
 		}
 	}
@@ -989,7 +988,11 @@ func validateLifecycleExpiration(diff *schema.ResourceDiff, i int) error {
 	return nil
 }
 
-func validateLifecycleTransition(transition map[string]interface{}, i int) error {
+func validateLifecycleTransition(transition map[string]interface{}) error {
+	// At this point, the "days" and "date" fields are initialized.
+	// Either with the filled values, or with default zero values, which makes
+	// the "ok" value obsolete.
+
 	daysVal, _ := transition["days"]
 	dateVal, _ := transition["date"]
 
@@ -1006,7 +1009,9 @@ func validateLifecycleTransition(transition map[string]interface{}, i int) error
 	}
 
 	if count == 0 {
-		return fmt.Errorf("lifecycle_rule.transition: one (only one) of 'days', 'date' should be defined")
+		// This case also happens when "days = 0", which is supported according to AWS tests.
+		// No errors.
+		return nil
 	}
 	if count > 1 {
 		return fmt.Errorf("lifecycle_rule.transition: 'days', 'date' are mutually exclusive")

--- a/internal/services/object/bucket.go
+++ b/internal/services/object/bucket.go
@@ -552,16 +552,8 @@ func resourceBucketLifecycleUpdate(ctx context.Context, conn *s3.Client, d *sche
 func extractFilter(r map[string]any, resourceData *schema.ResourceData) *s3Types.LifecycleRuleFilter {
 	prefix := r["prefix"].(string)
 	tags := ExpandObjectBucketTags(r["tags"])
-
-	var objectSizeGreaterThan *int64
-	if v, ok := resourceData.GetOk("object_size_greater_than"); ok {
-		objectSizeGreaterThan = new(int64(v.(int)))
-	}
-
-	var objectSizeLessThan *int64
-	if v, ok := resourceData.GetOk("object_size_less_than"); ok {
-		objectSizeLessThan = new(int64(v.(int)))
-	}
+	objectSizeGreaterThan := r["object_size_greater_than"].(int)
+	objectSizeLessThan := r["object_size_less_than"].(int)
 
 	filterElements := []any{prefix, tags, objectSizeGreaterThan, objectSizeLessThan}
 	fieldsCounter := 0
@@ -581,12 +573,12 @@ func extractFilter(r map[string]any, resourceData *schema.ResourceData) *s3Types
 			filter.Prefix = new(r["prefix"].(string))
 		}
 
-		if objectSizeGreaterThan != nil {
-			filter.ObjectSizeGreaterThan = new(r["object_size_greater_than"].(int64))
+		if objectSizeGreaterThan > 0 {
+			filter.ObjectSizeGreaterThan = new(int64(objectSizeGreaterThan))
 		}
 
-		if objectSizeLessThan != nil {
-			filter.ObjectSizeLessThan = new(r["object_size_less_than"].(int64))
+		if objectSizeLessThan > 0 {
+			filter.ObjectSizeLessThan = new(int64(objectSizeLessThan))
 		}
 	} else if fieldsCounter >= 2 {
 		// If several fields are set, put them into "filter.and"
@@ -600,12 +592,12 @@ func extractFilter(r map[string]any, resourceData *schema.ResourceData) *s3Types
 			lifecycleRuleAndOp.Prefix = new(r["prefix"].(string))
 		}
 
-		if objectSizeGreaterThan != nil {
-			lifecycleRuleAndOp.ObjectSizeGreaterThan = new(r["object_size_greater_than"].(int64))
+		if objectSizeGreaterThan > 0 {
+			lifecycleRuleAndOp.ObjectSizeGreaterThan = new(int64(objectSizeGreaterThan))
 		}
 
-		if objectSizeLessThan != nil {
-			lifecycleRuleAndOp.ObjectSizeLessThan = new(r["object_size_less_than"].(int64))
+		if objectSizeLessThan > 0 {
+			lifecycleRuleAndOp.ObjectSizeLessThan = new(int64(objectSizeLessThan))
 		}
 
 		filter.And = lifecycleRuleAndOp
@@ -622,8 +614,8 @@ func countFilters(i any) int {
 		if v != "" {
 			return 1
 		}
-	case *int64:
-		if v != nil {
+	case int:
+		if v > 0 {
 			return 1
 		}
 	case []s3Types.Tag:
@@ -854,6 +846,14 @@ func resourceBucketLifecycleRulesRead(
 					if len(filter.And.Tags) > 0 {
 						rule["tags"] = flattenObjectBucketTags(filter.And.Tags)
 					}
+					// ObjectSizeGreaterThan
+					if filter.And.ObjectSizeGreaterThan != nil && *filter.And.ObjectSizeGreaterThan > 0 {
+						rule["object_size_greater_than"] = filter.And.ObjectSizeGreaterThan
+					}
+					// ObjectSizeLessThan
+					if filter.And.ObjectSizeLessThan != nil && *filter.And.ObjectSizeLessThan > 0 {
+						rule["object_size_less_than"] = filter.And.ObjectSizeLessThan
+					}
 				} else {
 					// Prefix
 					if filter.Prefix != nil && aws.ToString(filter.Prefix) != "" {
@@ -862,6 +862,14 @@ func resourceBucketLifecycleRulesRead(
 					// Tag
 					if filter.Tag != nil {
 						rule["tags"] = flattenObjectBucketTags([]s3Types.Tag{*filter.Tag})
+					}
+					// ObjectSizeGreaterThan
+					if filter.ObjectSizeGreaterThan != nil && *filter.ObjectSizeGreaterThan > 0 {
+						rule["object_size_greater_than"] = filter.ObjectSizeGreaterThan
+					}
+					// ObjectSizeLessThan
+					if filter.ObjectSizeLessThan != nil && *filter.ObjectSizeLessThan > 0 {
+						rule["object_size_less_than"] = filter.ObjectSizeLessThan
 					}
 				}
 			} else {

--- a/internal/services/object/bucket.go
+++ b/internal/services/object/bucket.go
@@ -164,12 +164,12 @@ func bucketSchema() map[string]*schema.Schema {
 					"object_size_greated_than": {
 						Type:        schema.TypeInt,
 						Optional:    true,
-						Description: "", // FIXME
+						Description: "Minimum object size (in bytes) to which the rule applies",
 					},
 					"object_size_less_than": {
 						Type:        schema.TypeInt,
 						Optional:    true,
-						Description: "", // FIXME
+						Description: "Maximum object size (in bytes) to which the rule applies",
 					},
 					"enabled": {
 						Type:        schema.TypeBool,
@@ -186,24 +186,27 @@ func bucketSchema() map[string]*schema.Schema {
 						Optional:    true,
 						MaxItems:    1,
 						Description: "Specifies a period in the object's expire",
-						Elem: &schema.Resource{ // FIXME: au moins un des trois
+						Elem: &schema.Resource{
 							Schema: map[string]*schema.Schema{
 								"date": {
 									Type:         schema.TypeString,
 									Optional:     true,
 									ValidateFunc: validBucketLifecycleTimestamp,
-									Description:  "", // FIXME
+									Description:  "Specifies the date the object is to be moved or deleted. The date value must be in RFC3339 full-date format e.g. `2023-08-22`",
+									ExactlyOneOf: []string{"expiration.0.days", "expiration.0.date", "expiration.0.expired_object_delete_marker"},
 								},
 								"days": {
 									Type:         schema.TypeInt,
 									Optional:     true,
 									ValidateFunc: validation.IntAtLeast(0),
 									Description:  "Specifies the number of days after object creation when the specific rule action takes effect",
+									ExactlyOneOf: []string{"expiration.0.days", "expiration.0.date", "expiration.0.expired_object_delete_marker"},
 								},
 								"expired_object_delete_marker": {
-									Type:        schema.TypeBool,
-									Optional:    true,
-									Description: "", // FIXME
+									Type:         schema.TypeBool,
+									Optional:     true,
+									Description:  "Specifies whether Scaleway Object will remove a delete marker with no noncurrent versions. If set to `true`, the delete marker will be expired; if set to `false` the policy takes no action",
+									ExactlyOneOf: []string{"expiration.0.days", "expiration.0.date", "expiration.0.expired_object_delete_marker"},
 								},
 							},
 						},
@@ -213,19 +216,21 @@ func bucketSchema() map[string]*schema.Schema {
 						Optional:    true,
 						Set:         transitionHash,
 						Description: "Define when objects transition to another storage class",
-						Elem: &schema.Resource{ // FIXME: date or days mandatory
+						Elem: &schema.Resource{
 							Schema: map[string]*schema.Schema{
 								"date": {
 									Type:         schema.TypeString,
 									Optional:     true,
 									ValidateFunc: validBucketLifecycleTimestamp,
-									Description:  "", // FIXME
+									Description:  "Specifies the date objects are transitioned to the specified storage class. The date value must be in RFC3339 full-date format e.g. `2023-08-22`",
+									ExactlyOneOf: []string{"transition.0.days", "transition.0.date"},
 								},
 								"days": {
 									Type:         schema.TypeInt,
 									Optional:     true,
 									ValidateFunc: validation.IntAtLeast(0),
 									Description:  "Specifies the number of days after object creation when the specific rule action takes effect",
+									ExactlyOneOf: []string{"transition.0.days", "transition.0.date"},
 								},
 								"storage_class": {
 									Type:         schema.TypeString,
@@ -245,14 +250,14 @@ func bucketSchema() map[string]*schema.Schema {
 								"newer_noncurrent_versions": {
 									Type:         schema.TypeInt,
 									Optional:     true,
-									ValidateFunc: validation.IntBetween(0, 100),
-									Description:  "", // FIXME
+									ValidateFunc: validation.IntBetween(1, 100),
+									Description:  "Number of noncurrent versions Scaleway Object Storage will retain. Must be a non-zero positive integer",
 								},
 								"noncurrent_days": {
 									Type:         schema.TypeInt,
 									Optional:     true,
 									ValidateFunc: validation.IntAtLeast(1),
-									Description:  "", // FIXME
+									Description:  "Number of days an object is noncurrent before Scaleway Object Storage can perform the associated action. Must be a positive integer",
 								},
 							},
 						},
@@ -265,20 +270,20 @@ func bucketSchema() map[string]*schema.Schema {
 								"newer_noncurrent_versions": {
 									Type:         schema.TypeInt,
 									Optional:     true,
-									ValidateFunc: validation.IntBetween(0, 100),
-									Description:  "", // FIXME
+									ValidateFunc: validation.IntBetween(1, 100),
+									Description:  "Number of noncurrent versions Scaleway Object Storage will retain. Must be a non-zero positive integer",
 								},
 								"noncurrent_days": {
 									Type:         schema.TypeInt,
 									Required:     true,
 									ValidateFunc: validation.IntAtLeast(1),
-									Description:  "", // FIXME
+									Description:  "Number of days an object is noncurrent before Scaleway Object Storage can perform the associated action",
 								},
 								"storage_class": {
 									Type:         schema.TypeString,
 									Required:     true,
 									ValidateFunc: validation.StringInSlice(TransitionSCWStorageClassValues(), false),
-									Description:  "", // FIXME
+									Description:  "Specifies the Scaleway Object Storage class to which you want the object to transition",
 								},
 							},
 						},

--- a/internal/services/object/bucket.go
+++ b/internal/services/object/bucket.go
@@ -31,16 +31,8 @@ func ResourceBucket() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		SchemaFunc: bucketSchema,
-		CustomizeDiff: func(_ context.Context, diff *schema.ResourceDiff, _ any) error {
-			if diff.Get("object_lock_enabled").(bool) {
-				if diff.HasChange("versioning") && !diff.Get("versioning.0.enabled").(bool) {
-					return errors.New("versioning must be enabled when object lock is enabled")
-				}
-			}
-
-			return nil
-		},
+		SchemaFunc:    bucketSchema,
+		CustomizeDiff: validateLifecycle,
 	}
 }
 
@@ -193,20 +185,17 @@ func bucketSchema() map[string]*schema.Schema {
 									Optional:     true,
 									ValidateFunc: validBucketLifecycleTimestamp,
 									Description:  "Specifies the date the object is to be moved or deleted. The date value must be in RFC3339 full-date format e.g. `2023-08-22`",
-									ExactlyOneOf: []string{"expiration.0.days", "expiration.0.date", "expiration.0.expired_object_delete_marker"},
 								},
 								"days": {
 									Type:         schema.TypeInt,
 									Optional:     true,
-									ValidateFunc: validation.IntAtLeast(0),
+									ValidateFunc: validation.IntAtLeast(1),
 									Description:  "Specifies the number of days after object creation when the specific rule action takes effect",
-									ExactlyOneOf: []string{"expiration.0.days", "expiration.0.date", "expiration.0.expired_object_delete_marker"},
 								},
 								"expired_object_delete_marker": {
-									Type:         schema.TypeBool,
-									Optional:     true,
-									Description:  "Specifies whether Scaleway Object will remove a delete marker with no noncurrent versions. If set to `true`, the delete marker will be expired; if set to `false` the policy takes no action",
-									ExactlyOneOf: []string{"expiration.0.days", "expiration.0.date", "expiration.0.expired_object_delete_marker"},
+									Type:        schema.TypeBool,
+									Optional:    true,
+									Description: "Specifies whether Scaleway Object will remove a delete marker with no noncurrent versions. If set to `true`, the delete marker will be expired; if set to `false` the policy takes no action",
 								},
 							},
 						},
@@ -223,14 +212,12 @@ func bucketSchema() map[string]*schema.Schema {
 									Optional:     true,
 									ValidateFunc: validBucketLifecycleTimestamp,
 									Description:  "Specifies the date objects are transitioned to the specified storage class. The date value must be in RFC3339 full-date format e.g. `2023-08-22`",
-									ExactlyOneOf: []string{"transition.0.days", "transition.0.date"},
 								},
 								"days": {
 									Type:         schema.TypeInt,
 									Optional:     true,
 									ValidateFunc: validation.IntAtLeast(0),
 									Description:  "Specifies the number of days after object creation when the specific rule action takes effect",
-									ExactlyOneOf: []string{"transition.0.days", "transition.0.date"},
 								},
 								"storage_class": {
 									Type:         schema.TypeString,
@@ -919,4 +906,94 @@ func validBucketLifecycleTimestamp(v any, k string) (ws []string, errors []error
 	}
 
 	return
+}
+
+func validateLifecycle(ctx context.Context, diff *schema.ResourceDiff, meta interface{}) error {
+	// Object lock and versioning
+	if diff.Get("object_lock_enabled").(bool) {
+		if diff.HasChange("versioning") && !diff.Get("versioning.0.enabled").(bool) {
+			return errors.New("versioning must be enabled when object lock is enabled")
+		}
+	}
+
+	ruleCount := diff.Get("lifecycle_rule.#").(int)
+
+	for i := range ruleCount {
+		// Expiration
+		if _, ok := diff.GetOk(fmt.Sprintf("lifecycle_rule.%d.expiration", i)); ok {
+			if err := validateLifecycleExpiration(diff, i); err != nil {
+				return err
+			}
+		}
+
+		// Transition
+		if v, ok := diff.GetOk(fmt.Sprintf("lifecycle_rule.%d.transition", i)); ok {
+			// Special treatment for "TypeSet" (can't be simply indexed)
+			transitionSet := v.(*schema.Set)
+			for _, transitionRaw := range transitionSet.List() {
+				transition := transitionRaw.(map[string]interface{})
+				if err := validateLifecycleTransition(transition, i); err != nil {
+					return err
+				}
+
+			}
+		}
+	}
+
+	return nil
+}
+
+func validateLifecycleExpiration(diff *schema.ResourceDiff, i int) error {
+	prefix := fmt.Sprintf("lifecycle_rule.%d.expiration.0.", i)
+
+	_, daysOk := diff.GetOk(prefix + "days")
+	_, dateOk := diff.GetOk(prefix + "date")
+	_, markerOk := diff.GetOk(prefix + "expired_object_delete_marker")
+
+	// Implement "ExactlyOneOf"
+	count := 0
+	if daysOk {
+		count++
+	}
+	if dateOk {
+		count++
+	}
+	if markerOk {
+		count++
+	}
+
+	if count == 0 {
+		return fmt.Errorf("lifecycle_rule.%d.expiration: one (only one) of 'days', 'date', 'expired_object_delete_marker' should be defined", i)
+	}
+	if count > 1 {
+		return fmt.Errorf("lifecycle_rule.%d.expiration: 'days', 'date', 'expired_object_delete_marker' are mutually exclusive", i)
+	}
+
+	return nil
+}
+
+func validateLifecycleTransition(transition map[string]interface{}, i int) error {
+	daysVal, _ := transition["days"]
+	dateVal, _ := transition["date"]
+
+	days := daysVal.(int)
+	date := dateVal.(string)
+
+	// Implement "ExactlyOneOf"
+	count := 0
+	if days > 0 {
+		count++
+	}
+	if date != "" {
+		count++
+	}
+
+	if count == 0 {
+		return fmt.Errorf("lifecycle_rule.transition: one (only one) of 'days', 'date' should be defined")
+	}
+	if count > 1 {
+		return fmt.Errorf("lifecycle_rule.transition: 'days', 'date' are mutually exclusive")
+	}
+
+	return nil
 }

--- a/internal/services/object/bucket.go
+++ b/internal/services/object/bucket.go
@@ -161,7 +161,7 @@ func bucketSchema() map[string]*schema.Schema {
 						Optional:    true,
 						Description: "The tags associated with the bucket lifecycle",
 					},
-					"object_size_greated_than": {
+					"object_size_greater_than": {
 						Type:        schema.TypeInt,
 						Optional:    true,
 						Description: "Minimum object size (in bytes) to which the rule applies",
@@ -453,30 +453,7 @@ func resourceBucketLifecycleUpdate(ctx context.Context, conn *s3.Client, d *sche
 		rule := s3Types.LifecycleRule{}
 
 		// Filter
-		prefix := r["prefix"].(string)
-		tags := ExpandObjectBucketTags(r["tags"])
-		ruleHasPrefix := prefix != ""
-		filter := &s3Types.LifecycleRuleFilter{}
-
-		if len(tags) > 1 || (ruleHasPrefix && len(tags) == 1) {
-			lifecycleRuleAndOp := &s3Types.LifecycleRuleAndOperator{
-				Tags: tags,
-			}
-
-			if ruleHasPrefix {
-				lifecycleRuleAndOp.Prefix = new(r["prefix"].(string))
-			}
-
-			filter.And = lifecycleRuleAndOp
-		}
-
-		if !ruleHasPrefix && len(tags) == 1 {
-			filter.Tag = &tags[0]
-		} else if ruleHasPrefix && len(tags) == 0 {
-			filter.Prefix = new(r["prefix"].(string))
-		}
-
-		rule.Filter = filter
+		rule.Filter = extractFilter(r)
 
 		// ID
 		if val, ok := r["id"].(string); ok && val != "" {
@@ -551,6 +528,78 @@ func resourceBucketLifecycleUpdate(ctx context.Context, conn *s3.Client, d *sche
 	}
 
 	return nil
+}
+
+func extractFilter(r map[string]any) *s3Types.LifecycleRuleFilter {
+	prefix := r["prefix"].(string)
+	tags := ExpandObjectBucketTags(r["tags"])
+	objectSizeGreaterThan := r["object_size_greater_than"].(*int64)
+	objectSizeLessThan := r["object_size_less_than"].(*int64)
+
+	filterElements := []any{prefix, tags, objectSizeGreaterThan, objectSizeLessThan}
+	fieldsCounter := 0
+	for _, e := range filterElements {
+		if isSet(e) {
+			fieldsCounter++
+		}
+	}
+
+	filter := &s3Types.LifecycleRuleFilter{}
+
+	if fieldsCounter == 1 {
+		// If a single filter field is set, just put it in "filter"
+		if len(tags) > 0 {
+			filter.Tag = &tags[0]
+		}
+
+		if prefix != "" {
+			filter.Prefix = new(r["prefix"].(string))
+		}
+
+		if objectSizeGreaterThan != nil {
+			filter.ObjectSizeGreaterThan = new(r["object_size_greater_than"].(int64))
+		}
+
+		if objectSizeLessThan != nil {
+			filter.ObjectSizeLessThan = new(r["object_size_less_than"].(int64))
+		}
+	} else if fieldsCounter >= 2 {
+		// If several fields are set, put them into "filter.and"
+		lifecycleRuleAndOp := &s3Types.LifecycleRuleAndOperator{}
+
+		if len(tags) > 0 {
+			lifecycleRuleAndOp.Tags = tags
+		}
+
+		if prefix != "" {
+			lifecycleRuleAndOp.Prefix = new(r["prefix"].(string))
+		}
+
+		if objectSizeGreaterThan != nil {
+			lifecycleRuleAndOp.ObjectSizeGreaterThan = new(r["object_size_greater_than"].(int64))
+		}
+
+		if objectSizeLessThan != nil {
+			lifecycleRuleAndOp.ObjectSizeLessThan = new(r["object_size_less_than"].(int64))
+		}
+
+		filter.And = lifecycleRuleAndOp
+	}
+
+	return filter
+}
+
+func isSet(i any) bool {
+	switch v := i.(type) {
+	case string:
+		return v != ""
+	case *int64:
+		return v != nil
+	case []string:
+		return len(v) > 0 // This handles "v != nil" as well
+	default:
+		return i != nil
+	}
 }
 
 //gocyclo:ignore

--- a/internal/services/object/bucket.go
+++ b/internal/services/object/bucket.go
@@ -882,48 +882,8 @@ func resourceBucketLifecycleRulesRead(
 				rule["id"] = aws.ToString(lifecycleRule.ID)
 			}
 
-			filter := lifecycleRule.Filter
-			if filter != nil {
-				if filter.And != nil {
-					// Prefix
-					if filter.And.Prefix != nil && aws.ToString(filter.And.Prefix) != "" {
-						rule["prefix"] = aws.ToString(filter.And.Prefix)
-					}
-					// Tag
-					if len(filter.And.Tags) > 0 {
-						rule["tags"] = flattenObjectBucketTags(filter.And.Tags)
-					}
-					// ObjectSizeGreaterThan
-					if filter.And.ObjectSizeGreaterThan != nil && *filter.And.ObjectSizeGreaterThan > 0 {
-						rule["object_size_greater_than"] = filter.And.ObjectSizeGreaterThan
-					}
-					// ObjectSizeLessThan
-					if filter.And.ObjectSizeLessThan != nil && *filter.And.ObjectSizeLessThan > 0 {
-						rule["object_size_less_than"] = filter.And.ObjectSizeLessThan
-					}
-				} else {
-					// Prefix
-					if filter.Prefix != nil && aws.ToString(filter.Prefix) != "" {
-						rule["prefix"] = aws.ToString(filter.Prefix)
-					}
-					// Tag
-					if filter.Tag != nil {
-						rule["tags"] = flattenObjectBucketTags([]s3Types.Tag{*filter.Tag})
-					}
-					// ObjectSizeGreaterThan
-					if filter.ObjectSizeGreaterThan != nil && *filter.ObjectSizeGreaterThan > 0 {
-						rule["object_size_greater_than"] = filter.ObjectSizeGreaterThan
-					}
-					// ObjectSizeLessThan
-					if filter.ObjectSizeLessThan != nil && *filter.ObjectSizeLessThan > 0 {
-						rule["object_size_less_than"] = filter.ObjectSizeLessThan
-					}
-				}
-			} else {
-				if lifecycleRule.Filter != nil && lifecycleRule.Filter.Prefix != nil {
-					rule["prefix"] = aws.ToString(lifecycleRule.Filter.Prefix)
-				}
-			}
+			// Filter
+			resourceBucketLifecycleRulesFilterRead(lifecycleRule.Filter, rule)
 
 			// Enabled
 			if lifecycleRule.Status == s3Types.ExpirationStatusEnabled {
@@ -942,90 +902,156 @@ func resourceBucketLifecycleRulesRead(
 			}
 
 			// Expiration
-			if lifecycleRule.Expiration != nil {
-				e := make(map[string]any)
-				if lifecycleRule.Expiration.Days != nil {
-					e["days"] = int(aws.ToInt32(lifecycleRule.Expiration.Days))
-				}
+			resourceBucketLifecycleRulesExpirationRead(lifecycleRule.Expiration, rule)
 
-				if lifecycleRule.Expiration.Date != nil {
-					e["date"] = aws.ToString(new(lifecycleRule.Expiration.Date.Format("2006-01-02")))
-				}
-
-				if lifecycleRule.Expiration.ExpiredObjectDeleteMarker != nil {
-					e["expired_object_delete_marker"] = aws.ToBool(lifecycleRule.Expiration.ExpiredObjectDeleteMarker)
-				}
-
-				rule["expiration"] = []any{e}
-			}
-
-			// Transition
-			if len(lifecycleRule.Transitions) > 0 {
-				transitions := make([]any, 0, len(lifecycleRule.Transitions))
-
-				for _, v := range lifecycleRule.Transitions {
-					t := make(map[string]any)
-					if v.Days != nil {
-						t["days"] = int(aws.ToInt32(v.Days))
-					}
-
-					if v.Date != nil {
-						t["date"] = aws.ToString(new(v.Date.Format("2006-01-02")))
-					}
-
-					if v.StorageClass != "" {
-						t["storage_class"] = string(v.StorageClass)
-					}
-
-					transitions = append(transitions, t)
-				}
-
-				rule["transition"] = schema.NewSet(transitionHash, transitions)
-			}
+			// Transitions
+			resourceBucketLifecycleRulesTransitionsRead(lifecycleRule.Transitions, rule)
 
 			// NonCurrentVersionExpiration
-			if lifecycleRule.NoncurrentVersionExpiration != nil {
-				e := make(map[string]any)
-				if lifecycleRule.NoncurrentVersionExpiration.NewerNoncurrentVersions != nil {
-					e["newer_noncurrent_versions"] = int(aws.ToInt32(lifecycleRule.NoncurrentVersionExpiration.NewerNoncurrentVersions))
-				}
-
-				if lifecycleRule.NoncurrentVersionExpiration.NoncurrentDays != nil {
-					e["noncurrent_days"] = int(aws.ToInt32(lifecycleRule.NoncurrentVersionExpiration.NoncurrentDays))
-				}
-
-				rule["noncurrent_version_expiration"] = []any{e}
-			}
+			resourceBucketLifecycleRulesNonCurrentVersionExpiration(lifecycleRule.NoncurrentVersionExpiration, rule)
 
 			// NonCurrentVersionTransition
-			if len(lifecycleRule.NoncurrentVersionTransitions) > 0 {
-				noncurrentTransitions := make([]any, 0, len(lifecycleRule.NoncurrentVersionTransitions))
-
-				for _, v := range lifecycleRule.NoncurrentVersionTransitions {
-					t := make(map[string]any)
-					if v.NoncurrentDays != nil {
-						t["noncurrent_days"] = int(aws.ToInt32(v.NoncurrentDays))
-					}
-
-					if v.NewerNoncurrentVersions != nil {
-						t["newer_noncurrent_versions"] = int(aws.ToInt32(v.NewerNoncurrentVersions))
-					}
-
-					if v.StorageClass != "" {
-						t["storage_class"] = string(v.StorageClass)
-					}
-
-					noncurrentTransitions = append(noncurrentTransitions, t)
-				}
-
-				rule["noncurrent_version_transition"] = schema.NewSet(noncurrentVersionTransitionHash, noncurrentTransitions)
-			}
+			resourceBucketLifecycleRulesNonCurrentVersionTransitions(lifecycleRule.NoncurrentVersionTransitions, rule)
 
 			lifecycleRules = append(lifecycleRules, rule)
 		}
 	}
 
 	return lifecycleRules
+}
+
+func resourceBucketLifecycleRulesFilterRead(filter *s3Types.LifecycleRuleFilter, rule map[string]any) {
+	if filter == nil {
+		return
+	}
+
+	if filter.And != nil {
+		// Prefix
+		if filter.And.Prefix != nil && aws.ToString(filter.And.Prefix) != "" {
+			rule["prefix"] = aws.ToString(filter.And.Prefix)
+		}
+		// Tag
+		if len(filter.And.Tags) > 0 {
+			rule["tags"] = flattenObjectBucketTags(filter.And.Tags)
+		}
+		// ObjectSizeGreaterThan
+		if filter.And.ObjectSizeGreaterThan != nil && *filter.And.ObjectSizeGreaterThan > 0 {
+			rule["object_size_greater_than"] = filter.And.ObjectSizeGreaterThan
+		}
+		// ObjectSizeLessThan
+		if filter.And.ObjectSizeLessThan != nil && *filter.And.ObjectSizeLessThan > 0 {
+			rule["object_size_less_than"] = filter.And.ObjectSizeLessThan
+		}
+	} else {
+		// Prefix
+		if filter.Prefix != nil && aws.ToString(filter.Prefix) != "" {
+			rule["prefix"] = aws.ToString(filter.Prefix)
+		}
+		// Tag
+		if filter.Tag != nil {
+			rule["tags"] = flattenObjectBucketTags([]s3Types.Tag{*filter.Tag})
+		}
+		// ObjectSizeGreaterThan
+		if filter.ObjectSizeGreaterThan != nil && *filter.ObjectSizeGreaterThan > 0 {
+			rule["object_size_greater_than"] = filter.ObjectSizeGreaterThan
+		}
+		// ObjectSizeLessThan
+		if filter.ObjectSizeLessThan != nil && *filter.ObjectSizeLessThan > 0 {
+			rule["object_size_less_than"] = filter.ObjectSizeLessThan
+		}
+	}
+}
+
+func resourceBucketLifecycleRulesExpirationRead(expiration *s3Types.LifecycleExpiration, rule map[string]any) {
+	if expiration == nil {
+		return
+	}
+
+	e := make(map[string]any)
+	if expiration.Days != nil {
+		e["days"] = int(aws.ToInt32(expiration.Days))
+	}
+
+	if expiration.Date != nil {
+		e["date"] = aws.ToString(new(expiration.Date.Format("2006-01-02")))
+	}
+
+	if expiration.ExpiredObjectDeleteMarker != nil {
+		e["expired_object_delete_marker"] = aws.ToBool(expiration.ExpiredObjectDeleteMarker)
+	}
+
+	rule["expiration"] = []any{e}
+}
+
+func resourceBucketLifecycleRulesTransitionsRead(transitions []s3Types.Transition, rule map[string]any) {
+	if len(transitions) < 1 {
+		return
+	}
+
+	parsedTransitions := make([]any, 0, len(transitions))
+
+	for _, v := range transitions {
+		t := make(map[string]any)
+		if v.Days != nil {
+			t["days"] = int(aws.ToInt32(v.Days))
+		}
+
+		if v.Date != nil {
+			t["date"] = aws.ToString(new(v.Date.Format("2006-01-02")))
+		}
+
+		if v.StorageClass != "" {
+			t["storage_class"] = string(v.StorageClass)
+		}
+
+		parsedTransitions = append(parsedTransitions, t)
+	}
+
+	rule["transition"] = schema.NewSet(transitionHash, parsedTransitions)
+}
+
+func resourceBucketLifecycleRulesNonCurrentVersionExpiration(noncurrentExpiration *s3Types.NoncurrentVersionExpiration, rule map[string]any) {
+	if noncurrentExpiration == nil {
+		return
+	}
+
+	e := make(map[string]any)
+	if noncurrentExpiration.NewerNoncurrentVersions != nil {
+		e["newer_noncurrent_versions"] = int(aws.ToInt32(noncurrentExpiration.NewerNoncurrentVersions))
+	}
+
+	if noncurrentExpiration.NoncurrentDays != nil {
+		e["noncurrent_days"] = int(aws.ToInt32(noncurrentExpiration.NoncurrentDays))
+	}
+
+	rule["noncurrent_version_expiration"] = []any{e}
+}
+
+func resourceBucketLifecycleRulesNonCurrentVersionTransitions(noncurrentVersionTransitions []s3Types.NoncurrentVersionTransition, rule map[string]any) {
+	if len(noncurrentVersionTransitions) < 1 {
+		return
+	}
+
+	noncurrentTransitions := make([]any, 0, len(noncurrentVersionTransitions))
+
+	for _, v := range noncurrentVersionTransitions {
+		t := make(map[string]any)
+		if v.NoncurrentDays != nil {
+			t["noncurrent_days"] = int(aws.ToInt32(v.NoncurrentDays))
+		}
+
+		if v.NewerNoncurrentVersions != nil {
+			t["newer_noncurrent_versions"] = int(aws.ToInt32(v.NewerNoncurrentVersions))
+		}
+
+		if v.StorageClass != "" {
+			t["storage_class"] = string(v.StorageClass)
+		}
+
+		noncurrentTransitions = append(noncurrentTransitions, t)
+	}
+
+	rule["noncurrent_version_transition"] = schema.NewSet(noncurrentVersionTransitionHash, noncurrentTransitions)
 }
 
 /*

--- a/internal/services/object/bucket.go
+++ b/internal/services/object/bucket.go
@@ -602,6 +602,7 @@ func extractFilter(r map[string]any, resourceData *schema.ResourceData) *s3Types
 	objectSizeLessThan := r["object_size_less_than"].(int)
 
 	filterElements := []any{prefix, tags, objectSizeGreaterThan, objectSizeLessThan}
+
 	fieldsCounter := 0
 	for _, e := range filterElements {
 		fieldsCounter += countFilters(e)
@@ -1075,7 +1076,8 @@ func resourceObjectBucketDelete(ctx context.Context, d *schema.ResourceData, m a
 
 func validBucketLifecycleTimestamp(v any, k string) (ws []string, errors []error) {
 	value := v.(string)
-	_, err := time.Parse(time.RFC3339, fmt.Sprintf("%sT00:00:00Z", value))
+
+	_, err := time.Parse(time.RFC3339, value+"T00:00:00Z")
 	if err != nil {
 		errors = append(errors, fmt.Errorf(
 			"%q cannot be parsed as RFC3339 Timestamp Format", value))
@@ -1084,7 +1086,7 @@ func validBucketLifecycleTimestamp(v any, k string) (ws []string, errors []error
 	return
 }
 
-func validateBucket(ctx context.Context, diff *schema.ResourceDiff, meta interface{}) error {
+func validateBucket(ctx context.Context, diff *schema.ResourceDiff, meta any) error {
 	// Object lock and versioning
 	if diff.Get("object_lock_enabled").(bool) {
 		if diff.HasChange("versioning") && !diff.Get("versioning.0.enabled").(bool) {
@@ -1108,7 +1110,7 @@ func validateBucket(ctx context.Context, diff *schema.ResourceDiff, meta interfa
 			// Special treatment for "TypeSet" (can't be simply indexed)
 			transitionSet := v.(*schema.Set)
 			for _, transitionRaw := range transitionSet.List() {
-				transition := transitionRaw.(map[string]interface{})
+				transition := transitionRaw.(map[string]any)
 				if err := validateLifecycleTransition(transition); err != nil {
 					return err
 				}
@@ -1131,9 +1133,11 @@ func validateLifecycleExpiration(diff *schema.ResourceDiff, i int) error {
 	if daysOk {
 		count++
 	}
+
 	if dateOk {
 		count++
 	}
+
 	if markerOk {
 		count++
 	}
@@ -1141,6 +1145,7 @@ func validateLifecycleExpiration(diff *schema.ResourceDiff, i int) error {
 	if count == 0 {
 		return fmt.Errorf("lifecycle_rule.%d.expiration: one (only one) of 'days', 'date', 'expired_object_delete_marker' should be defined", i)
 	}
+
 	if count > 1 {
 		return fmt.Errorf("lifecycle_rule.%d.expiration: 'days', 'date', 'expired_object_delete_marker' are mutually exclusive", i)
 	}
@@ -1148,13 +1153,12 @@ func validateLifecycleExpiration(diff *schema.ResourceDiff, i int) error {
 	return nil
 }
 
-func validateLifecycleTransition(transition map[string]interface{}) error {
+func validateLifecycleTransition(transition map[string]any) error {
 	// At this point, the "days" and "date" fields are initialized.
 	// Either with the filled values, or with default zero values, which makes
 	// the "ok" value obsolete.
-
-	daysVal, _ := transition["days"]
-	dateVal, _ := transition["date"]
+	daysVal := transition["days"]
+	dateVal := transition["date"]
 
 	days := daysVal.(int)
 	date := dateVal.(string)
@@ -1164,6 +1168,7 @@ func validateLifecycleTransition(transition map[string]interface{}) error {
 	if days > 0 {
 		count++
 	}
+
 	if date != "" {
 		count++
 	}
@@ -1173,8 +1178,9 @@ func validateLifecycleTransition(transition map[string]interface{}) error {
 		// No errors.
 		return nil
 	}
+
 	if count > 1 {
-		return fmt.Errorf("lifecycle_rule.transition: 'days', 'date' are mutually exclusive")
+		return errors.New("lifecycle_rule.transition: 'days', 'date' are mutually exclusive")
 	}
 
 	return nil

--- a/internal/services/object/bucket.go
+++ b/internal/services/object/bucket.go
@@ -532,6 +532,52 @@ func resourceBucketLifecycleUpdate(ctx context.Context, conn *s3.Client, d *sche
 			}
 		}
 
+		// NoncurrentVersionExpiration
+		noncurrentVersionExpiration := d.Get(fmt.Sprintf("lifecycle_rule.%d.noncurrent_version_expiration", i)).([]any)
+		if len(noncurrentVersionExpiration) > 0 && noncurrentVersionExpiration[0] != nil {
+			expiration := noncurrentVersionExpiration[0].(map[string]any)
+			i := &s3Types.NoncurrentVersionExpiration{}
+
+			if val, ok := expiration["noncurrent_days"].(int); ok && val > 0 {
+				noncurrentDays := int32(val)
+				i.NoncurrentDays = aws.Int32(noncurrentDays)
+			}
+
+			if val, ok := expiration["newer_noncurrent_versions"].(int); ok && val > 0 {
+				newerNoncurrentVersions := int32(val)
+				i.NewerNoncurrentVersions = aws.Int32(newerNoncurrentVersions)
+			}
+
+			rule.NoncurrentVersionExpiration = i
+		}
+
+		// NoncurrentVersionTransitions
+		noncurrentVersionTransitions := d.Get(fmt.Sprintf("lifecycle_rule.%d.noncurrent_version_transition", i)).(*schema.Set).List()
+		if len(noncurrentVersionTransitions) > 0 {
+			rule.NoncurrentVersionTransitions = []s3Types.NoncurrentVersionTransition{}
+
+			for _, transition := range noncurrentVersionTransitions {
+				transition := transition.(map[string]any)
+				i := s3Types.NoncurrentVersionTransition{}
+
+				if val, ok := transition["storage_class"].(string); ok && val != "" {
+					i.StorageClass = s3Types.TransitionStorageClass(val)
+				}
+
+				if val, ok := transition["noncurrent_days"].(int); ok && val > 0 {
+					noncurrentDays := int32(val)
+					i.NoncurrentDays = aws.Int32(noncurrentDays)
+				}
+
+				if val, ok := transition["newer_noncurrent_versions"].(int); ok && val > 0 {
+					newerNoncurrentVersions := int32(val)
+					i.NewerNoncurrentVersions = aws.Int32(newerNoncurrentVersions)
+				}
+
+				rule.NoncurrentVersionTransitions = append(rule.NoncurrentVersionTransitions, i)
+			}
+		}
+
 		rules = append(rules, rule)
 	}
 
@@ -934,6 +980,44 @@ func resourceBucketLifecycleRulesRead(
 				}
 
 				rule["transition"] = schema.NewSet(transitionHash, transitions)
+			}
+
+			// NonCurrentVersionExpiration
+			if lifecycleRule.NoncurrentVersionExpiration != nil {
+				e := make(map[string]any)
+				if lifecycleRule.NoncurrentVersionExpiration.NewerNoncurrentVersions != nil {
+					e["newer_noncurrent_versions"] = int(aws.ToInt32(lifecycleRule.NoncurrentVersionExpiration.NewerNoncurrentVersions))
+				}
+
+				if lifecycleRule.NoncurrentVersionExpiration.NoncurrentDays != nil {
+					e["noncurrent_days"] = int(aws.ToInt32(lifecycleRule.NoncurrentVersionExpiration.NoncurrentDays))
+				}
+
+				rule["noncurrent_version_expiration"] = []any{e}
+			}
+
+			// NonCurrentVersionTransition
+			if len(lifecycleRule.NoncurrentVersionTransitions) > 0 {
+				noncurrentTransitions := make([]any, 0, len(lifecycleRule.NoncurrentVersionTransitions))
+
+				for _, v := range lifecycleRule.NoncurrentVersionTransitions {
+					t := make(map[string]any)
+					if v.NoncurrentDays != nil {
+						t["noncurrent_days"] = int(aws.ToInt32(v.NoncurrentDays))
+					}
+
+					if v.NewerNoncurrentVersions != nil {
+						t["newer_noncurrent_versions"] = int(aws.ToInt32(v.NewerNoncurrentVersions))
+					}
+
+					if v.StorageClass != "" {
+						t["storage_class"] = string(v.StorageClass)
+					}
+
+					noncurrentTransitions = append(noncurrentTransitions, t)
+				}
+
+				rule["noncurrent_version_transition"] = schema.NewSet(noncurrentVersionTransitionHash, noncurrentTransitions)
 			}
 
 			lifecycleRules = append(lifecycleRules, rule)

--- a/internal/services/object/bucket_test.go
+++ b/internal/services/object/bucket_test.go
@@ -574,6 +574,31 @@ func TestAccObjectBucket_Lifecycle(t *testing.T) {
 	})
 }
 
+func TestAccObjectBucket_Lifecycle_removeRule(t *testing.T) {
+	tt := acctest.NewTestTools(t)
+	defer tt.Cleanup()
+
+	bucketLifecycle := sdkacctest.RandomWithPrefix("tf-tests-scaleway-object-bucket-lifecycle")
+	resourceNameLifecycle := "scaleway_object_bucket.main-bucket-lifecycle"
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: tt.ProviderFactories,
+		CheckDestroy:             objectchecks.IsBucketDestroyed(tt),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketLifecycleConfigurationConfig_removeRule(bucketLifecycle),
+				Check: resource.ComposeTestCheckFunc(
+					objectchecks.CheckBucketExists(tt, "scaleway_object_bucket.main-bucket-lifecycle", true),
+					testAccCheckObjectBucketLifecycleConfigurationExists(tt, resourceNameLifecycle),
+					resource.TestCheckResourceAttr("scaleway_object_bucket.main-bucket-lifecycle", "name", bucketLifecycle),
+					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.0.id", "expire delete markers"),
+					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.0.expiration.0.expired_object_delete_marker", "true"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccObjectBucket_ObjectLock(t *testing.T) {
 	tt := acctest.NewTestTools(t)
 	defer tt.Cleanup()
@@ -987,4 +1012,23 @@ func testAccCheckObjectBucketLifecycleConfigurationExists(tt *acctest.TestTools,
 
 		return nil
 	}
+}
+
+func testAccBucketLifecycleConfigurationConfig_removeRule(rName string) string {
+	return fmt.Sprintf(`
+resource "scaleway_object_bucket" "main-bucket-lifecycle" {
+	name = "%s"
+	region = "%s"
+	acl = "private"
+
+  lifecycle_rule {
+    id      = "expire delete markers"
+    enabled = true
+
+    expiration {
+      expired_object_delete_marker = true
+    }
+  }
+}
+`, rName, objectTestsMainRegion)
 }

--- a/internal/services/object/bucket_test.go
+++ b/internal/services/object/bucket_test.go
@@ -609,6 +609,7 @@ func TestAccObjectBucket_Lifecycle_removeRule(t *testing.T) {
 					resource.TestCheckResourceAttr("scaleway_object_bucket.main-bucket-lifecycle", "name", bucketLifecycle),
 					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.0.id", "expire delete markers"),
 					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.0.prefix", ""),
 					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.0.expiration.0.expired_object_delete_marker", "true"),
 				),
 			},
@@ -642,8 +643,8 @@ func TestAccObjectBucket_Lifecycle_EmptyFilter_NonCurrentVersions(t *testing.T) 
 					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.0.noncurrent_version_expiration.0.newer_noncurrent_versions", "2"),
 					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.0.noncurrent_version_expiration.0.noncurrent_days", "30"),
 
-					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.0.noncurrent_version_transition.0.noncurrent_days", "20"),
-					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.0.noncurrent_version_transition.0.storage_class", "STANDARD_IA"),
+					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.0.noncurrent_version_transition.0.noncurrent_days", "40"),
+					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.0.noncurrent_version_transition.0.storage_class", "ONEZONE_IA"),
 				),
 			},
 		},
@@ -1125,17 +1126,13 @@ resource "scaleway_object_bucket" "main-bucket-lifecycle" {
     object_size_greater_than = 30
     object_size_less_than = 500
 
-    expiration {
-      expired_object_delete_marker = true
-    }
-
     noncurrent_version_expiration {
       newer_noncurrent_versions = 2
       noncurrent_days           = 30
     }
 
     noncurrent_version_transition {
-      noncurrent_days = 20
+      noncurrent_days = 40
       storage_class   = "ONEZONE_IA"
     }
 

--- a/internal/services/object/bucket_test.go
+++ b/internal/services/object/bucket_test.go
@@ -401,6 +401,174 @@ func TestAccObjectBucket_Lifecycle(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.1.abort_incomplete_multipart_upload_days", "30"),
 				),
 			},
+			{
+				Config: fmt.Sprintf(`
+					resource "scaleway_object_bucket" "main-bucket-lifecycle" {
+					name = "%s"
+					region = "%s"
+
+					lifecycle_rule {
+						id      = "id1"
+						prefix  = "path1/"
+						enabled = true
+
+						expiration {
+							days = 365
+						}
+
+						transition {
+							days          = 30
+							storage_class = "ONEZONE_IA"
+						}
+
+						transition {
+							days          = 60
+							storage_class = "GLACIER"
+						}
+
+						transition {
+							days          = 90
+							storage_class = "ONEZONE_IA"
+						}
+
+						transition {
+							days          = 120
+							storage_class = "GLACIER"
+						}
+
+						transition {
+							days          = 210
+							storage_class = "ONEZONE_IA"
+						}
+					}
+
+					lifecycle_rule {
+						id      = "id2"
+						prefix  = "path2/"
+						enabled = true
+
+						expiration {
+							date = "2016-01-12"
+						}
+					}
+
+					lifecycle_rule {
+						id      = "id3"
+						prefix  = "path3/"
+						enabled = true
+
+						transition {
+							days          = 0
+							storage_class = "GLACIER"
+						}
+					}
+
+					lifecycle_rule {
+						id      = "id4"
+						prefix  = "path4/"
+						enabled = true
+
+						tags = {
+							"tagKey"    = "tagValue"
+							"terraform" = "hashicorp"
+						}
+
+						expiration {
+							date = "2016-01-12"
+						}
+					}
+
+					lifecycle_rule {
+						id      = "id5"
+						enabled = true
+
+						tags = {
+							"tagKey"    = "tagValue"
+							"terraform" = "hashicorp"
+						}
+
+						transition {
+							days          = 0
+							storage_class = "GLACIER"
+						}
+					}
+
+					lifecycle_rule {
+						id      = "id6"
+						enabled = true
+
+						tags = {
+							"tagKey" = "tagValue"
+						}
+
+						transition {
+							days          = 0
+							storage_class = "GLACIER"
+						}
+					}
+				}`, bucketLifecycle, objectTestsMainRegion),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					objectchecks.CheckBucketExists(tt, "scaleway_object_bucket.main-bucket-lifecycle", true),
+					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.#", "6"),
+					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.0.id", "id1"),
+					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.0.prefix", "path1/"),
+					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.0.expiration.0.days", "365"),
+					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.0.expiration.0.date", ""),
+					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.0.expiration.0.expired_object_delete_marker", "false"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceNameLifecycle, "lifecycle_rule.0.transition.*", map[string]string{
+						"date":          "hehe",
+						"days":          "30",
+						"storage_class": "ONEZONE_IA",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceNameLifecycle, "lifecycle_rule.0.transition.*", map[string]string{
+						"date":          "",
+						"days":          "60",
+						"storage_class": "GLACIER",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceNameLifecycle, "lifecycle_rule.0.transition.*", map[string]string{
+						"date":          "",
+						"days":          "90",
+						"storage_class": "ONEZONE_IA",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceNameLifecycle, "lifecycle_rule.0.transition.*", map[string]string{
+						"date":          "",
+						"days":          "120",
+						"storage_class": "GLACIER",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceNameLifecycle, "lifecycle_rule.0.transition.*", map[string]string{
+						"date":          "",
+						"days":          "210",
+						"storage_class": "ONEZONE_IA",
+					}),
+					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.1.id", "id2"),
+					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.1.prefix", "path2/"),
+					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.1.expiration.0.date", "2016-01-12"),
+					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.1.expiration.0.days", "0"),
+					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.1.expiration.0.expired_object_delete_marker", "false"),
+					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.2.id", "id3"),
+					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.2.prefix", "path3/"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceNameLifecycle, "lifecycle_rule.2.transition.*", map[string]string{
+						"days": "0",
+					}),
+					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.3.id", "id4"),
+					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.3.prefix", "path4/"),
+					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.3.tags.tagKey", "tagValue"),
+					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.3.tags.terraform", "hashicorp"),
+					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.4.id", "id5"),
+					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.4.tags.tagKey", "tagValue"),
+					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.4.tags.terraform", "hashicorp"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceNameLifecycle, "lifecycle_rule.4.transition.*", map[string]string{
+						"days":          "0",
+						"storage_class": "GLACIER",
+					}),
+					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.5.id", "id6"),
+					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.5.tags.tagKey", "tagValue"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceNameLifecycle, "lifecycle_rule.5.transition.*", map[string]string{
+						"days":          "0",
+						"storage_class": "GLACIER",
+					}),
+				),
+			},
 		},
 	})
 }

--- a/internal/services/object/bucket_test.go
+++ b/internal/services/object/bucket_test.go
@@ -1115,7 +1115,6 @@ resource "scaleway_object_bucket" "main-bucket-lifecycle" {
 `, rName, objectTestsMainRegion)
 }
 
-// FIXME: remove "expiration" bloc after my update
 func testAccBucketLifecycleConfigurationConfig_emptyFilterNonCurrentVersions(rName string) string {
 	return fmt.Sprintf(`
 resource "scaleway_object_bucket" "main-bucket-lifecycle" {

--- a/internal/services/object/bucket_test.go
+++ b/internal/services/object/bucket_test.go
@@ -458,7 +458,7 @@ func TestAccObjectBucket_Lifecycle(t *testing.T) {
 						enabled = true
 
 						transition {
-							days          = 0
+							days          = 130
 							storage_class = "GLACIER"
 						}
 					}
@@ -516,7 +516,7 @@ func TestAccObjectBucket_Lifecycle(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.0.expiration.0.date", ""),
 					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.0.expiration.0.expired_object_delete_marker", "false"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceNameLifecycle, "lifecycle_rule.0.transition.*", map[string]string{
-						"date":          "hehe",
+						"date":          "",
 						"days":          "30",
 						"storage_class": "ONEZONE_IA",
 					}),
@@ -548,8 +548,8 @@ func TestAccObjectBucket_Lifecycle(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.2.id", "id3"),
 					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.2.prefix", "path3/"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceNameLifecycle, "lifecycle_rule.2.transition.*", map[string]string{
-						"days":          "0",
-						"storage_class": "ONEZONE_IA",
+						"days":          "130",
+						"storage_class": "GLACIER",
 					}),
 					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.3.id", "id4"),
 					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.3.prefix", "path4/"),

--- a/internal/services/object/bucket_test.go
+++ b/internal/services/object/bucket_test.go
@@ -585,6 +585,23 @@ func TestAccObjectBucket_Lifecycle_removeRule(t *testing.T) {
 		CheckDestroy:             objectchecks.IsBucketDestroyed(tt),
 		Steps: []resource.TestStep{
 			{
+				Config: testAccBucketLifecycleConfigurationConfig_removeRule_Setup(bucketLifecycle),
+				Check: resource.ComposeTestCheckFunc(
+					objectchecks.CheckBucketExists(tt, "scaleway_object_bucket.main-bucket-lifecycle", true),
+					testAccCheckObjectBucketLifecycleConfigurationExists(tt, resourceNameLifecycle),
+					resource.TestCheckResourceAttr("scaleway_object_bucket.main-bucket-lifecycle", "name", bucketLifecycle),
+
+					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.0.id", "to delete"),
+					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.0.prefix", "prefix/"),
+					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.0.expiration.0.days", "1"),
+
+					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.1.id", "expire delete markers"),
+					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.1.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.1.expiration.0.expired_object_delete_marker", "true"),
+				),
+			},
+			{
 				Config: testAccBucketLifecycleConfigurationConfig_removeRule(bucketLifecycle),
 				Check: resource.ComposeTestCheckFunc(
 					objectchecks.CheckBucketExists(tt, "scaleway_object_bucket.main-bucket-lifecycle", true),
@@ -1012,6 +1029,35 @@ func testAccCheckObjectBucketLifecycleConfigurationExists(tt *acctest.TestTools,
 
 		return nil
 	}
+}
+
+func testAccBucketLifecycleConfigurationConfig_removeRule_Setup(rName string) string {
+	return fmt.Sprintf(`
+resource "scaleway_object_bucket" "main-bucket-lifecycle" {
+	name = "%s"
+	region = "%s"
+	acl = "private"
+
+  lifecycle_rule {
+    id     = "to delete"
+	enabled = true
+    prefix = "prefix/"
+
+    expiration {
+      days = 1
+    }
+  }
+
+  lifecycle_rule {
+    id     = "expire delete markers"
+	enabled = true
+
+    expiration {
+      expired_object_delete_marker = true
+    }
+  }
+}
+`, rName, objectTestsMainRegion)
 }
 
 func testAccBucketLifecycleConfigurationConfig_removeRule(rName string) string {

--- a/internal/services/object/bucket_test.go
+++ b/internal/services/object/bucket_test.go
@@ -643,6 +643,7 @@ func TestAccObjectBucket_Lifecycle_EmptyFilter_NonCurrentVersions(t *testing.T) 
 					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.0.noncurrent_version_expiration.0.newer_noncurrent_versions", "2"),
 					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.0.noncurrent_version_expiration.0.noncurrent_days", "30"),
 
+					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.0.noncurrent_version_transition.0.newer_noncurrent_versions", "5"),
 					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.0.noncurrent_version_transition.0.noncurrent_days", "40"),
 					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.0.noncurrent_version_transition.0.storage_class", "ONEZONE_IA"),
 				),
@@ -1132,8 +1133,9 @@ resource "scaleway_object_bucket" "main-bucket-lifecycle" {
     }
 
     noncurrent_version_transition {
-      noncurrent_days = 40
-      storage_class   = "ONEZONE_IA"
+      newer_noncurrent_versions = 5
+      noncurrent_days           = 40
+      storage_class            	= "ONEZONE_IA"
     }
 
     enabled = true

--- a/internal/services/object/bucket_test.go
+++ b/internal/services/object/bucket_test.go
@@ -616,6 +616,40 @@ func TestAccObjectBucket_Lifecycle_removeRule(t *testing.T) {
 	})
 }
 
+func TestAccObjectBucket_Lifecycle_EmptyFilter_NonCurrentVersions(t *testing.T) {
+	tt := acctest.NewTestTools(t)
+	defer tt.Cleanup()
+
+	bucketLifecycle := sdkacctest.RandomWithPrefix("tf-tests-scaleway-object-bucket")
+	resourceNameLifecycle := "scaleway_object_bucket.main-bucket-lifecycle"
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: tt.ProviderFactories,
+		CheckDestroy:             objectchecks.IsBucketDestroyed(tt),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketLifecycleConfigurationConfig_emptyFilterNonCurrentVersions(bucketLifecycle),
+				Check: resource.ComposeTestCheckFunc(
+					objectchecks.CheckBucketExists(tt, resourceNameLifecycle, true),
+					testAccCheckObjectBucketLifecycleConfigurationExists(tt, resourceNameLifecycle),
+					resource.TestCheckResourceAttr(resourceNameLifecycle, "name", bucketLifecycle),
+
+					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.0.id", "noncurrent_versions_rule"),
+					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.0.prefix", ""),
+					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.0.object_size_greater_than", "30"),
+					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.0.object_size_less_than", "500"),
+
+					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.0.noncurrent_version_expiration.0.newer_noncurrent_versions", "2"),
+					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.0.noncurrent_version_expiration.0.noncurrent_days", "30"),
+
+					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.0.noncurrent_version_transition.0.noncurrent_days", "20"),
+					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.0.noncurrent_version_transition.0.storage_class", "STANDARD_IA"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccObjectBucket_ObjectLock(t *testing.T) {
 	tt := acctest.NewTestTools(t)
 	defer tt.Cleanup()
@@ -1075,6 +1109,43 @@ resource "scaleway_object_bucket" "main-bucket-lifecycle" {
       expired_object_delete_marker = true
     }
   }
+}
+`, rName, objectTestsMainRegion)
+}
+
+// FIXME: remove "expiration" bloc after my update
+func testAccBucketLifecycleConfigurationConfig_emptyFilterNonCurrentVersions(rName string) string {
+	return fmt.Sprintf(`
+resource "scaleway_object_bucket" "main-bucket-lifecycle" {
+  name = "%s"
+  region = "%s"
+
+  lifecycle_rule {
+    id = "noncurrent_versions_rule"
+    object_size_greater_than = 30
+    object_size_less_than = 500
+
+    expiration {
+      expired_object_delete_marker = true
+    }
+
+    noncurrent_version_expiration {
+      newer_noncurrent_versions = 2
+      noncurrent_days           = 30
+    }
+
+    noncurrent_version_transition {
+      noncurrent_days = 20
+      storage_class   = "ONEZONE_IA"
+    }
+
+    enabled = true
+  }
+}
+
+resource "scaleway_object_bucket_acl" "main" {
+  bucket = scaleway_object_bucket.main-bucket-lifecycle.id
+  acl    = "private"
 }
 `, rName, objectTestsMainRegion)
 }

--- a/internal/services/object/bucket_test.go
+++ b/internal/services/object/bucket_test.go
@@ -144,7 +144,7 @@ func TestAccObjectBucket_Lifecycle(t *testing.T) {
 						  		days = 365
 							}
 							transition {
-								days          = 30
+								days          = 90
 								storage_class = "GLACIER"
 							}
 						}
@@ -158,7 +158,7 @@ func TestAccObjectBucket_Lifecycle(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.0.prefix", "path1/"),
 					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.0.expiration.0.days", "365"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceNameLifecycle, "lifecycle_rule.0.transition.*", map[string]string{
-						"days":          "30",
+						"days":          "90",
 						"storage_class": "GLACIER",
 					}),
 				),
@@ -199,7 +199,7 @@ func TestAccObjectBucket_Lifecycle(t *testing.T) {
 			},
 			{
 				Config: fmt.Sprintf(`
-						resource "scaleway_object_bucket" "main-bucket-lifecycle"{
+						resource "scaleway_object_bucket" "main-bucket-lifecycle" {
 							name = "%s"
 							region = "%s"
 							acl = "private"
@@ -247,7 +247,7 @@ func TestAccObjectBucket_Lifecycle(t *testing.T) {
 								  	"terraform" = "hashicorp"
 								}
 								transition {
-								  	days          = 1
+								  	days          = 101
 								  	storage_class = "GLACIER"
 								}
 							}
@@ -259,7 +259,7 @@ func TestAccObjectBucket_Lifecycle(t *testing.T) {
 								  	"tagKey" = "tagValue"
 								}
 								transition {
-								  	days          = 1
+								  	days          = 102
 								  	storage_class = "GLACIER"
 								}
 							}
@@ -287,13 +287,13 @@ func TestAccObjectBucket_Lifecycle(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.3.tags.tagKey", "tagValue"),
 					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.3.tags.terraform", "hashicorp"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceNameLifecycle, "lifecycle_rule.3.transition.*", map[string]string{
-						"days":          "1",
+						"days":          "101",
 						"storage_class": "GLACIER",
 					}),
 					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.4.id", "id5"),
 					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.4.tags.tagKey", "tagValue"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceNameLifecycle, "lifecycle_rule.4.transition.*", map[string]string{
-						"days":          "1",
+						"days":          "102",
 						"storage_class": "GLACIER",
 					}),
 				),
@@ -374,8 +374,8 @@ func TestAccObjectBucket_Lifecycle(t *testing.T) {
 			{
 				Config: fmt.Sprintf(`
 						resource "scaleway_object_bucket" "main-bucket-lifecycle" {
-							name                = "%s"
-							region = "%s"
+							name           		= "%s"
+							region 				= "%s"
 							object_lock_enabled = true
 
 							lifecycle_rule {
@@ -422,7 +422,7 @@ func TestAccObjectBucket_Lifecycle(t *testing.T) {
 						}
 
 						transition {
-							days          = 60
+							days          = 95
 							storage_class = "GLACIER"
 						}
 
@@ -488,7 +488,7 @@ func TestAccObjectBucket_Lifecycle(t *testing.T) {
 						}
 
 						transition {
-							days          = 0
+							days          = 155
 							storage_class = "GLACIER"
 						}
 					}
@@ -502,7 +502,7 @@ func TestAccObjectBucket_Lifecycle(t *testing.T) {
 						}
 
 						transition {
-							days          = 0
+							days          = 156
 							storage_class = "GLACIER"
 						}
 					}
@@ -522,7 +522,7 @@ func TestAccObjectBucket_Lifecycle(t *testing.T) {
 					}),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceNameLifecycle, "lifecycle_rule.0.transition.*", map[string]string{
 						"date":          "",
-						"days":          "60",
+						"days":          "95",
 						"storage_class": "GLACIER",
 					}),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceNameLifecycle, "lifecycle_rule.0.transition.*", map[string]string{
@@ -548,7 +548,8 @@ func TestAccObjectBucket_Lifecycle(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.2.id", "id3"),
 					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.2.prefix", "path3/"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceNameLifecycle, "lifecycle_rule.2.transition.*", map[string]string{
-						"days": "0",
+						"days":          "0",
+						"storage_class": "ONEZONE_IA",
 					}),
 					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.3.id", "id4"),
 					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.3.prefix", "path4/"),
@@ -558,13 +559,13 @@ func TestAccObjectBucket_Lifecycle(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.4.tags.tagKey", "tagValue"),
 					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.4.tags.terraform", "hashicorp"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceNameLifecycle, "lifecycle_rule.4.transition.*", map[string]string{
-						"days":          "0",
+						"days":          "155",
 						"storage_class": "GLACIER",
 					}),
 					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.5.id", "id6"),
 					resource.TestCheckResourceAttr(resourceNameLifecycle, "lifecycle_rule.5.tags.tagKey", "tagValue"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceNameLifecycle, "lifecycle_rule.5.transition.*", map[string]string{
-						"days":          "0",
+						"days":          "156",
 						"storage_class": "GLACIER",
 					}),
 				),

--- a/internal/services/object/data_source_object_bucket_policy.go
+++ b/internal/services/object/data_source_object_bucket_policy.go
@@ -65,7 +65,7 @@ func DataSourceObjectBucketPolicyRead(ctx context.Context, d *schema.ResourceDat
 	}
 
 	policyString := "{}"
-	if err == nil && policy.Policy != nil {
+	if policy.Policy != nil {
 		policyString = aws.ToString(policy.Policy)
 	}
 

--- a/internal/services/object/helpers_object.go
+++ b/internal/services/object/helpers_object.go
@@ -585,6 +585,30 @@ func transitionHash(v any) int {
 	return types.StringHashcode(buf.String())
 }
 
+func noncurrentVersionTransitionHash(v any) int {
+	var buf bytes.Buffer
+
+	m, ok := v.(map[string]any)
+
+	if !ok {
+		return 0
+	}
+
+	if v, ok := m["noncurrent_days"]; ok {
+		buf.WriteString(fmt.Sprintf("%d-", v.(int)))
+	}
+
+	if v, ok := m["newer_noncurrent_versions"]; ok {
+		buf.WriteString(fmt.Sprintf("%d-", v.(int)))
+	}
+
+	if v, ok := m["storage_class"]; ok {
+		buf.WriteString(v.(string) + "-")
+	}
+
+	return types.StringHashcode(buf.String())
+}
+
 const (
 	// TransitionStorageClassStandard is a TransitionStorageClass enum value
 	TransitionStorageClassStandard = "STANDARD"

--- a/internal/services/object/testdata/object-bucket-basic.cassette.yaml
+++ b/internal/services/object/testdata/object-bucket-basic.cassette.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -18,7 +18,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 573699e4-0762-4fd4-b64f-c8773fbf0733
+                - 4bc9eff7-f2d4-423e-bd3d-c3cacb8119b8
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -26,8 +26,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124825Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud/
+                - 20260518T133517Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.nl-ams.scw.cloud/
         method: PUT
       response:
         proto: HTTP/2.0
@@ -42,16 +42,16 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 12 May 2026 12:48:25 GMT
+                - Mon, 18 May 2026 13:35:17 GMT
             Location:
-                - /tf-tests-scaleway-object-bucket-secondary-2001388040591926415
+                - /tf-tests-scaleway-object-bucket-secondary-238236636660294517
             X-Amz-Id-2:
-                - txgb29acf986aff425b8986-006a032199
+                - txg8ac1cef061034b339689-006a0b1595
             X-Amz-Request-Id:
-                - txgb29acf986aff425b8986-006a032199
+                - txg8ac1cef061034b339689-006a0b1595
         status: 200 OK
         code: 200
-        duration: 3.92880225s
+        duration: 4.523735083s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -60,7 +60,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -69,7 +69,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - abb5af1c-50c1-4d4f-a141-f40ee531c52a
+                - 3d8af556-4e48-4c84-9df0-a67767b5298a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -77,8 +77,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124825Z
-        url: https://tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud/
+                - 20260518T133517Z
+        url: https://tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud/
         method: PUT
       response:
         proto: HTTP/2.0
@@ -93,34 +93,85 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 12 May 2026 12:48:25 GMT
+                - Mon, 18 May 2026 13:35:17 GMT
             Location:
-                - /tf-tests-scaleway-object-bucket-main-region-652097813215812252
+                - /tf-tests-scaleway-object-bucket-basic-4974415671304108720
             X-Amz-Id-2:
-                - txgfd2ea3ea59fe427c95ae-006a032199
+                - txg4be0df87805f434fb0a0-006a0b1595
             X-Amz-Request-Id:
-                - txgfd2ea3ea59fe427c95ae-006a032199
+                - txg4be0df87805f434fb0a0-006a0b1595
         status: 200 OK
         code: 200
-        duration: 3.95795575s
+        duration: 4.526262167s
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 170
+        content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-main-region-7696764886433866557.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
-        body: <Tagging xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><TagSet><Tag><Key>foo</Key><Value>bar</Value></Tag><Tag><Key>baz</Key><Value>qux</Value></Tag></TagSet></Tagging>
+        body: ""
         form: {}
         headers:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 2a8e036b-6af0-4d32-b09a-8b7a83dc7cb1
+                - b8491fb0-8617-4687-b2c8-c8cc76eca4d3
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T133517Z
+        url: https://tf-tests-scaleway-object-bucket-main-region-7696764886433866557.s3.fr-par.scw.cloud/
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Length:
+                - "0"
+            Date:
+                - Mon, 18 May 2026 13:35:17 GMT
+            Location:
+                - /tf-tests-scaleway-object-bucket-main-region-7696764886433866557
+            X-Amz-Id-2:
+                - txgeaa14fef0f804d54946c-006a0b1595
+            X-Amz-Request-Id:
+                - txgeaa14fef0f804d54946c-006a0b1595
+        status: 200 OK
+        code: 200
+        duration: 4.526455667s
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 127
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: <Tagging xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><TagSet><Tag><Key>foo</Key><Value>bar</Value></Tag></TagSet></Tagging>
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 52411691-b629-466b-ae67-82b872562e07
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
@@ -128,12 +179,12 @@ interactions:
             User-Agent:
                 - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,Z,e
             X-Amz-Checksum-Crc32:
-                - Vm9bWA==
+                - Y9NeVA==
             X-Amz-Content-Sha256:
-                - 2b07a62db7be0f847b7208b34535d7acbbfec23ff29c04b5ca0176500fb16a32
+                - d68cba1a39d89eb72e49b2e5b04058846b60e88e6e32eae42901c4f57a4727a8
             X-Amz-Date:
-                - 20260512T124825Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T133517Z
+        url: https://tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud/?tagging=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -148,98 +199,45 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 12 May 2026 12:48:29 GMT
+                - Mon, 18 May 2026 13:35:21 GMT
             X-Amz-Id-2:
-                - txgb896d145c18b4b24b915-006a03219d
+                - txg1ffdb430aae942bf8e11-006a0b1599
             X-Amz-Request-Id:
-                - txgb896d145c18b4b24b915-006a03219d
+                - txg1ffdb430aae942bf8e11-006a0b1599
         status: 200 OK
         code: 200
-        duration: 69.724542ms
-    - id: 3
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 298a01db-d20e-4b43-b05b-a26298844a98
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,Z,e
-            X-Amz-Acl:
-                - private
-            X-Amz-Checksum-Crc32:
-                - AAAAAA==
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260512T124829Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud/?acl=
-        method: PUT
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 0
-        uncompressed: false
-        body: ""
-        headers:
-            Content-Length:
-                - "0"
-            Date:
-                - Tue, 12 May 2026 12:48:29 GMT
-            X-Amz-Id-2:
-                - txg148d68db49b24131ac62-006a03219d
-            X-Amz-Request-Id:
-                - txg148d68db49b24131ac62-006a03219d
-        status: 200 OK
-        code: 200
-        duration: 101.602209ms
+        duration: 48.125417ms
     - id: 4
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 170
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: <Tagging xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><TagSet><Tag><Key>baz</Key><Value>qux</Value></Tag><Tag><Key>foo</Key><Value>bar</Value></Tag></TagSet></Tagging>
         form: {}
         headers:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 86f29e78-e80f-4bc9-a3e3-abd432ab3c07
+                - 90c80756-c6d5-40b8-9303-9b63d8963420
             Amz-Sdk-Request:
                 - attempt=1; max=3
+            Content-Type:
+                - application/xml
             User-Agent:
                 - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,Z,e
-            X-Amz-Acl:
-                - private
             X-Amz-Checksum-Crc32:
-                - AAAAAA==
+                - e//g+w==
             X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+                - beb187c83e402aff34c9df8040ea088d93355ea5f38d5107ef606e64de31a28e
             X-Amz-Date:
-                - 20260512T124829Z
-        url: https://tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud/?acl=
+                - 20260518T133517Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.nl-ams.scw.cloud/?tagging=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -254,14 +252,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 12 May 2026 12:48:29 GMT
+                - Mon, 18 May 2026 13:35:21 GMT
             X-Amz-Id-2:
-                - txgc8fa3dfdc86a4dff8e52-006a03219d
+                - txg09fe98e6a4a94f0a8b7a-006a0b1599
             X-Amz-Request-Id:
-                - txgc8fa3dfdc86a4dff8e52-006a03219d
+                - txg09fe98e6a4a94f0a8b7a-006a0b1599
         status: 200 OK
         code: 200
-        duration: 143.137666ms
+        duration: 91.014ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -270,7 +268,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -279,684 +277,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 339f86ca-44da-4207-b47f-06feffd74e56
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260512T124829Z
-        url: https://tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud/?acl=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 698
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
-        headers:
-            Content-Length:
-                - "698"
-            Content-Type:
-                - text/xml; charset=utf-8
-            Date:
-                - Tue, 12 May 2026 12:48:29 GMT
-            X-Amz-Id-2:
-                - txg8c642a8f4b054cbdb138-006a03219d
-            X-Amz-Request-Id:
-                - txg8c642a8f4b054cbdb138-006a03219d
-        status: 200 OK
-        code: 200
-        duration: 57.01275ms
-    - id: 6
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - f28721d0-c7f3-41aa-875f-05911665abd5
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260512T124825Z
-        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/
-        method: PUT
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 0
-        uncompressed: false
-        body: ""
-        headers:
-            Content-Length:
-                - "0"
-            Date:
-                - Tue, 12 May 2026 12:48:25 GMT
-            Location:
-                - /tf-tests-scaleway-object-bucket-basic-1314313384735080249
-            X-Amz-Id-2:
-                - txg67f98d458e714f54b459-006a032199
-            X-Amz-Request-Id:
-                - txg67f98d458e714f54b459-006a032199
-        status: 200 OK
-        code: 200
-        duration: 4.162291667s
-    - id: 7
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 1f58cd7c-d1e7-494b-8b37-d88332737c32
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260512T124829Z
-        url: https://tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud/?object-lock=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 331
-        uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg95e14725d5444f67b2db-006a03219d</RequestId><HostId>txg95e14725d5444f67b2db-006a03219d</HostId><Resource>/tf-tests-scaleway-object-bucket-main-region-652097813215812252</Resource></Error>
-        headers:
-            Content-Length:
-                - "331"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 12 May 2026 12:48:29 GMT
-            X-Amz-Id-2:
-                - txg95e14725d5444f67b2db-006a03219d
-            X-Amz-Request-Id:
-                - txg95e14725d5444f67b2db-006a03219d
-        status: 404 Not Found
-        code: 404
-        duration: 30.436167ms
-    - id: 8
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 170
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: <Tagging xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><TagSet><Tag><Key>foo</Key><Value>bar</Value></Tag><Tag><Key>baz</Key><Value>qux</Value></Tag></TagSet></Tagging>
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 8d372aef-f7d2-4e4e-a35d-197884c3c01d
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            Content-Type:
-                - application/xml
-            User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,Z,e
-            X-Amz-Checksum-Crc32:
-                - Vm9bWA==
-            X-Amz-Content-Sha256:
-                - 2b07a62db7be0f847b7208b34535d7acbbfec23ff29c04b5ca0176500fb16a32
-            X-Amz-Date:
-                - 20260512T124829Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud/?tagging=
-        method: PUT
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 0
-        uncompressed: false
-        body: ""
-        headers:
-            Content-Length:
-                - "0"
-            Date:
-                - Tue, 12 May 2026 12:48:29 GMT
-            X-Amz-Id-2:
-                - txg3aa3d0e16a28438d9782-006a03219d
-            X-Amz-Request-Id:
-                - txg3aa3d0e16a28438d9782-006a03219d
-        status: 200 OK
-        code: 200
-        duration: 133.322042ms
-    - id: 9
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 282d2125-af86-4e0b-8403-f946f5852075
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260512T124829Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud/?acl=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 698
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
-        headers:
-            Content-Length:
-                - "698"
-            Content-Type:
-                - text/xml; charset=utf-8
-            Date:
-                - Tue, 12 May 2026 12:48:29 GMT
-            X-Amz-Id-2:
-                - txg05e56d33539d4f028535-006a03219d
-            X-Amz-Request-Id:
-                - txg05e56d33539d4f028535-006a03219d
-        status: 200 OK
-        code: 200
-        duration: 40.48425ms
-    - id: 10
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 127
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: <Tagging xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><TagSet><Tag><Key>foo</Key><Value>bar</Value></Tag></TagSet></Tagging>
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 77301101-89aa-4732-a3c2-bf8575f12854
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            Content-Type:
-                - application/xml
-            User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,Z,e
-            X-Amz-Checksum-Crc32:
-                - Y9NeVA==
-            X-Amz-Content-Sha256:
-                - d68cba1a39d89eb72e49b2e5b04058846b60e88e6e32eae42901c4f57a4727a8
-            X-Amz-Date:
-                - 20260512T124825Z
-        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?tagging=
-        method: PUT
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 0
-        uncompressed: false
-        body: ""
-        headers:
-            Content-Length:
-                - "0"
-            Date:
-                - Tue, 12 May 2026 12:48:29 GMT
-            X-Amz-Id-2:
-                - txg7fe79c0f47b34d078e45-006a03219d
-            X-Amz-Request-Id:
-                - txg7fe79c0f47b34d078e45-006a03219d
-        status: 200 OK
-        code: 200
-        duration: 152.934083ms
-    - id: 11
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - fa790782-a8ff-42d7-b44a-ef44b1abea54
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260512T124829Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud/?object-lock=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 330
-        uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg389aeb72fdba44baa57e-006a03219d</RequestId><HostId>txg389aeb72fdba44baa57e-006a03219d</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-2001388040591926415</Resource></Error>
-        headers:
-            Content-Length:
-                - "330"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 12 May 2026 12:48:29 GMT
-            X-Amz-Id-2:
-                - txg389aeb72fdba44baa57e-006a03219d
-            X-Amz-Request-Id:
-                - txg389aeb72fdba44baa57e-006a03219d
-        status: 404 Not Found
-        code: 404
-        duration: 59.722083ms
-    - id: 12
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 151bbcc6-39b7-4a6b-9ac7-cd853d9812ba
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260512T124829Z
-        url: https://tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud/
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 288
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-main-region-652097813215812252</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
-        headers:
-            Content-Length:
-                - "288"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 12 May 2026 12:48:29 GMT
-            X-Amz-Id-2:
-                - txg1021f4bb728f4929a6bf-006a03219d
-            X-Amz-Request-Id:
-                - txg1021f4bb728f4929a6bf-006a03219d
-        status: 200 OK
-        code: 200
-        duration: 146.207958ms
-    - id: 13
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - fd171cde-d6c5-4308-89b9-10c308aafb50
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260512T124829Z
-        url: https://tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud/?tagging=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 363
-        uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg9747bdb9881d45bea3ca-006a03219d</RequestId><HostId>txg9747bdb9881d45bea3ca-006a03219d</HostId><Resource>/tf-tests-scaleway-object-bucket-main-region-652097813215812252</Resource><BucketName>tf-tests-scaleway-object-bucket-main-region-652097813215812252</BucketName></Error>
-        headers:
-            Content-Length:
-                - "363"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 12 May 2026 12:48:29 GMT
-            X-Amz-Id-2:
-                - txg9747bdb9881d45bea3ca-006a03219d
-            X-Amz-Request-Id:
-                - txg9747bdb9881d45bea3ca-006a03219d
-        status: 404 Not Found
-        code: 404
-        duration: 23.162083ms
-    - id: 14
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 45094365-2be5-424b-a50d-dffe38c37020
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260512T124829Z
-        url: https://tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud/?cors=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 299
-        uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txge65900813ba14aae8586-006a03219d</RequestId><HostId>txge65900813ba14aae8586-006a03219d</HostId><Resource>/tf-tests-scaleway-object-bucket-main-region-652097813215812252</Resource></Error>
-        headers:
-            Content-Length:
-                - "299"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 12 May 2026 12:48:29 GMT
-            X-Amz-Id-2:
-                - txge65900813ba14aae8586-006a03219d
-            X-Amz-Request-Id:
-                - txge65900813ba14aae8586-006a03219d
-        status: 404 Not Found
-        code: 404
-        duration: 18.228125ms
-    - id: 15
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - ccbbf74b-5b8b-4565-a2ae-dce44342f808
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260512T124829Z
-        url: https://tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud/?versioning=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 107
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <VersioningConfiguration><Status></Status></VersioningConfiguration>
-        headers:
-            Content-Length:
-                - "107"
-            Content-Type:
-                - text/xml; charset=utf-8
-            Date:
-                - Tue, 12 May 2026 12:48:29 GMT
-            X-Amz-Id-2:
-                - txg83709f4cc1d745e0b905-006a03219d
-            X-Amz-Request-Id:
-                - txg83709f4cc1d745e0b905-006a03219d
-        status: 200 OK
-        code: 200
-        duration: 14.153875ms
-    - id: 16
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 74bed6b1-b2f0-482c-bc9b-10fbfbc165b2
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260512T124829Z
-        url: https://tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud/?lifecycle=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 396
-        uncompressed: false
-        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txg36b07d8394994e92a315-006a03219d</RequestId><HostId>txg36b07d8394994e92a315-006a03219d</HostId><Resource>/tf-tests-scaleway-object-bucket-main-region-652097813215812252</Resource><BucketName>tf-tests-scaleway-object-bucket-main-region-652097813215812252</BucketName></Error>
-        headers:
-            Content-Length:
-                - "396"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 12 May 2026 12:48:29 GMT
-            X-Amz-Id-2:
-                - txg36b07d8394994e92a315-006a03219d
-            X-Amz-Request-Id:
-                - txg36b07d8394994e92a315-006a03219d
-        status: 404 Not Found
-        code: 404
-        duration: 48.839833ms
-    - id: 17
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 5f54e247-9780-4d66-ba29-394650471954
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260512T124829Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud/
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 287
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-secondary-2001388040591926415</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
-        headers:
-            Content-Length:
-                - "287"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 12 May 2026 12:48:29 GMT
-            X-Amz-Id-2:
-                - txg652745a5422340c2b89c-006a03219d
-            X-Amz-Request-Id:
-                - txg652745a5422340c2b89c-006a03219d
-        status: 200 OK
-        code: 200
-        duration: 110.7125ms
-    - id: 18
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 302bccb5-72fe-4242-ac9b-5f55cd09089e
+                - d649bc15-4706-4ef8-8b35-a0e683dccf1d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -968,8 +289,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124829Z
-        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?acl=
+                - 20260518T133521Z
+        url: https://tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud/?acl=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -984,15 +305,15 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 12 May 2026 12:48:29 GMT
+                - Mon, 18 May 2026 13:35:21 GMT
             X-Amz-Id-2:
-                - txgc27c6cf7700d42a9927e-006a03219d
+                - txgae12843ead0641c8ad39-006a0b1599
             X-Amz-Request-Id:
-                - txgc27c6cf7700d42a9927e-006a03219d
+                - txgae12843ead0641c8ad39-006a0b1599
         status: 200 OK
         code: 200
-        duration: 140.345125ms
-    - id: 19
+        duration: 121.117084ms
+    - id: 6
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1000,7 +321,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-main-region-7696764886433866557.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1009,7 +330,113 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 2ae8654c-2bab-4f64-9697-786bc55fe86d
+                - 04f1f8cd-dc6c-4dc2-b61c-5b8ebed8d729
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,Z,e
+            X-Amz-Acl:
+                - private
+            X-Amz-Checksum-Crc32:
+                - AAAAAA==
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T133521Z
+        url: https://tf-tests-scaleway-object-bucket-main-region-7696764886433866557.s3.fr-par.scw.cloud/?acl=
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Length:
+                - "0"
+            Date:
+                - Mon, 18 May 2026 13:35:21 GMT
+            X-Amz-Id-2:
+                - txg8485003b0d0846fea7bd-006a0b1599
+            X-Amz-Request-Id:
+                - txg8485003b0d0846fea7bd-006a0b1599
+        status: 200 OK
+        code: 200
+        duration: 179.379209ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - a28a9fa9-db2f-4add-a394-0b28ddb587ba
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,Z,e
+            X-Amz-Acl:
+                - private
+            X-Amz-Checksum-Crc32:
+                - AAAAAA==
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T133521Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.nl-ams.scw.cloud/?acl=
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Length:
+                - "0"
+            Date:
+                - Mon, 18 May 2026 13:35:21 GMT
+            X-Amz-Id-2:
+                - txg9e1942b2145e432ba93b-006a0b1599
+            X-Amz-Request-Id:
+                - txg9e1942b2145e432ba93b-006a0b1599
+        status: 200 OK
+        code: 200
+        duration: 105.405ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-main-region-7696764886433866557.s3.fr-par.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - ffc1f814-535c-4dbd-aa32-5afd99719ed0
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1017,8 +444,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124829Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T133521Z
+        url: https://tf-tests-scaleway-object-bucket-main-region-7696764886433866557.s3.fr-par.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1026,26 +453,26 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 161
+        content_length: 698
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Tagging><TagSet><Tag><Key>foo</Key><Value>bar</Value></Tag><Tag><Key>baz</Key><Value>qux</Value></Tag></TagSet></Tagging>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
-                - "161"
+                - "698"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 12:48:29 GMT
+                - Mon, 18 May 2026 13:35:21 GMT
             X-Amz-Id-2:
-                - txg62d0e4cf458049828c2a-006a03219d
+                - txg7d82aba420224fcda211-006a0b1599
             X-Amz-Request-Id:
-                - txg62d0e4cf458049828c2a-006a03219d
+                - txg7d82aba420224fcda211-006a0b1599
         status: 200 OK
         code: 200
-        duration: 35.47225ms
-    - id: 20
+        duration: 32.797834ms
+    - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1053,7 +480,7 @@ interactions:
         content_length: 127
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: <Tagging xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><TagSet><Tag><Key>foo</Key><Value>bar</Value></Tag></TagSet></Tagging>
@@ -1062,7 +489,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7c34488e-edf7-4513-be13-5a9c527bd9c0
+                - 54640cfc-a57c-4c14-9914-be09c26a3e9a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
@@ -1074,8 +501,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - d68cba1a39d89eb72e49b2e5b04058846b60e88e6e32eae42901c4f57a4727a8
             X-Amz-Date:
-                - 20260512T124829Z
-        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?tagging=
+                - 20260518T133521Z
+        url: https://tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud/?tagging=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -1090,14 +517,589 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 12 May 2026 12:48:29 GMT
+                - Mon, 18 May 2026 13:35:21 GMT
             X-Amz-Id-2:
-                - txg78462a1d4f4c4ec3b933-006a03219d
+                - txgf99f7c279f7047829647-006a0b1599
             X-Amz-Request-Id:
-                - txg78462a1d4f4c4ec3b933-006a03219d
+                - txgf99f7c279f7047829647-006a0b1599
         status: 200 OK
         code: 200
-        duration: 48.416541ms
+        duration: 41.4775ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-main-region-7696764886433866557.s3.fr-par.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 934b20aa-0b0b-41f5-83b8-d29a88fffd8e
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T133521Z
+        url: https://tf-tests-scaleway-object-bucket-main-region-7696764886433866557.s3.fr-par.scw.cloud/?object-lock=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 332
+        uncompressed: false
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg8fa84d9d5d314c698d10-006a0b1599</RequestId><HostId>txg8fa84d9d5d314c698d10-006a0b1599</HostId><Resource>/tf-tests-scaleway-object-bucket-main-region-7696764886433866557</Resource></Error>
+        headers:
+            Content-Length:
+                - "332"
+            Content-Type:
+                - application/xml
+            Date:
+                - Mon, 18 May 2026 13:35:21 GMT
+            X-Amz-Id-2:
+                - txg8fa84d9d5d314c698d10-006a0b1599
+            X-Amz-Request-Id:
+                - txg8fa84d9d5d314c698d10-006a0b1599
+        status: 404 Not Found
+        code: 404
+        duration: 25.9975ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 170
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: <Tagging xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><TagSet><Tag><Key>baz</Key><Value>qux</Value></Tag><Tag><Key>foo</Key><Value>bar</Value></Tag></TagSet></Tagging>
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - cc507f68-4c35-4d8b-a1ca-5b5467f71b8e
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            Content-Type:
+                - application/xml
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,Z,e
+            X-Amz-Checksum-Crc32:
+                - e//g+w==
+            X-Amz-Content-Sha256:
+                - beb187c83e402aff34c9df8040ea088d93355ea5f38d5107ef606e64de31a28e
+            X-Amz-Date:
+                - 20260518T133521Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.nl-ams.scw.cloud/?tagging=
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Length:
+                - "0"
+            Date:
+                - Mon, 18 May 2026 13:35:21 GMT
+            X-Amz-Id-2:
+                - txg8509d0b5c3da481381a4-006a0b1599
+            X-Amz-Request-Id:
+                - txg8509d0b5c3da481381a4-006a0b1599
+        status: 200 OK
+        code: 200
+        duration: 96.115292ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - b74365f9-14bc-473b-b7d5-c2a30660e24e
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T133521Z
+        url: https://tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud/?acl=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 698
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+        headers:
+            Content-Length:
+                - "698"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Mon, 18 May 2026 13:35:21 GMT
+            X-Amz-Id-2:
+                - txgea53cbe414d74ccabe11-006a0b1599
+            X-Amz-Request-Id:
+                - txgea53cbe414d74ccabe11-006a0b1599
+        status: 200 OK
+        code: 200
+        duration: 118.887167ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 3b305bd9-5538-4069-be57-5fa2fabf5024
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T133521Z
+        url: https://tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud/?object-lock=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 326
+        uncompressed: false
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg1b386b0899664081bd8d-006a0b159a</RequestId><HostId>txg1b386b0899664081bd8d-006a0b159a</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-4974415671304108720</Resource></Error>
+        headers:
+            Content-Length:
+                - "326"
+            Content-Type:
+                - application/xml
+            Date:
+                - Mon, 18 May 2026 13:35:22 GMT
+            X-Amz-Id-2:
+                - txg1b386b0899664081bd8d-006a0b159a
+            X-Amz-Request-Id:
+                - txg1b386b0899664081bd8d-006a0b159a
+        status: 404 Not Found
+        code: 404
+        duration: 17.750125ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 07d3dcb5-7536-4750-a176-a9d2e172af58
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T133522Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.nl-ams.scw.cloud/?acl=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 698
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+        headers:
+            Content-Length:
+                - "698"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Mon, 18 May 2026 13:35:22 GMT
+            X-Amz-Id-2:
+                - txg8591ee7255554660af4c-006a0b159a
+            X-Amz-Request-Id:
+                - txg8591ee7255554660af4c-006a0b159a
+        status: 200 OK
+        code: 200
+        duration: 61.615542ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 2933ee62-8fb2-419c-8956-52cf5fa66898
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T133522Z
+        url: https://tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud/
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 283
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-basic-4974415671304108720</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+        headers:
+            Content-Length:
+                - "283"
+            Content-Type:
+                - application/xml
+            Date:
+                - Mon, 18 May 2026 13:35:22 GMT
+            X-Amz-Id-2:
+                - txg413bd3febe5b456bb9cb-006a0b159a
+            X-Amz-Request-Id:
+                - txg413bd3febe5b456bb9cb-006a0b159a
+        status: 200 OK
+        code: 200
+        duration: 18.136292ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 8380ea18-0bb2-460b-bba7-7cae618f3f24
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T133522Z
+        url: https://tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud/?tagging=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 118
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <Tagging><TagSet><Tag><Key>foo</Key><Value>bar</Value></Tag></TagSet></Tagging>
+        headers:
+            Content-Length:
+                - "118"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Mon, 18 May 2026 13:35:22 GMT
+            X-Amz-Id-2:
+                - txgcbe9163ba8d44fae9695-006a0b159a
+            X-Amz-Request-Id:
+                - txgcbe9163ba8d44fae9695-006a0b159a
+        status: 200 OK
+        code: 200
+        duration: 17.834917ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 38903104-7465-4751-bf91-de87328ceff9
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T133522Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.nl-ams.scw.cloud/?object-lock=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 329
+        uncompressed: false
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgeeab80e1376047c59976-006a0b159a</RequestId><HostId>txgeeab80e1376047c59976-006a0b159a</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-238236636660294517</Resource></Error>
+        headers:
+            Content-Length:
+                - "329"
+            Content-Type:
+                - application/xml
+            Date:
+                - Mon, 18 May 2026 13:35:22 GMT
+            X-Amz-Id-2:
+                - txgeeab80e1376047c59976-006a0b159a
+            X-Amz-Request-Id:
+                - txgeeab80e1376047c59976-006a0b159a
+        status: 404 Not Found
+        code: 404
+        duration: 35.529583ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - cf41af4e-e8f4-4ca8-90d8-7548bebabeaa
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T133522Z
+        url: https://tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud/?cors=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 294
+        uncompressed: false
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgdcf88807d1c34d039f3a-006a0b159a</RequestId><HostId>txgdcf88807d1c34d039f3a-006a0b159a</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-4974415671304108720</Resource></Error>
+        headers:
+            Content-Length:
+                - "294"
+            Content-Type:
+                - application/xml
+            Date:
+                - Mon, 18 May 2026 13:35:22 GMT
+            X-Amz-Id-2:
+                - txgdcf88807d1c34d039f3a-006a0b159a
+            X-Amz-Request-Id:
+                - txgdcf88807d1c34d039f3a-006a0b159a
+        status: 404 Not Found
+        code: 404
+        duration: 20.575083ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 6c2d3636-a0c5-48cc-9f21-ec0fbd4b080a
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T133522Z
+        url: https://tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud/?versioning=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 107
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <VersioningConfiguration><Status></Status></VersioningConfiguration>
+        headers:
+            Content-Length:
+                - "107"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Mon, 18 May 2026 13:35:22 GMT
+            X-Amz-Id-2:
+                - txgd18795871f6c4f90bfad-006a0b159a
+            X-Amz-Request-Id:
+                - txgd18795871f6c4f90bfad-006a0b159a
+        status: 200 OK
+        code: 200
+        duration: 19.627958ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 24505d60-1d3c-486d-82cc-5f281c8a9562
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T133522Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.nl-ams.scw.cloud/
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 286
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-secondary-238236636660294517</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+        headers:
+            Content-Length:
+                - "286"
+            Content-Type:
+                - application/xml
+            Date:
+                - Mon, 18 May 2026 13:35:22 GMT
+            X-Amz-Id-2:
+                - txg6a1b21846f1e426c8480-006a0b159a
+            X-Amz-Request-Id:
+                - txg6a1b21846f1e426c8480-006a0b159a
+        status: 200 OK
+        code: 200
+        duration: 71.504292ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1106,7 +1108,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1115,7 +1117,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 3c5cb2a9-feb8-44cf-be63-93138726b62c
+                - 08b0d535-702c-419f-88ee-ea6b4a016da5
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1123,8 +1125,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124829Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T133522Z
+        url: https://tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1132,23 +1134,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 298
+        content_length: 386
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgd096360c69a745b39572-006a03219d</RequestId><HostId>txgd096360c69a745b39572-006a03219d</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-2001388040591926415</Resource></Error>
+        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txge528862995984b97afb6-006a0b159a</RequestId><HostId>txge528862995984b97afb6-006a0b159a</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-4974415671304108720</Resource><BucketName>tf-tests-scaleway-object-bucket-basic-4974415671304108720</BucketName></Error>
         headers:
             Content-Length:
-                - "298"
+                - "386"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 12:48:29 GMT
+                - Mon, 18 May 2026 13:35:22 GMT
             X-Amz-Id-2:
-                - txgd096360c69a745b39572-006a03219d
+                - txge528862995984b97afb6-006a0b159a
             X-Amz-Request-Id:
-                - txgd096360c69a745b39572-006a03219d
+                - txge528862995984b97afb6-006a0b159a
         status: 404 Not Found
         code: 404
-        duration: 57.525042ms
+        duration: 124.079667ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1157,7 +1159,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1166,7 +1168,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f3a4824a-1408-40c0-a7c4-7a441f35e523
+                - 5c6e7bdf-f78d-4a8a-9109-53c7969d0e9b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1174,8 +1176,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124829Z
-        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?acl=
+                - 20260518T133522Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1183,25 +1185,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 698
+        content_length: 161
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+            <Tagging><TagSet><Tag><Key>baz</Key><Value>qux</Value></Tag><Tag><Key>foo</Key><Value>bar</Value></Tag></TagSet></Tagging>
         headers:
             Content-Length:
-                - "698"
+                - "161"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 12:48:29 GMT
+                - Mon, 18 May 2026 13:35:22 GMT
             X-Amz-Id-2:
-                - txge8b2d4f8741a47bfb13f-006a03219d
+                - txg5df1e50c3b5847f992c0-006a0b159a
             X-Amz-Request-Id:
-                - txge8b2d4f8741a47bfb13f-006a03219d
+                - txg5df1e50c3b5847f992c0-006a0b159a
         status: 200 OK
         code: 200
-        duration: 42.767584ms
+        duration: 156.232542ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1210,7 +1212,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1219,7 +1221,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 27c78549-2952-4c34-94fd-5b6f2f893b31
+                - 745aa136-6d62-4a5e-9318-1062b100f05c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1227,8 +1229,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124829Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T133522Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1236,25 +1238,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 107
+        content_length: 297
         uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <VersioningConfiguration><Status></Status></VersioningConfiguration>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgc237c7edc7f94e52b502-006a0b159a</RequestId><HostId>txgc237c7edc7f94e52b502-006a0b159a</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-238236636660294517</Resource></Error>
         headers:
             Content-Length:
-                - "107"
+                - "297"
             Content-Type:
-                - text/xml; charset=utf-8
+                - application/xml
             Date:
-                - Tue, 12 May 2026 12:48:29 GMT
+                - Mon, 18 May 2026 13:35:22 GMT
             X-Amz-Id-2:
-                - txgfcc4ff63f0394cf780c7-006a03219d
+                - txgc237c7edc7f94e52b502-006a0b159a
             X-Amz-Request-Id:
-                - txgfcc4ff63f0394cf780c7-006a03219d
-        status: 200 OK
-        code: 200
-        duration: 63.499ms
+                - txgc237c7edc7f94e52b502-006a0b159a
+        status: 404 Not Found
+        code: 404
+        duration: 23.961541ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1263,7 +1263,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1272,7 +1272,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c4b8410f-4e60-4958-a47b-cb97828ba10c
+                - 823113fb-9140-47bf-ac87-77ba672917a4
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1280,8 +1280,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124829Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T133522Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1289,23 +1289,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 394
+        content_length: 107
         uncompressed: false
-        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txg1a46a88ef80f435d8782-006a03219d</RequestId><HostId>txg1a46a88ef80f435d8782-006a03219d</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-2001388040591926415</Resource><BucketName>tf-tests-scaleway-object-bucket-secondary-2001388040591926415</BucketName></Error>
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <VersioningConfiguration><Status></Status></VersioningConfiguration>
         headers:
             Content-Length:
-                - "394"
+                - "107"
             Content-Type:
-                - application/xml
+                - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 12:48:29 GMT
+                - Mon, 18 May 2026 13:35:22 GMT
             X-Amz-Id-2:
-                - txg1a46a88ef80f435d8782-006a03219d
+                - txg59f31acc5e1941f4a90b-006a0b159a
             X-Amz-Request-Id:
-                - txg1a46a88ef80f435d8782-006a03219d
-        status: 404 Not Found
-        code: 404
-        duration: 117.580417ms
+                - txg59f31acc5e1941f4a90b-006a0b159a
+        status: 200 OK
+        code: 200
+        duration: 54.37675ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1314,7 +1316,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1323,7 +1325,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9daafcaf-bcf8-46c4-a5d0-b6f8272b5270
+                - f1d89c9f-9714-42a5-9dcc-ef95d74cc901
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1331,8 +1333,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124829Z
-        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?object-lock=
+                - 20260518T133522Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1340,23 +1342,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 326
+        content_length: 392
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgbbc8dc967f754653bf19-006a03219d</RequestId><HostId>txgbbc8dc967f754653bf19-006a03219d</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-1314313384735080249</Resource></Error>
+        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txg96bc5fad1d264f44ba0e-006a0b159a</RequestId><HostId>txg96bc5fad1d264f44ba0e-006a0b159a</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-238236636660294517</Resource><BucketName>tf-tests-scaleway-object-bucket-secondary-238236636660294517</BucketName></Error>
         headers:
             Content-Length:
-                - "326"
+                - "392"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 12:48:29 GMT
+                - Mon, 18 May 2026 13:35:22 GMT
             X-Amz-Id-2:
-                - txgbbc8dc967f754653bf19-006a03219d
+                - txg96bc5fad1d264f44ba0e-006a0b159a
             X-Amz-Request-Id:
-                - txgbbc8dc967f754653bf19-006a03219d
+                - txg96bc5fad1d264f44ba0e-006a0b159a
         status: 404 Not Found
         code: 404
-        duration: 183.428333ms
+        duration: 62.846875ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1365,7 +1367,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-main-region-7696764886433866557.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1374,7 +1376,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e6b139c5-6df7-4bda-830c-6712283d60ef
+                - efb42989-6177-4408-872c-41a26969d06a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1382,8 +1384,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124829Z
-        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/
+                - 20260518T133521Z
+        url: https://tf-tests-scaleway-object-bucket-main-region-7696764886433866557.s3.fr-par.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -1391,25 +1393,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 283
+        content_length: 289
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-basic-1314313384735080249</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-main-region-7696764886433866557</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "283"
+                - "289"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 12:48:29 GMT
+                - Mon, 18 May 2026 13:35:22 GMT
             X-Amz-Id-2:
-                - txg9d8039e063b543d69283-006a03219d
+                - txgba21a9455f424cb0a49f-006a0b159a
             X-Amz-Request-Id:
-                - txg9d8039e063b543d69283-006a03219d
+                - txgba21a9455f424cb0a49f-006a0b159a
         status: 200 OK
         code: 200
-        duration: 73.083041ms
+        duration: 755.216708ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1418,7 +1420,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-main-region-7696764886433866557.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1427,7 +1429,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4a2362ed-3e4a-400e-b510-0d1d261c85b4
+                - cef11af3-e5b2-49d4-ab06-3ba283f11ad7
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1435,8 +1437,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124829Z
-        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?tagging=
+                - 20260518T133522Z
+        url: https://tf-tests-scaleway-object-bucket-main-region-7696764886433866557.s3.fr-par.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1444,25 +1446,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 118
+        content_length: 365
         uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <Tagging><TagSet><Tag><Key>foo</Key><Value>bar</Value></Tag></TagSet></Tagging>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg1c827589c4e146cea40e-006a0b159a</RequestId><HostId>txg1c827589c4e146cea40e-006a0b159a</HostId><Resource>/tf-tests-scaleway-object-bucket-main-region-7696764886433866557</Resource><BucketName>tf-tests-scaleway-object-bucket-main-region-7696764886433866557</BucketName></Error>
         headers:
             Content-Length:
-                - "118"
+                - "365"
             Content-Type:
-                - text/xml; charset=utf-8
+                - application/xml
             Date:
-                - Tue, 12 May 2026 12:48:29 GMT
+                - Mon, 18 May 2026 13:35:22 GMT
             X-Amz-Id-2:
-                - txgfed8c20e18f2436084ad-006a03219d
+                - txg1c827589c4e146cea40e-006a0b159a
             X-Amz-Request-Id:
-                - txgfed8c20e18f2436084ad-006a03219d
-        status: 200 OK
-        code: 200
-        duration: 105.311375ms
+                - txg1c827589c4e146cea40e-006a0b159a
+        status: 404 Not Found
+        code: 404
+        duration: 1.796299333s
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1471,7 +1471,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-main-region-7696764886433866557.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1480,7 +1480,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 884feb7f-ab52-4af3-a91b-8d3b8062c79c
+                - 4543b210-c0e0-4bfb-a741-0e0af7c89e5c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1488,8 +1488,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124829Z
-        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?cors=
+                - 20260518T133522Z
+        url: https://tf-tests-scaleway-object-bucket-main-region-7696764886433866557.s3.fr-par.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1497,23 +1497,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 294
+        content_length: 300
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg97c618ac9c354cdd92bb-006a03219e</RequestId><HostId>txg97c618ac9c354cdd92bb-006a03219e</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-1314313384735080249</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg91f331ecb7904ec4a862-006a0b159c</RequestId><HostId>txg91f331ecb7904ec4a862-006a0b159c</HostId><Resource>/tf-tests-scaleway-object-bucket-main-region-7696764886433866557</Resource></Error>
         headers:
             Content-Length:
-                - "294"
+                - "300"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 12:48:30 GMT
+                - Mon, 18 May 2026 13:35:24 GMT
             X-Amz-Id-2:
-                - txg97c618ac9c354cdd92bb-006a03219e
+                - txg91f331ecb7904ec4a862-006a0b159c
             X-Amz-Request-Id:
-                - txg97c618ac9c354cdd92bb-006a03219e
+                - txg91f331ecb7904ec4a862-006a0b159c
         status: 404 Not Found
         code: 404
-        duration: 43.950166ms
+        duration: 295.275417ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1522,7 +1522,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-main-region-7696764886433866557.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1531,7 +1531,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 19766e1c-a7db-47d6-b9d3-df78ddd70da5
+                - 5586c869-d52d-415a-80d9-964035b4ab62
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1539,8 +1539,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124830Z
-        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?versioning=
+                - 20260518T133524Z
+        url: https://tf-tests-scaleway-object-bucket-main-region-7696764886433866557.s3.fr-par.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1559,14 +1559,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 12:48:30 GMT
+                - Mon, 18 May 2026 13:35:24 GMT
             X-Amz-Id-2:
-                - txg7b66f2ee0c254d6caaef-006a03219e
+                - txg788630aa11c64fe68b37-006a0b159c
             X-Amz-Request-Id:
-                - txg7b66f2ee0c254d6caaef-006a03219e
+                - txg788630aa11c64fe68b37-006a0b159c
         status: 200 OK
         code: 200
-        duration: 71.31575ms
+        duration: 13.834167ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1575,7 +1575,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-main-region-7696764886433866557.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1584,7 +1584,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - bb1f5a0d-491c-4a97-b2a0-786b6804f059
+                - bbe53540-b39e-415e-a38c-a5b6ebafbac7
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1592,8 +1592,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124830Z
-        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?lifecycle=
+                - 20260518T133524Z
+        url: https://tf-tests-scaleway-object-bucket-main-region-7696764886433866557.s3.fr-par.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1601,23 +1601,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 386
+        content_length: 398
         uncompressed: false
-        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txg745bb60612aa4e69ac44-006a03219e</RequestId><HostId>txg745bb60612aa4e69ac44-006a03219e</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-1314313384735080249</Resource><BucketName>tf-tests-scaleway-object-bucket-basic-1314313384735080249</BucketName></Error>
+        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txg017da3820bfa4198ba7c-006a0b159c</RequestId><HostId>txg017da3820bfa4198ba7c-006a0b159c</HostId><Resource>/tf-tests-scaleway-object-bucket-main-region-7696764886433866557</Resource><BucketName>tf-tests-scaleway-object-bucket-main-region-7696764886433866557</BucketName></Error>
         headers:
             Content-Length:
-                - "386"
+                - "398"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 12:48:30 GMT
+                - Mon, 18 May 2026 13:35:24 GMT
             X-Amz-Id-2:
-                - txg745bb60612aa4e69ac44-006a03219e
+                - txg017da3820bfa4198ba7c-006a0b159c
             X-Amz-Request-Id:
-                - txg745bb60612aa4e69ac44-006a03219e
+                - txg017da3820bfa4198ba7c-006a0b159c
         status: 404 Not Found
         code: 404
-        duration: 142.194167ms
+        duration: 102.955792ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1626,7 +1626,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1635,7 +1635,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 01cfd58c-c7b9-484c-b197-a3e576f56ee6
+                - ebc94861-746f-4a11-8b44-a1f7deeafe1b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1643,8 +1643,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124830Z
-        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/
+                - 20260518T133525Z
+        url: https://tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -1659,16 +1659,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 12:48:30 GMT
+                - Mon, 18 May 2026 13:35:25 GMT
             X-Amz-Bucket-Region:
                 - fr-par
             X-Amz-Id-2:
-                - txg92d7bbb53eaa401f8d51-006a03219e
+                - txg98265501005e4f6a97e8-006a0b159d
             X-Amz-Request-Id:
-                - txg92d7bbb53eaa401f8d51-006a03219e
+                - txg98265501005e4f6a97e8-006a0b159d
         status: 200 OK
         code: 200
-        duration: 76.847375ms
+        duration: 34.283ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1677,7 +1677,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1686,7 +1686,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 70fb330d-82b5-4ab0-855e-f1302bc06910
+                - d775f3b6-2777-43c4-a232-4dcbaa13c2a5
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1694,8 +1694,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124830Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud/
+                - 20260518T133525Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -1710,16 +1710,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 12:48:30 GMT
+                - Mon, 18 May 2026 13:35:25 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txgf2807c831bae425e8957-006a03219e
+                - txgb7e878ebc51941ba9f22-006a0b159d
             X-Amz-Request-Id:
-                - txgf2807c831bae425e8957-006a03219e
+                - txgb7e878ebc51941ba9f22-006a0b159d
         status: 200 OK
         code: 200
-        duration: 132.462583ms
+        duration: 185.799ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1728,7 +1728,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-main-region-7696764886433866557.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1737,7 +1737,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 3483597e-a2df-430a-948d-4bd9ef210f45
+                - 85496697-205e-4d4f-a218-ffbc40f28025
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1745,8 +1745,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124830Z
-        url: https://tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud/
+                - 20260518T133525Z
+        url: https://tf-tests-scaleway-object-bucket-main-region-7696764886433866557.s3.fr-par.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -1761,16 +1761,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 12:48:30 GMT
+                - Mon, 18 May 2026 13:35:25 GMT
             X-Amz-Bucket-Region:
                 - fr-par
             X-Amz-Id-2:
-                - txgea19c901c12348c7b086-006a03219e
+                - txg72173140cfd44787a363-006a0b159d
             X-Amz-Request-Id:
-                - txgea19c901c12348c7b086-006a03219e
+                - txg72173140cfd44787a363-006a0b159d
         status: 200 OK
         code: 200
-        duration: 52.760458ms
+        duration: 46.123584ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1779,7 +1779,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1788,7 +1788,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 163a7644-dd8f-48be-a5c5-4cf4c634dece
+                - 8564989c-ceca-4784-b977-b019cddc302a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1796,8 +1796,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124830Z
-        url: https://tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud/?acl=
+                - 20260518T133525Z
+        url: https://tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1816,14 +1816,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 12:48:30 GMT
+                - Mon, 18 May 2026 13:35:25 GMT
             X-Amz-Id-2:
-                - txg157fffacd47441f8b287-006a03219e
+                - txg63237521112549968a3c-006a0b159d
             X-Amz-Request-Id:
-                - txg157fffacd47441f8b287-006a03219e
+                - txg63237521112549968a3c-006a0b159d
         status: 200 OK
         code: 200
-        duration: 23.034417ms
+        duration: 22.193333ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1832,7 +1832,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1841,7 +1841,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b637e816-9c4b-4792-8c52-1c897ea0305f
+                - 88ea6b71-bba2-4b44-b188-c3e1f9251933
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1849,8 +1849,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124830Z
-        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?acl=
+                - 20260518T133525Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1869,14 +1869,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 12:48:30 GMT
+                - Mon, 18 May 2026 13:35:25 GMT
             X-Amz-Id-2:
-                - txg5458869146ea4b78a71f-006a03219e
+                - txg567b7b9977cf4578a749-006a0b159d
             X-Amz-Request-Id:
-                - txg5458869146ea4b78a71f-006a03219e
+                - txg567b7b9977cf4578a749-006a0b159d
         status: 200 OK
         code: 200
-        duration: 38.481875ms
+        duration: 64.501542ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1885,7 +1885,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-main-region-7696764886433866557.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1894,7 +1894,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 71f11ac4-a086-4b35-9f0f-477d4d7d1f62
+                - bbee3e73-31ae-4a1b-9d9a-76b3802f81da
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1902,8 +1902,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124830Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T133525Z
+        url: https://tf-tests-scaleway-object-bucket-main-region-7696764886433866557.s3.fr-par.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1922,14 +1922,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 12:48:30 GMT
+                - Mon, 18 May 2026 13:35:25 GMT
             X-Amz-Id-2:
-                - txg92125f7ff64f489687ee-006a03219e
+                - txgdfbcc17ef19e495babc4-006a0b159d
             X-Amz-Request-Id:
-                - txg92125f7ff64f489687ee-006a03219e
+                - txgdfbcc17ef19e495babc4-006a0b159d
         status: 200 OK
         code: 200
-        duration: 60.176709ms
+        duration: 84.108417ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1938,7 +1938,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-main-region-7696764886433866557.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1947,7 +1947,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - fea1f363-6f40-4a5c-8a02-6cccbddd1926
+                - a3459c1c-29ef-4ade-bf55-031b0cce4866
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1955,8 +1955,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124830Z
-        url: https://tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud/?object-lock=
+                - 20260518T133525Z
+        url: https://tf-tests-scaleway-object-bucket-main-region-7696764886433866557.s3.fr-par.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1964,23 +1964,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 331
+        content_length: 332
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg4479f698f6f644ce8784-006a03219e</RequestId><HostId>txg4479f698f6f644ce8784-006a03219e</HostId><Resource>/tf-tests-scaleway-object-bucket-main-region-652097813215812252</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg58475bc812f340119f93-006a0b159d</RequestId><HostId>txg58475bc812f340119f93-006a0b159d</HostId><Resource>/tf-tests-scaleway-object-bucket-main-region-7696764886433866557</Resource></Error>
         headers:
             Content-Length:
-                - "331"
+                - "332"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 12:48:30 GMT
+                - Mon, 18 May 2026 13:35:25 GMT
             X-Amz-Id-2:
-                - txg4479f698f6f644ce8784-006a03219e
+                - txg58475bc812f340119f93-006a0b159d
             X-Amz-Request-Id:
-                - txg4479f698f6f644ce8784-006a03219e
+                - txg58475bc812f340119f93-006a0b159d
         status: 404 Not Found
         code: 404
-        duration: 37.028958ms
+        duration: 22.402583ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1989,7 +1989,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1998,7 +1998,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - a84c5c2d-7cd1-4181-99e1-c579ba74a45a
+                - 23b06f40-e732-4673-9362-29fe2ea2c7a9
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2006,8 +2006,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124830Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T133525Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2015,23 +2015,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 330
+        content_length: 329
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txge801f0f1522340bab5ed-006a03219f</RequestId><HostId>txge801f0f1522340bab5ed-006a03219f</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-2001388040591926415</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgd4717997bc5242629308-006a0b159d</RequestId><HostId>txgd4717997bc5242629308-006a0b159d</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-238236636660294517</Resource></Error>
         headers:
             Content-Length:
-                - "330"
+                - "329"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 12:48:31 GMT
+                - Mon, 18 May 2026 13:35:25 GMT
             X-Amz-Id-2:
-                - txge801f0f1522340bab5ed-006a03219f
+                - txgd4717997bc5242629308-006a0b159d
             X-Amz-Request-Id:
-                - txge801f0f1522340bab5ed-006a03219f
+                - txgd4717997bc5242629308-006a0b159d
         status: 404 Not Found
         code: 404
-        duration: 40.881708ms
+        duration: 53.589875ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -2040,7 +2040,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-main-region-7696764886433866557.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2049,7 +2049,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 19d8013f-9716-473e-a1c4-469546d5ea44
+                - 2a540699-d40f-4b3d-99cf-eeea8d85e1e4
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2057,8 +2057,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124830Z
-        url: https://tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud/
+                - 20260518T133525Z
+        url: https://tf-tests-scaleway-object-bucket-main-region-7696764886433866557.s3.fr-par.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -2066,25 +2066,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 288
+        content_length: 289
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-main-region-652097813215812252</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-main-region-7696764886433866557</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "288"
+                - "289"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 12:48:30 GMT
+                - Mon, 18 May 2026 13:35:25 GMT
             X-Amz-Id-2:
-                - txga084441c1b0e43d8bf2f-006a03219e
+                - txg305ba2254d2849c29f4e-006a0b159d
             X-Amz-Request-Id:
-                - txga084441c1b0e43d8bf2f-006a03219e
+                - txg305ba2254d2849c29f4e-006a0b159d
         status: 200 OK
         code: 200
-        duration: 55.566875ms
+        duration: 28.74975ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -2093,7 +2093,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-main-region-7696764886433866557.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2102,7 +2102,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 1532bfc8-d63b-4904-b2cd-5ca86e46afaa
+                - dfc247de-adc1-4fad-b137-d950f057a84f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2110,8 +2110,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124830Z
-        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?object-lock=
+                - 20260518T133525Z
+        url: https://tf-tests-scaleway-object-bucket-main-region-7696764886433866557.s3.fr-par.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2119,23 +2119,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 326
+        content_length: 365
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg72c0bd6ea1e847918c44-006a03219e</RequestId><HostId>txg72c0bd6ea1e847918c44-006a03219e</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-1314313384735080249</Resource></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgc2e5ef9f18ed4ff49a92-006a0b159d</RequestId><HostId>txgc2e5ef9f18ed4ff49a92-006a0b159d</HostId><Resource>/tf-tests-scaleway-object-bucket-main-region-7696764886433866557</Resource><BucketName>tf-tests-scaleway-object-bucket-main-region-7696764886433866557</BucketName></Error>
         headers:
             Content-Length:
-                - "326"
+                - "365"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 12:48:30 GMT
+                - Mon, 18 May 2026 13:35:25 GMT
             X-Amz-Id-2:
-                - txg72c0bd6ea1e847918c44-006a03219e
+                - txgc2e5ef9f18ed4ff49a92-006a0b159d
             X-Amz-Request-Id:
-                - txg72c0bd6ea1e847918c44-006a03219e
+                - txgc2e5ef9f18ed4ff49a92-006a0b159d
         status: 404 Not Found
         code: 404
-        duration: 77.345041ms
+        duration: 14.770666ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -2144,7 +2144,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2153,7 +2153,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - fcebf174-26a9-41c5-9006-9b806da25b6d
+                - 6a0c5884-2335-4304-b7e3-228991510a11
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2161,997 +2161,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124830Z
-        url: https://tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud/?tagging=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 363
-        uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg9143abbcaaf2408a95d8-006a03219f</RequestId><HostId>txg9143abbcaaf2408a95d8-006a03219f</HostId><Resource>/tf-tests-scaleway-object-bucket-main-region-652097813215812252</Resource><BucketName>tf-tests-scaleway-object-bucket-main-region-652097813215812252</BucketName></Error>
-        headers:
-            Content-Length:
-                - "363"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 12 May 2026 12:48:31 GMT
-            X-Amz-Id-2:
-                - txg9143abbcaaf2408a95d8-006a03219f
-            X-Amz-Request-Id:
-                - txg9143abbcaaf2408a95d8-006a03219f
-        status: 404 Not Found
-        code: 404
-        duration: 16.446459ms
-    - id: 42
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - abd3e57a-7d82-4515-9edc-b93a4c4a6b92
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260512T124831Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud/
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 287
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-secondary-2001388040591926415</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
-        headers:
-            Content-Length:
-                - "287"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 12 May 2026 12:48:31 GMT
-            X-Amz-Id-2:
-                - txg464dd9d6cd8a47a3a492-006a03219f
-            X-Amz-Request-Id:
-                - txg464dd9d6cd8a47a3a492-006a03219f
-        status: 200 OK
-        code: 200
-        duration: 53.0325ms
-    - id: 43
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 1178f715-ae3f-4405-8dc9-76eff66f4136
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260512T124831Z
-        url: https://tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud/?cors=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 299
-        uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg115aa5a4f94d45e7bd8a-006a03219f</RequestId><HostId>txg115aa5a4f94d45e7bd8a-006a03219f</HostId><Resource>/tf-tests-scaleway-object-bucket-main-region-652097813215812252</Resource></Error>
-        headers:
-            Content-Length:
-                - "299"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 12 May 2026 12:48:31 GMT
-            X-Amz-Id-2:
-                - txg115aa5a4f94d45e7bd8a-006a03219f
-            X-Amz-Request-Id:
-                - txg115aa5a4f94d45e7bd8a-006a03219f
-        status: 404 Not Found
-        code: 404
-        duration: 21.755917ms
-    - id: 44
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 0fe41ed6-45c9-47e1-8ea9-6b760d4e2e29
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260512T124831Z
-        url: https://tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud/?versioning=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 107
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <VersioningConfiguration><Status></Status></VersioningConfiguration>
-        headers:
-            Content-Length:
-                - "107"
-            Content-Type:
-                - text/xml; charset=utf-8
-            Date:
-                - Tue, 12 May 2026 12:48:31 GMT
-            X-Amz-Id-2:
-                - txg24edb16e751243b4ba49-006a03219f
-            X-Amz-Request-Id:
-                - txg24edb16e751243b4ba49-006a03219f
-        status: 200 OK
-        code: 200
-        duration: 16.908167ms
-    - id: 45
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 7574bd7c-8e91-43d2-b0e1-8c87e11995d4
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260512T124831Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud/?tagging=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 161
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <Tagging><TagSet><Tag><Key>foo</Key><Value>bar</Value></Tag><Tag><Key>baz</Key><Value>qux</Value></Tag></TagSet></Tagging>
-        headers:
-            Content-Length:
-                - "161"
-            Content-Type:
-                - text/xml; charset=utf-8
-            Date:
-                - Tue, 12 May 2026 12:48:31 GMT
-            X-Amz-Id-2:
-                - txga31a3a023da24ab5a798-006a03219f
-            X-Amz-Request-Id:
-                - txga31a3a023da24ab5a798-006a03219f
-        status: 200 OK
-        code: 200
-        duration: 38.827792ms
-    - id: 46
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 99f8d6cf-d5d9-4ad2-8483-73ec7e59a8d1
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260512T124830Z
-        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 283
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-basic-1314313384735080249</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
-        headers:
-            Content-Length:
-                - "283"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 12 May 2026 12:48:31 GMT
-            X-Amz-Id-2:
-                - txgef5cb2976914470c831d-006a03219f
-            X-Amz-Request-Id:
-                - txgef5cb2976914470c831d-006a03219f
-        status: 200 OK
-        code: 200
-        duration: 84.651625ms
-    - id: 47
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 03da3f8a-1e70-491b-b839-bb8250d68168
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260512T124831Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud/?cors=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 298
-        uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg2b438eeb519846ee9acc-006a03219f</RequestId><HostId>txg2b438eeb519846ee9acc-006a03219f</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-2001388040591926415</Resource></Error>
-        headers:
-            Content-Length:
-                - "298"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 12 May 2026 12:48:31 GMT
-            X-Amz-Id-2:
-                - txg2b438eeb519846ee9acc-006a03219f
-            X-Amz-Request-Id:
-                - txg2b438eeb519846ee9acc-006a03219f
-        status: 404 Not Found
-        code: 404
-        duration: 21.995667ms
-    - id: 48
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - f483545c-f908-4d37-a999-3020cc388160
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260512T124831Z
-        url: https://tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud/?lifecycle=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 396
-        uncompressed: false
-        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txg822878f2a12b430f9a9c-006a03219f</RequestId><HostId>txg822878f2a12b430f9a9c-006a03219f</HostId><Resource>/tf-tests-scaleway-object-bucket-main-region-652097813215812252</Resource><BucketName>tf-tests-scaleway-object-bucket-main-region-652097813215812252</BucketName></Error>
-        headers:
-            Content-Length:
-                - "396"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 12 May 2026 12:48:31 GMT
-            X-Amz-Id-2:
-                - txg822878f2a12b430f9a9c-006a03219f
-            X-Amz-Request-Id:
-                - txg822878f2a12b430f9a9c-006a03219f
-        status: 404 Not Found
-        code: 404
-        duration: 69.888334ms
-    - id: 49
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - d28b51f9-89d4-4c18-a080-b07d79078859
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260512T124831Z
-        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?tagging=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 118
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <Tagging><TagSet><Tag><Key>foo</Key><Value>bar</Value></Tag></TagSet></Tagging>
-        headers:
-            Content-Length:
-                - "118"
-            Content-Type:
-                - text/xml; charset=utf-8
-            Date:
-                - Tue, 12 May 2026 12:48:31 GMT
-            X-Amz-Id-2:
-                - txg3de8853c1ecc4f34a41f-006a03219f
-            X-Amz-Request-Id:
-                - txg3de8853c1ecc4f34a41f-006a03219f
-        status: 200 OK
-        code: 200
-        duration: 51.262208ms
-    - id: 50
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - cd6694fa-3edf-4eb1-8148-9c37a5a37f00
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260512T124831Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud/?versioning=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 107
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <VersioningConfiguration><Status></Status></VersioningConfiguration>
-        headers:
-            Content-Length:
-                - "107"
-            Content-Type:
-                - text/xml; charset=utf-8
-            Date:
-                - Tue, 12 May 2026 12:48:31 GMT
-            X-Amz-Id-2:
-                - txg495c64a1642a423da2f1-006a03219f
-            X-Amz-Request-Id:
-                - txg495c64a1642a423da2f1-006a03219f
-        status: 200 OK
-        code: 200
-        duration: 38.151416ms
-    - id: 51
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 2edcdd91-a5b1-4217-9430-b89941176333
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260512T124831Z
-        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?cors=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 294
-        uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg0ebffbac322540ffbc25-006a03219f</RequestId><HostId>txg0ebffbac322540ffbc25-006a03219f</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-1314313384735080249</Resource></Error>
-        headers:
-            Content-Length:
-                - "294"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 12 May 2026 12:48:31 GMT
-            X-Amz-Id-2:
-                - txg0ebffbac322540ffbc25-006a03219f
-            X-Amz-Request-Id:
-                - txg0ebffbac322540ffbc25-006a03219f
-        status: 404 Not Found
-        code: 404
-        duration: 8.478125ms
-    - id: 52
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 1a79d3b5-d345-4a53-a6c6-3e541dd88fbb
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260512T124831Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud/?lifecycle=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 394
-        uncompressed: false
-        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txg76f637c01bd84e8bb040-006a03219f</RequestId><HostId>txg76f637c01bd84e8bb040-006a03219f</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-2001388040591926415</Resource><BucketName>tf-tests-scaleway-object-bucket-secondary-2001388040591926415</BucketName></Error>
-        headers:
-            Content-Length:
-                - "394"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 12 May 2026 12:48:31 GMT
-            X-Amz-Id-2:
-                - txg76f637c01bd84e8bb040-006a03219f
-            X-Amz-Request-Id:
-                - txg76f637c01bd84e8bb040-006a03219f
-        status: 404 Not Found
-        code: 404
-        duration: 60.17675ms
-    - id: 53
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - bee29527-9435-4b2e-95c7-a7824414166b
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260512T124831Z
-        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?versioning=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 107
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <VersioningConfiguration><Status></Status></VersioningConfiguration>
-        headers:
-            Content-Length:
-                - "107"
-            Content-Type:
-                - text/xml; charset=utf-8
-            Date:
-                - Tue, 12 May 2026 12:48:31 GMT
-            X-Amz-Id-2:
-                - txg5f003c4da990443dad82-006a03219f
-            X-Amz-Request-Id:
-                - txg5f003c4da990443dad82-006a03219f
-        status: 200 OK
-        code: 200
-        duration: 136.902083ms
-    - id: 54
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 85b48395-5f15-449a-b26b-199801476980
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260512T124831Z
-        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?lifecycle=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 386
-        uncompressed: false
-        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txga6f5cff61b4c45a59961-006a03219f</RequestId><HostId>txga6f5cff61b4c45a59961-006a03219f</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-1314313384735080249</Resource><BucketName>tf-tests-scaleway-object-bucket-basic-1314313384735080249</BucketName></Error>
-        headers:
-            Content-Length:
-                - "386"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 12 May 2026 12:48:31 GMT
-            X-Amz-Id-2:
-                - txga6f5cff61b4c45a59961-006a03219f
-            X-Amz-Request-Id:
-                - txga6f5cff61b4c45a59961-006a03219f
-        status: 404 Not Found
-        code: 404
-        duration: 136.828125ms
-    - id: 55
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - e56ab968-de47-4efd-9594-11b4b79145d2
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260512T124831Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud/?acl=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 698
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
-        headers:
-            Content-Length:
-                - "698"
-            Content-Type:
-                - text/xml; charset=utf-8
-            Date:
-                - Tue, 12 May 2026 12:48:31 GMT
-            X-Amz-Id-2:
-                - txg98c6ff6b6ce74e7692f6-006a03219f
-            X-Amz-Request-Id:
-                - txg98c6ff6b6ce74e7692f6-006a03219f
-        status: 200 OK
-        code: 200
-        duration: 54.404375ms
-    - id: 56
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - e62f3de8-23b6-4614-963f-dfc8df37b974
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260512T124831Z
-        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?acl=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 698
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
-        headers:
-            Content-Length:
-                - "698"
-            Content-Type:
-                - text/xml; charset=utf-8
-            Date:
-                - Tue, 12 May 2026 12:48:31 GMT
-            X-Amz-Id-2:
-                - txg6a90a177a64c4b95ba7c-006a03219f
-            X-Amz-Request-Id:
-                - txg6a90a177a64c4b95ba7c-006a03219f
-        status: 200 OK
-        code: 200
-        duration: 54.529792ms
-    - id: 57
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 48c551d3-f39e-43fd-a4e0-09a0a5d64d61
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260512T124831Z
-        url: https://tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud/?acl=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 698
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
-        headers:
-            Content-Length:
-                - "698"
-            Content-Type:
-                - text/xml; charset=utf-8
-            Date:
-                - Tue, 12 May 2026 12:48:31 GMT
-            X-Amz-Id-2:
-                - txg2600d317419a46ada65c-006a03219f
-            X-Amz-Request-Id:
-                - txg2600d317419a46ada65c-006a03219f
-        status: 200 OK
-        code: 200
-        duration: 101.842875ms
-    - id: 58
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 898a7f48-2fbc-4d50-99e7-67071bd3cd64
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260512T124831Z
-        url: https://tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud/?object-lock=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 331
-        uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg5226a0a9a4b94fbea831-006a03219f</RequestId><HostId>txg5226a0a9a4b94fbea831-006a03219f</HostId><Resource>/tf-tests-scaleway-object-bucket-main-region-652097813215812252</Resource></Error>
-        headers:
-            Content-Length:
-                - "331"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 12 May 2026 12:48:31 GMT
-            X-Amz-Id-2:
-                - txg5226a0a9a4b94fbea831-006a03219f
-            X-Amz-Request-Id:
-                - txg5226a0a9a4b94fbea831-006a03219f
-        status: 404 Not Found
-        code: 404
-        duration: 11.900042ms
-    - id: 59
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - d05b06a3-bd1a-45ec-b5c7-a9a3d6fe51d8
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260512T124831Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud/?object-lock=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 330
-        uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg558f1661745947c49864-006a03219f</RequestId><HostId>txg558f1661745947c49864-006a03219f</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-2001388040591926415</Resource></Error>
-        headers:
-            Content-Length:
-                - "330"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 12 May 2026 12:48:31 GMT
-            X-Amz-Id-2:
-                - txg558f1661745947c49864-006a03219f
-            X-Amz-Request-Id:
-                - txg558f1661745947c49864-006a03219f
-        status: 404 Not Found
-        code: 404
-        duration: 82.283041ms
-    - id: 60
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 23dba3ab-1758-401a-90d2-1e1c5898e029
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260512T124831Z
-        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?object-lock=
+                - 20260518T133525Z
+        url: https://tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3161,22 +2172,22 @@ interactions:
         trailer: {}
         content_length: 326
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgb2d37f9e966c4aff9ba4-006a03219f</RequestId><HostId>txgb2d37f9e966c4aff9ba4-006a03219f</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-1314313384735080249</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg895c4ba011604529b139-006a0b159d</RequestId><HostId>txg895c4ba011604529b139-006a0b159d</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-4974415671304108720</Resource></Error>
         headers:
             Content-Length:
                 - "326"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 12:48:31 GMT
+                - Mon, 18 May 2026 13:35:25 GMT
             X-Amz-Id-2:
-                - txgb2d37f9e966c4aff9ba4-006a03219f
+                - txg895c4ba011604529b139-006a0b159d
             X-Amz-Request-Id:
-                - txgb2d37f9e966c4aff9ba4-006a03219f
+                - txg895c4ba011604529b139-006a0b159d
         status: 404 Not Found
         code: 404
-        duration: 99.980542ms
-    - id: 61
+        duration: 131.160125ms
+    - id: 42
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3184,7 +2195,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-main-region-7696764886433866557.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3193,7 +2204,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7b30a6d1-3167-4394-ba4d-ffa8dd451ceb
+                - 763921c3-4e2e-4b41-bdd3-ae4edd2c6930
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3201,8 +2212,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124831Z
-        url: https://tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud/
+                - 20260518T133525Z
+        url: https://tf-tests-scaleway-object-bucket-main-region-7696764886433866557.s3.fr-par.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3210,26 +2221,77 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 288
+        content_length: 300
+        uncompressed: false
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg8100bc4b32554b21bae9-006a0b159d</RequestId><HostId>txg8100bc4b32554b21bae9-006a0b159d</HostId><Resource>/tf-tests-scaleway-object-bucket-main-region-7696764886433866557</Resource></Error>
+        headers:
+            Content-Length:
+                - "300"
+            Content-Type:
+                - application/xml
+            Date:
+                - Mon, 18 May 2026 13:35:25 GMT
+            X-Amz-Id-2:
+                - txg8100bc4b32554b21bae9-006a0b159d
+            X-Amz-Request-Id:
+                - txg8100bc4b32554b21bae9-006a0b159d
+        status: 404 Not Found
+        code: 404
+        duration: 26.493416ms
+    - id: 43
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 32ebc752-ad4f-4a1d-974c-f7c7ba4feaf8
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T133525Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.nl-ams.scw.cloud/
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 286
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-main-region-652097813215812252</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-secondary-238236636660294517</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "288"
+                - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 12:48:31 GMT
+                - Mon, 18 May 2026 13:35:25 GMT
             X-Amz-Id-2:
-                - txg57a022b7d7974d5ea1f1-006a03219f
+                - txgc56ec3672d6e45e9a860-006a0b159d
             X-Amz-Request-Id:
-                - txg57a022b7d7974d5ea1f1-006a03219f
+                - txgc56ec3672d6e45e9a860-006a0b159d
         status: 200 OK
         code: 200
-        duration: 101.770375ms
-    - id: 62
+        duration: 78.316375ms
+    - id: 44
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3237,7 +2299,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-main-region-7696764886433866557.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3246,7 +2308,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c21598d1-c24c-445f-8153-121e08c15e8f
+                - 4403cd91-a5a3-4ac2-ac4e-a840b341efb5
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3254,8 +2316,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124831Z
-        url: https://tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud/?tagging=
+                - 20260518T133525Z
+        url: https://tf-tests-scaleway-object-bucket-main-region-7696764886433866557.s3.fr-par.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3263,77 +2325,26 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 363
-        uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg20c7f94745eb4badbf00-006a03219f</RequestId><HostId>txg20c7f94745eb4badbf00-006a03219f</HostId><Resource>/tf-tests-scaleway-object-bucket-main-region-652097813215812252</Resource><BucketName>tf-tests-scaleway-object-bucket-main-region-652097813215812252</BucketName></Error>
-        headers:
-            Content-Length:
-                - "363"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 12 May 2026 12:48:31 GMT
-            X-Amz-Id-2:
-                - txg20c7f94745eb4badbf00-006a03219f
-            X-Amz-Request-Id:
-                - txg20c7f94745eb4badbf00-006a03219f
-        status: 404 Not Found
-        code: 404
-        duration: 13.289833ms
-    - id: 63
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 39c02600-9774-4a2d-898b-011365747a3f
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260512T124831Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud/
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 287
+        content_length: 107
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-secondary-2001388040591926415</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <VersioningConfiguration><Status></Status></VersioningConfiguration>
         headers:
             Content-Length:
-                - "287"
+                - "107"
             Content-Type:
-                - application/xml
+                - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 12:48:31 GMT
+                - Mon, 18 May 2026 13:35:25 GMT
             X-Amz-Id-2:
-                - txg1dbad8873aed4b199ca4-006a03219f
+                - txgc12aaabe82a74aeeade1-006a0b159d
             X-Amz-Request-Id:
-                - txg1dbad8873aed4b199ca4-006a03219f
+                - txgc12aaabe82a74aeeade1-006a0b159d
         status: 200 OK
         code: 200
-        duration: 96.006541ms
-    - id: 64
+        duration: 57.140084ms
+    - id: 45
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3341,7 +2352,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-main-region-7696764886433866557.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3350,7 +2361,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 644502bb-1160-497f-8787-9e5eb2bb3e50
+                - 3a56caac-230e-435d-a890-79badcfb0176
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3358,8 +2369,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124831Z
-        url: https://tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud/?cors=
+                - 20260518T133525Z
+        url: https://tf-tests-scaleway-object-bucket-main-region-7696764886433866557.s3.fr-par.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3367,24 +2378,24 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 299
+        content_length: 398
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgce397e7cc7de490a981c-006a03219f</RequestId><HostId>txgce397e7cc7de490a981c-006a03219f</HostId><Resource>/tf-tests-scaleway-object-bucket-main-region-652097813215812252</Resource></Error>
+        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txgd41fd1b3c44c45448482-006a0b159d</RequestId><HostId>txgd41fd1b3c44c45448482-006a0b159d</HostId><Resource>/tf-tests-scaleway-object-bucket-main-region-7696764886433866557</Resource><BucketName>tf-tests-scaleway-object-bucket-main-region-7696764886433866557</BucketName></Error>
         headers:
             Content-Length:
-                - "299"
+                - "398"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 12:48:31 GMT
+                - Mon, 18 May 2026 13:35:25 GMT
             X-Amz-Id-2:
-                - txgce397e7cc7de490a981c-006a03219f
+                - txgd41fd1b3c44c45448482-006a0b159d
             X-Amz-Request-Id:
-                - txgce397e7cc7de490a981c-006a03219f
+                - txgd41fd1b3c44c45448482-006a0b159d
         status: 404 Not Found
         code: 404
-        duration: 9.741417ms
-    - id: 65
+        duration: 13.683291ms
+    - id: 46
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3392,7 +2403,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3401,7 +2412,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b734e560-3bbf-429b-ba10-542316c5db3d
+                - 535dd943-cdd5-48d7-8d17-db351e163064
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3409,8 +2420,61 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124831Z
-        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/
+                - 20260518T133525Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.nl-ams.scw.cloud/?tagging=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 161
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <Tagging><TagSet><Tag><Key>baz</Key><Value>qux</Value></Tag><Tag><Key>foo</Key><Value>bar</Value></Tag></TagSet></Tagging>
+        headers:
+            Content-Length:
+                - "161"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Mon, 18 May 2026 13:35:25 GMT
+            X-Amz-Id-2:
+                - txgd42dda78a28f4ea49b32-006a0b159d
+            X-Amz-Request-Id:
+                - txgd42dda78a28f4ea49b32-006a0b159d
+        status: 200 OK
+        code: 200
+        duration: 64.451875ms
+    - id: 47
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 040d1d27-200d-415c-9c7d-197dd2e5447d
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T133525Z
+        url: https://tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -3422,22 +2486,22 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-basic-1314313384735080249</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-basic-4974415671304108720</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "283"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 12:48:31 GMT
+                - Mon, 18 May 2026 13:35:25 GMT
             X-Amz-Id-2:
-                - txg43e975fbf1bc4b47bd28-006a03219f
+                - txg0158ec73115c4de3954e-006a0b159d
             X-Amz-Request-Id:
-                - txg43e975fbf1bc4b47bd28-006a03219f
+                - txg0158ec73115c4de3954e-006a0b159d
         status: 200 OK
         code: 200
-        duration: 87.008084ms
-    - id: 66
+        duration: 159.968917ms
+    - id: 48
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3445,7 +2509,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3454,7 +2518,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f51f6b92-8cbc-49d4-acac-a578afa2c87b
+                - f59d88dc-da50-47b6-a0f5-4fa4d6863f26
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3462,8 +2526,163 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124831Z
-        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?tagging=
+                - 20260518T133525Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.nl-ams.scw.cloud/?cors=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 297
+        uncompressed: false
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg1c8eb440431c429ab2b8-006a0b159d</RequestId><HostId>txg1c8eb440431c429ab2b8-006a0b159d</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-238236636660294517</Resource></Error>
+        headers:
+            Content-Length:
+                - "297"
+            Content-Type:
+                - application/xml
+            Date:
+                - Mon, 18 May 2026 13:35:25 GMT
+            X-Amz-Id-2:
+                - txg1c8eb440431c429ab2b8-006a0b159d
+            X-Amz-Request-Id:
+                - txg1c8eb440431c429ab2b8-006a0b159d
+        status: 404 Not Found
+        code: 404
+        duration: 54.805834ms
+    - id: 49
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 3e966af6-dd6a-4852-b588-c6d8ffcbe0e7
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T133525Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.nl-ams.scw.cloud/?versioning=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 107
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <VersioningConfiguration><Status></Status></VersioningConfiguration>
+        headers:
+            Content-Length:
+                - "107"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Mon, 18 May 2026 13:35:25 GMT
+            X-Amz-Id-2:
+                - txg4e60b9f1555341688da7-006a0b159d
+            X-Amz-Request-Id:
+                - txg4e60b9f1555341688da7-006a0b159d
+        status: 200 OK
+        code: 200
+        duration: 36.820666ms
+    - id: 50
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 46c8c4b3-1bd1-4e25-a6e1-36a0c04544b1
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T133525Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.nl-ams.scw.cloud/?lifecycle=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 392
+        uncompressed: false
+        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txgcaa6db58e696407194f0-006a0b159d</RequestId><HostId>txgcaa6db58e696407194f0-006a0b159d</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-238236636660294517</Resource><BucketName>tf-tests-scaleway-object-bucket-secondary-238236636660294517</BucketName></Error>
+        headers:
+            Content-Length:
+                - "392"
+            Content-Type:
+                - application/xml
+            Date:
+                - Mon, 18 May 2026 13:35:25 GMT
+            X-Amz-Id-2:
+                - txgcaa6db58e696407194f0-006a0b159d
+            X-Amz-Request-Id:
+                - txgcaa6db58e696407194f0-006a0b159d
+        status: 404 Not Found
+        code: 404
+        duration: 32.459292ms
+    - id: 51
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - adc03d56-fd64-444a-ad5f-fc3ff2ab1d98
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T133525Z
+        url: https://tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3482,15 +2701,15 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 12:48:31 GMT
+                - Mon, 18 May 2026 13:35:25 GMT
             X-Amz-Id-2:
-                - txg70583effd841451db1e5-006a03219f
+                - txgb2ebaa2a46af4e67932b-006a0b159d
             X-Amz-Request-Id:
-                - txg70583effd841451db1e5-006a03219f
+                - txgb2ebaa2a46af4e67932b-006a0b159d
         status: 200 OK
         code: 200
-        duration: 44.3475ms
-    - id: 67
+        duration: 105.340416ms
+    - id: 52
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3498,7 +2717,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3507,7 +2726,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 35b6a689-e5c8-4bf1-a171-3a7243978f67
+                - 3a2d01b8-e365-4cb4-9768-b5946c44e600
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3515,8 +2734,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124831Z
-        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?cors=
+                - 20260518T133525Z
+        url: https://tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3526,22 +2745,22 @@ interactions:
         trailer: {}
         content_length: 294
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg06ad258528f2484ab3a7-006a03219f</RequestId><HostId>txg06ad258528f2484ab3a7-006a03219f</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-1314313384735080249</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg712887d227544c6498d4-006a0b159e</RequestId><HostId>txg712887d227544c6498d4-006a0b159e</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-4974415671304108720</Resource></Error>
         headers:
             Content-Length:
                 - "294"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 12:48:31 GMT
+                - Mon, 18 May 2026 13:35:26 GMT
             X-Amz-Id-2:
-                - txg06ad258528f2484ab3a7-006a03219f
+                - txg712887d227544c6498d4-006a0b159e
             X-Amz-Request-Id:
-                - txg06ad258528f2484ab3a7-006a03219f
+                - txg712887d227544c6498d4-006a0b159e
         status: 404 Not Found
         code: 404
-        duration: 10.930583ms
-    - id: 68
+        duration: 59.148041ms
+    - id: 53
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3549,7 +2768,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3558,7 +2777,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4f373e90-fb59-4d06-9386-c464d12edf35
+                - aa8b5d2f-09c0-4072-813e-aadd54acca94
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3566,8 +2785,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124831Z
-        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?versioning=
+                - 20260518T133526Z
+        url: https://tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3586,15 +2805,15 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 12:48:31 GMT
+                - Mon, 18 May 2026 13:35:26 GMT
             X-Amz-Id-2:
-                - txg12899c60b7bf4935886f-006a03219f
+                - txg6c87fdc5362f4b5fa8cc-006a0b159e
             X-Amz-Request-Id:
-                - txg12899c60b7bf4935886f-006a03219f
+                - txg6c87fdc5362f4b5fa8cc-006a0b159e
         status: 200 OK
         code: 200
-        duration: 14.583291ms
-    - id: 69
+        duration: 12.847667ms
+    - id: 54
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3602,7 +2821,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3611,7 +2830,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e2cd5c5d-fa44-4402-96d0-7cfd42914af7
+                - af4c865f-75be-41a5-91e8-5d6e44278565
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3619,61 +2838,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124831Z
-        url: https://tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud/?versioning=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 107
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <VersioningConfiguration><Status></Status></VersioningConfiguration>
-        headers:
-            Content-Length:
-                - "107"
-            Content-Type:
-                - text/xml; charset=utf-8
-            Date:
-                - Tue, 12 May 2026 12:48:31 GMT
-            X-Amz-Id-2:
-                - txg024c601d4978425fb59c-006a03219f
-            X-Amz-Request-Id:
-                - txg024c601d4978425fb59c-006a03219f
-        status: 200 OK
-        code: 200
-        duration: 78.599959ms
-    - id: 70
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 37d033fc-cc4c-43c0-a1ac-e8d5f88a4957
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260512T124831Z
-        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?lifecycle=
+                - 20260518T133526Z
+        url: https://tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3683,22 +2849,22 @@ interactions:
         trailer: {}
         content_length: 386
         uncompressed: false
-        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txg880ecce6d9304913b2dc-006a03219f</RequestId><HostId>txg880ecce6d9304913b2dc-006a03219f</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-1314313384735080249</Resource><BucketName>tf-tests-scaleway-object-bucket-basic-1314313384735080249</BucketName></Error>
+        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txgdd6f2b2cb5e9447f8112-006a0b159e</RequestId><HostId>txgdd6f2b2cb5e9447f8112-006a0b159e</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-4974415671304108720</Resource><BucketName>tf-tests-scaleway-object-bucket-basic-4974415671304108720</BucketName></Error>
         headers:
             Content-Length:
                 - "386"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 12:48:31 GMT
+                - Mon, 18 May 2026 13:35:26 GMT
             X-Amz-Id-2:
-                - txg880ecce6d9304913b2dc-006a03219f
+                - txgdd6f2b2cb5e9447f8112-006a0b159e
             X-Amz-Request-Id:
-                - txg880ecce6d9304913b2dc-006a03219f
+                - txgdd6f2b2cb5e9447f8112-006a0b159e
         status: 404 Not Found
         code: 404
-        duration: 13.803291ms
-    - id: 71
+        duration: 136.621125ms
+    - id: 55
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3706,7 +2872,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3715,7 +2881,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 48e23b92-a62e-4a88-a24a-2aa781d43f36
+                - b9697a80-9835-48fd-8397-9ff1869cf58a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3723,8 +2889,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124831Z
-        url: https://tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud/?lifecycle=
+                - 20260518T133526Z
+        url: https://tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3732,24 +2898,26 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 396
+        content_length: 698
         uncompressed: false
-        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txgf41a2a622bd746178961-006a03219f</RequestId><HostId>txgf41a2a622bd746178961-006a03219f</HostId><Resource>/tf-tests-scaleway-object-bucket-main-region-652097813215812252</Resource><BucketName>tf-tests-scaleway-object-bucket-main-region-652097813215812252</BucketName></Error>
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
-                - "396"
+                - "698"
             Content-Type:
-                - application/xml
+                - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 12:48:31 GMT
+                - Mon, 18 May 2026 13:35:26 GMT
             X-Amz-Id-2:
-                - txgf41a2a622bd746178961-006a03219f
+                - txg48f3609aa290444a9cd0-006a0b159e
             X-Amz-Request-Id:
-                - txgf41a2a622bd746178961-006a03219f
-        status: 404 Not Found
-        code: 404
-        duration: 18.67325ms
-    - id: 72
+                - txg48f3609aa290444a9cd0-006a0b159e
+        status: 200 OK
+        code: 200
+        duration: 14.241334ms
+    - id: 56
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3757,7 +2925,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-main-region-7696764886433866557.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3766,7 +2934,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d20378d2-d4b2-4bd7-a8e0-6ce1569e284d
+                - e1fcdf2a-642e-4f81-a2ff-5ee2852f32a4
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3774,8 +2942,530 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124831Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T133526Z
+        url: https://tf-tests-scaleway-object-bucket-main-region-7696764886433866557.s3.fr-par.scw.cloud/?acl=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 698
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+        headers:
+            Content-Length:
+                - "698"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Mon, 18 May 2026 13:35:26 GMT
+            X-Amz-Id-2:
+                - txg7271a4cd68df40abbde2-006a0b159e
+            X-Amz-Request-Id:
+                - txg7271a4cd68df40abbde2-006a0b159e
+        status: 200 OK
+        code: 200
+        duration: 15.294ms
+    - id: 57
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 7c9ccf9a-4750-416d-a80c-e3d587c13a0a
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T133526Z
+        url: https://tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud/?object-lock=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 326
+        uncompressed: false
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg9280c50bd4c641c297d1-006a0b159e</RequestId><HostId>txg9280c50bd4c641c297d1-006a0b159e</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-4974415671304108720</Resource></Error>
+        headers:
+            Content-Length:
+                - "326"
+            Content-Type:
+                - application/xml
+            Date:
+                - Mon, 18 May 2026 13:35:26 GMT
+            X-Amz-Id-2:
+                - txg9280c50bd4c641c297d1-006a0b159e
+            X-Amz-Request-Id:
+                - txg9280c50bd4c641c297d1-006a0b159e
+        status: 404 Not Found
+        code: 404
+        duration: 19.725792ms
+    - id: 58
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - a4eaea3b-ab58-4704-a3a1-4201ebdbaa5d
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T133526Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.nl-ams.scw.cloud/?acl=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 698
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+        headers:
+            Content-Length:
+                - "698"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Mon, 18 May 2026 13:35:26 GMT
+            X-Amz-Id-2:
+                - txg23f4e5e6999c435cb790-006a0b159e
+            X-Amz-Request-Id:
+                - txg23f4e5e6999c435cb790-006a0b159e
+        status: 200 OK
+        code: 200
+        duration: 62.366292ms
+    - id: 59
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 1b13d318-efbf-4def-9968-2a000d9782f3
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T133526Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.nl-ams.scw.cloud/?object-lock=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 329
+        uncompressed: false
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg607e423ad5334dc6bb4a-006a0b159e</RequestId><HostId>txg607e423ad5334dc6bb4a-006a0b159e</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-238236636660294517</Resource></Error>
+        headers:
+            Content-Length:
+                - "329"
+            Content-Type:
+                - application/xml
+            Date:
+                - Mon, 18 May 2026 13:35:26 GMT
+            X-Amz-Id-2:
+                - txg607e423ad5334dc6bb4a-006a0b159e
+            X-Amz-Request-Id:
+                - txg607e423ad5334dc6bb4a-006a0b159e
+        status: 404 Not Found
+        code: 404
+        duration: 34.825375ms
+    - id: 60
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 6cf21e51-4e3f-4727-9c9c-1e2d2757a0bc
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T133526Z
+        url: https://tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud/
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 283
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-basic-4974415671304108720</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+        headers:
+            Content-Length:
+                - "283"
+            Content-Type:
+                - application/xml
+            Date:
+                - Mon, 18 May 2026 13:35:26 GMT
+            X-Amz-Id-2:
+                - txg6a9444f4e0df41d79839-006a0b159e
+            X-Amz-Request-Id:
+                - txg6a9444f4e0df41d79839-006a0b159e
+        status: 200 OK
+        code: 200
+        duration: 85.765917ms
+    - id: 61
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - f8341a3c-a011-40e1-844e-97d7ec9fb82c
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T133526Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.nl-ams.scw.cloud/
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 286
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-secondary-238236636660294517</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+        headers:
+            Content-Length:
+                - "286"
+            Content-Type:
+                - application/xml
+            Date:
+                - Mon, 18 May 2026 13:35:26 GMT
+            X-Amz-Id-2:
+                - txg5cdac4a152824eee844d-006a0b159e
+            X-Amz-Request-Id:
+                - txg5cdac4a152824eee844d-006a0b159e
+        status: 200 OK
+        code: 200
+        duration: 103.570916ms
+    - id: 62
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-main-region-7696764886433866557.s3.fr-par.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 45adfc90-e543-4720-911a-33ed313e28a3
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T133526Z
+        url: https://tf-tests-scaleway-object-bucket-main-region-7696764886433866557.s3.fr-par.scw.cloud/?object-lock=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 332
+        uncompressed: false
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgd72e4d799865433d93ed-006a0b159e</RequestId><HostId>txgd72e4d799865433d93ed-006a0b159e</HostId><Resource>/tf-tests-scaleway-object-bucket-main-region-7696764886433866557</Resource></Error>
+        headers:
+            Content-Length:
+                - "332"
+            Content-Type:
+                - application/xml
+            Date:
+                - Mon, 18 May 2026 13:35:26 GMT
+            X-Amz-Id-2:
+                - txgd72e4d799865433d93ed-006a0b159e
+            X-Amz-Request-Id:
+                - txgd72e4d799865433d93ed-006a0b159e
+        status: 404 Not Found
+        code: 404
+        duration: 189.549459ms
+    - id: 63
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 1c19e6ac-caaa-4d77-b845-8490325cbc19
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T133526Z
+        url: https://tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud/?tagging=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 118
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <Tagging><TagSet><Tag><Key>foo</Key><Value>bar</Value></Tag></TagSet></Tagging>
+        headers:
+            Content-Length:
+                - "118"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Mon, 18 May 2026 13:35:26 GMT
+            X-Amz-Id-2:
+                - txgdfa24796be154a0fb7ee-006a0b159e
+            X-Amz-Request-Id:
+                - txgdfa24796be154a0fb7ee-006a0b159e
+        status: 200 OK
+        code: 200
+        duration: 101.127542ms
+    - id: 64
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 33f88491-dd30-4585-b6e5-ec99b6555237
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T133526Z
+        url: https://tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud/?cors=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 294
+        uncompressed: false
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg8b2b18ca59d04f02ae33-006a0b159e</RequestId><HostId>txg8b2b18ca59d04f02ae33-006a0b159e</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-4974415671304108720</Resource></Error>
+        headers:
+            Content-Length:
+                - "294"
+            Content-Type:
+                - application/xml
+            Date:
+                - Mon, 18 May 2026 13:35:26 GMT
+            X-Amz-Id-2:
+                - txg8b2b18ca59d04f02ae33-006a0b159e
+            X-Amz-Request-Id:
+                - txg8b2b18ca59d04f02ae33-006a0b159e
+        status: 404 Not Found
+        code: 404
+        duration: 13.3995ms
+    - id: 65
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - ef0c12f7-45ac-423e-88c5-b92de075ca87
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T133526Z
+        url: https://tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud/?versioning=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 107
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <VersioningConfiguration><Status></Status></VersioningConfiguration>
+        headers:
+            Content-Length:
+                - "107"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Mon, 18 May 2026 13:35:26 GMT
+            X-Amz-Id-2:
+                - txg64afbca7b11f48408bec-006a0b159e
+            X-Amz-Request-Id:
+                - txg64afbca7b11f48408bec-006a0b159e
+        status: 200 OK
+        code: 200
+        duration: 18.19225ms
+    - id: 66
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 5a34db0e-88a3-4ecb-a50a-0e29b63d0c94
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T133526Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3787,22 +3477,22 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Tagging><TagSet><Tag><Key>foo</Key><Value>bar</Value></Tag><Tag><Key>baz</Key><Value>qux</Value></Tag></TagSet></Tagging>
+            <Tagging><TagSet><Tag><Key>baz</Key><Value>qux</Value></Tag><Tag><Key>foo</Key><Value>bar</Value></Tag></TagSet></Tagging>
         headers:
             Content-Length:
                 - "161"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 12:48:31 GMT
+                - Mon, 18 May 2026 13:35:26 GMT
             X-Amz-Id-2:
-                - txg7caf987f931f41f780ad-006a03219f
+                - txgd6fde28835904d8a95ed-006a0b159e
             X-Amz-Request-Id:
-                - txg7caf987f931f41f780ad-006a03219f
+                - txgd6fde28835904d8a95ed-006a0b159e
         status: 200 OK
         code: 200
-        duration: 154.815625ms
-    - id: 73
+        duration: 71.916666ms
+    - id: 67
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3810,7 +3500,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3819,7 +3509,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 83b18329-63d6-4655-960b-d099c8b6a58d
+                - c53e3b1d-0bdf-4f6e-b1c8-e1d6bf0aa9ee
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3827,8 +3517,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124831Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T133526Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3836,24 +3526,24 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 298
+        content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg4e23f6a4408a4f21ade5-006a0321a0</RequestId><HostId>txg4e23f6a4408a4f21ade5-006a0321a0</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-2001388040591926415</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgcebaa4a70d444bc183c4-006a0b159e</RequestId><HostId>txgcebaa4a70d444bc183c4-006a0b159e</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-238236636660294517</Resource></Error>
         headers:
             Content-Length:
-                - "298"
+                - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 12:48:32 GMT
+                - Mon, 18 May 2026 13:35:26 GMT
             X-Amz-Id-2:
-                - txg4e23f6a4408a4f21ade5-006a0321a0
+                - txgcebaa4a70d444bc183c4-006a0b159e
             X-Amz-Request-Id:
-                - txg4e23f6a4408a4f21ade5-006a0321a0
+                - txgcebaa4a70d444bc183c4-006a0b159e
         status: 404 Not Found
         code: 404
-        duration: 19.252459ms
-    - id: 74
+        duration: 33.103625ms
+    - id: 68
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3861,7 +3551,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3870,7 +3560,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 62503016-2d42-475a-b25a-83726fe3bf15
+                - 4d535e11-3b9b-45fa-81bd-e5cc34f5765b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3878,8 +3568,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124832Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T133526Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3898,14 +3588,324 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 12:48:32 GMT
+                - Mon, 18 May 2026 13:35:26 GMT
             X-Amz-Id-2:
-                - txg9c29ce1a45994b9aadb2-006a0321a0
+                - txg9015aec8cd044bc8802b-006a0b159e
             X-Amz-Request-Id:
-                - txg9c29ce1a45994b9aadb2-006a0321a0
+                - txg9015aec8cd044bc8802b-006a0b159e
         status: 200 OK
         code: 200
-        duration: 57.886125ms
+        duration: 22.306416ms
+    - id: 69
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 38261cc1-e67f-43a0-8cf2-7f92caf97339
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T133526Z
+        url: https://tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud/?lifecycle=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 386
+        uncompressed: false
+        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txgf48af6e35c6141378948-006a0b159e</RequestId><HostId>txgf48af6e35c6141378948-006a0b159e</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-4974415671304108720</Resource><BucketName>tf-tests-scaleway-object-bucket-basic-4974415671304108720</BucketName></Error>
+        headers:
+            Content-Length:
+                - "386"
+            Content-Type:
+                - application/xml
+            Date:
+                - Mon, 18 May 2026 13:35:26 GMT
+            X-Amz-Id-2:
+                - txgf48af6e35c6141378948-006a0b159e
+            X-Amz-Request-Id:
+                - txgf48af6e35c6141378948-006a0b159e
+        status: 404 Not Found
+        code: 404
+        duration: 84.40975ms
+    - id: 70
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-main-region-7696764886433866557.s3.fr-par.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - e6213a16-5217-40df-8f69-a78a9f94096b
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T133526Z
+        url: https://tf-tests-scaleway-object-bucket-main-region-7696764886433866557.s3.fr-par.scw.cloud/
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 289
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-main-region-7696764886433866557</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+        headers:
+            Content-Length:
+                - "289"
+            Content-Type:
+                - application/xml
+            Date:
+                - Mon, 18 May 2026 13:35:26 GMT
+            X-Amz-Id-2:
+                - txgc75ff91cdf954af4a8ec-006a0b159e
+            X-Amz-Request-Id:
+                - txgc75ff91cdf954af4a8ec-006a0b159e
+        status: 200 OK
+        code: 200
+        duration: 182.9055ms
+    - id: 71
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-main-region-7696764886433866557.s3.fr-par.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - c9809bb7-a97e-4e15-ba1f-4dfe93d892cb
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T133526Z
+        url: https://tf-tests-scaleway-object-bucket-main-region-7696764886433866557.s3.fr-par.scw.cloud/?tagging=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 365
+        uncompressed: false
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg4daf2ba431c54ec288ea-006a0b159e</RequestId><HostId>txg4daf2ba431c54ec288ea-006a0b159e</HostId><Resource>/tf-tests-scaleway-object-bucket-main-region-7696764886433866557</Resource><BucketName>tf-tests-scaleway-object-bucket-main-region-7696764886433866557</BucketName></Error>
+        headers:
+            Content-Length:
+                - "365"
+            Content-Type:
+                - application/xml
+            Date:
+                - Mon, 18 May 2026 13:35:26 GMT
+            X-Amz-Id-2:
+                - txg4daf2ba431c54ec288ea-006a0b159e
+            X-Amz-Request-Id:
+                - txg4daf2ba431c54ec288ea-006a0b159e
+        status: 404 Not Found
+        code: 404
+        duration: 18.2315ms
+    - id: 72
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - cadae344-40ed-46b5-8595-aaeafa4ea332
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T133526Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.nl-ams.scw.cloud/?lifecycle=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 392
+        uncompressed: false
+        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txg9e522e729808420cb4de-006a0b159e</RequestId><HostId>txg9e522e729808420cb4de-006a0b159e</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-238236636660294517</Resource><BucketName>tf-tests-scaleway-object-bucket-secondary-238236636660294517</BucketName></Error>
+        headers:
+            Content-Length:
+                - "392"
+            Content-Type:
+                - application/xml
+            Date:
+                - Mon, 18 May 2026 13:35:26 GMT
+            X-Amz-Id-2:
+                - txg9e522e729808420cb4de-006a0b159e
+            X-Amz-Request-Id:
+                - txg9e522e729808420cb4de-006a0b159e
+        status: 404 Not Found
+        code: 404
+        duration: 87.54025ms
+    - id: 73
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-main-region-7696764886433866557.s3.fr-par.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 4c25cfc4-2423-4163-9740-fa8b00e0fbb4
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T133526Z
+        url: https://tf-tests-scaleway-object-bucket-main-region-7696764886433866557.s3.fr-par.scw.cloud/?cors=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 300
+        uncompressed: false
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg9005f861cdd74bacbeac-006a0b159e</RequestId><HostId>txg9005f861cdd74bacbeac-006a0b159e</HostId><Resource>/tf-tests-scaleway-object-bucket-main-region-7696764886433866557</Resource></Error>
+        headers:
+            Content-Length:
+                - "300"
+            Content-Type:
+                - application/xml
+            Date:
+                - Mon, 18 May 2026 13:35:26 GMT
+            X-Amz-Id-2:
+                - txg9005f861cdd74bacbeac-006a0b159e
+            X-Amz-Request-Id:
+                - txg9005f861cdd74bacbeac-006a0b159e
+        status: 404 Not Found
+        code: 404
+        duration: 13.5085ms
+    - id: 74
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-main-region-7696764886433866557.s3.fr-par.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - a590d6fa-d6c9-4f86-9224-b75f9e1b64f6
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T133526Z
+        url: https://tf-tests-scaleway-object-bucket-main-region-7696764886433866557.s3.fr-par.scw.cloud/?versioning=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 107
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <VersioningConfiguration><Status></Status></VersioningConfiguration>
+        headers:
+            Content-Length:
+                - "107"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Mon, 18 May 2026 13:35:26 GMT
+            X-Amz-Id-2:
+                - txgeb5c4cf3980d49afadc6-006a0b159e
+            X-Amz-Request-Id:
+                - txgeb5c4cf3980d49afadc6-006a0b159e
+        status: 200 OK
+        code: 200
+        duration: 177.87925ms
     - id: 75
       request:
         proto: HTTP/1.1
@@ -3914,7 +3914,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-main-region-7696764886433866557.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3923,7 +3923,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 41ef113f-20a4-435e-8397-49bb705cc35e
+                - 2b8be288-0167-416c-b59e-da8ff377b90b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3931,8 +3931,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124832Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T133526Z
+        url: https://tf-tests-scaleway-object-bucket-main-region-7696764886433866557.s3.fr-par.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3940,23 +3940,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 394
+        content_length: 398
         uncompressed: false
-        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txg3674ed3b43fa46dead0f-006a0321a0</RequestId><HostId>txg3674ed3b43fa46dead0f-006a0321a0</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-2001388040591926415</Resource><BucketName>tf-tests-scaleway-object-bucket-secondary-2001388040591926415</BucketName></Error>
+        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txgcb70bde2568c4022bf54-006a0b159f</RequestId><HostId>txgcb70bde2568c4022bf54-006a0b159f</HostId><Resource>/tf-tests-scaleway-object-bucket-main-region-7696764886433866557</Resource><BucketName>tf-tests-scaleway-object-bucket-main-region-7696764886433866557</BucketName></Error>
         headers:
             Content-Length:
-                - "394"
+                - "398"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 12:48:32 GMT
+                - Mon, 18 May 2026 13:35:27 GMT
             X-Amz-Id-2:
-                - txg3674ed3b43fa46dead0f-006a0321a0
+                - txgcb70bde2568c4022bf54-006a0b159f
             X-Amz-Request-Id:
-                - txg3674ed3b43fa46dead0f-006a0321a0
+                - txgcb70bde2568c4022bf54-006a0b159f
         status: 404 Not Found
         code: 404
-        duration: 37.028417ms
+        duration: 810.486291ms
     - id: 76
       request:
         proto: HTTP/1.1
@@ -3965,7 +3965,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3974,7 +3974,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 53e93e0a-07e7-4b0a-a8da-b34a5c79426a
+                - c13c02fc-1027-4a5e-8225-f296ac359ef6
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3986,8 +3986,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124832Z
-        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?acl=
+                - 20260518T133528Z
+        url: https://tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud/?acl=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -4002,14 +4002,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 12 May 2026 12:48:32 GMT
+                - Mon, 18 May 2026 13:35:28 GMT
             X-Amz-Id-2:
-                - txg426a10eed9624f22b3b7-006a0321a0
+                - txgb648ec272e9e496d836d-006a0b15a0
             X-Amz-Request-Id:
-                - txg426a10eed9624f22b3b7-006a0321a0
+                - txgb648ec272e9e496d836d-006a0b15a0
         status: 200 OK
         code: 200
-        duration: 167.236042ms
+        duration: 56.119416ms
     - id: 77
       request:
         proto: HTTP/1.1
@@ -4018,7 +4018,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4027,7 +4027,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 8d537e36-9e91-4e11-adfc-ad5de5453891
+                - 79e66e8c-25b3-4aad-b141-bef1258f043c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4035,8 +4035,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124832Z
-        url: https://tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud/
+                - 20260518T133528Z
+        url: https://tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud/?tagging=
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -4049,14 +4049,14 @@ interactions:
         body: ""
         headers:
             Date:
-                - Tue, 12 May 2026 12:48:32 GMT
+                - Mon, 18 May 2026 13:35:28 GMT
             X-Amz-Id-2:
-                - txg59e1f50c83b148a89347-006a0321a0
+                - txgd1f9b4cba61040a2abd1-006a0b15a0
             X-Amz-Request-Id:
-                - txg59e1f50c83b148a89347-006a0321a0
+                - txgd1f9b4cba61040a2abd1-006a0b15a0
         status: 204 No Content
         code: 204
-        duration: 170.806792ms
+        duration: 21.934833ms
     - id: 78
       request:
         proto: HTTP/1.1
@@ -4065,7 +4065,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4074,7 +4074,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4ed20714-c19c-4ef3-808a-8915ebe53fa6
+                - 841dbba6-4793-426f-9edf-be61e6ce2761
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4082,55 +4082,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124832Z
-        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?tagging=
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 0
-        uncompressed: false
-        body: ""
-        headers:
-            Date:
-                - Tue, 12 May 2026 12:48:32 GMT
-            X-Amz-Id-2:
-                - txgb37899e3e09f4307a14b-006a0321a0
-            X-Amz-Request-Id:
-                - txgb37899e3e09f4307a14b-006a0321a0
-        status: 204 No Content
-        code: 204
-        duration: 51.978542ms
-    - id: 79
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 727eb06b-57ed-430f-852b-520047882adc
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260512T124832Z
-        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?acl=
+                - 20260518T133528Z
+        url: https://tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4149,15 +4102,15 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 12:48:32 GMT
+                - Mon, 18 May 2026 13:35:28 GMT
             X-Amz-Id-2:
-                - txg3afbd24a2f5c42a898ed-006a0321a0
+                - txg846410b5e4b2414cbb77-006a0b15a0
             X-Amz-Request-Id:
-                - txg3afbd24a2f5c42a898ed-006a0321a0
+                - txg846410b5e4b2414cbb77-006a0b15a0
         status: 200 OK
         code: 200
-        duration: 8.358084ms
-    - id: 80
+        duration: 13.489084ms
+    - id: 79
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -4165,7 +4118,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4174,7 +4127,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 47ff5de5-2dfc-42ca-b65d-f25b63b73217
+                - af2b734c-1431-4eb3-ba33-c427401ca5ec
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4182,8 +4135,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124832Z
-        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?object-lock=
+                - 20260518T133528Z
+        url: https://tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4193,22 +4146,22 @@ interactions:
         trailer: {}
         content_length: 326
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgb9fb4eb64d3441aba252-006a0321a0</RequestId><HostId>txgb9fb4eb64d3441aba252-006a0321a0</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-1314313384735080249</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg73022b3c4a30427fb33c-006a0b15a0</RequestId><HostId>txg73022b3c4a30427fb33c-006a0b15a0</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-4974415671304108720</Resource></Error>
         headers:
             Content-Length:
                 - "326"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 12:48:32 GMT
+                - Mon, 18 May 2026 13:35:28 GMT
             X-Amz-Id-2:
-                - txgb9fb4eb64d3441aba252-006a0321a0
+                - txg73022b3c4a30427fb33c-006a0b15a0
             X-Amz-Request-Id:
-                - txgb9fb4eb64d3441aba252-006a0321a0
+                - txg73022b3c4a30427fb33c-006a0b15a0
         status: 404 Not Found
         code: 404
-        duration: 10.721167ms
-    - id: 81
+        duration: 12.697125ms
+    - id: 80
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -4216,7 +4169,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4225,7 +4178,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 2fcf329b-7016-43e0-ac5e-0fa156583169
+                - fd2b5d68-949e-4e56-bca4-fe70f06987c1
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4233,8 +4186,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124832Z
-        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/
+                - 20260518T133528Z
+        url: https://tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -4246,22 +4199,22 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-basic-1314313384735080249</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-basic-4974415671304108720</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "283"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 12:48:32 GMT
+                - Mon, 18 May 2026 13:35:28 GMT
             X-Amz-Id-2:
-                - txgc7543294aed843ca8976-006a0321a0
+                - txg3cbdb7038e8c49d69086-006a0b15a0
             X-Amz-Request-Id:
-                - txgc7543294aed843ca8976-006a0321a0
+                - txg3cbdb7038e8c49d69086-006a0b15a0
         status: 200 OK
         code: 200
-        duration: 16.774375ms
-    - id: 82
+        duration: 13.64825ms
+    - id: 81
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -4269,7 +4222,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4278,7 +4231,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b3868232-1ee1-4b85-bb42-8b343aaf1352
+                - 6b0b5e71-9909-4942-8ee7-c9d1d9e1d87f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4286,8 +4239,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124832Z
-        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?tagging=
+                - 20260518T133528Z
+        url: https://tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4297,22 +4250,22 @@ interactions:
         trailer: {}
         content_length: 353
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg228cb2a7e8ef40ab8337-006a0321a0</RequestId><HostId>txg228cb2a7e8ef40ab8337-006a0321a0</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-1314313384735080249</Resource><BucketName>tf-tests-scaleway-object-bucket-basic-1314313384735080249</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg679a8aeef0364274ac86-006a0b15a0</RequestId><HostId>txg679a8aeef0364274ac86-006a0b15a0</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-4974415671304108720</Resource><BucketName>tf-tests-scaleway-object-bucket-basic-4974415671304108720</BucketName></Error>
         headers:
             Content-Length:
                 - "353"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 12:48:32 GMT
+                - Mon, 18 May 2026 13:35:28 GMT
             X-Amz-Id-2:
-                - txg228cb2a7e8ef40ab8337-006a0321a0
+                - txg679a8aeef0364274ac86-006a0b15a0
             X-Amz-Request-Id:
-                - txg228cb2a7e8ef40ab8337-006a0321a0
+                - txg679a8aeef0364274ac86-006a0b15a0
         status: 404 Not Found
         code: 404
-        duration: 8.806417ms
-    - id: 83
+        duration: 11.898541ms
+    - id: 82
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -4320,7 +4273,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4329,7 +4282,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ed4b5780-5dec-4832-9809-0f0d59a8357c
+                - 9d7c5952-41df-4d27-8679-af6f11eacebf
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4337,8 +4290,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124832Z
-        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?cors=
+                - 20260518T133528Z
+        url: https://tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4348,22 +4301,22 @@ interactions:
         trailer: {}
         content_length: 294
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg9c24afbfa22f4144bca5-006a0321a0</RequestId><HostId>txg9c24afbfa22f4144bca5-006a0321a0</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-1314313384735080249</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg927de9c475144afda4d1-006a0b15a0</RequestId><HostId>txg927de9c475144afda4d1-006a0b15a0</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-4974415671304108720</Resource></Error>
         headers:
             Content-Length:
                 - "294"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 12:48:32 GMT
+                - Mon, 18 May 2026 13:35:28 GMT
             X-Amz-Id-2:
-                - txg9c24afbfa22f4144bca5-006a0321a0
+                - txg927de9c475144afda4d1-006a0b15a0
             X-Amz-Request-Id:
-                - txg9c24afbfa22f4144bca5-006a0321a0
+                - txg927de9c475144afda4d1-006a0b15a0
         status: 404 Not Found
         code: 404
-        duration: 7.995375ms
-    - id: 84
+        duration: 13.637ms
+    - id: 83
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -4371,7 +4324,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4380,7 +4333,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - a75a1d6e-8d97-4f9d-988b-1276776c12b4
+                - f4b204c8-958e-46db-8030-9dbc58fa6a4e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4388,8 +4341,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124832Z
-        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?versioning=
+                - 20260518T133528Z
+        url: https://tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4408,15 +4361,15 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 12:48:32 GMT
+                - Mon, 18 May 2026 13:35:28 GMT
             X-Amz-Id-2:
-                - txg0a5ed1ce24204054bc30-006a0321a0
+                - txg5a2197980b21485ca01f-006a0b15a0
             X-Amz-Request-Id:
-                - txg0a5ed1ce24204054bc30-006a0321a0
+                - txg5a2197980b21485ca01f-006a0b15a0
         status: 200 OK
         code: 200
-        duration: 8.519208ms
-    - id: 85
+        duration: 31.772ms
+    - id: 84
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -4424,7 +4377,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4433,7 +4386,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 27fa026b-51d2-4004-9aa8-aae457bd0c72
+                - a4cadf23-decd-4551-958f-e28dc445041c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4441,8 +4394,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124832Z
-        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?lifecycle=
+                - 20260518T133528Z
+        url: https://tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4452,22 +4405,22 @@ interactions:
         trailer: {}
         content_length: 386
         uncompressed: false
-        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txg5fa6fa45aa424f43b8e4-006a0321a0</RequestId><HostId>txg5fa6fa45aa424f43b8e4-006a0321a0</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-1314313384735080249</Resource><BucketName>tf-tests-scaleway-object-bucket-basic-1314313384735080249</BucketName></Error>
+        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txg892a90654b524497ad27-006a0b15a0</RequestId><HostId>txg892a90654b524497ad27-006a0b15a0</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-4974415671304108720</Resource><BucketName>tf-tests-scaleway-object-bucket-basic-4974415671304108720</BucketName></Error>
         headers:
             Content-Length:
                 - "386"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 12:48:32 GMT
+                - Mon, 18 May 2026 13:35:28 GMT
             X-Amz-Id-2:
-                - txg5fa6fa45aa424f43b8e4-006a0321a0
+                - txg892a90654b524497ad27-006a0b15a0
             X-Amz-Request-Id:
-                - txg5fa6fa45aa424f43b8e4-006a0321a0
+                - txg892a90654b524497ad27-006a0b15a0
         status: 404 Not Found
         code: 404
-        duration: 27.0825ms
-    - id: 86
+        duration: 14.069917ms
+    - id: 85
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -4475,7 +4428,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4484,7 +4437,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 18044edb-0d60-4cc0-a7d6-77462079b015
+                - 98669ed0-2812-4504-b346-bc2220b28531
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4492,8 +4445,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124832Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud/
+                - 20260518T133528Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.nl-ams.scw.cloud/
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -4506,15 +4459,15 @@ interactions:
         body: ""
         headers:
             Date:
-                - Tue, 12 May 2026 12:48:32 GMT
+                - Mon, 18 May 2026 13:35:28 GMT
             X-Amz-Id-2:
-                - txg65b6af4e7bc8418bb0d4-006a0321a0
+                - txg287928d41a49458fbbc9-006a0b15a0
             X-Amz-Request-Id:
-                - txg65b6af4e7bc8418bb0d4-006a0321a0
+                - txg287928d41a49458fbbc9-006a0b15a0
         status: 204 No Content
         code: 204
-        duration: 450.279625ms
-    - id: 87
+        duration: 211.236291ms
+    - id: 86
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -4522,7 +4475,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud
+        host: tf-tests-scaleway-object-bucket-main-region-7696764886433866557.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4531,7 +4484,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7747a452-f5b7-4233-a111-dba30f3b4450
+                - bacf7e38-f188-434a-a6ea-2582ce8dacec
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4539,8 +4492,55 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124832Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud/
+                - 20260518T133528Z
+        url: https://tf-tests-scaleway-object-bucket-main-region-7696764886433866557.s3.fr-par.scw.cloud/
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Date:
+                - Mon, 18 May 2026 13:35:28 GMT
+            X-Amz-Id-2:
+                - txgbdb188fc3276405b9e45-006a0b15a0
+            X-Amz-Request-Id:
+                - txgbdb188fc3276405b9e45-006a0b15a0
+        status: 204 No Content
+        code: 204
+        duration: 321.002834ms
+    - id: 87
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.pl-waw.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 1440a23c-5013-4c41-b27d-e2748e81c997
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T133528Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.pl-waw.scw.cloud/
         method: PUT
       response:
         proto: HTTP/2.0
@@ -4555,16 +4555,16 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 12 May 2026 12:48:33 GMT
+                - Mon, 18 May 2026 13:35:28 GMT
             Location:
-                - /tf-tests-scaleway-object-bucket-secondary-2001388040591926415
+                - /tf-tests-scaleway-object-bucket-secondary-238236636660294517
             X-Amz-Id-2:
-                - txgdd1210f501234e22a1dc-006a0321a1
+                - txg30dfeedb4bb1444a9e96-006a0b15a0
             X-Amz-Request-Id:
-                - txgdd1210f501234e22a1dc-006a0321a1
+                - txg30dfeedb4bb1444a9e96-006a0b15a0
         status: 200 OK
         code: 200
-        duration: 852.185667ms
+        duration: 866.442542ms
     - id: 88
       request:
         proto: HTTP/1.1
@@ -4573,7 +4573,7 @@ interactions:
         content_length: 127
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.pl-waw.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: <Tagging xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><TagSet><Tag><Key>foo</Key><Value>bar</Value></Tag></TagSet></Tagging>
@@ -4582,7 +4582,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - cdfe9d69-2398-408d-8c11-64adcda96c7e
+                - 46c7a98c-c993-43a4-8efe-35656cc5be3d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
@@ -4594,8 +4594,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - d68cba1a39d89eb72e49b2e5b04058846b60e88e6e32eae42901c4f57a4727a8
             X-Amz-Date:
-                - 20260512T124833Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud/?tagging=
+                - 20260518T133528Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.pl-waw.scw.cloud/?tagging=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -4610,14 +4610,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 12 May 2026 12:48:33 GMT
+                - Mon, 18 May 2026 13:35:29 GMT
             X-Amz-Id-2:
-                - txg0ca7ec1dd6b140919b04-006a0321a1
+                - txgedfd80d4a0a64fce8245-006a0b15a1
             X-Amz-Request-Id:
-                - txg0ca7ec1dd6b140919b04-006a0321a1
+                - txgedfd80d4a0a64fce8245-006a0b15a1
         status: 200 OK
         code: 200
-        duration: 458.446042ms
+        duration: 1.574289s
     - id: 89
       request:
         proto: HTTP/1.1
@@ -4626,7 +4626,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.pl-waw.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4635,7 +4635,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e2259d8c-2ac8-4ca5-9990-8a146f51425a
+                - 6fd904b4-e2d5-4900-a192-ae580f21304a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4647,8 +4647,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124834Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud/?acl=
+                - 20260518T133530Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.pl-waw.scw.cloud/?acl=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -4663,14 +4663,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 12 May 2026 12:48:34 GMT
+                - Mon, 18 May 2026 13:35:30 GMT
             X-Amz-Id-2:
-                - txg255679a02716438ebbbe-006a0321a2
+                - txg7997721493594994a087-006a0b15a2
             X-Amz-Request-Id:
-                - txg255679a02716438ebbbe-006a0321a2
+                - txg7997721493594994a087-006a0b15a2
         status: 200 OK
         code: 200
-        duration: 742.548792ms
+        duration: 489.184375ms
     - id: 90
       request:
         proto: HTTP/1.1
@@ -4679,7 +4679,7 @@ interactions:
         content_length: 127
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.pl-waw.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: <Tagging xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><TagSet><Tag><Key>foo</Key><Value>bar</Value></Tag></TagSet></Tagging>
@@ -4688,7 +4688,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - cb60339e-8d7c-423f-8a1a-dedfcb60165a
+                - 5e55a761-f05c-4a06-b268-303b2675b416
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
@@ -4700,8 +4700,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - d68cba1a39d89eb72e49b2e5b04058846b60e88e6e32eae42901c4f57a4727a8
             X-Amz-Date:
-                - 20260512T124834Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud/?tagging=
+                - 20260518T133530Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.pl-waw.scw.cloud/?tagging=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -4716,14 +4716,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 12 May 2026 12:48:34 GMT
+                - Mon, 18 May 2026 13:35:31 GMT
             X-Amz-Id-2:
-                - txg7dd92154cfa34f93a2bb-006a0321a2
+                - txg7569f599ae924cb297f4-006a0b15a3
             X-Amz-Request-Id:
-                - txg7dd92154cfa34f93a2bb-006a0321a2
+                - txg7569f599ae924cb297f4-006a0b15a3
         status: 200 OK
         code: 200
-        duration: 387.86575ms
+        duration: 819.539042ms
     - id: 91
       request:
         proto: HTTP/1.1
@@ -4732,7 +4732,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.pl-waw.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4741,7 +4741,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 73497f09-4a6e-4cc5-be5b-1d5e1537950f
+                - 0ed0a881-a4c9-4583-9010-a274e6fd5361
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4749,8 +4749,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124835Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud/?acl=
+                - 20260518T133531Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.pl-waw.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4769,14 +4769,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 12:48:35 GMT
+                - Mon, 18 May 2026 13:35:32 GMT
             X-Amz-Id-2:
-                - txg93598a8920bc4ba09eba-006a0321a3
+                - txg6b30e556a609459c9417-006a0b15a4
             X-Amz-Request-Id:
-                - txg93598a8920bc4ba09eba-006a0321a3
+                - txg6b30e556a609459c9417-006a0b15a4
         status: 200 OK
         code: 200
-        duration: 252.752833ms
+        duration: 137.288709ms
     - id: 92
       request:
         proto: HTTP/1.1
@@ -4785,7 +4785,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.pl-waw.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4794,7 +4794,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 820c80db-7b0e-4b1d-9b16-0a6b8685c60a
+                - d3ae5d01-a746-4a4b-a1d4-008c6932be86
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4802,8 +4802,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124835Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud/?object-lock=
+                - 20260518T133532Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.pl-waw.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4811,23 +4811,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 330
+        content_length: 329
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg39710330144749cebc1a-006a0321a3</RequestId><HostId>txg39710330144749cebc1a-006a0321a3</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-2001388040591926415</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg2b43619cab62435697ae-006a0b15a4</RequestId><HostId>txg2b43619cab62435697ae-006a0b15a4</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-238236636660294517</Resource></Error>
         headers:
             Content-Length:
-                - "330"
+                - "329"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 12:48:35 GMT
+                - Mon, 18 May 2026 13:35:32 GMT
             X-Amz-Id-2:
-                - txg39710330144749cebc1a-006a0321a3
+                - txg2b43619cab62435697ae-006a0b15a4
             X-Amz-Request-Id:
-                - txg39710330144749cebc1a-006a0321a3
+                - txg2b43619cab62435697ae-006a0b15a4
         status: 404 Not Found
         code: 404
-        duration: 208.839666ms
+        duration: 121.906416ms
     - id: 93
       request:
         proto: HTTP/1.1
@@ -4836,7 +4836,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.pl-waw.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4845,7 +4845,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 3875b587-2c9c-40bf-a2ab-51ae0cefae53
+                - 6a65e5d4-58d3-4034-bcd4-2ea3645922b2
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4853,8 +4853,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124835Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud/
+                - 20260518T133532Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.pl-waw.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -4862,25 +4862,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 287
+        content_length: 286
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-secondary-2001388040591926415</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-secondary-238236636660294517</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "287"
+                - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 12:48:35 GMT
+                - Mon, 18 May 2026 13:35:32 GMT
             X-Amz-Id-2:
-                - txg0dd7618658d542ed8d3f-006a0321a3
+                - txgb1eca4f100fc4958a575-006a0b15a4
             X-Amz-Request-Id:
-                - txg0dd7618658d542ed8d3f-006a0321a3
+                - txgb1eca4f100fc4958a575-006a0b15a4
         status: 200 OK
         code: 200
-        duration: 265.30425ms
+        duration: 1.005236875s
     - id: 94
       request:
         proto: HTTP/1.1
@@ -4889,7 +4889,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.pl-waw.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4898,7 +4898,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 49eb76a4-2a02-4bb1-a810-3b434db4e49a
+                - b0357f01-6ae1-4b3b-b95e-a201c7ea45ea
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4906,8 +4906,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124835Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud/?tagging=
+                - 20260518T133532Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.pl-waw.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4926,14 +4926,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 12:48:36 GMT
+                - Mon, 18 May 2026 13:35:33 GMT
             X-Amz-Id-2:
-                - txga0be1a9445a84cbfa5a6-006a0321a4
+                - txgfafd7025f8ad49d5a1fe-006a0b15a5
             X-Amz-Request-Id:
-                - txga0be1a9445a84cbfa5a6-006a0321a4
+                - txgfafd7025f8ad49d5a1fe-006a0b15a5
         status: 200 OK
         code: 200
-        duration: 254.905083ms
+        duration: 281.178958ms
     - id: 95
       request:
         proto: HTTP/1.1
@@ -4942,7 +4942,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.pl-waw.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4951,7 +4951,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 960711e2-c5c3-403f-a7a6-dbf1b5cbeb34
+                - a3e1a1f2-2622-45ec-976e-207b1c1a4c10
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4959,8 +4959,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124836Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud/?cors=
+                - 20260518T133533Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.pl-waw.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4968,23 +4968,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 298
+        content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg9f5e2c1734a9405893a2-006a0321a4</RequestId><HostId>txg9f5e2c1734a9405893a2-006a0321a4</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-2001388040591926415</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg2a0f530b6dee42b79bdb-006a0b15a5</RequestId><HostId>txg2a0f530b6dee42b79bdb-006a0b15a5</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-238236636660294517</Resource></Error>
         headers:
             Content-Length:
-                - "298"
+                - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 12:48:36 GMT
+                - Mon, 18 May 2026 13:35:33 GMT
             X-Amz-Id-2:
-                - txg9f5e2c1734a9405893a2-006a0321a4
+                - txg2a0f530b6dee42b79bdb-006a0b15a5
             X-Amz-Request-Id:
-                - txg9f5e2c1734a9405893a2-006a0321a4
+                - txg2a0f530b6dee42b79bdb-006a0b15a5
         status: 404 Not Found
         code: 404
-        duration: 65.413375ms
+        duration: 42.536667ms
     - id: 96
       request:
         proto: HTTP/1.1
@@ -4993,7 +4993,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.pl-waw.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5002,7 +5002,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ecc316e7-6855-4270-a6ff-7df396f4d657
+                - 14605b2d-8796-41b7-9415-14a9457184e9
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5010,8 +5010,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124836Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud/?versioning=
+                - 20260518T133533Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.pl-waw.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5030,14 +5030,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 12:48:36 GMT
+                - Mon, 18 May 2026 13:35:33 GMT
             X-Amz-Id-2:
-                - txga90cae7581654e148069-006a0321a4
+                - txg9df556bf7c944549a3cf-006a0b15a5
             X-Amz-Request-Id:
-                - txga90cae7581654e148069-006a0321a4
+                - txg9df556bf7c944549a3cf-006a0b15a5
         status: 200 OK
         code: 200
-        duration: 443.268333ms
+        duration: 1.6620675s
     - id: 97
       request:
         proto: HTTP/1.1
@@ -5046,7 +5046,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.pl-waw.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5055,7 +5055,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b10f2861-dcb3-44ef-872b-54db09bb9292
+                - 80feea07-df92-40c2-b908-86c1cb66dfec
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5063,8 +5063,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124836Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud/?lifecycle=
+                - 20260518T133533Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.pl-waw.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5072,23 +5072,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 394
+        content_length: 392
         uncompressed: false
-        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txgc413e22d3cf646168d8d-006a0321a4</RequestId><HostId>txgc413e22d3cf646168d8d-006a0321a4</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-2001388040591926415</Resource><BucketName>tf-tests-scaleway-object-bucket-secondary-2001388040591926415</BucketName></Error>
+        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txg429d290f771d4698b019-006a0b15a7</RequestId><HostId>txg429d290f771d4698b019-006a0b15a7</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-238236636660294517</Resource><BucketName>tf-tests-scaleway-object-bucket-secondary-238236636660294517</BucketName></Error>
         headers:
             Content-Length:
-                - "394"
+                - "392"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 12:48:36 GMT
+                - Mon, 18 May 2026 13:35:35 GMT
             X-Amz-Id-2:
-                - txgc413e22d3cf646168d8d-006a0321a4
+                - txg429d290f771d4698b019-006a0b15a7
             X-Amz-Request-Id:
-                - txgc413e22d3cf646168d8d-006a0321a4
+                - txg429d290f771d4698b019-006a0b15a7
         status: 404 Not Found
         code: 404
-        duration: 222.524959ms
+        duration: 44.775542ms
     - id: 98
       request:
         proto: HTTP/1.1
@@ -5097,7 +5097,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5106,7 +5106,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 95d01f74-6724-4308-99ff-8d3d84ccae01
+                - 04fe377c-0715-43b6-a6df-1cc9845331be
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5114,8 +5114,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124837Z
-        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/
+                - 20260518T133535Z
+        url: https://tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -5130,16 +5130,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 12:48:37 GMT
+                - Mon, 18 May 2026 13:35:35 GMT
             X-Amz-Bucket-Region:
                 - fr-par
             X-Amz-Id-2:
-                - txg7d7f3693e3614498a614-006a0321a5
+                - txg404e0a46c97c4e318979-006a0b15a7
             X-Amz-Request-Id:
-                - txg7d7f3693e3614498a614-006a0321a5
+                - txg404e0a46c97c4e318979-006a0b15a7
         status: 200 OK
         code: 200
-        duration: 15.249042ms
+        duration: 88.923ms
     - id: 99
       request:
         proto: HTTP/1.1
@@ -5148,7 +5148,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.pl-waw.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5157,7 +5157,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 2da2626d-e629-4142-9c4c-b1b0dfe3d1c3
+                - a9f23698-0c01-44fd-9774-356b5e061b69
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5165,8 +5165,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124837Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud/
+                - 20260518T133535Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.pl-waw.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -5181,16 +5181,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 12:48:37 GMT
+                - Mon, 18 May 2026 13:35:35 GMT
             X-Amz-Bucket-Region:
                 - pl-waw
             X-Amz-Id-2:
-                - txgcd6a0d8c91dd4ef8b20f-006a0321a5
+                - txg2c3e45b19ede466b963e-006a0b15a7
             X-Amz-Request-Id:
-                - txgcd6a0d8c91dd4ef8b20f-006a0321a5
+                - txg2c3e45b19ede466b963e-006a0b15a7
         status: 200 OK
         code: 200
-        duration: 194.11125ms
+        duration: 115.132167ms
     - id: 100
       request:
         proto: HTTP/1.1
@@ -5199,7 +5199,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5208,7 +5208,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - cdddde24-33fb-4231-ac49-39c67123f58a
+                - cb7b7241-2518-47b8-a80e-b1f57c38398b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5216,8 +5216,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124837Z
-        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?acl=
+                - 20260518T133535Z
+        url: https://tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5236,14 +5236,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 12:48:37 GMT
+                - Mon, 18 May 2026 13:35:35 GMT
             X-Amz-Id-2:
-                - txg1ad133942aca43608955-006a0321a5
+                - txge7afea4e50c14d5b82cb-006a0b15a7
             X-Amz-Request-Id:
-                - txg1ad133942aca43608955-006a0321a5
+                - txge7afea4e50c14d5b82cb-006a0b15a7
         status: 200 OK
         code: 200
-        duration: 25.223333ms
+        duration: 48.601375ms
     - id: 101
       request:
         proto: HTTP/1.1
@@ -5252,7 +5252,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5261,7 +5261,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - cec8e21c-c504-4a5c-b920-1214f0dba96c
+                - 2c3fa265-4d44-4499-8ddc-9b830c60e4be
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5269,8 +5269,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124837Z
-        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?object-lock=
+                - 20260518T133535Z
+        url: https://tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5280,21 +5280,21 @@ interactions:
         trailer: {}
         content_length: 326
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg69173594487c496794d1-006a0321a5</RequestId><HostId>txg69173594487c496794d1-006a0321a5</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-1314313384735080249</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgbedbb34cb4414803b79e-006a0b15a7</RequestId><HostId>txgbedbb34cb4414803b79e-006a0b15a7</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-4974415671304108720</Resource></Error>
         headers:
             Content-Length:
                 - "326"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 12:48:37 GMT
+                - Mon, 18 May 2026 13:35:35 GMT
             X-Amz-Id-2:
-                - txg69173594487c496794d1-006a0321a5
+                - txgbedbb34cb4414803b79e-006a0b15a7
             X-Amz-Request-Id:
-                - txg69173594487c496794d1-006a0321a5
+                - txgbedbb34cb4414803b79e-006a0b15a7
         status: 404 Not Found
         code: 404
-        duration: 9.79575ms
+        duration: 21.2675ms
     - id: 102
       request:
         proto: HTTP/1.1
@@ -5303,7 +5303,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5312,7 +5312,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d94fb168-1a5a-4aa3-bee6-1907cc7087a9
+                - 7ad4b2e3-a97b-467e-b76a-98c8c725d934
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5320,8 +5320,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124837Z
-        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/
+                - 20260518T133535Z
+        url: https://tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -5333,21 +5333,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-basic-1314313384735080249</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-basic-4974415671304108720</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "283"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 12:48:37 GMT
+                - Mon, 18 May 2026 13:35:36 GMT
             X-Amz-Id-2:
-                - txg63f75771638046bfa108-006a0321a5
+                - txge4ab82b859a844a886de-006a0b15a8
             X-Amz-Request-Id:
-                - txg63f75771638046bfa108-006a0321a5
+                - txge4ab82b859a844a886de-006a0b15a8
         status: 200 OK
         code: 200
-        duration: 78.214375ms
+        duration: 110.457792ms
     - id: 103
       request:
         proto: HTTP/1.1
@@ -5356,7 +5356,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5365,7 +5365,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 2150d49a-11f4-4186-84dc-d1f2d69278ee
+                - 5dbf031b-aa3b-4ccb-b98a-5d7e218ae9dc
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5373,8 +5373,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124837Z
-        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?tagging=
+                - 20260518T133536Z
+        url: https://tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5384,21 +5384,21 @@ interactions:
         trailer: {}
         content_length: 353
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg2fa6bd860f394cee822a-006a0321a5</RequestId><HostId>txg2fa6bd860f394cee822a-006a0321a5</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-1314313384735080249</Resource><BucketName>tf-tests-scaleway-object-bucket-basic-1314313384735080249</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg726a5425998d44499206-006a0b15a8</RequestId><HostId>txg726a5425998d44499206-006a0b15a8</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-4974415671304108720</Resource><BucketName>tf-tests-scaleway-object-bucket-basic-4974415671304108720</BucketName></Error>
         headers:
             Content-Length:
                 - "353"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 12:48:37 GMT
+                - Mon, 18 May 2026 13:35:36 GMT
             X-Amz-Id-2:
-                - txg2fa6bd860f394cee822a-006a0321a5
+                - txg726a5425998d44499206-006a0b15a8
             X-Amz-Request-Id:
-                - txg2fa6bd860f394cee822a-006a0321a5
+                - txg726a5425998d44499206-006a0b15a8
         status: 404 Not Found
         code: 404
-        duration: 19.402333ms
+        duration: 26.206417ms
     - id: 104
       request:
         proto: HTTP/1.1
@@ -5407,7 +5407,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5416,7 +5416,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5940f08c-c327-4c47-88c1-23ee77617ed0
+                - 974e6438-af8a-4269-8530-0ec6761b8d4e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5424,8 +5424,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124837Z
-        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?cors=
+                - 20260518T133536Z
+        url: https://tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5435,21 +5435,21 @@ interactions:
         trailer: {}
         content_length: 294
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgdea3a81d9bc74aeda63f-006a0321a5</RequestId><HostId>txgdea3a81d9bc74aeda63f-006a0321a5</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-1314313384735080249</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgd3f82621c38e4ea48bcd-006a0b15a8</RequestId><HostId>txgd3f82621c38e4ea48bcd-006a0b15a8</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-4974415671304108720</Resource></Error>
         headers:
             Content-Length:
                 - "294"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 12:48:37 GMT
+                - Mon, 18 May 2026 13:35:36 GMT
             X-Amz-Id-2:
-                - txgdea3a81d9bc74aeda63f-006a0321a5
+                - txgd3f82621c38e4ea48bcd-006a0b15a8
             X-Amz-Request-Id:
-                - txgdea3a81d9bc74aeda63f-006a0321a5
+                - txgd3f82621c38e4ea48bcd-006a0b15a8
         status: 404 Not Found
         code: 404
-        duration: 22.610917ms
+        duration: 15.742667ms
     - id: 105
       request:
         proto: HTTP/1.1
@@ -5458,7 +5458,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.pl-waw.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5467,7 +5467,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 64e0c528-9d21-4206-97ed-fb6ef087f286
+                - 1eddd980-7193-4f36-af1f-331dbb496332
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5475,112 +5475,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124837Z
-        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?versioning=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 107
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <VersioningConfiguration><Status></Status></VersioningConfiguration>
-        headers:
-            Content-Length:
-                - "107"
-            Content-Type:
-                - text/xml; charset=utf-8
-            Date:
-                - Tue, 12 May 2026 12:48:37 GMT
-            X-Amz-Id-2:
-                - txg9e4f6356e6d4426ea6c5-006a0321a5
-            X-Amz-Request-Id:
-                - txg9e4f6356e6d4426ea6c5-006a0321a5
-        status: 200 OK
-        code: 200
-        duration: 34.973042ms
-    - id: 106
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 9f282225-6a7d-4c39-afa3-186608f0671a
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260512T124837Z
-        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?lifecycle=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 386
-        uncompressed: false
-        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txg777caa10c2064b64b4fa-006a0321a5</RequestId><HostId>txg777caa10c2064b64b4fa-006a0321a5</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-1314313384735080249</Resource><BucketName>tf-tests-scaleway-object-bucket-basic-1314313384735080249</BucketName></Error>
-        headers:
-            Content-Length:
-                - "386"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 12 May 2026 12:48:37 GMT
-            X-Amz-Id-2:
-                - txg777caa10c2064b64b4fa-006a0321a5
-            X-Amz-Request-Id:
-                - txg777caa10c2064b64b4fa-006a0321a5
-        status: 404 Not Found
-        code: 404
-        duration: 8.946042ms
-    - id: 107
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - cb3c158e-3f02-40d3-8dff-66bc85312fd0
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260512T124837Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud/?acl=
+                - 20260518T133535Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.pl-waw.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5599,15 +5495,15 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 12:48:37 GMT
+                - Mon, 18 May 2026 13:35:35 GMT
             X-Amz-Id-2:
-                - txge9e866bbe7d64c10bfd9-006a0321a5
+                - txg9ee3456809fb477089ab-006a0b15a7
             X-Amz-Request-Id:
-                - txge9e866bbe7d64c10bfd9-006a0321a5
+                - txg9ee3456809fb477089ab-006a0b15a7
         status: 200 OK
         code: 200
-        duration: 352.456625ms
-    - id: 108
+        duration: 228.903ms
+    - id: 106
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -5615,7 +5511,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud
+        host: tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5624,7 +5520,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c5d4e0bf-6bfc-4093-a082-ec8db2848527
+                - 25c77531-1ba8-4d6c-b6f8-8e9652cf526d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5632,216 +5528,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124837Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud/?object-lock=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 330
-        uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg55e5acab4c6d40b2a6b0-006a0321a5</RequestId><HostId>txg55e5acab4c6d40b2a6b0-006a0321a5</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-2001388040591926415</Resource></Error>
-        headers:
-            Content-Length:
-                - "330"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 12 May 2026 12:48:37 GMT
-            X-Amz-Id-2:
-                - txg55e5acab4c6d40b2a6b0-006a0321a5
-            X-Amz-Request-Id:
-                - txg55e5acab4c6d40b2a6b0-006a0321a5
-        status: 404 Not Found
-        code: 404
-        duration: 52.381834ms
-    - id: 109
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 1e40ab20-60cd-40f3-841b-68ae397e81eb
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260512T124837Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud/
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 287
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-secondary-2001388040591926415</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
-        headers:
-            Content-Length:
-                - "287"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 12 May 2026 12:48:38 GMT
-            X-Amz-Id-2:
-                - txg3e7d610b4bbc437fb679-006a0321a6
-            X-Amz-Request-Id:
-                - txg3e7d610b4bbc437fb679-006a0321a6
-        status: 200 OK
-        code: 200
-        duration: 691.416791ms
-    - id: 110
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 6c2f4d8c-c706-4387-ace1-3f4bdf997793
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260512T124838Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud/?tagging=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 118
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <Tagging><TagSet><Tag><Key>foo</Key><Value>bar</Value></Tag></TagSet></Tagging>
-        headers:
-            Content-Length:
-                - "118"
-            Content-Type:
-                - text/xml; charset=utf-8
-            Date:
-                - Tue, 12 May 2026 12:48:38 GMT
-            X-Amz-Id-2:
-                - txgedc5ef62c65a4c3c8e12-006a0321a6
-            X-Amz-Request-Id:
-                - txgedc5ef62c65a4c3c8e12-006a0321a6
-        status: 200 OK
-        code: 200
-        duration: 243.73625ms
-    - id: 111
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 36c726ea-0e62-40b8-8ef3-91d6647190f0
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260512T124838Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud/?cors=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 298
-        uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg190c7e7dc9434581be0a-006a0321a6</RequestId><HostId>txg190c7e7dc9434581be0a-006a0321a6</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-2001388040591926415</Resource></Error>
-        headers:
-            Content-Length:
-                - "298"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 12 May 2026 12:48:38 GMT
-            X-Amz-Id-2:
-                - txg190c7e7dc9434581be0a-006a0321a6
-            X-Amz-Request-Id:
-                - txg190c7e7dc9434581be0a-006a0321a6
-        status: 404 Not Found
-        code: 404
-        duration: 215.588625ms
-    - id: 112
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 6051330b-27e7-4aaf-9229-67a6305f4f87
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20260512T124838Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud/?versioning=
+                - 20260518T133536Z
+        url: https://tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5860,14 +5548,326 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 12:48:39 GMT
+                - Mon, 18 May 2026 13:35:36 GMT
             X-Amz-Id-2:
-                - txg9b6782160a7a42119a86-006a0321a7
+                - txgdadc7a46b05849de8aad-006a0b15a8
             X-Amz-Request-Id:
-                - txg9b6782160a7a42119a86-006a0321a7
+                - txgdadc7a46b05849de8aad-006a0b15a8
         status: 200 OK
         code: 200
-        duration: 375.79275ms
+        duration: 52.309084ms
+    - id: 107
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 30f20e60-3b4f-435d-932b-c78108d67843
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T133536Z
+        url: https://tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud/?lifecycle=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 386
+        uncompressed: false
+        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txgb47294a895744241b908-006a0b15a8</RequestId><HostId>txgb47294a895744241b908-006a0b15a8</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-4974415671304108720</Resource><BucketName>tf-tests-scaleway-object-bucket-basic-4974415671304108720</BucketName></Error>
+        headers:
+            Content-Length:
+                - "386"
+            Content-Type:
+                - application/xml
+            Date:
+                - Mon, 18 May 2026 13:35:36 GMT
+            X-Amz-Id-2:
+                - txgb47294a895744241b908-006a0b15a8
+            X-Amz-Request-Id:
+                - txgb47294a895744241b908-006a0b15a8
+        status: 404 Not Found
+        code: 404
+        duration: 79.302333ms
+    - id: 108
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.pl-waw.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 7a838377-a939-4225-890c-6002cb7acbf3
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T133535Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.pl-waw.scw.cloud/?object-lock=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 329
+        uncompressed: false
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg4f54d6cb5d4e4b209bf7-006a0b15a8</RequestId><HostId>txg4f54d6cb5d4e4b209bf7-006a0b15a8</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-238236636660294517</Resource></Error>
+        headers:
+            Content-Length:
+                - "329"
+            Content-Type:
+                - application/xml
+            Date:
+                - Mon, 18 May 2026 13:35:36 GMT
+            X-Amz-Id-2:
+                - txg4f54d6cb5d4e4b209bf7-006a0b15a8
+            X-Amz-Request-Id:
+                - txg4f54d6cb5d4e4b209bf7-006a0b15a8
+        status: 404 Not Found
+        code: 404
+        duration: 190.235917ms
+    - id: 109
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.pl-waw.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 270ad831-cfbd-43d3-b5b2-9996a7d84354
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T133536Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.pl-waw.scw.cloud/
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 286
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-secondary-238236636660294517</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+        headers:
+            Content-Length:
+                - "286"
+            Content-Type:
+                - application/xml
+            Date:
+                - Mon, 18 May 2026 13:35:36 GMT
+            X-Amz-Id-2:
+                - txgeeef04f8b1f44956a277-006a0b15a8
+            X-Amz-Request-Id:
+                - txgeeef04f8b1f44956a277-006a0b15a8
+        status: 200 OK
+        code: 200
+        duration: 450.793458ms
+    - id: 110
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.pl-waw.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - ad89b622-02bd-4944-b8e2-51007352e028
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T133536Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.pl-waw.scw.cloud/?tagging=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 118
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <Tagging><TagSet><Tag><Key>foo</Key><Value>bar</Value></Tag></TagSet></Tagging>
+        headers:
+            Content-Length:
+                - "118"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Mon, 18 May 2026 13:35:36 GMT
+            X-Amz-Id-2:
+                - txgbf449b524ccc4a628a66-006a0b15a8
+            X-Amz-Request-Id:
+                - txgbf449b524ccc4a628a66-006a0b15a8
+        status: 200 OK
+        code: 200
+        duration: 958.225667ms
+    - id: 111
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.pl-waw.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 5dc3a740-fa52-4fba-8154-72b2bebb636f
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T133536Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.pl-waw.scw.cloud/?cors=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 297
+        uncompressed: false
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txge292bab479cf4faf9d8c-006a0b15a9</RequestId><HostId>txge292bab479cf4faf9d8c-006a0b15a9</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-238236636660294517</Resource></Error>
+        headers:
+            Content-Length:
+                - "297"
+            Content-Type:
+                - application/xml
+            Date:
+                - Mon, 18 May 2026 13:35:37 GMT
+            X-Amz-Id-2:
+                - txge292bab479cf4faf9d8c-006a0b15a9
+            X-Amz-Request-Id:
+                - txge292bab479cf4faf9d8c-006a0b15a9
+        status: 404 Not Found
+        code: 404
+        duration: 238.79675ms
+    - id: 112
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.pl-waw.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 06b657f5-e372-4565-8cda-9d61bd4f5442
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T133537Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.pl-waw.scw.cloud/?versioning=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 107
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <VersioningConfiguration><Status></Status></VersioningConfiguration>
+        headers:
+            Content-Length:
+                - "107"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Mon, 18 May 2026 13:35:38 GMT
+            X-Amz-Id-2:
+                - txg886bed2725424a84ae3c-006a0b15aa
+            X-Amz-Request-Id:
+                - txg886bed2725424a84ae3c-006a0b15aa
+        status: 200 OK
+        code: 200
+        duration: 2.161588875s
     - id: 113
       request:
         proto: HTTP/1.1
@@ -5876,7 +5876,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.pl-waw.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5885,7 +5885,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 732362c8-c376-4726-8b4e-06c3a84f8436
+                - 80d99a25-599d-4795-b2f9-31be8adb2616
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5893,8 +5893,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124839Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud/?lifecycle=
+                - 20260518T133538Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.pl-waw.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5902,23 +5902,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 394
+        content_length: 392
         uncompressed: false
-        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txg0c48f9f0b5c14e52b11b-006a0321a7</RequestId><HostId>txg0c48f9f0b5c14e52b11b-006a0321a7</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-2001388040591926415</Resource><BucketName>tf-tests-scaleway-object-bucket-secondary-2001388040591926415</BucketName></Error>
+        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txg350fd53e6f11485fa372-006a0b15ac</RequestId><HostId>txg350fd53e6f11485fa372-006a0b15ac</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-238236636660294517</Resource><BucketName>tf-tests-scaleway-object-bucket-secondary-238236636660294517</BucketName></Error>
         headers:
             Content-Length:
-                - "394"
+                - "392"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 12:48:39 GMT
+                - Mon, 18 May 2026 13:35:40 GMT
             X-Amz-Id-2:
-                - txg0c48f9f0b5c14e52b11b-006a0321a7
+                - txg350fd53e6f11485fa372-006a0b15ac
             X-Amz-Request-Id:
-                - txg0c48f9f0b5c14e52b11b-006a0321a7
+                - txg350fd53e6f11485fa372-006a0b15ac
         status: 404 Not Found
         code: 404
-        duration: 281.807459ms
+        duration: 213.932083ms
     - id: 114
       request:
         proto: HTTP/1.1
@@ -5927,7 +5927,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.pl-waw.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5936,7 +5936,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ebe7c265-d134-44fe-b05f-59d3a40732e6
+                - 46e73a31-a105-4489-a152-23a7a9297c4c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5944,8 +5944,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124840Z
-        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/
+                - 20260518T133540Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-238236636660294517.s3.pl-waw.scw.cloud/
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -5958,14 +5958,14 @@ interactions:
         body: ""
         headers:
             Date:
-                - Tue, 12 May 2026 12:48:40 GMT
+                - Mon, 18 May 2026 13:35:40 GMT
             X-Amz-Id-2:
-                - txg2f88577860df443396f6-006a0321a8
+                - txg34adeaece8e7440fa50d-006a0b15ac
             X-Amz-Request-Id:
-                - txg2f88577860df443396f6-006a0321a8
+                - txg34adeaece8e7440fa50d-006a0b15ac
         status: 204 No Content
         code: 204
-        duration: 256.449417ms
+        duration: 1.231159125s
     - id: 115
       request:
         proto: HTTP/1.1
@@ -5974,7 +5974,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud
+        host: tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5983,7 +5983,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4a99ca1b-ae97-4d43-91a0-1cbd4151c949
+                - caf6ea54-a5cc-4b83-b4a1-4a1b6bbebaae
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5991,8 +5991,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T124840Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud/
+                - 20260518T133540Z
+        url: https://tf-tests-scaleway-object-bucket-basic-4974415671304108720.s3.fr-par.scw.cloud/
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -6005,11 +6005,11 @@ interactions:
         body: ""
         headers:
             Date:
-                - Tue, 12 May 2026 12:48:40 GMT
+                - Mon, 18 May 2026 13:35:40 GMT
             X-Amz-Id-2:
-                - txg6695a18901e843bdb663-006a0321a8
+                - txg1d67601f1191454e89e3-006a0b15ac
             X-Amz-Request-Id:
-                - txg6695a18901e843bdb663-006a0321a8
+                - txg1d67601f1191454e89e3-006a0b15ac
         status: 204 No Content
         code: 204
-        duration: 396.697625ms
+        duration: 1.230642583s

--- a/internal/services/object/testdata/object-bucket-basic.cassette.yaml
+++ b/internal/services/object/testdata/object-bucket-basic.cassette.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -18,16 +18,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - a65103e3-8f88-4b0d-b074-77001ec41622
+                - 573699e4-0762-4fd4-b64f-c8773fbf0733
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162238Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.nl-ams.scw.cloud/
+                - 20260512T124825Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud/
         method: PUT
       response:
         proto: HTTP/2.0
@@ -42,16 +42,16 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 10 Dec 2024 16:22:38 GMT
+                - Tue, 12 May 2026 12:48:25 GMT
             Location:
-                - /tf-tests-scaleway-object-bucket-secondary-2430854061085752549
+                - /tf-tests-scaleway-object-bucket-secondary-2001388040591926415
             X-Amz-Id-2:
-                - txga96ba6b967fa4ef2a9bf-0067586ace
+                - txgb29acf986aff425b8986-006a032199
             X-Amz-Request-Id:
-                - txga96ba6b967fa4ef2a9bf-0067586ace
+                - txgb29acf986aff425b8986-006a032199
         status: 200 OK
         code: 200
-        duration: 354.249916ms
+        duration: 3.92880225s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -60,7 +60,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-main-region-5405544164764476592.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -69,16 +69,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5e242d3b-64ef-41d4-b898-6d493aca0a95
+                - abb5af1c-50c1-4d4f-a141-f40ee531c52a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162238Z
-        url: https://tf-tests-scaleway-object-bucket-main-region-5405544164764476592.s3.fr-par.scw.cloud/
+                - 20260512T124825Z
+        url: https://tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud/
         method: PUT
       response:
         proto: HTTP/2.0
@@ -93,16 +93,16 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 10 Dec 2024 16:22:38 GMT
+                - Tue, 12 May 2026 12:48:25 GMT
             Location:
-                - /tf-tests-scaleway-object-bucket-main-region-5405544164764476592
+                - /tf-tests-scaleway-object-bucket-main-region-652097813215812252
             X-Amz-Id-2:
-                - txg8d08c3d87fd84c28ba6b-0067586ace
+                - txgfd2ea3ea59fe427c95ae-006a032199
             X-Amz-Request-Id:
-                - txg8d08c3d87fd84c28ba6b-0067586ace
+                - txgfd2ea3ea59fe427c95ae-006a032199
         status: 200 OK
         code: 200
-        duration: 368.430583ms
+        duration: 3.95795575s
     - id: 2
       request:
         proto: HTTP/1.1
@@ -111,7 +111,7 @@ interactions:
         content_length: 170
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: <Tagging xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><TagSet><Tag><Key>foo</Key><Value>bar</Value></Tag><Tag><Key>baz</Key><Value>qux</Value></Tag></TagSet></Tagging>
@@ -120,20 +120,20 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d0fc8697-065a-4427-b806-3ed6903d778a
+                - 2a8e036b-6af0-4d32-b09a-8b7a83dc7cb1
             Amz-Sdk-Request:
                 - attempt=1; max=3
-            Content-Md5:
-                - ziaankj55BixQT31uaj1mQ==
             Content-Type:
                 - application/xml
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,Z,e
+            X-Amz-Checksum-Crc32:
+                - Vm9bWA==
             X-Amz-Content-Sha256:
                 - 2b07a62db7be0f847b7208b34535d7acbbfec23ff29c04b5ca0176500fb16a32
             X-Amz-Date:
-                - 20241210T162239Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.nl-ams.scw.cloud/?tagging=
+                - 20260512T124825Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud/?tagging=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -148,14 +148,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 10 Dec 2024 16:22:39 GMT
+                - Tue, 12 May 2026 12:48:29 GMT
             X-Amz-Id-2:
-                - txg1de2a29544c844879b32-0067586acf
+                - txgb896d145c18b4b24b915-006a03219d
             X-Amz-Request-Id:
-                - txg1de2a29544c844879b32-0067586acf
+                - txgb896d145c18b4b24b915-006a03219d
         status: 200 OK
         code: 200
-        duration: 39.179167ms
+        duration: 69.724542ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -164,7 +164,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-main-region-5405544164764476592.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -173,18 +173,20 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b80e9f6c-6324-4adb-87dc-9f2bc7e26a3e
+                - 298a01db-d20e-4b43-b05b-a26298844a98
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,Z,e
             X-Amz-Acl:
                 - private
+            X-Amz-Checksum-Crc32:
+                - AAAAAA==
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162239Z
-        url: https://tf-tests-scaleway-object-bucket-main-region-5405544164764476592.s3.fr-par.scw.cloud/?acl=
+                - 20260512T124829Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud/?acl=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -199,14 +201,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 10 Dec 2024 16:22:39 GMT
+                - Tue, 12 May 2026 12:48:29 GMT
             X-Amz-Id-2:
-                - txg70a1629e0e4c4161afc8-0067586acf
+                - txg148d68db49b24131ac62-006a03219d
             X-Amz-Request-Id:
-                - txg70a1629e0e4c4161afc8-0067586acf
+                - txg148d68db49b24131ac62-006a03219d
         status: 200 OK
         code: 200
-        duration: 64.667041ms
+        duration: 101.602209ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -215,7 +217,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -224,18 +226,20 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9023f254-6511-4fe3-a22c-6790eb9cec1c
+                - 86f29e78-e80f-4bc9-a3e3-abd432ab3c07
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,Z,e
             X-Amz-Acl:
                 - private
+            X-Amz-Checksum-Crc32:
+                - AAAAAA==
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162239Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.nl-ams.scw.cloud/?acl=
+                - 20260512T124829Z
+        url: https://tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud/?acl=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -250,14 +254,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 10 Dec 2024 16:22:39 GMT
+                - Tue, 12 May 2026 12:48:29 GMT
             X-Amz-Id-2:
-                - txgf7e6f4ec3f5b4eb98910-0067586acf
+                - txgc8fa3dfdc86a4dff8e52-006a03219d
             X-Amz-Request-Id:
-                - txgf7e6f4ec3f5b4eb98910-0067586acf
+                - txgc8fa3dfdc86a4dff8e52-006a03219d
         status: 200 OK
         code: 200
-        duration: 75.593792ms
+        duration: 143.137666ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -266,7 +270,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-main-region-5405544164764476592.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -275,16 +279,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f63f0def-a39d-4af1-9f5f-c75639c6bf7d
+                - 339f86ca-44da-4207-b47f-06feffd74e56
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162239Z
-        url: https://tf-tests-scaleway-object-bucket-main-region-5405544164764476592.s3.fr-par.scw.cloud/?acl=
+                - 20260512T124829Z
+        url: https://tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -296,21 +300,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
                 - "698"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:39 GMT
+                - Tue, 12 May 2026 12:48:29 GMT
             X-Amz-Id-2:
-                - txgcd01506d0c8b4f348424-0067586acf
+                - txg8c642a8f4b054cbdb138-006a03219d
             X-Amz-Request-Id:
-                - txgcd01506d0c8b4f348424-0067586acf
+                - txg8c642a8f4b054cbdb138-006a03219d
         status: 200 OK
         code: 200
-        duration: 44.399167ms
+        duration: 57.01275ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -319,7 +323,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-main-region-5405544164764476592.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -328,16 +332,67 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 985fd4c5-d6ec-4e54-b58b-186db1ad777a
+                - f28721d0-c7f3-41aa-875f-05911665abd5
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162239Z
-        url: https://tf-tests-scaleway-object-bucket-main-region-5405544164764476592.s3.fr-par.scw.cloud/?object-lock=
+                - 20260512T124825Z
+        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Length:
+                - "0"
+            Date:
+                - Tue, 12 May 2026 12:48:25 GMT
+            Location:
+                - /tf-tests-scaleway-object-bucket-basic-1314313384735080249
+            X-Amz-Id-2:
+                - txg67f98d458e714f54b459-006a032199
+            X-Amz-Request-Id:
+                - txg67f98d458e714f54b459-006a032199
+        status: 200 OK
+        code: 200
+        duration: 4.162291667s
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 1f58cd7c-d1e7-494b-8b37-d88332737c32
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260512T124829Z
+        url: https://tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -345,24 +400,24 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 332
+        content_length: 331
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgf9b9086e9ee440b19fb6-0067586acf</RequestId><HostId>txgf9b9086e9ee440b19fb6-0067586acf</HostId><Resource>/tf-tests-scaleway-object-bucket-main-region-5405544164764476592</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg95e14725d5444f67b2db-006a03219d</RequestId><HostId>txg95e14725d5444f67b2db-006a03219d</HostId><Resource>/tf-tests-scaleway-object-bucket-main-region-652097813215812252</Resource></Error>
         headers:
             Content-Length:
-                - "332"
+                - "331"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:39 GMT
+                - Tue, 12 May 2026 12:48:29 GMT
             X-Amz-Id-2:
-                - txgf9b9086e9ee440b19fb6-0067586acf
+                - txg95e14725d5444f67b2db-006a03219d
             X-Amz-Request-Id:
-                - txgf9b9086e9ee440b19fb6-0067586acf
+                - txg95e14725d5444f67b2db-006a03219d
         status: 404 Not Found
         code: 404
-        duration: 36.694667ms
-    - id: 7
+        duration: 30.436167ms
+    - id: 8
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -370,7 +425,7 @@ interactions:
         content_length: 170
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: <Tagging xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><TagSet><Tag><Key>foo</Key><Value>bar</Value></Tag><Tag><Key>baz</Key><Value>qux</Value></Tag></TagSet></Tagging>
@@ -379,20 +434,20 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4b86adee-2e15-4c8b-b7c9-7741ebc76f9e
+                - 8d372aef-f7d2-4e4e-a35d-197884c3c01d
             Amz-Sdk-Request:
                 - attempt=1; max=3
-            Content-Md5:
-                - ziaankj55BixQT31uaj1mQ==
             Content-Type:
                 - application/xml
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,Z,e
+            X-Amz-Checksum-Crc32:
+                - Vm9bWA==
             X-Amz-Content-Sha256:
                 - 2b07a62db7be0f847b7208b34535d7acbbfec23ff29c04b5ca0176500fb16a32
             X-Amz-Date:
-                - 20241210T162239Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.nl-ams.scw.cloud/?tagging=
+                - 20260512T124829Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud/?tagging=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -407,65 +462,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 10 Dec 2024 16:22:39 GMT
+                - Tue, 12 May 2026 12:48:29 GMT
             X-Amz-Id-2:
-                - txg5a58283b74d142bebd74-0067586acf
+                - txg3aa3d0e16a28438d9782-006a03219d
             X-Amz-Request-Id:
-                - txg5a58283b74d142bebd74-0067586acf
+                - txg3aa3d0e16a28438d9782-006a03219d
         status: 200 OK
         code: 200
-        duration: 45.759125ms
-    - id: 8
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - f0a0d93d-703f-4a9e-85cc-4552b3500662
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20241210T162238Z
-        url: https://tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud/
-        method: PUT
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 0
-        uncompressed: false
-        body: ""
-        headers:
-            Content-Length:
-                - "0"
-            Date:
-                - Tue, 10 Dec 2024 16:22:38 GMT
-            Location:
-                - /tf-tests-scaleway-object-bucket-basic-7045227858940344981
-            X-Amz-Id-2:
-                - txg43c72bc80bfc4e7f8409-0067586ace
-            X-Amz-Request-Id:
-                - txg43c72bc80bfc4e7f8409-0067586ace
-        status: 200 OK
-        code: 200
-        duration: 538.566166ms
+        duration: 133.322042ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -474,7 +478,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -483,16 +487,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 601b0e0f-b249-4dd2-a0f3-073071b75dad
+                - 282d2125-af86-4e0b-8403-f946f5852075
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162239Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.nl-ams.scw.cloud/?acl=
+                - 20260512T124829Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -504,74 +508,74 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
                 - "698"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:39 GMT
+                - Tue, 12 May 2026 12:48:29 GMT
             X-Amz-Id-2:
-                - txg4bba086b58734c93ba93-0067586acf
+                - txg05e56d33539d4f028535-006a03219d
             X-Amz-Request-Id:
-                - txg4bba086b58734c93ba93-0067586acf
+                - txg05e56d33539d4f028535-006a03219d
         status: 200 OK
         code: 200
-        duration: 26.544167ms
+        duration: 40.48425ms
     - id: 10
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 127
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-main-region-5405544164764476592.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: <Tagging xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><TagSet><Tag><Key>foo</Key><Value>bar</Value></Tag></TagSet></Tagging>
         form: {}
         headers:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 88fb871c-909d-4c8a-b0ff-3200f9323e34
+                - 77301101-89aa-4732-a3c2-bf8575f12854
             Amz-Sdk-Request:
                 - attempt=1; max=3
+            Content-Type:
+                - application/xml
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,Z,e
+            X-Amz-Checksum-Crc32:
+                - Y9NeVA==
             X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+                - d68cba1a39d89eb72e49b2e5b04058846b60e88e6e32eae42901c4f57a4727a8
             X-Amz-Date:
-                - 20241210T162239Z
-        url: https://tf-tests-scaleway-object-bucket-main-region-5405544164764476592.s3.fr-par.scw.cloud/
-        method: GET
+                - 20260512T124825Z
+        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?tagging=
+        method: PUT
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 289
+        content_length: 0
         uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-main-region-5405544164764476592</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+        body: ""
         headers:
             Content-Length:
-                - "289"
-            Content-Type:
-                - application/xml
+                - "0"
             Date:
-                - Tue, 10 Dec 2024 16:22:39 GMT
+                - Tue, 12 May 2026 12:48:29 GMT
             X-Amz-Id-2:
-                - txgfec4094fc25b47018c99-0067586acf
+                - txg7fe79c0f47b34d078e45-006a03219d
             X-Amz-Request-Id:
-                - txgfec4094fc25b47018c99-0067586acf
+                - txg7fe79c0f47b34d078e45-006a03219d
         status: 200 OK
         code: 200
-        duration: 51.517959ms
+        duration: 152.934083ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -580,7 +584,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -589,16 +593,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - bd27d647-d3a3-4e1c-acd0-36e7a4a16cc8
+                - fa790782-a8ff-42d7-b44a-ef44b1abea54
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162239Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260512T124829Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -608,21 +612,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg9a17bbf30e94482cbcf7-0067586acf</RequestId><HostId>txg9a17bbf30e94482cbcf7-0067586acf</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-2430854061085752549</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg389aeb72fdba44baa57e-006a03219d</RequestId><HostId>txg389aeb72fdba44baa57e-006a03219d</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-2001388040591926415</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:39 GMT
+                - Tue, 12 May 2026 12:48:29 GMT
             X-Amz-Id-2:
-                - txg9a17bbf30e94482cbcf7-0067586acf
+                - txg389aeb72fdba44baa57e-006a03219d
             X-Amz-Request-Id:
-                - txg9a17bbf30e94482cbcf7-0067586acf
+                - txg389aeb72fdba44baa57e-006a03219d
         status: 404 Not Found
         code: 404
-        duration: 29.60975ms
+        duration: 59.722083ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -631,7 +635,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-main-region-5405544164764476592.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -640,16 +644,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 918b6726-c073-4385-9a7b-4bd89cbf17d5
+                - 151bbcc6-39b7-4a6b-9ac7-cd853d9812ba
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162239Z
-        url: https://tf-tests-scaleway-object-bucket-main-region-5405544164764476592.s3.fr-par.scw.cloud/?tagging=
+                - 20260512T124829Z
+        url: https://tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -657,76 +661,76 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 365
+        content_length: 288
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgb1a2d46ea1354fa6b226-0067586acf</RequestId><HostId>txgb1a2d46ea1354fa6b226-0067586acf</HostId><Resource>/tf-tests-scaleway-object-bucket-main-region-5405544164764476592</Resource><BucketName>tf-tests-scaleway-object-bucket-main-region-5405544164764476592</BucketName></Error>
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-main-region-652097813215812252</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "365"
+                - "288"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:39 GMT
+                - Tue, 12 May 2026 12:48:29 GMT
             X-Amz-Id-2:
-                - txgb1a2d46ea1354fa6b226-0067586acf
+                - txg1021f4bb728f4929a6bf-006a03219d
             X-Amz-Request-Id:
-                - txgb1a2d46ea1354fa6b226-0067586acf
-        status: 404 Not Found
-        code: 404
-        duration: 16.254833ms
+                - txg1021f4bb728f4929a6bf-006a03219d
+        status: 200 OK
+        code: 200
+        duration: 146.207958ms
     - id: 13
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
-        body: <Tagging xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><TagSet><Tag><Key>foo</Key><Value>bar</Value></Tag></TagSet></Tagging>
+        body: ""
         form: {}
         headers:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f82c7709-e9ec-4d0a-96be-512b8e4d20e7
+                - fd171cde-d6c5-4308-89b9-10c308aafb50
             Amz-Sdk-Request:
                 - attempt=1; max=3
-            Content-Md5:
-                - GLaI7og/rAKomUfPePCCFQ==
-            Content-Type:
-                - application/xml
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
-                - d68cba1a39d89eb72e49b2e5b04058846b60e88e6e32eae42901c4f57a4727a8
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162239Z
-        url: https://tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud/?tagging=
-        method: PUT
+                - 20260512T124829Z
+        url: https://tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud/?tagging=
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 363
         uncompressed: false
-        body: ""
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg9747bdb9881d45bea3ca-006a03219d</RequestId><HostId>txg9747bdb9881d45bea3ca-006a03219d</HostId><Resource>/tf-tests-scaleway-object-bucket-main-region-652097813215812252</Resource><BucketName>tf-tests-scaleway-object-bucket-main-region-652097813215812252</BucketName></Error>
         headers:
             Content-Length:
-                - "0"
+                - "363"
+            Content-Type:
+                - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:39 GMT
+                - Tue, 12 May 2026 12:48:29 GMT
             X-Amz-Id-2:
-                - txg54c0c1ff5b5f48d7b71c-0067586acf
+                - txg9747bdb9881d45bea3ca-006a03219d
             X-Amz-Request-Id:
-                - txg54c0c1ff5b5f48d7b71c-0067586acf
-        status: 200 OK
-        code: 200
-        duration: 73.830959ms
+                - txg9747bdb9881d45bea3ca-006a03219d
+        status: 404 Not Found
+        code: 404
+        duration: 23.162083ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -735,7 +739,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-main-region-5405544164764476592.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -744,16 +748,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c336ba88-b892-44c5-b117-8763fa64838e
+                - 45094365-2be5-424b-a50d-dffe38c37020
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162239Z
-        url: https://tf-tests-scaleway-object-bucket-main-region-5405544164764476592.s3.fr-par.scw.cloud/?cors=
+                - 20260512T124829Z
+        url: https://tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -761,23 +765,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 300
+        content_length: 299
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg6a553b0876df4e73b07d-0067586acf</RequestId><HostId>txg6a553b0876df4e73b07d-0067586acf</HostId><Resource>/tf-tests-scaleway-object-bucket-main-region-5405544164764476592</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txge65900813ba14aae8586-006a03219d</RequestId><HostId>txge65900813ba14aae8586-006a03219d</HostId><Resource>/tf-tests-scaleway-object-bucket-main-region-652097813215812252</Resource></Error>
         headers:
             Content-Length:
-                - "300"
+                - "299"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:39 GMT
+                - Tue, 12 May 2026 12:48:29 GMT
             X-Amz-Id-2:
-                - txg6a553b0876df4e73b07d-0067586acf
+                - txge65900813ba14aae8586-006a03219d
             X-Amz-Request-Id:
-                - txg6a553b0876df4e73b07d-0067586acf
+                - txge65900813ba14aae8586-006a03219d
         status: 404 Not Found
         code: 404
-        duration: 52.6765ms
+        duration: 18.228125ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -786,7 +790,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-main-region-5405544164764476592.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -795,16 +799,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4d98942c-cc25-4606-8c38-432d5ea36c1e
+                - ccbbf74b-5b8b-4565-a2ae-dce44342f808
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162239Z
-        url: https://tf-tests-scaleway-object-bucket-main-region-5405544164764476592.s3.fr-par.scw.cloud/?versioning=
+                - 20260512T124829Z
+        url: https://tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -812,25 +816,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 155
+        content_length: 107
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Status></Status></VersioningConfiguration>
+            <VersioningConfiguration><Status></Status></VersioningConfiguration>
         headers:
             Content-Length:
-                - "155"
+                - "107"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:39 GMT
+                - Tue, 12 May 2026 12:48:29 GMT
             X-Amz-Id-2:
-                - txg601dc912fc2349a69215-0067586acf
+                - txg83709f4cc1d745e0b905-006a03219d
             X-Amz-Request-Id:
-                - txg601dc912fc2349a69215-0067586acf
+                - txg83709f4cc1d745e0b905-006a03219d
         status: 200 OK
         code: 200
-        duration: 12.884625ms
+        duration: 14.153875ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -839,7 +843,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-main-region-5405544164764476592.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -848,16 +852,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - fbf68d41-9b06-4015-8dae-98c6daeac076
+                - 74bed6b1-b2f0-482c-bc9b-10fbfbc165b2
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162239Z
-        url: https://tf-tests-scaleway-object-bucket-main-region-5405544164764476592.s3.fr-par.scw.cloud/?lifecycle=
+                - 20260512T124829Z
+        url: https://tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -865,23 +869,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 398
+        content_length: 396
         uncompressed: false
-        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txg539043f20a4548c4af37-0067586acf</RequestId><HostId>txg539043f20a4548c4af37-0067586acf</HostId><Resource>/tf-tests-scaleway-object-bucket-main-region-5405544164764476592</Resource><BucketName>tf-tests-scaleway-object-bucket-main-region-5405544164764476592</BucketName></Error>
+        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txg36b07d8394994e92a315-006a03219d</RequestId><HostId>txg36b07d8394994e92a315-006a03219d</HostId><Resource>/tf-tests-scaleway-object-bucket-main-region-652097813215812252</Resource><BucketName>tf-tests-scaleway-object-bucket-main-region-652097813215812252</BucketName></Error>
         headers:
             Content-Length:
-                - "398"
+                - "396"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:39 GMT
+                - Tue, 12 May 2026 12:48:29 GMT
             X-Amz-Id-2:
-                - txg539043f20a4548c4af37-0067586acf
+                - txg36b07d8394994e92a315-006a03219d
             X-Amz-Request-Id:
-                - txg539043f20a4548c4af37-0067586acf
+                - txg36b07d8394994e92a315-006a03219d
         status: 404 Not Found
         code: 404
-        duration: 15.079833ms
+        duration: 48.839833ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -890,7 +894,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -899,16 +903,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - bc41779b-3744-4ebc-ae4b-8ebde6d698ab
+                - 5f54e247-9780-4d66-ba29-394650471954
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162239Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.nl-ams.scw.cloud/
+                - 20260512T124829Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -920,21 +924,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-secondary-2430854061085752549</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-secondary-2001388040591926415</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:39 GMT
+                - Tue, 12 May 2026 12:48:29 GMT
             X-Amz-Id-2:
-                - txg22e96f51d5cf4c779097-0067586acf
+                - txg652745a5422340c2b89c-006a03219d
             X-Amz-Request-Id:
-                - txg22e96f51d5cf4c779097-0067586acf
+                - txg652745a5422340c2b89c-006a03219d
         status: 200 OK
         code: 200
-        duration: 93.32275ms
+        duration: 110.7125ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -943,7 +947,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -952,18 +956,20 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7c96b2b5-c6ea-47fd-b826-68fd0e895236
+                - 302bccb5-72fe-4242-ac9b-5f55cd09089e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,Z,e
             X-Amz-Acl:
                 - private
+            X-Amz-Checksum-Crc32:
+                - AAAAAA==
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162239Z
-        url: https://tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud/?acl=
+                - 20260512T124829Z
+        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?acl=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -978,76 +984,23 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 10 Dec 2024 16:22:39 GMT
+                - Tue, 12 May 2026 12:48:29 GMT
             X-Amz-Id-2:
-                - txgd6056398de9b44e88016-0067586acf
+                - txgc27c6cf7700d42a9927e-006a03219d
             X-Amz-Request-Id:
-                - txgd6056398de9b44e88016-0067586acf
+                - txgc27c6cf7700d42a9927e-006a03219d
         status: 200 OK
         code: 200
-        duration: 73.722291ms
+        duration: 140.345125ms
     - id: 19
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: <Tagging xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><TagSet><Tag><Key>foo</Key><Value>bar</Value></Tag></TagSet></Tagging>
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - c3b8a733-cb6d-4569-9653-b5abffb7521d
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            Content-Md5:
-                - GLaI7og/rAKomUfPePCCFQ==
-            Content-Type:
-                - application/xml
-            User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
-            X-Amz-Content-Sha256:
-                - d68cba1a39d89eb72e49b2e5b04058846b60e88e6e32eae42901c4f57a4727a8
-            X-Amz-Date:
-                - 20241210T162239Z
-        url: https://tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud/?tagging=
-        method: PUT
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 0
-        uncompressed: false
-        body: ""
-        headers:
-            Content-Length:
-                - "0"
-            Date:
-                - Tue, 10 Dec 2024 16:22:39 GMT
-            X-Amz-Id-2:
-                - txg413a4e0c627c4a2ea831-0067586acf
-            X-Amz-Request-Id:
-                - txg413a4e0c627c4a2ea831-0067586acf
-        status: 200 OK
-        code: 200
-        duration: 31.588666ms
-    - id: 20
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1056,16 +1009,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - af3c6b4a-d04c-41a0-9e4e-efb30471a31e
+                - 2ae8654c-2bab-4f64-9697-786bc55fe86d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162239Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.nl-ams.scw.cloud/?tagging=
+                - 20260512T124829Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1084,14 +1037,67 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:39 GMT
+                - Tue, 12 May 2026 12:48:29 GMT
             X-Amz-Id-2:
-                - txg48b6f995a1674597b217-0067586acf
+                - txg62d0e4cf458049828c2a-006a03219d
             X-Amz-Request-Id:
-                - txg48b6f995a1674597b217-0067586acf
+                - txg62d0e4cf458049828c2a-006a03219d
         status: 200 OK
         code: 200
-        duration: 77.495666ms
+        duration: 35.47225ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 127
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: <Tagging xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><TagSet><Tag><Key>foo</Key><Value>bar</Value></Tag></TagSet></Tagging>
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 7c34488e-edf7-4513-be13-5a9c527bd9c0
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            Content-Type:
+                - application/xml
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,Z,e
+            X-Amz-Checksum-Crc32:
+                - Y9NeVA==
+            X-Amz-Content-Sha256:
+                - d68cba1a39d89eb72e49b2e5b04058846b60e88e6e32eae42901c4f57a4727a8
+            X-Amz-Date:
+                - 20260512T124829Z
+        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?tagging=
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Length:
+                - "0"
+            Date:
+                - Tue, 12 May 2026 12:48:29 GMT
+            X-Amz-Id-2:
+                - txg78462a1d4f4c4ec3b933-006a03219d
+            X-Amz-Request-Id:
+                - txg78462a1d4f4c4ec3b933-006a03219d
+        status: 200 OK
+        code: 200
+        duration: 48.416541ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1100,7 +1106,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1109,16 +1115,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 91a14005-343c-4dd5-bbcf-bf646968b4d9
+                - 3c5cb2a9-feb8-44cf-be63-93138726b62c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162239Z
-        url: https://tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud/?acl=
+                - 20260512T124829Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1126,25 +1132,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 698
+        content_length: 298
         uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgd096360c69a745b39572-006a03219d</RequestId><HostId>txgd096360c69a745b39572-006a03219d</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-2001388040591926415</Resource></Error>
         headers:
             Content-Length:
-                - "698"
+                - "298"
             Content-Type:
-                - text/xml; charset=utf-8
+                - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:39 GMT
+                - Tue, 12 May 2026 12:48:29 GMT
             X-Amz-Id-2:
-                - txg06973f7cccaa44378613-0067586acf
+                - txgd096360c69a745b39572-006a03219d
             X-Amz-Request-Id:
-                - txg06973f7cccaa44378613-0067586acf
-        status: 200 OK
-        code: 200
-        duration: 47.076959ms
+                - txgd096360c69a745b39572-006a03219d
+        status: 404 Not Found
+        code: 404
+        duration: 57.525042ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1153,7 +1157,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1162,16 +1166,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 79c9a749-c78f-44c0-80e7-2c31e459267a
+                - f3a4824a-1408-40c0-a7c4-7a441f35e523
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162239Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.nl-ams.scw.cloud/?cors=
+                - 20260512T124829Z
+        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1179,23 +1183,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 298
+        content_length: 698
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg95bc318887c247088938-0067586acf</RequestId><HostId>txg95bc318887c247088938-0067586acf</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-2430854061085752549</Resource></Error>
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
-                - "298"
+                - "698"
             Content-Type:
-                - application/xml
+                - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:39 GMT
+                - Tue, 12 May 2026 12:48:29 GMT
             X-Amz-Id-2:
-                - txg95bc318887c247088938-0067586acf
+                - txge8b2d4f8741a47bfb13f-006a03219d
             X-Amz-Request-Id:
-                - txg95bc318887c247088938-0067586acf
-        status: 404 Not Found
-        code: 404
-        duration: 29.143916ms
+                - txge8b2d4f8741a47bfb13f-006a03219d
+        status: 200 OK
+        code: 200
+        duration: 42.767584ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1204,7 +1210,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1213,16 +1219,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 6fe8f466-2b7d-4db2-95f5-8ed21740a870
+                - 27c78549-2952-4c34-94fd-5b6f2f893b31
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162239Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.nl-ams.scw.cloud/?versioning=
+                - 20260512T124829Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1230,25 +1236,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 155
+        content_length: 107
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Status></Status></VersioningConfiguration>
+            <VersioningConfiguration><Status></Status></VersioningConfiguration>
         headers:
             Content-Length:
-                - "155"
+                - "107"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:39 GMT
+                - Tue, 12 May 2026 12:48:29 GMT
             X-Amz-Id-2:
-                - txg018dc054e52e4877a53d-0067586acf
+                - txgfcc4ff63f0394cf780c7-006a03219d
             X-Amz-Request-Id:
-                - txg018dc054e52e4877a53d-0067586acf
+                - txgfcc4ff63f0394cf780c7-006a03219d
         status: 200 OK
         code: 200
-        duration: 27.852542ms
+        duration: 63.499ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1257,7 +1263,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1266,16 +1272,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - dac50e0a-484f-47bf-ac38-86e184472312
+                - c4b8410f-4e60-4958-a47b-cb97828ba10c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162239Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T124829Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1285,21 +1291,21 @@ interactions:
         trailer: {}
         content_length: 394
         uncompressed: false
-        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txgf94c06ec137c42f7b6d1-0067586acf</RequestId><HostId>txgf94c06ec137c42f7b6d1-0067586acf</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-2430854061085752549</Resource><BucketName>tf-tests-scaleway-object-bucket-secondary-2430854061085752549</BucketName></Error>
+        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txg1a46a88ef80f435d8782-006a03219d</RequestId><HostId>txg1a46a88ef80f435d8782-006a03219d</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-2001388040591926415</Resource><BucketName>tf-tests-scaleway-object-bucket-secondary-2001388040591926415</BucketName></Error>
         headers:
             Content-Length:
                 - "394"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:39 GMT
+                - Tue, 12 May 2026 12:48:29 GMT
             X-Amz-Id-2:
-                - txgf94c06ec137c42f7b6d1-0067586acf
+                - txg1a46a88ef80f435d8782-006a03219d
             X-Amz-Request-Id:
-                - txgf94c06ec137c42f7b6d1-0067586acf
+                - txg1a46a88ef80f435d8782-006a03219d
         status: 404 Not Found
         code: 404
-        duration: 26.0755ms
+        duration: 117.580417ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1308,7 +1314,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1317,16 +1323,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - bde1355e-daea-4319-b3da-5dfdb88516b4
+                - 9daafcaf-bcf8-46c4-a5d0-b6f8272b5270
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162239Z
-        url: https://tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud/?object-lock=
+                - 20260512T124829Z
+        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1336,21 +1342,21 @@ interactions:
         trailer: {}
         content_length: 326
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg377e0712ae994a4d921f-0067586acf</RequestId><HostId>txg377e0712ae994a4d921f-0067586acf</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-7045227858940344981</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgbbc8dc967f754653bf19-006a03219d</RequestId><HostId>txgbbc8dc967f754653bf19-006a03219d</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-1314313384735080249</Resource></Error>
         headers:
             Content-Length:
                 - "326"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:39 GMT
+                - Tue, 12 May 2026 12:48:29 GMT
             X-Amz-Id-2:
-                - txg377e0712ae994a4d921f-0067586acf
+                - txgbbc8dc967f754653bf19-006a03219d
             X-Amz-Request-Id:
-                - txg377e0712ae994a4d921f-0067586acf
+                - txgbbc8dc967f754653bf19-006a03219d
         status: 404 Not Found
         code: 404
-        duration: 76.101667ms
+        duration: 183.428333ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1359,7 +1365,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1368,16 +1374,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f49a11e3-4249-4cdc-8c3f-4bce9cf65723
+                - e6b139c5-6df7-4bda-830c-6712283d60ef
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162239Z
-        url: https://tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud/
+                - 20260512T124829Z
+        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -1389,21 +1395,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-basic-7045227858940344981</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-basic-1314313384735080249</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "283"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:39 GMT
+                - Tue, 12 May 2026 12:48:29 GMT
             X-Amz-Id-2:
-                - txg1e57029a4d434c7fabe0-0067586acf
+                - txg9d8039e063b543d69283-006a03219d
             X-Amz-Request-Id:
-                - txg1e57029a4d434c7fabe0-0067586acf
+                - txg9d8039e063b543d69283-006a03219d
         status: 200 OK
         code: 200
-        duration: 77.103042ms
+        duration: 73.083041ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1412,7 +1418,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1421,16 +1427,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 41ddce82-9818-4bd0-811e-5134b09011ef
+                - 4a2362ed-3e4a-400e-b510-0d1d261c85b4
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162239Z
-        url: https://tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud/?tagging=
+                - 20260512T124829Z
+        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1449,14 +1455,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:39 GMT
+                - Tue, 12 May 2026 12:48:29 GMT
             X-Amz-Id-2:
-                - txg37988a3577924a768881-0067586acf
+                - txgfed8c20e18f2436084ad-006a03219d
             X-Amz-Request-Id:
-                - txg37988a3577924a768881-0067586acf
+                - txgfed8c20e18f2436084ad-006a03219d
         status: 200 OK
         code: 200
-        duration: 18.155709ms
+        duration: 105.311375ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1465,7 +1471,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1474,16 +1480,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 40d38e7b-f8a4-4abc-95b3-4b423e4651ba
+                - 884feb7f-ab52-4af3-a91b-8d3b8062c79c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162239Z
-        url: https://tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud/?cors=
+                - 20260512T124829Z
+        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1493,21 +1499,21 @@ interactions:
         trailer: {}
         content_length: 294
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgf67f7183ca8d4132b1d2-0067586acf</RequestId><HostId>txgf67f7183ca8d4132b1d2-0067586acf</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-7045227858940344981</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg97c618ac9c354cdd92bb-006a03219e</RequestId><HostId>txg97c618ac9c354cdd92bb-006a03219e</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-1314313384735080249</Resource></Error>
         headers:
             Content-Length:
                 - "294"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:39 GMT
+                - Tue, 12 May 2026 12:48:30 GMT
             X-Amz-Id-2:
-                - txgf67f7183ca8d4132b1d2-0067586acf
+                - txg97c618ac9c354cdd92bb-006a03219e
             X-Amz-Request-Id:
-                - txgf67f7183ca8d4132b1d2-0067586acf
+                - txg97c618ac9c354cdd92bb-006a03219e
         status: 404 Not Found
         code: 404
-        duration: 32.600833ms
+        duration: 43.950166ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1516,7 +1522,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1525,16 +1531,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 370dc30e-7c53-45be-90be-fc4eed68ea47
+                - 19766e1c-a7db-47d6-b9d3-df78ddd70da5
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162239Z
-        url: https://tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud/?versioning=
+                - 20260512T124830Z
+        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1542,25 +1548,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 155
+        content_length: 107
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Status></Status></VersioningConfiguration>
+            <VersioningConfiguration><Status></Status></VersioningConfiguration>
         headers:
             Content-Length:
-                - "155"
+                - "107"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:39 GMT
+                - Tue, 12 May 2026 12:48:30 GMT
             X-Amz-Id-2:
-                - txgefd491fd07b749b49425-0067586acf
+                - txg7b66f2ee0c254d6caaef-006a03219e
             X-Amz-Request-Id:
-                - txgefd491fd07b749b49425-0067586acf
+                - txg7b66f2ee0c254d6caaef-006a03219e
         status: 200 OK
         code: 200
-        duration: 34.229709ms
+        duration: 71.31575ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1569,7 +1575,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1578,16 +1584,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - bf01d38d-dbed-4a48-8714-4d3cb3a1a280
+                - bb1f5a0d-491c-4a97-b2a0-786b6804f059
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162239Z
-        url: https://tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud/?lifecycle=
+                - 20260512T124830Z
+        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1597,21 +1603,21 @@ interactions:
         trailer: {}
         content_length: 386
         uncompressed: false
-        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txg1268870407474bc98ac7-0067586acf</RequestId><HostId>txg1268870407474bc98ac7-0067586acf</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-7045227858940344981</Resource><BucketName>tf-tests-scaleway-object-bucket-basic-7045227858940344981</BucketName></Error>
+        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txg745bb60612aa4e69ac44-006a03219e</RequestId><HostId>txg745bb60612aa4e69ac44-006a03219e</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-1314313384735080249</Resource><BucketName>tf-tests-scaleway-object-bucket-basic-1314313384735080249</BucketName></Error>
         headers:
             Content-Length:
                 - "386"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:39 GMT
+                - Tue, 12 May 2026 12:48:30 GMT
             X-Amz-Id-2:
-                - txg1268870407474bc98ac7-0067586acf
+                - txg745bb60612aa4e69ac44-006a03219e
             X-Amz-Request-Id:
-                - txg1268870407474bc98ac7-0067586acf
+                - txg745bb60612aa4e69ac44-006a03219e
         status: 404 Not Found
         code: 404
-        duration: 10.654167ms
+        duration: 142.194167ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1620,7 +1626,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1629,16 +1635,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 8dba28f1-a854-4e4c-8b1f-6d616feef9ad
+                - 01cfd58c-c7b9-484c-b197-a3e576f56ee6
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162239Z
-        url: https://tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud/
+                - 20260512T124830Z
+        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -1653,16 +1659,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:39 GMT
+                - Tue, 12 May 2026 12:48:30 GMT
             X-Amz-Bucket-Region:
                 - fr-par
             X-Amz-Id-2:
-                - txgb9da159626854e2db53a-0067586acf
+                - txg92d7bbb53eaa401f8d51-006a03219e
             X-Amz-Request-Id:
-                - txgb9da159626854e2db53a-0067586acf
+                - txg92d7bbb53eaa401f8d51-006a03219e
         status: 200 OK
         code: 200
-        duration: 12.326792ms
+        duration: 76.847375ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1671,7 +1677,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1680,16 +1686,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - eba6dc1c-a171-4ab7-8f86-0d7960a4d725
+                - 70fb330d-82b5-4ab0-855e-f1302bc06910
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162239Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.nl-ams.scw.cloud/
+                - 20260512T124830Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -1704,16 +1710,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:39 GMT
+                - Tue, 12 May 2026 12:48:30 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txgc21aaac330ec467692b7-0067586acf
+                - txgf2807c831bae425e8957-006a03219e
             X-Amz-Request-Id:
-                - txgc21aaac330ec467692b7-0067586acf
+                - txgf2807c831bae425e8957-006a03219e
         status: 200 OK
         code: 200
-        duration: 27.854333ms
+        duration: 132.462583ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1722,7 +1728,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-main-region-5405544164764476592.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1731,16 +1737,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 1ef9c900-bc3f-4a08-a21c-3bd00e4033e7
+                - 3483597e-a2df-430a-948d-4bd9ef210f45
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162239Z
-        url: https://tf-tests-scaleway-object-bucket-main-region-5405544164764476592.s3.fr-par.scw.cloud/
+                - 20260512T124830Z
+        url: https://tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -1755,16 +1761,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:40 GMT
+                - Tue, 12 May 2026 12:48:30 GMT
             X-Amz-Bucket-Region:
                 - fr-par
             X-Amz-Id-2:
-                - txg29d0ee51c5ab4fb4b4e8-0067586ad0
+                - txgea19c901c12348c7b086-006a03219e
             X-Amz-Request-Id:
-                - txg29d0ee51c5ab4fb4b4e8-0067586ad0
+                - txgea19c901c12348c7b086-006a03219e
         status: 200 OK
         code: 200
-        duration: 10.794917ms
+        duration: 52.760458ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1773,7 +1779,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1782,16 +1788,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 86e2033e-0a91-454f-a8ee-775516e2cb5a
+                - 163a7644-dd8f-48be-a5c5-4cf4c634dece
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162241Z
-        url: https://tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud/?acl=
+                - 20260512T124830Z
+        url: https://tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1803,21 +1809,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
                 - "698"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:41 GMT
+                - Tue, 12 May 2026 12:48:30 GMT
             X-Amz-Id-2:
-                - txg7bf2e98816cc423b9f89-0067586ad1
+                - txg157fffacd47441f8b287-006a03219e
             X-Amz-Request-Id:
-                - txg7bf2e98816cc423b9f89-0067586ad1
+                - txg157fffacd47441f8b287-006a03219e
         status: 200 OK
         code: 200
-        duration: 9.487666ms
+        duration: 23.034417ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1826,7 +1832,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1835,16 +1841,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7ff379d3-87a7-46d3-b4c4-28667237df0d
+                - b637e816-9c4b-4792-8c52-1c897ea0305f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162241Z
-        url: https://tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud/?object-lock=
+                - 20260512T124830Z
+        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1852,23 +1858,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 326
+        content_length: 698
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgf789bdd9ccef4134a19f-0067586ad1</RequestId><HostId>txgf789bdd9ccef4134a19f-0067586ad1</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-7045227858940344981</Resource></Error>
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
-                - "326"
+                - "698"
             Content-Type:
-                - application/xml
+                - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:41 GMT
+                - Tue, 12 May 2026 12:48:30 GMT
             X-Amz-Id-2:
-                - txgf789bdd9ccef4134a19f-0067586ad1
+                - txg5458869146ea4b78a71f-006a03219e
             X-Amz-Request-Id:
-                - txgf789bdd9ccef4134a19f-0067586ad1
-        status: 404 Not Found
-        code: 404
-        duration: 7.585ms
+                - txg5458869146ea4b78a71f-006a03219e
+        status: 200 OK
+        code: 200
+        duration: 38.481875ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1877,7 +1885,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1886,16 +1894,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 6eea2404-9d33-46e6-8c4a-9fb26720b8d2
+                - 71f11ac4-a086-4b35-9f0f-477d4d7d1f62
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162241Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.nl-ams.scw.cloud/?acl=
+                - 20260512T124830Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1907,21 +1915,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
                 - "698"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:41 GMT
+                - Tue, 12 May 2026 12:48:30 GMT
             X-Amz-Id-2:
-                - txgffae9a2575f748ab8e1b-0067586ad1
+                - txg92125f7ff64f489687ee-006a03219e
             X-Amz-Request-Id:
-                - txgffae9a2575f748ab8e1b-0067586ad1
+                - txg92125f7ff64f489687ee-006a03219e
         status: 200 OK
         code: 200
-        duration: 26.640791ms
+        duration: 60.176709ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1930,7 +1938,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1939,16 +1947,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 27ad4752-60a8-49d4-9588-3de00ff8c880
+                - fea1f363-6f40-4a5c-8a02-6cccbddd1926
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162241Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260512T124830Z
+        url: https://tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1956,23 +1964,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 330
+        content_length: 331
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgb3be34cdf46046109f2b-0067586ad1</RequestId><HostId>txgb3be34cdf46046109f2b-0067586ad1</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-2430854061085752549</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg4479f698f6f644ce8784-006a03219e</RequestId><HostId>txg4479f698f6f644ce8784-006a03219e</HostId><Resource>/tf-tests-scaleway-object-bucket-main-region-652097813215812252</Resource></Error>
         headers:
             Content-Length:
-                - "330"
+                - "331"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:41 GMT
+                - Tue, 12 May 2026 12:48:30 GMT
             X-Amz-Id-2:
-                - txgb3be34cdf46046109f2b-0067586ad1
+                - txg4479f698f6f644ce8784-006a03219e
             X-Amz-Request-Id:
-                - txgb3be34cdf46046109f2b-0067586ad1
+                - txg4479f698f6f644ce8784-006a03219e
         status: 404 Not Found
         code: 404
-        duration: 26.951583ms
+        duration: 37.028958ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1981,7 +1989,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1990,16 +1998,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e6db0d5e-5b36-4041-bcab-7b30eb1e59c6
+                - a84c5c2d-7cd1-4181-99e1-c579ba74a45a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162241Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.nl-ams.scw.cloud/
+                - 20260512T124830Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2007,25 +2015,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 287
+        content_length: 330
         uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-secondary-2430854061085752549</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txge801f0f1522340bab5ed-006a03219f</RequestId><HostId>txge801f0f1522340bab5ed-006a03219f</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-2001388040591926415</Resource></Error>
         headers:
             Content-Length:
-                - "287"
+                - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:41 GMT
+                - Tue, 12 May 2026 12:48:31 GMT
             X-Amz-Id-2:
-                - txg42a3eec511f440cab825-0067586ad1
+                - txge801f0f1522340bab5ed-006a03219f
             X-Amz-Request-Id:
-                - txg42a3eec511f440cab825-0067586ad1
-        status: 200 OK
-        code: 200
-        duration: 54.9805ms
+                - txge801f0f1522340bab5ed-006a03219f
+        status: 404 Not Found
+        code: 404
+        duration: 40.881708ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -2034,7 +2040,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2043,16 +2049,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 21d0f952-e40b-4018-94c8-dbf0bf093f43
+                - 19d8013f-9716-473e-a1c4-469546d5ea44
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162241Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.nl-ams.scw.cloud/?tagging=
+                - 20260512T124830Z
+        url: https://tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -2060,25 +2066,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 161
+        content_length: 288
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Tagging><TagSet><Tag><Key>foo</Key><Value>bar</Value></Tag><Tag><Key>baz</Key><Value>qux</Value></Tag></TagSet></Tagging>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-main-region-652097813215812252</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "161"
+                - "288"
             Content-Type:
-                - text/xml; charset=utf-8
+                - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:41 GMT
+                - Tue, 12 May 2026 12:48:30 GMT
             X-Amz-Id-2:
-                - txgf63d113ff136421baf6b-0067586ad1
+                - txga084441c1b0e43d8bf2f-006a03219e
             X-Amz-Request-Id:
-                - txgf63d113ff136421baf6b-0067586ad1
+                - txga084441c1b0e43d8bf2f-006a03219e
         status: 200 OK
         code: 200
-        duration: 31.241584ms
+        duration: 55.566875ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -2087,7 +2093,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2096,1160 +2102,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ef4c5c02-4650-437a-b0a5-dbe805be990d
+                - 1532bfc8-d63b-4904-b2cd-5ca86e46afaa
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162241Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.nl-ams.scw.cloud/?cors=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 298
-        uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgaf87c72c611b4c138a71-0067586ad1</RequestId><HostId>txgaf87c72c611b4c138a71-0067586ad1</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-2430854061085752549</Resource></Error>
-        headers:
-            Content-Length:
-                - "298"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 10 Dec 2024 16:22:41 GMT
-            X-Amz-Id-2:
-                - txgaf87c72c611b4c138a71-0067586ad1
-            X-Amz-Request-Id:
-                - txgaf87c72c611b4c138a71-0067586ad1
-        status: 404 Not Found
-        code: 404
-        duration: 26.72ms
-    - id: 41
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 35c72db7-9090-4dca-b162-3c9789b07393
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20241210T162241Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.nl-ams.scw.cloud/?versioning=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 155
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Status></Status></VersioningConfiguration>
-        headers:
-            Content-Length:
-                - "155"
-            Content-Type:
-                - text/xml; charset=utf-8
-            Date:
-                - Tue, 10 Dec 2024 16:22:41 GMT
-            X-Amz-Id-2:
-                - txga0f18c8e00d346ada577-0067586ad1
-            X-Amz-Request-Id:
-                - txga0f18c8e00d346ada577-0067586ad1
-        status: 200 OK
-        code: 200
-        duration: 26.43625ms
-    - id: 42
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - dc003cfd-5dbc-4af1-9ca0-e5a29c837b8c
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20241210T162241Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.nl-ams.scw.cloud/?lifecycle=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 394
-        uncompressed: false
-        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txg163399be43cf4ea2a61e-0067586ad1</RequestId><HostId>txg163399be43cf4ea2a61e-0067586ad1</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-2430854061085752549</Resource><BucketName>tf-tests-scaleway-object-bucket-secondary-2430854061085752549</BucketName></Error>
-        headers:
-            Content-Length:
-                - "394"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 10 Dec 2024 16:22:41 GMT
-            X-Amz-Id-2:
-                - txg163399be43cf4ea2a61e-0067586ad1
-            X-Amz-Request-Id:
-                - txg163399be43cf4ea2a61e-0067586ad1
-        status: 404 Not Found
-        code: 404
-        duration: 25.657375ms
-    - id: 43
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-main-region-5405544164764476592.s3.fr-par.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - b5f415e6-f485-41f6-b3c8-1823aacc09e4
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20241210T162241Z
-        url: https://tf-tests-scaleway-object-bucket-main-region-5405544164764476592.s3.fr-par.scw.cloud/?acl=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 698
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
-        headers:
-            Content-Length:
-                - "698"
-            Content-Type:
-                - text/xml; charset=utf-8
-            Date:
-                - Tue, 10 Dec 2024 16:22:41 GMT
-            X-Amz-Id-2:
-                - txgc04b378b88774285a730-0067586ad1
-            X-Amz-Request-Id:
-                - txgc04b378b88774285a730-0067586ad1
-        status: 200 OK
-        code: 200
-        duration: 399.049958ms
-    - id: 44
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-main-region-5405544164764476592.s3.fr-par.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 48ab64db-2932-454b-b286-b9abb2b989d8
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20241210T162241Z
-        url: https://tf-tests-scaleway-object-bucket-main-region-5405544164764476592.s3.fr-par.scw.cloud/?object-lock=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 332
-        uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txga93785e4bf0448f896bf-0067586ad1</RequestId><HostId>txga93785e4bf0448f896bf-0067586ad1</HostId><Resource>/tf-tests-scaleway-object-bucket-main-region-5405544164764476592</Resource></Error>
-        headers:
-            Content-Length:
-                - "332"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 10 Dec 2024 16:22:41 GMT
-            X-Amz-Id-2:
-                - txga93785e4bf0448f896bf-0067586ad1
-            X-Amz-Request-Id:
-                - txga93785e4bf0448f896bf-0067586ad1
-        status: 404 Not Found
-        code: 404
-        duration: 20.802125ms
-    - id: 45
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-main-region-5405544164764476592.s3.fr-par.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 7d81fbb2-49af-4d69-8281-b81956745ccf
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20241210T162241Z
-        url: https://tf-tests-scaleway-object-bucket-main-region-5405544164764476592.s3.fr-par.scw.cloud/
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 289
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-main-region-5405544164764476592</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
-        headers:
-            Content-Length:
-                - "289"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 10 Dec 2024 16:22:41 GMT
-            X-Amz-Id-2:
-                - txg532ccdb4e65548ada41a-0067586ad1
-            X-Amz-Request-Id:
-                - txg532ccdb4e65548ada41a-0067586ad1
-        status: 200 OK
-        code: 200
-        duration: 57.802916ms
-    - id: 46
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-main-region-5405544164764476592.s3.fr-par.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - f37a60ee-7db5-432f-a480-69c9e71e58b2
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20241210T162241Z
-        url: https://tf-tests-scaleway-object-bucket-main-region-5405544164764476592.s3.fr-par.scw.cloud/?tagging=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 365
-        uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg9f42ad2f282a405ca672-0067586ad1</RequestId><HostId>txg9f42ad2f282a405ca672-0067586ad1</HostId><Resource>/tf-tests-scaleway-object-bucket-main-region-5405544164764476592</Resource><BucketName>tf-tests-scaleway-object-bucket-main-region-5405544164764476592</BucketName></Error>
-        headers:
-            Content-Length:
-                - "365"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 10 Dec 2024 16:22:41 GMT
-            X-Amz-Id-2:
-                - txg9f42ad2f282a405ca672-0067586ad1
-            X-Amz-Request-Id:
-                - txg9f42ad2f282a405ca672-0067586ad1
-        status: 404 Not Found
-        code: 404
-        duration: 12.52175ms
-    - id: 47
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-main-region-5405544164764476592.s3.fr-par.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - f3c37425-90c6-44cb-a306-5fa5016fb277
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20241210T162241Z
-        url: https://tf-tests-scaleway-object-bucket-main-region-5405544164764476592.s3.fr-par.scw.cloud/?cors=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 300
-        uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg3a4a811a4bcd40e1bda7-0067586ad1</RequestId><HostId>txg3a4a811a4bcd40e1bda7-0067586ad1</HostId><Resource>/tf-tests-scaleway-object-bucket-main-region-5405544164764476592</Resource></Error>
-        headers:
-            Content-Length:
-                - "300"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 10 Dec 2024 16:22:41 GMT
-            X-Amz-Id-2:
-                - txg3a4a811a4bcd40e1bda7-0067586ad1
-            X-Amz-Request-Id:
-                - txg3a4a811a4bcd40e1bda7-0067586ad1
-        status: 404 Not Found
-        code: 404
-        duration: 13.343416ms
-    - id: 48
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-main-region-5405544164764476592.s3.fr-par.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 44857442-1822-40c9-9ac1-bd900905e270
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20241210T162241Z
-        url: https://tf-tests-scaleway-object-bucket-main-region-5405544164764476592.s3.fr-par.scw.cloud/?versioning=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 155
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Status></Status></VersioningConfiguration>
-        headers:
-            Content-Length:
-                - "155"
-            Content-Type:
-                - text/xml; charset=utf-8
-            Date:
-                - Tue, 10 Dec 2024 16:22:41 GMT
-            X-Amz-Id-2:
-                - txgd437a8c384894b8dbd30-0067586ad1
-            X-Amz-Request-Id:
-                - txgd437a8c384894b8dbd30-0067586ad1
-        status: 200 OK
-        code: 200
-        duration: 15.304125ms
-    - id: 49
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-main-region-5405544164764476592.s3.fr-par.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 24f52ba9-e222-4164-804d-189fad55f86d
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20241210T162241Z
-        url: https://tf-tests-scaleway-object-bucket-main-region-5405544164764476592.s3.fr-par.scw.cloud/?lifecycle=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 398
-        uncompressed: false
-        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txg6ab2668de76a4ad0945c-0067586ad1</RequestId><HostId>txg6ab2668de76a4ad0945c-0067586ad1</HostId><Resource>/tf-tests-scaleway-object-bucket-main-region-5405544164764476592</Resource><BucketName>tf-tests-scaleway-object-bucket-main-region-5405544164764476592</BucketName></Error>
-        headers:
-            Content-Length:
-                - "398"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 10 Dec 2024 16:22:41 GMT
-            X-Amz-Id-2:
-                - txg6ab2668de76a4ad0945c-0067586ad1
-            X-Amz-Request-Id:
-                - txg6ab2668de76a4ad0945c-0067586ad1
-        status: 404 Not Found
-        code: 404
-        duration: 13.596667ms
-    - id: 50
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 2de8f331-20a2-4398-9602-da9cca612e5e
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20241210T162241Z
-        url: https://tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud/
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 283
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-basic-7045227858940344981</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
-        headers:
-            Content-Length:
-                - "283"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 10 Dec 2024 16:22:41 GMT
-            X-Amz-Id-2:
-                - txgfa49b74b870b47b2a756-0067586ad1
-            X-Amz-Request-Id:
-                - txgfa49b74b870b47b2a756-0067586ad1
-        status: 200 OK
-        code: 200
-        duration: 606.004833ms
-    - id: 51
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 6c532d4d-7da8-484b-9f52-e2a3f2333b1c
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20241210T162241Z
-        url: https://tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud/?tagging=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 118
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <Tagging><TagSet><Tag><Key>foo</Key><Value>bar</Value></Tag></TagSet></Tagging>
-        headers:
-            Content-Length:
-                - "118"
-            Content-Type:
-                - text/xml; charset=utf-8
-            Date:
-                - Tue, 10 Dec 2024 16:22:41 GMT
-            X-Amz-Id-2:
-                - txgc09703bea78846319296-0067586ad1
-            X-Amz-Request-Id:
-                - txgc09703bea78846319296-0067586ad1
-        status: 200 OK
-        code: 200
-        duration: 8.107125ms
-    - id: 52
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - c96f8ac5-de13-4638-92cb-0018c11e4f20
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20241210T162241Z
-        url: https://tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud/?cors=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 294
-        uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg3569146119ca4fee94d4-0067586ad1</RequestId><HostId>txg3569146119ca4fee94d4-0067586ad1</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-7045227858940344981</Resource></Error>
-        headers:
-            Content-Length:
-                - "294"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 10 Dec 2024 16:22:41 GMT
-            X-Amz-Id-2:
-                - txg3569146119ca4fee94d4-0067586ad1
-            X-Amz-Request-Id:
-                - txg3569146119ca4fee94d4-0067586ad1
-        status: 404 Not Found
-        code: 404
-        duration: 27.135583ms
-    - id: 53
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - ad24576c-c3cd-45d8-a009-fbf5ab770b6f
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20241210T162241Z
-        url: https://tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud/?versioning=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 155
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Status></Status></VersioningConfiguration>
-        headers:
-            Content-Length:
-                - "155"
-            Content-Type:
-                - text/xml; charset=utf-8
-            Date:
-                - Tue, 10 Dec 2024 16:22:41 GMT
-            X-Amz-Id-2:
-                - txg78864e9daea44c6f85f2-0067586ad1
-            X-Amz-Request-Id:
-                - txg78864e9daea44c6f85f2-0067586ad1
-        status: 200 OK
-        code: 200
-        duration: 16.075709ms
-    - id: 54
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 2284b85d-a365-4858-9ee4-ff75cf07e029
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20241210T162241Z
-        url: https://tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud/?lifecycle=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 386
-        uncompressed: false
-        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txg85833fe09dcc4f1484e9-0067586ad2</RequestId><HostId>txg85833fe09dcc4f1484e9-0067586ad2</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-7045227858940344981</Resource><BucketName>tf-tests-scaleway-object-bucket-basic-7045227858940344981</BucketName></Error>
-        headers:
-            Content-Length:
-                - "386"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 10 Dec 2024 16:22:42 GMT
-            X-Amz-Id-2:
-                - txg85833fe09dcc4f1484e9-0067586ad2
-            X-Amz-Request-Id:
-                - txg85833fe09dcc4f1484e9-0067586ad2
-        status: 404 Not Found
-        code: 404
-        duration: 12.23475ms
-    - id: 55
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - ffdc7511-50a2-4100-a9d5-da5b0e414baf
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20241210T162243Z
-        url: https://tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud/?acl=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 698
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
-        headers:
-            Content-Length:
-                - "698"
-            Content-Type:
-                - text/xml; charset=utf-8
-            Date:
-                - Tue, 10 Dec 2024 16:22:43 GMT
-            X-Amz-Id-2:
-                - txgcd49df747ba6463faa52-0067586ad3
-            X-Amz-Request-Id:
-                - txgcd49df747ba6463faa52-0067586ad3
-        status: 200 OK
-        code: 200
-        duration: 11.618833ms
-    - id: 56
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-main-region-5405544164764476592.s3.fr-par.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 142e4cfc-01ce-49ed-ad0e-dbc7ad07d08a
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20241210T162243Z
-        url: https://tf-tests-scaleway-object-bucket-main-region-5405544164764476592.s3.fr-par.scw.cloud/?acl=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 698
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
-        headers:
-            Content-Length:
-                - "698"
-            Content-Type:
-                - text/xml; charset=utf-8
-            Date:
-                - Tue, 10 Dec 2024 16:22:43 GMT
-            X-Amz-Id-2:
-                - txg5962997715be4a1aa63a-0067586ad3
-            X-Amz-Request-Id:
-                - txg5962997715be4a1aa63a-0067586ad3
-        status: 200 OK
-        code: 200
-        duration: 19.714125ms
-    - id: 57
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 30549994-9ea6-4370-a683-6715fce928e9
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20241210T162243Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.nl-ams.scw.cloud/?acl=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 698
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
-        headers:
-            Content-Length:
-                - "698"
-            Content-Type:
-                - text/xml; charset=utf-8
-            Date:
-                - Tue, 10 Dec 2024 16:22:43 GMT
-            X-Amz-Id-2:
-                - txg5d0dd6670abb4a5e96ce-0067586ad3
-            X-Amz-Request-Id:
-                - txg5d0dd6670abb4a5e96ce-0067586ad3
-        status: 200 OK
-        code: 200
-        duration: 30.818875ms
-    - id: 58
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-main-region-5405544164764476592.s3.fr-par.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 7bdc0d5f-4933-429c-bdf1-6b14f94ccc17
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20241210T162243Z
-        url: https://tf-tests-scaleway-object-bucket-main-region-5405544164764476592.s3.fr-par.scw.cloud/?object-lock=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 332
-        uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg3c42734d80aa4cb1b820-0067586ad3</RequestId><HostId>txg3c42734d80aa4cb1b820-0067586ad3</HostId><Resource>/tf-tests-scaleway-object-bucket-main-region-5405544164764476592</Resource></Error>
-        headers:
-            Content-Length:
-                - "332"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 10 Dec 2024 16:22:43 GMT
-            X-Amz-Id-2:
-                - txg3c42734d80aa4cb1b820-0067586ad3
-            X-Amz-Request-Id:
-                - txg3c42734d80aa4cb1b820-0067586ad3
-        status: 404 Not Found
-        code: 404
-        duration: 15.241209ms
-    - id: 59
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-main-region-5405544164764476592.s3.fr-par.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 97d72128-bed6-4ca7-bdfd-ab6b125a4f27
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20241210T162243Z
-        url: https://tf-tests-scaleway-object-bucket-main-region-5405544164764476592.s3.fr-par.scw.cloud/
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 289
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-main-region-5405544164764476592</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
-        headers:
-            Content-Length:
-                - "289"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 10 Dec 2024 16:22:43 GMT
-            X-Amz-Id-2:
-                - txgf399c7e4196b4558a94f-0067586ad3
-            X-Amz-Request-Id:
-                - txgf399c7e4196b4558a94f-0067586ad3
-        status: 200 OK
-        code: 200
-        duration: 8.708208ms
-    - id: 60
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-main-region-5405544164764476592.s3.fr-par.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - a3db18dd-9bcb-4503-927b-c46073c42c8d
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20241210T162243Z
-        url: https://tf-tests-scaleway-object-bucket-main-region-5405544164764476592.s3.fr-par.scw.cloud/?tagging=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 365
-        uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txge4712c363a714830b8ab-0067586ad3</RequestId><HostId>txge4712c363a714830b8ab-0067586ad3</HostId><Resource>/tf-tests-scaleway-object-bucket-main-region-5405544164764476592</Resource><BucketName>tf-tests-scaleway-object-bucket-main-region-5405544164764476592</BucketName></Error>
-        headers:
-            Content-Length:
-                - "365"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 10 Dec 2024 16:22:43 GMT
-            X-Amz-Id-2:
-                - txge4712c363a714830b8ab-0067586ad3
-            X-Amz-Request-Id:
-                - txge4712c363a714830b8ab-0067586ad3
-        status: 404 Not Found
-        code: 404
-        duration: 12.120708ms
-    - id: 61
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.nl-ams.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - bf1b23c4-5af4-402d-a3d5-46495821363b
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20241210T162243Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.nl-ams.scw.cloud/?object-lock=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 330
-        uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg6e1792e8b2aa4f3cbd48-0067586ad3</RequestId><HostId>txg6e1792e8b2aa4f3cbd48-0067586ad3</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-2430854061085752549</Resource></Error>
-        headers:
-            Content-Length:
-                - "330"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 10 Dec 2024 16:22:43 GMT
-            X-Amz-Id-2:
-                - txg6e1792e8b2aa4f3cbd48-0067586ad3
-            X-Amz-Request-Id:
-                - txg6e1792e8b2aa4f3cbd48-0067586ad3
-        status: 404 Not Found
-        code: 404
-        duration: 25.164875ms
-    - id: 62
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 7412853d-d13b-470f-b82e-610fd0e9fce0
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20241210T162243Z
-        url: https://tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud/?object-lock=
+                - 20260512T124830Z
+        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3259,22 +2121,22 @@ interactions:
         trailer: {}
         content_length: 326
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg114db2eab7674373a368-0067586ad3</RequestId><HostId>txg114db2eab7674373a368-0067586ad3</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-7045227858940344981</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg72c0bd6ea1e847918c44-006a03219e</RequestId><HostId>txg72c0bd6ea1e847918c44-006a03219e</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-1314313384735080249</Resource></Error>
         headers:
             Content-Length:
                 - "326"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:43 GMT
+                - Tue, 12 May 2026 12:48:30 GMT
             X-Amz-Id-2:
-                - txg114db2eab7674373a368-0067586ad3
+                - txg72c0bd6ea1e847918c44-006a03219e
             X-Amz-Request-Id:
-                - txg114db2eab7674373a368-0067586ad3
+                - txg72c0bd6ea1e847918c44-006a03219e
         status: 404 Not Found
         code: 404
-        duration: 55.86125ms
-    - id: 63
+        duration: 77.345041ms
+    - id: 41
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3282,7 +2144,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3291,16 +2153,67 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9012be5d-b460-4898-9110-de06bdd71a35
+                - fcebf174-26a9-41c5-9006-9b806da25b6d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162243Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.nl-ams.scw.cloud/
+                - 20260512T124830Z
+        url: https://tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud/?tagging=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 363
+        uncompressed: false
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg9143abbcaaf2408a95d8-006a03219f</RequestId><HostId>txg9143abbcaaf2408a95d8-006a03219f</HostId><Resource>/tf-tests-scaleway-object-bucket-main-region-652097813215812252</Resource><BucketName>tf-tests-scaleway-object-bucket-main-region-652097813215812252</BucketName></Error>
+        headers:
+            Content-Length:
+                - "363"
+            Content-Type:
+                - application/xml
+            Date:
+                - Tue, 12 May 2026 12:48:31 GMT
+            X-Amz-Id-2:
+                - txg9143abbcaaf2408a95d8-006a03219f
+            X-Amz-Request-Id:
+                - txg9143abbcaaf2408a95d8-006a03219f
+        status: 404 Not Found
+        code: 404
+        duration: 16.446459ms
+    - id: 42
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - abd3e57a-7d82-4515-9edc-b93a4c4a6b92
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260512T124831Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -3312,22 +2225,22 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-secondary-2430854061085752549</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-secondary-2001388040591926415</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:43 GMT
+                - Tue, 12 May 2026 12:48:31 GMT
             X-Amz-Id-2:
-                - txgdc76a031bdd4460abd69-0067586ad3
+                - txg464dd9d6cd8a47a3a492-006a03219f
             X-Amz-Request-Id:
-                - txgdc76a031bdd4460abd69-0067586ad3
+                - txg464dd9d6cd8a47a3a492-006a03219f
         status: 200 OK
         code: 200
-        duration: 35.911709ms
-    - id: 64
+        duration: 53.0325ms
+    - id: 43
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3335,7 +2248,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-main-region-5405544164764476592.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3344,16 +2257,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d485c956-4f43-4e3d-a244-ed112bd281cf
+                - 1178f715-ae3f-4405-8dc9-76eff66f4136
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162243Z
-        url: https://tf-tests-scaleway-object-bucket-main-region-5405544164764476592.s3.fr-par.scw.cloud/?cors=
+                - 20260512T124831Z
+        url: https://tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3361,24 +2274,24 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 300
+        content_length: 299
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg963e7bb3c72a4befbae8-0067586ad3</RequestId><HostId>txg963e7bb3c72a4befbae8-0067586ad3</HostId><Resource>/tf-tests-scaleway-object-bucket-main-region-5405544164764476592</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg115aa5a4f94d45e7bd8a-006a03219f</RequestId><HostId>txg115aa5a4f94d45e7bd8a-006a03219f</HostId><Resource>/tf-tests-scaleway-object-bucket-main-region-652097813215812252</Resource></Error>
         headers:
             Content-Length:
-                - "300"
+                - "299"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:43 GMT
+                - Tue, 12 May 2026 12:48:31 GMT
             X-Amz-Id-2:
-                - txg963e7bb3c72a4befbae8-0067586ad3
+                - txg115aa5a4f94d45e7bd8a-006a03219f
             X-Amz-Request-Id:
-                - txg963e7bb3c72a4befbae8-0067586ad3
+                - txg115aa5a4f94d45e7bd8a-006a03219f
         status: 404 Not Found
         code: 404
-        duration: 41.249458ms
-    - id: 65
+        duration: 21.755917ms
+    - id: 44
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3386,7 +2299,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3395,16 +2308,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ce69c6e7-c431-4430-a003-3c8cd69c6fcc
+                - 0fe41ed6-45c9-47e1-8ea9-6b760d4e2e29
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162243Z
-        url: https://tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud/
+                - 20260512T124831Z
+        url: https://tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3412,26 +2325,26 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 283
+        content_length: 107
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-basic-7045227858940344981</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <VersioningConfiguration><Status></Status></VersioningConfiguration>
         headers:
             Content-Length:
-                - "283"
+                - "107"
             Content-Type:
-                - application/xml
+                - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:43 GMT
+                - Tue, 12 May 2026 12:48:31 GMT
             X-Amz-Id-2:
-                - txg3632890b18a14c5eb180-0067586ad3
+                - txg24edb16e751243b4ba49-006a03219f
             X-Amz-Request-Id:
-                - txg3632890b18a14c5eb180-0067586ad3
+                - txg24edb16e751243b4ba49-006a03219f
         status: 200 OK
         code: 200
-        duration: 44.839916ms
-    - id: 66
+        duration: 16.908167ms
+    - id: 45
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3439,7 +2352,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3448,16 +2361,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 6cd23d12-7f15-4cb8-9975-8be26624a0f2
+                - 7574bd7c-8e91-43d2-b0e1-8c87e11995d4
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162243Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.nl-ams.scw.cloud/?tagging=
+                - 20260512T124831Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3476,14 +2389,1107 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:43 GMT
+                - Tue, 12 May 2026 12:48:31 GMT
             X-Amz-Id-2:
-                - txg4a66f780260949f39348-0067586ad3
+                - txga31a3a023da24ab5a798-006a03219f
             X-Amz-Request-Id:
-                - txg4a66f780260949f39348-0067586ad3
+                - txga31a3a023da24ab5a798-006a03219f
         status: 200 OK
         code: 200
-        duration: 26.002917ms
+        duration: 38.827792ms
+    - id: 46
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 99f8d6cf-d5d9-4ad2-8483-73ec7e59a8d1
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260512T124830Z
+        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 283
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-basic-1314313384735080249</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+        headers:
+            Content-Length:
+                - "283"
+            Content-Type:
+                - application/xml
+            Date:
+                - Tue, 12 May 2026 12:48:31 GMT
+            X-Amz-Id-2:
+                - txgef5cb2976914470c831d-006a03219f
+            X-Amz-Request-Id:
+                - txgef5cb2976914470c831d-006a03219f
+        status: 200 OK
+        code: 200
+        duration: 84.651625ms
+    - id: 47
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 03da3f8a-1e70-491b-b839-bb8250d68168
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260512T124831Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud/?cors=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 298
+        uncompressed: false
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg2b438eeb519846ee9acc-006a03219f</RequestId><HostId>txg2b438eeb519846ee9acc-006a03219f</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-2001388040591926415</Resource></Error>
+        headers:
+            Content-Length:
+                - "298"
+            Content-Type:
+                - application/xml
+            Date:
+                - Tue, 12 May 2026 12:48:31 GMT
+            X-Amz-Id-2:
+                - txg2b438eeb519846ee9acc-006a03219f
+            X-Amz-Request-Id:
+                - txg2b438eeb519846ee9acc-006a03219f
+        status: 404 Not Found
+        code: 404
+        duration: 21.995667ms
+    - id: 48
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - f483545c-f908-4d37-a999-3020cc388160
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260512T124831Z
+        url: https://tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud/?lifecycle=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 396
+        uncompressed: false
+        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txg822878f2a12b430f9a9c-006a03219f</RequestId><HostId>txg822878f2a12b430f9a9c-006a03219f</HostId><Resource>/tf-tests-scaleway-object-bucket-main-region-652097813215812252</Resource><BucketName>tf-tests-scaleway-object-bucket-main-region-652097813215812252</BucketName></Error>
+        headers:
+            Content-Length:
+                - "396"
+            Content-Type:
+                - application/xml
+            Date:
+                - Tue, 12 May 2026 12:48:31 GMT
+            X-Amz-Id-2:
+                - txg822878f2a12b430f9a9c-006a03219f
+            X-Amz-Request-Id:
+                - txg822878f2a12b430f9a9c-006a03219f
+        status: 404 Not Found
+        code: 404
+        duration: 69.888334ms
+    - id: 49
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - d28b51f9-89d4-4c18-a080-b07d79078859
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260512T124831Z
+        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?tagging=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 118
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <Tagging><TagSet><Tag><Key>foo</Key><Value>bar</Value></Tag></TagSet></Tagging>
+        headers:
+            Content-Length:
+                - "118"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Tue, 12 May 2026 12:48:31 GMT
+            X-Amz-Id-2:
+                - txg3de8853c1ecc4f34a41f-006a03219f
+            X-Amz-Request-Id:
+                - txg3de8853c1ecc4f34a41f-006a03219f
+        status: 200 OK
+        code: 200
+        duration: 51.262208ms
+    - id: 50
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - cd6694fa-3edf-4eb1-8148-9c37a5a37f00
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260512T124831Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud/?versioning=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 107
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <VersioningConfiguration><Status></Status></VersioningConfiguration>
+        headers:
+            Content-Length:
+                - "107"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Tue, 12 May 2026 12:48:31 GMT
+            X-Amz-Id-2:
+                - txg495c64a1642a423da2f1-006a03219f
+            X-Amz-Request-Id:
+                - txg495c64a1642a423da2f1-006a03219f
+        status: 200 OK
+        code: 200
+        duration: 38.151416ms
+    - id: 51
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 2edcdd91-a5b1-4217-9430-b89941176333
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260512T124831Z
+        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?cors=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 294
+        uncompressed: false
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg0ebffbac322540ffbc25-006a03219f</RequestId><HostId>txg0ebffbac322540ffbc25-006a03219f</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-1314313384735080249</Resource></Error>
+        headers:
+            Content-Length:
+                - "294"
+            Content-Type:
+                - application/xml
+            Date:
+                - Tue, 12 May 2026 12:48:31 GMT
+            X-Amz-Id-2:
+                - txg0ebffbac322540ffbc25-006a03219f
+            X-Amz-Request-Id:
+                - txg0ebffbac322540ffbc25-006a03219f
+        status: 404 Not Found
+        code: 404
+        duration: 8.478125ms
+    - id: 52
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 1a79d3b5-d345-4a53-a6c6-3e541dd88fbb
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260512T124831Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud/?lifecycle=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 394
+        uncompressed: false
+        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txg76f637c01bd84e8bb040-006a03219f</RequestId><HostId>txg76f637c01bd84e8bb040-006a03219f</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-2001388040591926415</Resource><BucketName>tf-tests-scaleway-object-bucket-secondary-2001388040591926415</BucketName></Error>
+        headers:
+            Content-Length:
+                - "394"
+            Content-Type:
+                - application/xml
+            Date:
+                - Tue, 12 May 2026 12:48:31 GMT
+            X-Amz-Id-2:
+                - txg76f637c01bd84e8bb040-006a03219f
+            X-Amz-Request-Id:
+                - txg76f637c01bd84e8bb040-006a03219f
+        status: 404 Not Found
+        code: 404
+        duration: 60.17675ms
+    - id: 53
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - bee29527-9435-4b2e-95c7-a7824414166b
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260512T124831Z
+        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?versioning=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 107
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <VersioningConfiguration><Status></Status></VersioningConfiguration>
+        headers:
+            Content-Length:
+                - "107"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Tue, 12 May 2026 12:48:31 GMT
+            X-Amz-Id-2:
+                - txg5f003c4da990443dad82-006a03219f
+            X-Amz-Request-Id:
+                - txg5f003c4da990443dad82-006a03219f
+        status: 200 OK
+        code: 200
+        duration: 136.902083ms
+    - id: 54
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 85b48395-5f15-449a-b26b-199801476980
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260512T124831Z
+        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?lifecycle=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 386
+        uncompressed: false
+        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txga6f5cff61b4c45a59961-006a03219f</RequestId><HostId>txga6f5cff61b4c45a59961-006a03219f</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-1314313384735080249</Resource><BucketName>tf-tests-scaleway-object-bucket-basic-1314313384735080249</BucketName></Error>
+        headers:
+            Content-Length:
+                - "386"
+            Content-Type:
+                - application/xml
+            Date:
+                - Tue, 12 May 2026 12:48:31 GMT
+            X-Amz-Id-2:
+                - txga6f5cff61b4c45a59961-006a03219f
+            X-Amz-Request-Id:
+                - txga6f5cff61b4c45a59961-006a03219f
+        status: 404 Not Found
+        code: 404
+        duration: 136.828125ms
+    - id: 55
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - e56ab968-de47-4efd-9594-11b4b79145d2
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260512T124831Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud/?acl=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 698
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+        headers:
+            Content-Length:
+                - "698"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Tue, 12 May 2026 12:48:31 GMT
+            X-Amz-Id-2:
+                - txg98c6ff6b6ce74e7692f6-006a03219f
+            X-Amz-Request-Id:
+                - txg98c6ff6b6ce74e7692f6-006a03219f
+        status: 200 OK
+        code: 200
+        duration: 54.404375ms
+    - id: 56
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - e62f3de8-23b6-4614-963f-dfc8df37b974
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260512T124831Z
+        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?acl=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 698
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+        headers:
+            Content-Length:
+                - "698"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Tue, 12 May 2026 12:48:31 GMT
+            X-Amz-Id-2:
+                - txg6a90a177a64c4b95ba7c-006a03219f
+            X-Amz-Request-Id:
+                - txg6a90a177a64c4b95ba7c-006a03219f
+        status: 200 OK
+        code: 200
+        duration: 54.529792ms
+    - id: 57
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 48c551d3-f39e-43fd-a4e0-09a0a5d64d61
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260512T124831Z
+        url: https://tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud/?acl=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 698
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+        headers:
+            Content-Length:
+                - "698"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Tue, 12 May 2026 12:48:31 GMT
+            X-Amz-Id-2:
+                - txg2600d317419a46ada65c-006a03219f
+            X-Amz-Request-Id:
+                - txg2600d317419a46ada65c-006a03219f
+        status: 200 OK
+        code: 200
+        duration: 101.842875ms
+    - id: 58
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 898a7f48-2fbc-4d50-99e7-67071bd3cd64
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260512T124831Z
+        url: https://tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud/?object-lock=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 331
+        uncompressed: false
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg5226a0a9a4b94fbea831-006a03219f</RequestId><HostId>txg5226a0a9a4b94fbea831-006a03219f</HostId><Resource>/tf-tests-scaleway-object-bucket-main-region-652097813215812252</Resource></Error>
+        headers:
+            Content-Length:
+                - "331"
+            Content-Type:
+                - application/xml
+            Date:
+                - Tue, 12 May 2026 12:48:31 GMT
+            X-Amz-Id-2:
+                - txg5226a0a9a4b94fbea831-006a03219f
+            X-Amz-Request-Id:
+                - txg5226a0a9a4b94fbea831-006a03219f
+        status: 404 Not Found
+        code: 404
+        duration: 11.900042ms
+    - id: 59
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - d05b06a3-bd1a-45ec-b5c7-a9a3d6fe51d8
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260512T124831Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud/?object-lock=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 330
+        uncompressed: false
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg558f1661745947c49864-006a03219f</RequestId><HostId>txg558f1661745947c49864-006a03219f</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-2001388040591926415</Resource></Error>
+        headers:
+            Content-Length:
+                - "330"
+            Content-Type:
+                - application/xml
+            Date:
+                - Tue, 12 May 2026 12:48:31 GMT
+            X-Amz-Id-2:
+                - txg558f1661745947c49864-006a03219f
+            X-Amz-Request-Id:
+                - txg558f1661745947c49864-006a03219f
+        status: 404 Not Found
+        code: 404
+        duration: 82.283041ms
+    - id: 60
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 23dba3ab-1758-401a-90d2-1e1c5898e029
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260512T124831Z
+        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?object-lock=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 326
+        uncompressed: false
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgb2d37f9e966c4aff9ba4-006a03219f</RequestId><HostId>txgb2d37f9e966c4aff9ba4-006a03219f</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-1314313384735080249</Resource></Error>
+        headers:
+            Content-Length:
+                - "326"
+            Content-Type:
+                - application/xml
+            Date:
+                - Tue, 12 May 2026 12:48:31 GMT
+            X-Amz-Id-2:
+                - txgb2d37f9e966c4aff9ba4-006a03219f
+            X-Amz-Request-Id:
+                - txgb2d37f9e966c4aff9ba4-006a03219f
+        status: 404 Not Found
+        code: 404
+        duration: 99.980542ms
+    - id: 61
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 7b30a6d1-3167-4394-ba4d-ffa8dd451ceb
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260512T124831Z
+        url: https://tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud/
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 288
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-main-region-652097813215812252</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+        headers:
+            Content-Length:
+                - "288"
+            Content-Type:
+                - application/xml
+            Date:
+                - Tue, 12 May 2026 12:48:31 GMT
+            X-Amz-Id-2:
+                - txg57a022b7d7974d5ea1f1-006a03219f
+            X-Amz-Request-Id:
+                - txg57a022b7d7974d5ea1f1-006a03219f
+        status: 200 OK
+        code: 200
+        duration: 101.770375ms
+    - id: 62
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - c21598d1-c24c-445f-8153-121e08c15e8f
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260512T124831Z
+        url: https://tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud/?tagging=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 363
+        uncompressed: false
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg20c7f94745eb4badbf00-006a03219f</RequestId><HostId>txg20c7f94745eb4badbf00-006a03219f</HostId><Resource>/tf-tests-scaleway-object-bucket-main-region-652097813215812252</Resource><BucketName>tf-tests-scaleway-object-bucket-main-region-652097813215812252</BucketName></Error>
+        headers:
+            Content-Length:
+                - "363"
+            Content-Type:
+                - application/xml
+            Date:
+                - Tue, 12 May 2026 12:48:31 GMT
+            X-Amz-Id-2:
+                - txg20c7f94745eb4badbf00-006a03219f
+            X-Amz-Request-Id:
+                - txg20c7f94745eb4badbf00-006a03219f
+        status: 404 Not Found
+        code: 404
+        duration: 13.289833ms
+    - id: 63
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 39c02600-9774-4a2d-898b-011365747a3f
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260512T124831Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud/
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 287
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-secondary-2001388040591926415</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+        headers:
+            Content-Length:
+                - "287"
+            Content-Type:
+                - application/xml
+            Date:
+                - Tue, 12 May 2026 12:48:31 GMT
+            X-Amz-Id-2:
+                - txg1dbad8873aed4b199ca4-006a03219f
+            X-Amz-Request-Id:
+                - txg1dbad8873aed4b199ca4-006a03219f
+        status: 200 OK
+        code: 200
+        duration: 96.006541ms
+    - id: 64
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 644502bb-1160-497f-8787-9e5eb2bb3e50
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260512T124831Z
+        url: https://tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud/?cors=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 299
+        uncompressed: false
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgce397e7cc7de490a981c-006a03219f</RequestId><HostId>txgce397e7cc7de490a981c-006a03219f</HostId><Resource>/tf-tests-scaleway-object-bucket-main-region-652097813215812252</Resource></Error>
+        headers:
+            Content-Length:
+                - "299"
+            Content-Type:
+                - application/xml
+            Date:
+                - Tue, 12 May 2026 12:48:31 GMT
+            X-Amz-Id-2:
+                - txgce397e7cc7de490a981c-006a03219f
+            X-Amz-Request-Id:
+                - txgce397e7cc7de490a981c-006a03219f
+        status: 404 Not Found
+        code: 404
+        duration: 9.741417ms
+    - id: 65
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - b734e560-3bbf-429b-ba10-542316c5db3d
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260512T124831Z
+        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 283
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-basic-1314313384735080249</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+        headers:
+            Content-Length:
+                - "283"
+            Content-Type:
+                - application/xml
+            Date:
+                - Tue, 12 May 2026 12:48:31 GMT
+            X-Amz-Id-2:
+                - txg43e975fbf1bc4b47bd28-006a03219f
+            X-Amz-Request-Id:
+                - txg43e975fbf1bc4b47bd28-006a03219f
+        status: 200 OK
+        code: 200
+        duration: 87.008084ms
+    - id: 66
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - f51f6b92-8cbc-49d4-acac-a578afa2c87b
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260512T124831Z
+        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?tagging=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 118
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <Tagging><TagSet><Tag><Key>foo</Key><Value>bar</Value></Tag></TagSet></Tagging>
+        headers:
+            Content-Length:
+                - "118"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Tue, 12 May 2026 12:48:31 GMT
+            X-Amz-Id-2:
+                - txg70583effd841451db1e5-006a03219f
+            X-Amz-Request-Id:
+                - txg70583effd841451db1e5-006a03219f
+        status: 200 OK
+        code: 200
+        duration: 44.3475ms
     - id: 67
       request:
         proto: HTTP/1.1
@@ -3492,7 +3498,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3501,16 +3507,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 14209ec1-fc05-4918-bbbc-fb2c2285204f
+                - 35b6a689-e5c8-4bf1-a171-3a7243978f67
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162243Z
-        url: https://tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud/?tagging=
+                - 20260512T124831Z
+        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3518,25 +3524,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 118
+        content_length: 294
         uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <Tagging><TagSet><Tag><Key>foo</Key><Value>bar</Value></Tag></TagSet></Tagging>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg06ad258528f2484ab3a7-006a03219f</RequestId><HostId>txg06ad258528f2484ab3a7-006a03219f</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-1314313384735080249</Resource></Error>
         headers:
             Content-Length:
-                - "118"
+                - "294"
             Content-Type:
-                - text/xml; charset=utf-8
+                - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:43 GMT
+                - Tue, 12 May 2026 12:48:31 GMT
             X-Amz-Id-2:
-                - txga6a7b83677f24452958e-0067586ad3
+                - txg06ad258528f2484ab3a7-006a03219f
             X-Amz-Request-Id:
-                - txga6a7b83677f24452958e-0067586ad3
-        status: 200 OK
-        code: 200
-        duration: 13.547708ms
+                - txg06ad258528f2484ab3a7-006a03219f
+        status: 404 Not Found
+        code: 404
+        duration: 10.930583ms
     - id: 68
       request:
         proto: HTTP/1.1
@@ -3545,7 +3549,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3554,16 +3558,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b8b96a70-172f-404f-b3c4-bab442f0bfc5
+                - 4f373e90-fb59-4d06-9386-c464d12edf35
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162243Z
-        url: https://tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud/?cors=
+                - 20260512T124831Z
+        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3571,23 +3575,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 294
+        content_length: 107
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg2d8722415ec541e485fb-0067586ad3</RequestId><HostId>txg2d8722415ec541e485fb-0067586ad3</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-7045227858940344981</Resource></Error>
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <VersioningConfiguration><Status></Status></VersioningConfiguration>
         headers:
             Content-Length:
-                - "294"
+                - "107"
             Content-Type:
-                - application/xml
+                - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:43 GMT
+                - Tue, 12 May 2026 12:48:31 GMT
             X-Amz-Id-2:
-                - txg2d8722415ec541e485fb-0067586ad3
+                - txg12899c60b7bf4935886f-006a03219f
             X-Amz-Request-Id:
-                - txg2d8722415ec541e485fb-0067586ad3
-        status: 404 Not Found
-        code: 404
-        duration: 9.97ms
+                - txg12899c60b7bf4935886f-006a03219f
+        status: 200 OK
+        code: 200
+        duration: 14.583291ms
     - id: 69
       request:
         proto: HTTP/1.1
@@ -3596,7 +3602,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-main-region-5405544164764476592.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3605,16 +3611,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 99d982e4-eedd-432d-aa40-bfe4beab6325
+                - e2cd5c5d-fa44-4402-96d0-7cfd42914af7
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162243Z
-        url: https://tf-tests-scaleway-object-bucket-main-region-5405544164764476592.s3.fr-par.scw.cloud/?versioning=
+                - 20260512T124831Z
+        url: https://tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3622,25 +3628,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 155
+        content_length: 107
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Status></Status></VersioningConfiguration>
+            <VersioningConfiguration><Status></Status></VersioningConfiguration>
         headers:
             Content-Length:
-                - "155"
+                - "107"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:43 GMT
+                - Tue, 12 May 2026 12:48:31 GMT
             X-Amz-Id-2:
-                - txg04c07e0c83b24f9a9c4e-0067586ad3
+                - txg024c601d4978425fb59c-006a03219f
             X-Amz-Request-Id:
-                - txg04c07e0c83b24f9a9c4e-0067586ad3
+                - txg024c601d4978425fb59c-006a03219f
         status: 200 OK
         code: 200
-        duration: 47.53675ms
+        duration: 78.599959ms
     - id: 70
       request:
         proto: HTTP/1.1
@@ -3649,7 +3655,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3658,16 +3664,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - de1417f1-4630-41c6-bc28-4dbcc50c90cd
+                - 37d033fc-cc4c-43c0-a1ac-e8d5f88a4957
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162243Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.nl-ams.scw.cloud/?cors=
+                - 20260512T124831Z
+        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3675,23 +3681,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 298
+        content_length: 386
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg9150a0911f544781a5a9-0067586ad3</RequestId><HostId>txg9150a0911f544781a5a9-0067586ad3</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-2430854061085752549</Resource></Error>
+        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txg880ecce6d9304913b2dc-006a03219f</RequestId><HostId>txg880ecce6d9304913b2dc-006a03219f</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-1314313384735080249</Resource><BucketName>tf-tests-scaleway-object-bucket-basic-1314313384735080249</BucketName></Error>
         headers:
             Content-Length:
-                - "298"
+                - "386"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:43 GMT
+                - Tue, 12 May 2026 12:48:31 GMT
             X-Amz-Id-2:
-                - txg9150a0911f544781a5a9-0067586ad3
+                - txg880ecce6d9304913b2dc-006a03219f
             X-Amz-Request-Id:
-                - txg9150a0911f544781a5a9-0067586ad3
+                - txg880ecce6d9304913b2dc-006a03219f
         status: 404 Not Found
         code: 404
-        duration: 27.054375ms
+        duration: 13.803291ms
     - id: 71
       request:
         proto: HTTP/1.1
@@ -3700,7 +3706,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3709,16 +3715,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d82d5daa-c547-4e99-9c4d-ff6636aadcd0
+                - 48e23b92-a62e-4a88-a24a-2aa781d43f36
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162243Z
-        url: https://tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud/?versioning=
+                - 20260512T124831Z
+        url: https://tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3726,25 +3732,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 155
+        content_length: 396
         uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Status></Status></VersioningConfiguration>
+        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txgf41a2a622bd746178961-006a03219f</RequestId><HostId>txgf41a2a622bd746178961-006a03219f</HostId><Resource>/tf-tests-scaleway-object-bucket-main-region-652097813215812252</Resource><BucketName>tf-tests-scaleway-object-bucket-main-region-652097813215812252</BucketName></Error>
         headers:
             Content-Length:
-                - "155"
+                - "396"
             Content-Type:
-                - text/xml; charset=utf-8
+                - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:43 GMT
+                - Tue, 12 May 2026 12:48:31 GMT
             X-Amz-Id-2:
-                - txgedc3d054a2c346279fc0-0067586ad3
+                - txgf41a2a622bd746178961-006a03219f
             X-Amz-Request-Id:
-                - txgedc3d054a2c346279fc0-0067586ad3
-        status: 200 OK
-        code: 200
-        duration: 11.35225ms
+                - txgf41a2a622bd746178961-006a03219f
+        status: 404 Not Found
+        code: 404
+        duration: 18.67325ms
     - id: 72
       request:
         proto: HTTP/1.1
@@ -3753,7 +3757,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3762,16 +3766,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 19a617ca-4681-4380-a316-b7ede592b1ff
+                - d20378d2-d4b2-4bd7-a8e0-6ce1569e284d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162243Z
-        url: https://tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud/?lifecycle=
+                - 20260512T124831Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3779,23 +3783,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 386
+        content_length: 161
         uncompressed: false
-        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txg84f81fd060df432083fe-0067586ad3</RequestId><HostId>txg84f81fd060df432083fe-0067586ad3</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-7045227858940344981</Resource><BucketName>tf-tests-scaleway-object-bucket-basic-7045227858940344981</BucketName></Error>
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <Tagging><TagSet><Tag><Key>foo</Key><Value>bar</Value></Tag><Tag><Key>baz</Key><Value>qux</Value></Tag></TagSet></Tagging>
         headers:
             Content-Length:
-                - "386"
+                - "161"
             Content-Type:
-                - application/xml
+                - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:43 GMT
+                - Tue, 12 May 2026 12:48:31 GMT
             X-Amz-Id-2:
-                - txg84f81fd060df432083fe-0067586ad3
+                - txg7caf987f931f41f780ad-006a03219f
             X-Amz-Request-Id:
-                - txg84f81fd060df432083fe-0067586ad3
-        status: 404 Not Found
-        code: 404
-        duration: 7.835ms
+                - txg7caf987f931f41f780ad-006a03219f
+        status: 200 OK
+        code: 200
+        duration: 154.815625ms
     - id: 73
       request:
         proto: HTTP/1.1
@@ -3804,7 +3810,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-main-region-5405544164764476592.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3813,16 +3819,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c84375f8-8394-4af4-b6ac-2e4203ac8d43
+                - 83b18329-63d6-4655-960b-d099c8b6a58d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162243Z
-        url: https://tf-tests-scaleway-object-bucket-main-region-5405544164764476592.s3.fr-par.scw.cloud/?lifecycle=
+                - 20260512T124831Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3830,23 +3836,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 398
+        content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txg3ccee07dad154dbfaae5-0067586ad3</RequestId><HostId>txg3ccee07dad154dbfaae5-0067586ad3</HostId><Resource>/tf-tests-scaleway-object-bucket-main-region-5405544164764476592</Resource><BucketName>tf-tests-scaleway-object-bucket-main-region-5405544164764476592</BucketName></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg4e23f6a4408a4f21ade5-006a0321a0</RequestId><HostId>txg4e23f6a4408a4f21ade5-006a0321a0</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-2001388040591926415</Resource></Error>
         headers:
             Content-Length:
-                - "398"
+                - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:43 GMT
+                - Tue, 12 May 2026 12:48:32 GMT
             X-Amz-Id-2:
-                - txg3ccee07dad154dbfaae5-0067586ad3
+                - txg4e23f6a4408a4f21ade5-006a0321a0
             X-Amz-Request-Id:
-                - txg3ccee07dad154dbfaae5-0067586ad3
+                - txg4e23f6a4408a4f21ade5-006a0321a0
         status: 404 Not Found
         code: 404
-        duration: 11.914916ms
+        duration: 19.252459ms
     - id: 74
       request:
         proto: HTTP/1.1
@@ -3855,7 +3861,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3864,16 +3870,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 82b7a9b4-f96c-4762-9dfc-b166e4b37c49
+                - 62503016-2d42-475a-b25a-83726fe3bf15
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162243Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.nl-ams.scw.cloud/?versioning=
+                - 20260512T124832Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3881,25 +3887,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 155
+        content_length: 107
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Status></Status></VersioningConfiguration>
+            <VersioningConfiguration><Status></Status></VersioningConfiguration>
         headers:
             Content-Length:
-                - "155"
+                - "107"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:43 GMT
+                - Tue, 12 May 2026 12:48:32 GMT
             X-Amz-Id-2:
-                - txg5c73a1e5dfeb43cd8e17-0067586ad3
+                - txg9c29ce1a45994b9aadb2-006a0321a0
             X-Amz-Request-Id:
-                - txg5c73a1e5dfeb43cd8e17-0067586ad3
+                - txg9c29ce1a45994b9aadb2-006a0321a0
         status: 200 OK
         code: 200
-        duration: 26.799958ms
+        duration: 57.886125ms
     - id: 75
       request:
         proto: HTTP/1.1
@@ -3908,7 +3914,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3917,16 +3923,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 81933091-8afb-4446-a9e6-3518d74330ab
+                - 41ef113f-20a4-435e-8397-49bb705cc35e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162243Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T124832Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3936,21 +3942,21 @@ interactions:
         trailer: {}
         content_length: 394
         uncompressed: false
-        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txg5e4d2284a4c54a2daf1b-0067586ad3</RequestId><HostId>txg5e4d2284a4c54a2daf1b-0067586ad3</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-2430854061085752549</Resource><BucketName>tf-tests-scaleway-object-bucket-secondary-2430854061085752549</BucketName></Error>
+        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txg3674ed3b43fa46dead0f-006a0321a0</RequestId><HostId>txg3674ed3b43fa46dead0f-006a0321a0</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-2001388040591926415</Resource><BucketName>tf-tests-scaleway-object-bucket-secondary-2001388040591926415</BucketName></Error>
         headers:
             Content-Length:
                 - "394"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:43 GMT
+                - Tue, 12 May 2026 12:48:32 GMT
             X-Amz-Id-2:
-                - txg5e4d2284a4c54a2daf1b-0067586ad3
+                - txg3674ed3b43fa46dead0f-006a0321a0
             X-Amz-Request-Id:
-                - txg5e4d2284a4c54a2daf1b-0067586ad3
+                - txg3674ed3b43fa46dead0f-006a0321a0
         status: 404 Not Found
         code: 404
-        duration: 29.928416ms
+        duration: 37.028417ms
     - id: 76
       request:
         proto: HTTP/1.1
@@ -3959,7 +3965,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3968,17 +3974,21 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 3f45ec8a-2c44-467d-a055-987a9331c55d
+                - 53e93e0a-07e7-4b0a-a8da-b34a5c79426a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,Z,e
+            X-Amz-Acl:
+                - public-read
+            X-Amz-Checksum-Crc32:
+                - AAAAAA==
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162244Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.nl-ams.scw.cloud/
-        method: DELETE
+                - 20260512T124832Z
+        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?acl=
+        method: PUT
       response:
         proto: HTTP/2.0
         proto_major: 2
@@ -3989,15 +3999,17 @@ interactions:
         uncompressed: false
         body: ""
         headers:
+            Content-Length:
+                - "0"
             Date:
-                - Tue, 10 Dec 2024 16:22:44 GMT
+                - Tue, 12 May 2026 12:48:32 GMT
             X-Amz-Id-2:
-                - txg0d1f77bf24814249af87-0067586ad4
+                - txg426a10eed9624f22b3b7-006a0321a0
             X-Amz-Request-Id:
-                - txg0d1f77bf24814249af87-0067586ad4
-        status: 204 No Content
-        code: 204
-        duration: 71.556125ms
+                - txg426a10eed9624f22b3b7-006a0321a0
+        status: 200 OK
+        code: 200
+        duration: 167.236042ms
     - id: 77
       request:
         proto: HTTP/1.1
@@ -4006,7 +4018,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4015,19 +4027,17 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 782f6a0f-e5ce-4439-9dc6-bd09b6c38e97
+                - 8d537e36-9e91-4e11-adfc-ad5de5453891
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
-            X-Amz-Acl:
-                - public-read
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162244Z
-        url: https://tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud/?acl=
-        method: PUT
+                - 20260512T124832Z
+        url: https://tf-tests-scaleway-object-bucket-main-region-652097813215812252.s3.fr-par.scw.cloud/
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
@@ -4038,17 +4048,15 @@ interactions:
         uncompressed: false
         body: ""
         headers:
-            Content-Length:
-                - "0"
             Date:
-                - Tue, 10 Dec 2024 16:22:44 GMT
+                - Tue, 12 May 2026 12:48:32 GMT
             X-Amz-Id-2:
-                - txg4a9643b733c74b6590eb-0067586ad4
+                - txg59e1f50c83b148a89347-006a0321a0
             X-Amz-Request-Id:
-                - txg4a9643b733c74b6590eb-0067586ad4
-        status: 200 OK
-        code: 200
-        duration: 57.870542ms
+                - txg59e1f50c83b148a89347-006a0321a0
+        status: 204 No Content
+        code: 204
+        duration: 170.806792ms
     - id: 78
       request:
         proto: HTTP/1.1
@@ -4057,7 +4065,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-main-region-5405544164764476592.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4066,16 +4074,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 8d4b56f6-7315-4839-a4f4-e229d1985991
+                - 4ed20714-c19c-4ef3-808a-8915ebe53fa6
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162244Z
-        url: https://tf-tests-scaleway-object-bucket-main-region-5405544164764476592.s3.fr-par.scw.cloud/
+                - 20260512T124832Z
+        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?tagging=
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -4088,14 +4096,14 @@ interactions:
         body: ""
         headers:
             Date:
-                - Tue, 10 Dec 2024 16:22:44 GMT
+                - Tue, 12 May 2026 12:48:32 GMT
             X-Amz-Id-2:
-                - txgcbd183312f8d400d9056-0067586ad4
+                - txgb37899e3e09f4307a14b-006a0321a0
             X-Amz-Request-Id:
-                - txgcbd183312f8d400d9056-0067586ad4
+                - txgb37899e3e09f4307a14b-006a0321a0
         status: 204 No Content
         code: 204
-        duration: 83.373542ms
+        duration: 51.978542ms
     - id: 79
       request:
         proto: HTTP/1.1
@@ -4104,7 +4112,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4113,36 +4121,42 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d8ee2f8d-1fca-4ecb-9199-4cd966d86a5a
+                - 727eb06b-57ed-430f-852b-520047882adc
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162244Z
-        url: https://tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud/?tagging=
-        method: DELETE
+                - 20260512T124832Z
+        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?acl=
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 890
         uncompressed: false
-        body: ""
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="Group"><URI>http://acs.amazonaws.com/groups/global/AllUsers</URI></Grantee><Permission>READ</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
+            Content-Length:
+                - "890"
+            Content-Type:
+                - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:44 GMT
+                - Tue, 12 May 2026 12:48:32 GMT
             X-Amz-Id-2:
-                - txgd1ad9b439a6048f89866-0067586ad4
+                - txg3afbd24a2f5c42a898ed-006a0321a0
             X-Amz-Request-Id:
-                - txgd1ad9b439a6048f89866-0067586ad4
-        status: 204 No Content
-        code: 204
-        duration: 58.659709ms
+                - txg3afbd24a2f5c42a898ed-006a0321a0
+        status: 200 OK
+        code: 200
+        duration: 8.358084ms
     - id: 80
       request:
         proto: HTTP/1.1
@@ -4151,7 +4165,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4160,16 +4174,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 8c29405c-a7e8-4f1c-a77e-87afa96d14e3
+                - 47ff5de5-2dfc-42ca-b65d-f25b63b73217
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162244Z
-        url: https://tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud/?acl=
+                - 20260512T124832Z
+        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4177,25 +4191,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 890
+        content_length: 326
         uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="Group"><URI>http://acs.amazonaws.com/groups/global/AllUsers</URI></Grantee><Permission>READ</Permission></Grant></AccessControlList></AccessControlPolicy>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgb9fb4eb64d3441aba252-006a0321a0</RequestId><HostId>txgb9fb4eb64d3441aba252-006a0321a0</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-1314313384735080249</Resource></Error>
         headers:
             Content-Length:
-                - "890"
+                - "326"
             Content-Type:
-                - text/xml; charset=utf-8
+                - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:44 GMT
+                - Tue, 12 May 2026 12:48:32 GMT
             X-Amz-Id-2:
-                - txgb2b6df8918e347a09941-0067586ad4
+                - txgb9fb4eb64d3441aba252-006a0321a0
             X-Amz-Request-Id:
-                - txgb2b6df8918e347a09941-0067586ad4
-        status: 200 OK
-        code: 200
-        duration: 9.341292ms
+                - txgb9fb4eb64d3441aba252-006a0321a0
+        status: 404 Not Found
+        code: 404
+        duration: 10.721167ms
     - id: 81
       request:
         proto: HTTP/1.1
@@ -4204,7 +4216,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4213,67 +4225,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 255803cb-f8d4-4a02-98df-d8194afa1d5e
+                - 2fcf329b-7016-43e0-ac5e-0fa156583169
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162244Z
-        url: https://tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud/?object-lock=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 326
-        uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg0453104c942d46b98904-0067586ad4</RequestId><HostId>txg0453104c942d46b98904-0067586ad4</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-7045227858940344981</Resource></Error>
-        headers:
-            Content-Length:
-                - "326"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 10 Dec 2024 16:22:44 GMT
-            X-Amz-Id-2:
-                - txg0453104c942d46b98904-0067586ad4
-            X-Amz-Request-Id:
-                - txg0453104c942d46b98904-0067586ad4
-        status: 404 Not Found
-        code: 404
-        duration: 8.091041ms
-    - id: 82
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 10f771e3-cdec-4678-ad85-cee319c2bf87
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20241210T162244Z
-        url: https://tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud/
+                - 20260512T124832Z
+        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -4285,22 +4246,22 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-basic-7045227858940344981</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-basic-1314313384735080249</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "283"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:44 GMT
+                - Tue, 12 May 2026 12:48:32 GMT
             X-Amz-Id-2:
-                - txg5d51b0e893d64786bb87-0067586ad4
+                - txgc7543294aed843ca8976-006a0321a0
             X-Amz-Request-Id:
-                - txg5d51b0e893d64786bb87-0067586ad4
+                - txgc7543294aed843ca8976-006a0321a0
         status: 200 OK
         code: 200
-        duration: 11.095083ms
-    - id: 83
+        duration: 16.774375ms
+    - id: 82
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -4308,7 +4269,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4317,16 +4278,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0244de96-1aba-4aaa-8039-8800e2845bf7
+                - b3868232-1ee1-4b85-bb42-8b343aaf1352
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162244Z
-        url: https://tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud/?tagging=
+                - 20260512T124832Z
+        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4336,22 +4297,22 @@ interactions:
         trailer: {}
         content_length: 353
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg02e7b7ccce564b90bc6d-0067586ad4</RequestId><HostId>txg02e7b7ccce564b90bc6d-0067586ad4</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-7045227858940344981</Resource><BucketName>tf-tests-scaleway-object-bucket-basic-7045227858940344981</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg228cb2a7e8ef40ab8337-006a0321a0</RequestId><HostId>txg228cb2a7e8ef40ab8337-006a0321a0</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-1314313384735080249</Resource><BucketName>tf-tests-scaleway-object-bucket-basic-1314313384735080249</BucketName></Error>
         headers:
             Content-Length:
                 - "353"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:44 GMT
+                - Tue, 12 May 2026 12:48:32 GMT
             X-Amz-Id-2:
-                - txg02e7b7ccce564b90bc6d-0067586ad4
+                - txg228cb2a7e8ef40ab8337-006a0321a0
             X-Amz-Request-Id:
-                - txg02e7b7ccce564b90bc6d-0067586ad4
+                - txg228cb2a7e8ef40ab8337-006a0321a0
         status: 404 Not Found
         code: 404
-        duration: 20.356959ms
-    - id: 84
+        duration: 8.806417ms
+    - id: 83
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -4359,7 +4320,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4368,16 +4329,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - a3da34c9-9e6b-4abc-be8d-5198c988e977
+                - ed4b5780-5dec-4832-9809-0f0d59a8357c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162244Z
-        url: https://tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud/?cors=
+                - 20260512T124832Z
+        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4387,21 +4348,74 @@ interactions:
         trailer: {}
         content_length: 294
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgfdc7f4a560144cbfb6e3-0067586ad4</RequestId><HostId>txgfdc7f4a560144cbfb6e3-0067586ad4</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-7045227858940344981</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg9c24afbfa22f4144bca5-006a0321a0</RequestId><HostId>txg9c24afbfa22f4144bca5-006a0321a0</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-1314313384735080249</Resource></Error>
         headers:
             Content-Length:
                 - "294"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:44 GMT
+                - Tue, 12 May 2026 12:48:32 GMT
             X-Amz-Id-2:
-                - txgfdc7f4a560144cbfb6e3-0067586ad4
+                - txg9c24afbfa22f4144bca5-006a0321a0
             X-Amz-Request-Id:
-                - txgfdc7f4a560144cbfb6e3-0067586ad4
+                - txg9c24afbfa22f4144bca5-006a0321a0
         status: 404 Not Found
         code: 404
-        duration: 50.628291ms
+        duration: 7.995375ms
+    - id: 84
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - a75a1d6e-8d97-4f9d-988b-1276776c12b4
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260512T124832Z
+        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?versioning=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 107
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <VersioningConfiguration><Status></Status></VersioningConfiguration>
+        headers:
+            Content-Length:
+                - "107"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Tue, 12 May 2026 12:48:32 GMT
+            X-Amz-Id-2:
+                - txg0a5ed1ce24204054bc30-006a0321a0
+            X-Amz-Request-Id:
+                - txg0a5ed1ce24204054bc30-006a0321a0
+        status: 200 OK
+        code: 200
+        duration: 8.519208ms
     - id: 85
       request:
         proto: HTTP/1.1
@@ -4410,7 +4424,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4419,69 +4433,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0e012cf1-e8ef-4650-a234-3a7e17be87b8
+                - 27fa026b-51d2-4004-9aa8-aae457bd0c72
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162245Z
-        url: https://tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud/?versioning=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 155
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Status></Status></VersioningConfiguration>
-        headers:
-            Content-Length:
-                - "155"
-            Content-Type:
-                - text/xml; charset=utf-8
-            Date:
-                - Tue, 10 Dec 2024 16:22:45 GMT
-            X-Amz-Id-2:
-                - txg52a3e6b702fe4465a852-0067586ad5
-            X-Amz-Request-Id:
-                - txg52a3e6b702fe4465a852-0067586ad5
-        status: 200 OK
-        code: 200
-        duration: 8.033708ms
-    - id: 86
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - fc875b23-305a-4602-bd53-2d3bc08616ea
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20241210T162245Z
-        url: https://tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud/?lifecycle=
+                - 20260512T124832Z
+        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4491,21 +4452,68 @@ interactions:
         trailer: {}
         content_length: 386
         uncompressed: false
-        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txg764dbfb252044bcb8b25-0067586ad5</RequestId><HostId>txg764dbfb252044bcb8b25-0067586ad5</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-7045227858940344981</Resource><BucketName>tf-tests-scaleway-object-bucket-basic-7045227858940344981</BucketName></Error>
+        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txg5fa6fa45aa424f43b8e4-006a0321a0</RequestId><HostId>txg5fa6fa45aa424f43b8e4-006a0321a0</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-1314313384735080249</Resource><BucketName>tf-tests-scaleway-object-bucket-basic-1314313384735080249</BucketName></Error>
         headers:
             Content-Length:
                 - "386"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:45 GMT
+                - Tue, 12 May 2026 12:48:32 GMT
             X-Amz-Id-2:
-                - txg764dbfb252044bcb8b25-0067586ad5
+                - txg5fa6fa45aa424f43b8e4-006a0321a0
             X-Amz-Request-Id:
-                - txg764dbfb252044bcb8b25-0067586ad5
+                - txg5fa6fa45aa424f43b8e4-006a0321a0
         status: 404 Not Found
         code: 404
-        duration: 12.316ms
+        duration: 27.0825ms
+    - id: 86
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 18044edb-0d60-4cc0-a7d6-77462079b015
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260512T124832Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.nl-ams.scw.cloud/
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Date:
+                - Tue, 12 May 2026 12:48:32 GMT
+            X-Amz-Id-2:
+                - txg65b6af4e7bc8418bb0d4-006a0321a0
+            X-Amz-Request-Id:
+                - txg65b6af4e7bc8418bb0d4-006a0321a0
+        status: 204 No Content
+        code: 204
+        duration: 450.279625ms
     - id: 87
       request:
         proto: HTTP/1.1
@@ -4514,7 +4522,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.pl-waw.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4523,16 +4531,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4f349724-1683-4fd1-b0a5-7033b9819382
+                - 7747a452-f5b7-4233-a111-dba30f3b4450
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162244Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.pl-waw.scw.cloud/
+                - 20260512T124832Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud/
         method: PUT
       response:
         proto: HTTP/2.0
@@ -4547,16 +4555,16 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 10 Dec 2024 16:22:45 GMT
+                - Tue, 12 May 2026 12:48:33 GMT
             Location:
-                - /tf-tests-scaleway-object-bucket-secondary-2430854061085752549
+                - /tf-tests-scaleway-object-bucket-secondary-2001388040591926415
             X-Amz-Id-2:
-                - txgd55faa484e8842a3a3af-0067586ad5
+                - txgdd1210f501234e22a1dc-006a0321a1
             X-Amz-Request-Id:
-                - txgd55faa484e8842a3a3af-0067586ad5
+                - txgdd1210f501234e22a1dc-006a0321a1
         status: 200 OK
         code: 200
-        duration: 1.3696615s
+        duration: 852.185667ms
     - id: 88
       request:
         proto: HTTP/1.1
@@ -4565,7 +4573,7 @@ interactions:
         content_length: 127
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.pl-waw.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: <Tagging xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><TagSet><Tag><Key>foo</Key><Value>bar</Value></Tag></TagSet></Tagging>
@@ -4574,20 +4582,20 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 8f7430d9-024c-452f-b806-9ce23dc7692e
+                - cdfe9d69-2398-408d-8c11-64adcda96c7e
             Amz-Sdk-Request:
                 - attempt=1; max=3
-            Content-Md5:
-                - GLaI7og/rAKomUfPePCCFQ==
             Content-Type:
                 - application/xml
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,Z,e
+            X-Amz-Checksum-Crc32:
+                - Y9NeVA==
             X-Amz-Content-Sha256:
                 - d68cba1a39d89eb72e49b2e5b04058846b60e88e6e32eae42901c4f57a4727a8
             X-Amz-Date:
-                - 20241210T162246Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.pl-waw.scw.cloud/?tagging=
+                - 20260512T124833Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud/?tagging=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -4602,14 +4610,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 10 Dec 2024 16:22:46 GMT
+                - Tue, 12 May 2026 12:48:33 GMT
             X-Amz-Id-2:
-                - txg2c2747aaadac4cbe91b9-0067586ad6
+                - txg0ca7ec1dd6b140919b04-006a0321a1
             X-Amz-Request-Id:
-                - txg2c2747aaadac4cbe91b9-0067586ad6
+                - txg0ca7ec1dd6b140919b04-006a0321a1
         status: 200 OK
         code: 200
-        duration: 543.122042ms
+        duration: 458.446042ms
     - id: 89
       request:
         proto: HTTP/1.1
@@ -4618,7 +4626,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.pl-waw.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4627,18 +4635,20 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 27b1b426-b972-4ea7-9e01-547287ea0f3f
+                - e2259d8c-2ac8-4ca5-9990-8a146f51425a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,Z,e
             X-Amz-Acl:
                 - private
+            X-Amz-Checksum-Crc32:
+                - AAAAAA==
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162246Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.pl-waw.scw.cloud/?acl=
+                - 20260512T124834Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud/?acl=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -4653,14 +4663,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 10 Dec 2024 16:22:46 GMT
+                - Tue, 12 May 2026 12:48:34 GMT
             X-Amz-Id-2:
-                - txgee2efe0623044a838b63-0067586ad6
+                - txg255679a02716438ebbbe-006a0321a2
             X-Amz-Request-Id:
-                - txgee2efe0623044a838b63-0067586ad6
+                - txg255679a02716438ebbbe-006a0321a2
         status: 200 OK
         code: 200
-        duration: 532.219084ms
+        duration: 742.548792ms
     - id: 90
       request:
         proto: HTTP/1.1
@@ -4669,7 +4679,7 @@ interactions:
         content_length: 127
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.pl-waw.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: <Tagging xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><TagSet><Tag><Key>foo</Key><Value>bar</Value></Tag></TagSet></Tagging>
@@ -4678,20 +4688,20 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c1f055af-5865-4ab8-84f4-263b207be3b9
+                - cb60339e-8d7c-423f-8a1a-dedfcb60165a
             Amz-Sdk-Request:
                 - attempt=1; max=3
-            Content-Md5:
-                - GLaI7og/rAKomUfPePCCFQ==
             Content-Type:
                 - application/xml
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,Z,e
+            X-Amz-Checksum-Crc32:
+                - Y9NeVA==
             X-Amz-Content-Sha256:
                 - d68cba1a39d89eb72e49b2e5b04058846b60e88e6e32eae42901c4f57a4727a8
             X-Amz-Date:
-                - 20241210T162247Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.pl-waw.scw.cloud/?tagging=
+                - 20260512T124834Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud/?tagging=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -4706,14 +4716,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 10 Dec 2024 16:22:47 GMT
+                - Tue, 12 May 2026 12:48:34 GMT
             X-Amz-Id-2:
-                - txg33672fa2e8f245978498-0067586ad7
+                - txg7dd92154cfa34f93a2bb-006a0321a2
             X-Amz-Request-Id:
-                - txg33672fa2e8f245978498-0067586ad7
+                - txg7dd92154cfa34f93a2bb-006a0321a2
         status: 200 OK
         code: 200
-        duration: 581.506208ms
+        duration: 387.86575ms
     - id: 91
       request:
         proto: HTTP/1.1
@@ -4722,7 +4732,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.pl-waw.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4731,16 +4741,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 2d1f9c8f-ad24-444c-84d6-a03d761faaad
+                - 73497f09-4a6e-4cc5-be5b-1d5e1537950f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162247Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.pl-waw.scw.cloud/?acl=
+                - 20260512T124835Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4752,21 +4762,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
                 - "698"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:47 GMT
+                - Tue, 12 May 2026 12:48:35 GMT
             X-Amz-Id-2:
-                - txg38ec98f1bfb34454b53b-0067586ad7
+                - txg93598a8920bc4ba09eba-006a0321a3
             X-Amz-Request-Id:
-                - txg38ec98f1bfb34454b53b-0067586ad7
+                - txg93598a8920bc4ba09eba-006a0321a3
         status: 200 OK
         code: 200
-        duration: 314.539125ms
+        duration: 252.752833ms
     - id: 92
       request:
         proto: HTTP/1.1
@@ -4775,7 +4785,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.pl-waw.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4784,16 +4794,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e77c3473-939c-4704-9813-d3dbf7ee0a14
+                - 820c80db-7b0e-4b1d-9b16-0a6b8685c60a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162248Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.pl-waw.scw.cloud/?object-lock=
+                - 20260512T124835Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4803,21 +4813,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg65f4d2f0be9d4eb4a81e-0067586ad8</RequestId><HostId>txg65f4d2f0be9d4eb4a81e-0067586ad8</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-2430854061085752549</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg39710330144749cebc1a-006a0321a3</RequestId><HostId>txg39710330144749cebc1a-006a0321a3</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-2001388040591926415</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:48 GMT
+                - Tue, 12 May 2026 12:48:35 GMT
             X-Amz-Id-2:
-                - txg65f4d2f0be9d4eb4a81e-0067586ad8
+                - txg39710330144749cebc1a-006a0321a3
             X-Amz-Request-Id:
-                - txg65f4d2f0be9d4eb4a81e-0067586ad8
+                - txg39710330144749cebc1a-006a0321a3
         status: 404 Not Found
         code: 404
-        duration: 319.740208ms
+        duration: 208.839666ms
     - id: 93
       request:
         proto: HTTP/1.1
@@ -4826,7 +4836,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.pl-waw.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4835,16 +4845,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 6f782f68-e57f-4720-b340-5d3c9b4c1229
+                - 3875b587-2c9c-40bf-a2ab-51ae0cefae53
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162248Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.pl-waw.scw.cloud/
+                - 20260512T124835Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -4856,21 +4866,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-secondary-2430854061085752549</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-secondary-2001388040591926415</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:48 GMT
+                - Tue, 12 May 2026 12:48:35 GMT
             X-Amz-Id-2:
-                - txgb9f057f8f1a9473eaa79-0067586ad8
+                - txg0dd7618658d542ed8d3f-006a0321a3
             X-Amz-Request-Id:
-                - txgb9f057f8f1a9473eaa79-0067586ad8
+                - txg0dd7618658d542ed8d3f-006a0321a3
         status: 200 OK
         code: 200
-        duration: 391.074416ms
+        duration: 265.30425ms
     - id: 94
       request:
         proto: HTTP/1.1
@@ -4879,7 +4889,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.pl-waw.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4888,16 +4898,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ff5eb0ad-91b3-4919-8890-8505245f9d57
+                - 49eb76a4-2a02-4bb1-a810-3b434db4e49a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162248Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.pl-waw.scw.cloud/?tagging=
+                - 20260512T124835Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4916,14 +4926,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:48 GMT
+                - Tue, 12 May 2026 12:48:36 GMT
             X-Amz-Id-2:
-                - txg47ea8548ce274529a6bf-0067586ad8
+                - txga0be1a9445a84cbfa5a6-006a0321a4
             X-Amz-Request-Id:
-                - txg47ea8548ce274529a6bf-0067586ad8
+                - txga0be1a9445a84cbfa5a6-006a0321a4
         status: 200 OK
         code: 200
-        duration: 286.250083ms
+        duration: 254.905083ms
     - id: 95
       request:
         proto: HTTP/1.1
@@ -4932,7 +4942,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.pl-waw.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4941,16 +4951,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b4318015-b138-4228-8cb5-5f65272a9502
+                - 960711e2-c5c3-403f-a7a6-dbf1b5cbeb34
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162249Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.pl-waw.scw.cloud/?cors=
+                - 20260512T124836Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4960,21 +4970,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgcac1f158f81e45679c06-0067586ad9</RequestId><HostId>txgcac1f158f81e45679c06-0067586ad9</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-2430854061085752549</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg9f5e2c1734a9405893a2-006a0321a4</RequestId><HostId>txg9f5e2c1734a9405893a2-006a0321a4</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-2001388040591926415</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:49 GMT
+                - Tue, 12 May 2026 12:48:36 GMT
             X-Amz-Id-2:
-                - txgcac1f158f81e45679c06-0067586ad9
+                - txg9f5e2c1734a9405893a2-006a0321a4
             X-Amz-Request-Id:
-                - txgcac1f158f81e45679c06-0067586ad9
+                - txg9f5e2c1734a9405893a2-006a0321a4
         status: 404 Not Found
         code: 404
-        duration: 290.990792ms
+        duration: 65.413375ms
     - id: 96
       request:
         proto: HTTP/1.1
@@ -4983,7 +4993,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.pl-waw.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4992,16 +5002,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ea59b0c8-6d6f-43ff-b85d-c54c284c4e25
+                - ecc316e7-6855-4270-a6ff-7df396f4d657
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162249Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.pl-waw.scw.cloud/?versioning=
+                - 20260512T124836Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5009,25 +5019,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 155
+        content_length: 107
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Status></Status></VersioningConfiguration>
+            <VersioningConfiguration><Status></Status></VersioningConfiguration>
         headers:
             Content-Length:
-                - "155"
+                - "107"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:49 GMT
+                - Tue, 12 May 2026 12:48:36 GMT
             X-Amz-Id-2:
-                - txge3286186bf98471aa14b-0067586ad9
+                - txga90cae7581654e148069-006a0321a4
             X-Amz-Request-Id:
-                - txge3286186bf98471aa14b-0067586ad9
+                - txga90cae7581654e148069-006a0321a4
         status: 200 OK
         code: 200
-        duration: 322.350708ms
+        duration: 443.268333ms
     - id: 97
       request:
         proto: HTTP/1.1
@@ -5036,7 +5046,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.pl-waw.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5045,16 +5055,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - deac4f4d-1b92-4867-ba81-a3e2287561e2
+                - b10f2861-dcb3-44ef-872b-54db09bb9292
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162249Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.pl-waw.scw.cloud/?lifecycle=
+                - 20260512T124836Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5064,21 +5074,21 @@ interactions:
         trailer: {}
         content_length: 394
         uncompressed: false
-        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txg5a0712ba3ebf4bdca629-0067586ad9</RequestId><HostId>txg5a0712ba3ebf4bdca629-0067586ad9</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-2430854061085752549</Resource><BucketName>tf-tests-scaleway-object-bucket-secondary-2430854061085752549</BucketName></Error>
+        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txgc413e22d3cf646168d8d-006a0321a4</RequestId><HostId>txgc413e22d3cf646168d8d-006a0321a4</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-2001388040591926415</Resource><BucketName>tf-tests-scaleway-object-bucket-secondary-2001388040591926415</BucketName></Error>
         headers:
             Content-Length:
                 - "394"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:49 GMT
+                - Tue, 12 May 2026 12:48:36 GMT
             X-Amz-Id-2:
-                - txg5a0712ba3ebf4bdca629-0067586ad9
+                - txgc413e22d3cf646168d8d-006a0321a4
             X-Amz-Request-Id:
-                - txg5a0712ba3ebf4bdca629-0067586ad9
+                - txgc413e22d3cf646168d8d-006a0321a4
         status: 404 Not Found
         code: 404
-        duration: 45.609042ms
+        duration: 222.524959ms
     - id: 98
       request:
         proto: HTTP/1.1
@@ -5087,7 +5097,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5096,16 +5106,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 3f463d58-4982-449d-a91f-dc27cd46da37
+                - 95d01f74-6724-4308-99ff-8d3d84ccae01
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162250Z
-        url: https://tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud/
+                - 20260512T124837Z
+        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -5120,16 +5130,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:50 GMT
+                - Tue, 12 May 2026 12:48:37 GMT
             X-Amz-Bucket-Region:
                 - fr-par
             X-Amz-Id-2:
-                - txg5eb7af5dab084144a345-0067586ada
+                - txg7d7f3693e3614498a614-006a0321a5
             X-Amz-Request-Id:
-                - txg5eb7af5dab084144a345-0067586ada
+                - txg7d7f3693e3614498a614-006a0321a5
         status: 200 OK
         code: 200
-        duration: 76.126792ms
+        duration: 15.249042ms
     - id: 99
       request:
         proto: HTTP/1.1
@@ -5138,7 +5148,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.pl-waw.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5147,16 +5157,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 34406890-2c95-4fa4-b847-651c1d6e29d8
+                - 2da2626d-e629-4142-9c4c-b1b0dfe3d1c3
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162250Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.pl-waw.scw.cloud/
+                - 20260512T124837Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -5171,16 +5181,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:50 GMT
+                - Tue, 12 May 2026 12:48:37 GMT
             X-Amz-Bucket-Region:
                 - pl-waw
             X-Amz-Id-2:
-                - txgca3d94819e024f7c93f0-0067586ada
+                - txgcd6a0d8c91dd4ef8b20f-006a0321a5
             X-Amz-Request-Id:
-                - txgca3d94819e024f7c93f0-0067586ada
+                - txgcd6a0d8c91dd4ef8b20f-006a0321a5
         status: 200 OK
         code: 200
-        duration: 337.220583ms
+        duration: 194.11125ms
     - id: 100
       request:
         proto: HTTP/1.1
@@ -5189,7 +5199,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5198,16 +5208,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 3b9e553f-a0c5-4490-87a9-9b43e6ad32e5
+                - cdddde24-33fb-4231-ac49-39c67123f58a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162251Z
-        url: https://tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud/?acl=
+                - 20260512T124837Z
+        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5219,21 +5229,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="Group"><URI>http://acs.amazonaws.com/groups/global/AllUsers</URI></Grantee><Permission>READ</Permission></Grant></AccessControlList></AccessControlPolicy>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="Group"><URI>http://acs.amazonaws.com/groups/global/AllUsers</URI></Grantee><Permission>READ</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
                 - "890"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:51 GMT
+                - Tue, 12 May 2026 12:48:37 GMT
             X-Amz-Id-2:
-                - txg36913ef3cf5045949d99-0067586adb
+                - txg1ad133942aca43608955-006a0321a5
             X-Amz-Request-Id:
-                - txg36913ef3cf5045949d99-0067586adb
+                - txg1ad133942aca43608955-006a0321a5
         status: 200 OK
         code: 200
-        duration: 19.523375ms
+        duration: 25.223333ms
     - id: 101
       request:
         proto: HTTP/1.1
@@ -5242,7 +5252,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5251,16 +5261,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f9cdebda-e2d1-4086-ad98-7791e46a0364
+                - cec8e21c-c504-4a5c-b920-1214f0dba96c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162251Z
-        url: https://tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud/?object-lock=
+                - 20260512T124837Z
+        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5270,21 +5280,21 @@ interactions:
         trailer: {}
         content_length: 326
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg7691def0599048809162-0067586adb</RequestId><HostId>txg7691def0599048809162-0067586adb</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-7045227858940344981</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg69173594487c496794d1-006a0321a5</RequestId><HostId>txg69173594487c496794d1-006a0321a5</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-1314313384735080249</Resource></Error>
         headers:
             Content-Length:
                 - "326"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:51 GMT
+                - Tue, 12 May 2026 12:48:37 GMT
             X-Amz-Id-2:
-                - txg7691def0599048809162-0067586adb
+                - txg69173594487c496794d1-006a0321a5
             X-Amz-Request-Id:
-                - txg7691def0599048809162-0067586adb
+                - txg69173594487c496794d1-006a0321a5
         status: 404 Not Found
         code: 404
-        duration: 44.346917ms
+        duration: 9.79575ms
     - id: 102
       request:
         proto: HTTP/1.1
@@ -5293,7 +5303,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5302,16 +5312,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 95e6066a-f3bf-4467-b864-6b18222a4d42
+                - d94fb168-1a5a-4aa3-bee6-1907cc7087a9
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162251Z
-        url: https://tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud/
+                - 20260512T124837Z
+        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -5323,21 +5333,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-basic-7045227858940344981</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-basic-1314313384735080249</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "283"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:51 GMT
+                - Tue, 12 May 2026 12:48:37 GMT
             X-Amz-Id-2:
-                - txg9baea34037f44c0c9120-0067586adb
+                - txg63f75771638046bfa108-006a0321a5
             X-Amz-Request-Id:
-                - txg9baea34037f44c0c9120-0067586adb
+                - txg63f75771638046bfa108-006a0321a5
         status: 200 OK
         code: 200
-        duration: 87.924ms
+        duration: 78.214375ms
     - id: 103
       request:
         proto: HTTP/1.1
@@ -5346,7 +5356,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.pl-waw.scw.cloud
+        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5355,16 +5365,222 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 98e68f20-fb03-4ea2-b34e-9b420cc7eb69
+                - 2150d49a-11f4-4186-84dc-d1f2d69278ee
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162251Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.pl-waw.scw.cloud/?acl=
+                - 20260512T124837Z
+        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?tagging=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 353
+        uncompressed: false
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg2fa6bd860f394cee822a-006a0321a5</RequestId><HostId>txg2fa6bd860f394cee822a-006a0321a5</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-1314313384735080249</Resource><BucketName>tf-tests-scaleway-object-bucket-basic-1314313384735080249</BucketName></Error>
+        headers:
+            Content-Length:
+                - "353"
+            Content-Type:
+                - application/xml
+            Date:
+                - Tue, 12 May 2026 12:48:37 GMT
+            X-Amz-Id-2:
+                - txg2fa6bd860f394cee822a-006a0321a5
+            X-Amz-Request-Id:
+                - txg2fa6bd860f394cee822a-006a0321a5
+        status: 404 Not Found
+        code: 404
+        duration: 19.402333ms
+    - id: 104
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 5940f08c-c327-4c47-88c1-23ee77617ed0
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260512T124837Z
+        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?cors=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 294
+        uncompressed: false
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgdea3a81d9bc74aeda63f-006a0321a5</RequestId><HostId>txgdea3a81d9bc74aeda63f-006a0321a5</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-1314313384735080249</Resource></Error>
+        headers:
+            Content-Length:
+                - "294"
+            Content-Type:
+                - application/xml
+            Date:
+                - Tue, 12 May 2026 12:48:37 GMT
+            X-Amz-Id-2:
+                - txgdea3a81d9bc74aeda63f-006a0321a5
+            X-Amz-Request-Id:
+                - txgdea3a81d9bc74aeda63f-006a0321a5
+        status: 404 Not Found
+        code: 404
+        duration: 22.610917ms
+    - id: 105
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 64e0c528-9d21-4206-97ed-fb6ef087f286
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260512T124837Z
+        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?versioning=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 107
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <VersioningConfiguration><Status></Status></VersioningConfiguration>
+        headers:
+            Content-Length:
+                - "107"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Tue, 12 May 2026 12:48:37 GMT
+            X-Amz-Id-2:
+                - txg9e4f6356e6d4426ea6c5-006a0321a5
+            X-Amz-Request-Id:
+                - txg9e4f6356e6d4426ea6c5-006a0321a5
+        status: 200 OK
+        code: 200
+        duration: 34.973042ms
+    - id: 106
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 9f282225-6a7d-4c39-afa3-186608f0671a
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260512T124837Z
+        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/?lifecycle=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 386
+        uncompressed: false
+        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txg777caa10c2064b64b4fa-006a0321a5</RequestId><HostId>txg777caa10c2064b64b4fa-006a0321a5</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-1314313384735080249</Resource><BucketName>tf-tests-scaleway-object-bucket-basic-1314313384735080249</BucketName></Error>
+        headers:
+            Content-Length:
+                - "386"
+            Content-Type:
+                - application/xml
+            Date:
+                - Tue, 12 May 2026 12:48:37 GMT
+            X-Amz-Id-2:
+                - txg777caa10c2064b64b4fa-006a0321a5
+            X-Amz-Request-Id:
+                - txg777caa10c2064b64b4fa-006a0321a5
+        status: 404 Not Found
+        code: 404
+        duration: 8.946042ms
+    - id: 107
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - cb3c158e-3f02-40d3-8dff-66bc85312fd0
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260512T124837Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5376,227 +5592,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
                 - "698"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:51 GMT
+                - Tue, 12 May 2026 12:48:37 GMT
             X-Amz-Id-2:
-                - txg14da3c54fea34eef906f-0067586adb
+                - txge9e866bbe7d64c10bfd9-006a0321a5
             X-Amz-Request-Id:
-                - txg14da3c54fea34eef906f-0067586adb
+                - txge9e866bbe7d64c10bfd9-006a0321a5
         status: 200 OK
         code: 200
-        duration: 167.298083ms
-    - id: 104
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 3781935b-2bce-48e7-8bc4-dbe400cdf981
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20241210T162251Z
-        url: https://tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud/?tagging=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 353
-        uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgc2443de01e0249b9a568-0067586adb</RequestId><HostId>txgc2443de01e0249b9a568-0067586adb</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-7045227858940344981</Resource><BucketName>tf-tests-scaleway-object-bucket-basic-7045227858940344981</BucketName></Error>
-        headers:
-            Content-Length:
-                - "353"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 10 Dec 2024 16:22:51 GMT
-            X-Amz-Id-2:
-                - txgc2443de01e0249b9a568-0067586adb
-            X-Amz-Request-Id:
-                - txgc2443de01e0249b9a568-0067586adb
-        status: 404 Not Found
-        code: 404
-        duration: 12.73025ms
-    - id: 105
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - dc91fec0-9be4-4520-8862-392fa9066ef2
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20241210T162251Z
-        url: https://tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud/?cors=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 294
-        uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg7b2e9183d0b94d8f9b89-0067586adb</RequestId><HostId>txg7b2e9183d0b94d8f9b89-0067586adb</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-7045227858940344981</Resource></Error>
-        headers:
-            Content-Length:
-                - "294"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 10 Dec 2024 16:22:51 GMT
-            X-Amz-Id-2:
-                - txg7b2e9183d0b94d8f9b89-0067586adb
-            X-Amz-Request-Id:
-                - txg7b2e9183d0b94d8f9b89-0067586adb
-        status: 404 Not Found
-        code: 404
-        duration: 44.707708ms
-    - id: 106
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - 7ea2d6e1-cb3b-453a-ba4c-bcc7558c0f56
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20241210T162251Z
-        url: https://tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud/?versioning=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 155
-        uncompressed: false
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Status></Status></VersioningConfiguration>
-        headers:
-            Content-Length:
-                - "155"
-            Content-Type:
-                - text/xml; charset=utf-8
-            Date:
-                - Tue, 10 Dec 2024 16:22:51 GMT
-            X-Amz-Id-2:
-                - txgf1b71cb65d9f4989be62-0067586adb
-            X-Amz-Request-Id:
-                - txgf1b71cb65d9f4989be62-0067586adb
-        status: 200 OK
-        code: 200
-        duration: 70.544667ms
-    - id: 107
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - identity
-            Amz-Sdk-Invocation-Id:
-                - b2f088e8-03e9-4dea-bb54-df25154cb556
-            Amz-Sdk-Request:
-                - attempt=1; max=3
-            User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
-            X-Amz-Content-Sha256:
-                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-            X-Amz-Date:
-                - 20241210T162251Z
-        url: https://tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud/?lifecycle=
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 386
-        uncompressed: false
-        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txge80f34763ff84334b209-0067586adb</RequestId><HostId>txge80f34763ff84334b209-0067586adb</HostId><Resource>/tf-tests-scaleway-object-bucket-basic-7045227858940344981</Resource><BucketName>tf-tests-scaleway-object-bucket-basic-7045227858940344981</BucketName></Error>
-        headers:
-            Content-Length:
-                - "386"
-            Content-Type:
-                - application/xml
-            Date:
-                - Tue, 10 Dec 2024 16:22:51 GMT
-            X-Amz-Id-2:
-                - txge80f34763ff84334b209-0067586adb
-            X-Amz-Request-Id:
-                - txge80f34763ff84334b209-0067586adb
-        status: 404 Not Found
-        code: 404
-        duration: 11.818417ms
+        duration: 352.456625ms
     - id: 108
       request:
         proto: HTTP/1.1
@@ -5605,7 +5615,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.pl-waw.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5614,16 +5624,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 13e7de71-9149-4acc-8bdd-b4705efcd14a
+                - c5d4e0bf-6bfc-4093-a082-ec8db2848527
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162251Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.pl-waw.scw.cloud/?object-lock=
+                - 20260512T124837Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5633,21 +5643,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg5e4a1300fc67400dbbec-0067586adb</RequestId><HostId>txg5e4a1300fc67400dbbec-0067586adb</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-2430854061085752549</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg55e5acab4c6d40b2a6b0-006a0321a5</RequestId><HostId>txg55e5acab4c6d40b2a6b0-006a0321a5</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-2001388040591926415</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:51 GMT
+                - Tue, 12 May 2026 12:48:37 GMT
             X-Amz-Id-2:
-                - txg5e4a1300fc67400dbbec-0067586adb
+                - txg55e5acab4c6d40b2a6b0-006a0321a5
             X-Amz-Request-Id:
-                - txg5e4a1300fc67400dbbec-0067586adb
+                - txg55e5acab4c6d40b2a6b0-006a0321a5
         status: 404 Not Found
         code: 404
-        duration: 295.921583ms
+        duration: 52.381834ms
     - id: 109
       request:
         proto: HTTP/1.1
@@ -5656,7 +5666,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.pl-waw.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5665,16 +5675,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 575943fb-9ee5-4bbf-9051-fafc8849a1a6
+                - 1e40ab20-60cd-40f3-841b-68ae397e81eb
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162252Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.pl-waw.scw.cloud/
+                - 20260512T124837Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -5686,21 +5696,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-secondary-2430854061085752549</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-secondary-2001388040591926415</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:52 GMT
+                - Tue, 12 May 2026 12:48:38 GMT
             X-Amz-Id-2:
-                - txg67c85dfbbd22468cab85-0067586adc
+                - txg3e7d610b4bbc437fb679-006a0321a6
             X-Amz-Request-Id:
-                - txg67c85dfbbd22468cab85-0067586adc
+                - txg3e7d610b4bbc437fb679-006a0321a6
         status: 200 OK
         code: 200
-        duration: 75.603292ms
+        duration: 691.416791ms
     - id: 110
       request:
         proto: HTTP/1.1
@@ -5709,7 +5719,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.pl-waw.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5718,16 +5728,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e4c1cb95-1f5a-4687-8b28-65c4ef6e4370
+                - 6c2f4d8c-c706-4387-ace1-3f4bdf997793
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162252Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.pl-waw.scw.cloud/?tagging=
+                - 20260512T124838Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5746,14 +5756,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:52 GMT
+                - Tue, 12 May 2026 12:48:38 GMT
             X-Amz-Id-2:
-                - txg5f88b8f96d204f3d9ee1-0067586adc
+                - txgedc5ef62c65a4c3c8e12-006a0321a6
             X-Amz-Request-Id:
-                - txg5f88b8f96d204f3d9ee1-0067586adc
+                - txgedc5ef62c65a4c3c8e12-006a0321a6
         status: 200 OK
         code: 200
-        duration: 320.896292ms
+        duration: 243.73625ms
     - id: 111
       request:
         proto: HTTP/1.1
@@ -5762,7 +5772,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.pl-waw.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5771,16 +5781,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 87b09b4c-cf79-46ab-8a29-1491b51a3f66
+                - 36c726ea-0e62-40b8-8ef3-91d6647190f0
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162252Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.pl-waw.scw.cloud/?cors=
+                - 20260512T124838Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5790,21 +5800,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgd44dcfa5ad0c4985b0af-0067586adc</RequestId><HostId>txgd44dcfa5ad0c4985b0af-0067586adc</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-2430854061085752549</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg190c7e7dc9434581be0a-006a0321a6</RequestId><HostId>txg190c7e7dc9434581be0a-006a0321a6</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-2001388040591926415</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:52 GMT
+                - Tue, 12 May 2026 12:48:38 GMT
             X-Amz-Id-2:
-                - txgd44dcfa5ad0c4985b0af-0067586adc
+                - txg190c7e7dc9434581be0a-006a0321a6
             X-Amz-Request-Id:
-                - txgd44dcfa5ad0c4985b0af-0067586adc
+                - txg190c7e7dc9434581be0a-006a0321a6
         status: 404 Not Found
         code: 404
-        duration: 318.510958ms
+        duration: 215.588625ms
     - id: 112
       request:
         proto: HTTP/1.1
@@ -5813,7 +5823,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.pl-waw.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5822,16 +5832,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5f6e865e-61a4-46c2-82f3-b592cb0ac382
+                - 6051330b-27e7-4aaf-9229-67a6305f4f87
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162252Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.pl-waw.scw.cloud/?versioning=
+                - 20260512T124838Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5839,25 +5849,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 155
+        content_length: 107
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Status></Status></VersioningConfiguration>
+            <VersioningConfiguration><Status></Status></VersioningConfiguration>
         headers:
             Content-Length:
-                - "155"
+                - "107"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:52 GMT
+                - Tue, 12 May 2026 12:48:39 GMT
             X-Amz-Id-2:
-                - txg43aa20e10d6c4275b396-0067586adc
+                - txg9b6782160a7a42119a86-006a0321a7
             X-Amz-Request-Id:
-                - txg43aa20e10d6c4275b396-0067586adc
+                - txg9b6782160a7a42119a86-006a0321a7
         status: 200 OK
         code: 200
-        duration: 45.282583ms
+        duration: 375.79275ms
     - id: 113
       request:
         proto: HTTP/1.1
@@ -5866,7 +5876,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.pl-waw.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5875,16 +5885,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c7310c6a-f93e-44b3-8116-61ee64a5c9b8
+                - 732362c8-c376-4726-8b4e-06c3a84f8436
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162252Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.pl-waw.scw.cloud/?lifecycle=
+                - 20260512T124839Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5894,21 +5904,21 @@ interactions:
         trailer: {}
         content_length: 394
         uncompressed: false
-        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txg55c542c32f684849a0c5-0067586adc</RequestId><HostId>txg55c542c32f684849a0c5-0067586adc</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-2430854061085752549</Resource><BucketName>tf-tests-scaleway-object-bucket-secondary-2430854061085752549</BucketName></Error>
+        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txg0c48f9f0b5c14e52b11b-006a0321a7</RequestId><HostId>txg0c48f9f0b5c14e52b11b-006a0321a7</HostId><Resource>/tf-tests-scaleway-object-bucket-secondary-2001388040591926415</Resource><BucketName>tf-tests-scaleway-object-bucket-secondary-2001388040591926415</BucketName></Error>
         headers:
             Content-Length:
                 - "394"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:52 GMT
+                - Tue, 12 May 2026 12:48:39 GMT
             X-Amz-Id-2:
-                - txg55c542c32f684849a0c5-0067586adc
+                - txg0c48f9f0b5c14e52b11b-006a0321a7
             X-Amz-Request-Id:
-                - txg55c542c32f684849a0c5-0067586adc
+                - txg0c48f9f0b5c14e52b11b-006a0321a7
         status: 404 Not Found
         code: 404
-        duration: 44.30975ms
+        duration: 281.807459ms
     - id: 114
       request:
         proto: HTTP/1.1
@@ -5917,7 +5927,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud
+        host: tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5926,16 +5936,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e450dd7d-819f-4184-bf88-2df3c7808a25
+                - ebe7c265-d134-44fe-b05f-59d3a40732e6
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162254Z
-        url: https://tf-tests-scaleway-object-bucket-basic-7045227858940344981.s3.fr-par.scw.cloud/
+                - 20260512T124840Z
+        url: https://tf-tests-scaleway-object-bucket-basic-1314313384735080249.s3.fr-par.scw.cloud/
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -5948,14 +5958,14 @@ interactions:
         body: ""
         headers:
             Date:
-                - Tue, 10 Dec 2024 16:22:54 GMT
+                - Tue, 12 May 2026 12:48:40 GMT
             X-Amz-Id-2:
-                - txg92ed233fc58440948992-0067586ade
+                - txg2f88577860df443396f6-006a0321a8
             X-Amz-Request-Id:
-                - txg92ed233fc58440948992-0067586ade
+                - txg2f88577860df443396f6-006a0321a8
         status: 204 No Content
         code: 204
-        duration: 173.03725ms
+        duration: 256.449417ms
     - id: 115
       request:
         proto: HTTP/1.1
@@ -5964,7 +5974,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.pl-waw.scw.cloud
+        host: tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5973,16 +5983,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 04060482-c9a7-49dd-a307-31b915e03e5a
+                - 4a99ca1b-ae97-4d43-91a0-1cbd4151c949
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162254Z
-        url: https://tf-tests-scaleway-object-bucket-secondary-2430854061085752549.s3.pl-waw.scw.cloud/
+                - 20260512T124840Z
+        url: https://tf-tests-scaleway-object-bucket-secondary-2001388040591926415.s3.pl-waw.scw.cloud/
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -5995,11 +6005,11 @@ interactions:
         body: ""
         headers:
             Date:
-                - Tue, 10 Dec 2024 16:22:54 GMT
+                - Tue, 12 May 2026 12:48:40 GMT
             X-Amz-Id-2:
-                - txg9a455636fd9f49359487-0067586ade
+                - txg6695a18901e843bdb663-006a0321a8
             X-Amz-Request-Id:
-                - txg9a455636fd9f49359487-0067586ade
+                - txg6695a18901e843bdb663-006a0321a8
         status: 204 No Content
         code: 204
-        duration: 393.8865ms
+        duration: 396.697625ms

--- a/internal/services/object/testdata/object-bucket-lifecycle-empty-filter-non-current-versions.cassette.yaml
+++ b/internal/services/object/testdata/object-bucket-lifecycle-empty-filter-non-current-versions.cassette.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -18,7 +18,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d65b23e8-70ff-4b6a-b5f0-3f72e3913685
+                - 2eca8314-8718-4e41-9a67-d5c5df23a04a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -26,8 +26,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T110951Z
-        url: https://tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud/
+                - 20260518T133731Z
+        url: https://tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud/
         method: PUT
       response:
         proto: HTTP/2.0
@@ -42,16 +42,16 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 18 May 2026 11:09:51 GMT
+                - Mon, 18 May 2026 13:37:31 GMT
             Location:
-                - /tf-tests-scaleway-object-bucket-6929862902340098161
+                - /tf-tests-scaleway-object-bucket-3220788108341742018
             X-Amz-Id-2:
-                - txg535469d35d584636b18b-006a0af37f
+                - txg082b7c3b219c44a5827e-006a0b161b
             X-Amz-Request-Id:
-                - txg535469d35d584636b18b-006a0af37f
+                - txg082b7c3b219c44a5827e-006a0b161b
         status: 200 OK
         code: 200
-        duration: 4.918620583s
+        duration: 5.028012958s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -60,7 +60,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -69,7 +69,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 04e37b61-d8f7-4446-bf11-648333f7a206
+                - 5ad7de37-e047-40a6-8b95-82bf2cd5dbd4
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -81,8 +81,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T110956Z
-        url: https://tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T133736Z
+        url: https://tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud/?acl=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -97,14 +97,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 18 May 2026 11:09:56 GMT
+                - Mon, 18 May 2026 13:37:36 GMT
             X-Amz-Id-2:
-                - txg6740f02587394484b299-006a0af384
+                - txgf49d1acbcc8f4942b0e3-006a0b1620
             X-Amz-Request-Id:
-                - txg6740f02587394484b299-006a0af384
+                - txgf49d1acbcc8f4942b0e3-006a0b1620
         status: 200 OK
         code: 200
-        duration: 70.96325ms
+        duration: 111.953041ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -113,7 +113,7 @@ interactions:
         content_length: 619
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Filter><And><ObjectSizeGreaterThan>30</ObjectSizeGreaterThan><ObjectSizeLessThan>500</ObjectSizeLessThan></And></Filter><ID>noncurrent_versions_rule</ID><NoncurrentVersionExpiration><NewerNoncurrentVersions>2</NewerNoncurrentVersions><NoncurrentDays>30</NoncurrentDays></NoncurrentVersionExpiration><NoncurrentVersionTransition><NewerNoncurrentVersions>5</NewerNoncurrentVersions><NoncurrentDays>40</NoncurrentDays><StorageClass>ONEZONE_IA</StorageClass></NoncurrentVersionTransition><Status>Enabled</Status></Rule></LifecycleConfiguration>
@@ -122,7 +122,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c3ea018b-0899-43d0-84ed-3463b622e346
+                - 993858a4-fa5a-47ee-b30f-f3fa6479fe54
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
@@ -134,8 +134,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - 04a7e60965c971620ffc96e994ca50b76ab3e5f5528963e58fe2f99b47b7b217
             X-Amz-Date:
-                - 20260518T110956Z
-        url: https://tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T133736Z
+        url: https://tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -150,14 +150,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 18 May 2026 11:09:56 GMT
+                - Mon, 18 May 2026 13:37:36 GMT
             X-Amz-Id-2:
-                - txg237bb5884cff454e89cd-006a0af384
+                - txg5b74b647f0d7478a87f6-006a0b1620
             X-Amz-Request-Id:
-                - txg237bb5884cff454e89cd-006a0af384
+                - txg5b74b647f0d7478a87f6-006a0b1620
         status: 200 OK
         code: 200
-        duration: 89.779208ms
+        duration: 105.815917ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -166,7 +166,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -175,7 +175,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 3f8fe9ec-4f0f-4268-a0f0-e89e3f572300
+                - dd0e4041-58ab-406b-8e07-3674dde77d43
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -183,8 +183,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T110956Z
-        url: https://tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T133736Z
+        url: https://tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -203,14 +203,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 11:09:56 GMT
+                - Mon, 18 May 2026 13:37:36 GMT
             X-Amz-Id-2:
-                - txgbea7cce1612a47d8baae-006a0af384
+                - txgdc8e0ed268714f65af3d-006a0b1620
             X-Amz-Request-Id:
-                - txgbea7cce1612a47d8baae-006a0af384
+                - txgdc8e0ed268714f65af3d-006a0b1620
         status: 200 OK
         code: 200
-        duration: 34.665416ms
+        duration: 67.89025ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -219,7 +219,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -228,7 +228,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - dff504cf-c5ab-4e5c-86a7-d7dd042f630f
+                - 77633a0f-8277-4d0c-b6f3-752a91162306
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -236,8 +236,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T110956Z
-        url: https://tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T133736Z
+        url: https://tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -247,21 +247,21 @@ interactions:
         trailer: {}
         content_length: 320
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg0acab65c84a741dab349-006a0af384</RequestId><HostId>txg0acab65c84a741dab349-006a0af384</HostId><Resource>/tf-tests-scaleway-object-bucket-6929862902340098161</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg60f4ff3372f74e489980-006a0b1621</RequestId><HostId>txg60f4ff3372f74e489980-006a0b1621</HostId><Resource>/tf-tests-scaleway-object-bucket-3220788108341742018</Resource></Error>
         headers:
             Content-Length:
                 - "320"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 11:09:56 GMT
+                - Mon, 18 May 2026 13:37:37 GMT
             X-Amz-Id-2:
-                - txg0acab65c84a741dab349-006a0af384
+                - txg60f4ff3372f74e489980-006a0b1621
             X-Amz-Request-Id:
-                - txg0acab65c84a741dab349-006a0af384
+                - txg60f4ff3372f74e489980-006a0b1621
         status: 404 Not Found
         code: 404
-        duration: 35.793083ms
+        duration: 52.87475ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -270,7 +270,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -279,7 +279,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0d9d6217-eabe-46ff-9328-4e37844b0545
+                - 9e7b7ff6-496d-4522-8556-ccd771a99274
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -287,8 +287,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T110956Z
-        url: https://tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud/
+                - 20260518T133737Z
+        url: https://tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -300,21 +300,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-6929862902340098161</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-3220788108341742018</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "277"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 11:09:56 GMT
+                - Mon, 18 May 2026 13:37:37 GMT
             X-Amz-Id-2:
-                - txg925a2cb5c32944898b72-006a0af384
+                - txg356faedfc0d248b6bf31-006a0b1621
             X-Amz-Request-Id:
-                - txg925a2cb5c32944898b72-006a0af384
+                - txg356faedfc0d248b6bf31-006a0b1621
         status: 200 OK
         code: 200
-        duration: 96.603125ms
+        duration: 73.609333ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -323,7 +323,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -332,7 +332,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7a5a47ea-b4fa-4824-a3e0-9db41370c06f
+                - d55963b7-a8e6-49e1-918c-5e32cc3481d3
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -340,8 +340,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T110956Z
-        url: https://tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T133737Z
+        url: https://tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -351,21 +351,21 @@ interactions:
         trailer: {}
         content_length: 341
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgbf925af64bc44a4ca9bb-006a0af384</RequestId><HostId>txgbf925af64bc44a4ca9bb-006a0af384</HostId><Resource>/tf-tests-scaleway-object-bucket-6929862902340098161</Resource><BucketName>tf-tests-scaleway-object-bucket-6929862902340098161</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg44d48ddc4ef34a3da1fa-006a0b1621</RequestId><HostId>txg44d48ddc4ef34a3da1fa-006a0b1621</HostId><Resource>/tf-tests-scaleway-object-bucket-3220788108341742018</Resource><BucketName>tf-tests-scaleway-object-bucket-3220788108341742018</BucketName></Error>
         headers:
             Content-Length:
                 - "341"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 11:09:56 GMT
+                - Mon, 18 May 2026 13:37:37 GMT
             X-Amz-Id-2:
-                - txgbf925af64bc44a4ca9bb-006a0af384
+                - txg44d48ddc4ef34a3da1fa-006a0b1621
             X-Amz-Request-Id:
-                - txgbf925af64bc44a4ca9bb-006a0af384
+                - txg44d48ddc4ef34a3da1fa-006a0b1621
         status: 404 Not Found
         code: 404
-        duration: 112.099209ms
+        duration: 36.364208ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -374,7 +374,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -383,7 +383,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b69cf94c-2435-44d8-9285-4cf120c2122d
+                - f7c57bbf-e545-45e7-8a7e-bea4401c0f4e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -391,8 +391,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T110956Z
-        url: https://tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T133737Z
+        url: https://tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -402,21 +402,21 @@ interactions:
         trailer: {}
         content_length: 288
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg8e9da3a9d8d14aa1a6f1-006a0af384</RequestId><HostId>txg8e9da3a9d8d14aa1a6f1-006a0af384</HostId><Resource>/tf-tests-scaleway-object-bucket-6929862902340098161</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg47f1baeeffe8451aaaba-006a0b1621</RequestId><HostId>txg47f1baeeffe8451aaaba-006a0b1621</HostId><Resource>/tf-tests-scaleway-object-bucket-3220788108341742018</Resource></Error>
         headers:
             Content-Length:
                 - "288"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 11:09:56 GMT
+                - Mon, 18 May 2026 13:37:37 GMT
             X-Amz-Id-2:
-                - txg8e9da3a9d8d14aa1a6f1-006a0af384
+                - txg47f1baeeffe8451aaaba-006a0b1621
             X-Amz-Request-Id:
-                - txg8e9da3a9d8d14aa1a6f1-006a0af384
+                - txg47f1baeeffe8451aaaba-006a0b1621
         status: 404 Not Found
         code: 404
-        duration: 50.991583ms
+        duration: 49.667208ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -425,7 +425,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -434,7 +434,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 8445cace-931e-461f-aa4a-4b910216c049
+                - 0c7abb57-a99f-472e-a784-75615f846e65
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -442,8 +442,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T110956Z
-        url: https://tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T133737Z
+        url: https://tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -462,14 +462,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 11:09:56 GMT
+                - Mon, 18 May 2026 13:37:37 GMT
             X-Amz-Id-2:
-                - txg7bc410cbd54c4de891c4-006a0af384
+                - txg1fdd73ddf09846d0a4e5-006a0b1621
             X-Amz-Request-Id:
-                - txg7bc410cbd54c4de891c4-006a0af384
+                - txg1fdd73ddf09846d0a4e5-006a0b1621
         status: 200 OK
         code: 200
-        duration: 35.0075ms
+        duration: 62.198167ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -478,7 +478,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -487,7 +487,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 95cbbaff-c09a-400e-b3dd-f4e52f58c5f1
+                - ab326c85-1633-4b35-a99f-3cbea88ab9d0
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -495,8 +495,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T110956Z
-        url: https://tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T133737Z
+        url: https://tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -515,14 +515,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 11:09:56 GMT
+                - Mon, 18 May 2026 13:37:37 GMT
             X-Amz-Id-2:
-                - txg18936e7708564bfebdc8-006a0af384
+                - txgc084b0d2b0484da88a4b-006a0b1621
             X-Amz-Request-Id:
-                - txg18936e7708564bfebdc8-006a0af384
+                - txgc084b0d2b0484da88a4b-006a0b1621
         status: 200 OK
         code: 200
-        duration: 30.498084ms
+        duration: 34.529917ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -531,7 +531,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -540,7 +540,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 426ecc05-f2b9-4ff7-ae03-ecf9443b617f
+                - 9d6ee84e-3d47-499b-a485-1a521d3d6994
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -552,8 +552,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T110956Z
-        url: https://tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T133737Z
+        url: https://tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud/?acl=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -568,14 +568,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 18 May 2026 11:09:56 GMT
+                - Mon, 18 May 2026 13:37:37 GMT
             X-Amz-Id-2:
-                - txg4c72445540a14f77b640-006a0af384
+                - txg7b948bc8ce7d4cb0b454-006a0b1621
             X-Amz-Request-Id:
-                - txg4c72445540a14f77b640-006a0af384
+                - txg7b948bc8ce7d4cb0b454-006a0b1621
         status: 200 OK
         code: 200
-        duration: 400.286166ms
+        duration: 87.207292ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -584,7 +584,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -593,7 +593,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d7661e98-5892-459f-b84d-b8d0846e8855
+                - f7063a7e-63cd-40a7-be8f-81bbd18e0e01
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -601,8 +601,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T110957Z
-        url: https://tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T133737Z
+        url: https://tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -621,14 +621,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 11:09:57 GMT
+                - Mon, 18 May 2026 13:37:37 GMT
             X-Amz-Id-2:
-                - txgce0090b2fcf743e692eb-006a0af385
+                - txgf78c770210e54013b864-006a0b1621
             X-Amz-Request-Id:
-                - txgce0090b2fcf743e692eb-006a0af385
+                - txgf78c770210e54013b864-006a0b1621
         status: 200 OK
         code: 200
-        duration: 37.993667ms
+        duration: 34.067125ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -637,7 +637,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -646,7 +646,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e8e47d60-afb3-49a8-96a9-f8a7b39f8c78
+                - dfc9c533-75f8-4f1b-81bf-0467fb5e871f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -654,8 +654,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T110957Z
-        url: https://tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud/
+                - 20260518T133737Z
+        url: https://tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -670,16 +670,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 11:09:57 GMT
+                - Mon, 18 May 2026 13:37:37 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txg0c731d8f8c054bcbb4ab-006a0af385
+                - txg0cf17107a270480b85b8-006a0b1621
             X-Amz-Request-Id:
-                - txg0c731d8f8c054bcbb4ab-006a0af385
+                - txg0cf17107a270480b85b8-006a0b1621
         status: 200 OK
         code: 200
-        duration: 62.326417ms
+        duration: 60.657375ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -688,7 +688,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -697,7 +697,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c29ca9e7-ed0a-43eb-a773-d1a88c1e9be4
+                - 0bab1ac7-3e1e-4fe8-9276-f46a44e834ba
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -705,8 +705,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T110957Z
-        url: https://tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T133737Z
+        url: https://tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -725,14 +725,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 11:09:57 GMT
+                - Mon, 18 May 2026 13:37:37 GMT
             X-Amz-Id-2:
-                - txg549e17861dfa48169f52-006a0af385
+                - txgda34d708d38648918d1c-006a0b1621
             X-Amz-Request-Id:
-                - txg549e17861dfa48169f52-006a0af385
+                - txgda34d708d38648918d1c-006a0b1621
         status: 200 OK
         code: 200
-        duration: 53.528ms
+        duration: 51.592125ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -741,7 +741,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -750,7 +750,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4e7b299b-64a1-4d95-831c-41df758b264e
+                - 2360fa70-a33d-4dec-b295-c8caee27ccf4
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -758,8 +758,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T110957Z
-        url: https://tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T133737Z
+        url: https://tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -778,14 +778,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 11:09:57 GMT
+                - Mon, 18 May 2026 13:37:37 GMT
             X-Amz-Id-2:
-                - txgdbf5ac18ab0041e5b819-006a0af385
+                - txg670f8aabf754456eb4f2-006a0b1621
             X-Amz-Request-Id:
-                - txgdbf5ac18ab0041e5b819-006a0af385
+                - txg670f8aabf754456eb4f2-006a0b1621
         status: 200 OK
         code: 200
-        duration: 44.456459ms
+        duration: 52.078125ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -794,7 +794,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -803,7 +803,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 8ff462d1-a5c2-4c00-9e6c-847c8a528df9
+                - 73f09809-2f89-4509-8002-a51109f0e6be
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -811,8 +811,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T110957Z
-        url: https://tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T133737Z
+        url: https://tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -822,21 +822,21 @@ interactions:
         trailer: {}
         content_length: 320
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg1731cc92bb0243afa5b8-006a0af385</RequestId><HostId>txg1731cc92bb0243afa5b8-006a0af385</HostId><Resource>/tf-tests-scaleway-object-bucket-6929862902340098161</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg098a243d8fe1476089ee-006a0b1622</RequestId><HostId>txg098a243d8fe1476089ee-006a0b1622</HostId><Resource>/tf-tests-scaleway-object-bucket-3220788108341742018</Resource></Error>
         headers:
             Content-Length:
                 - "320"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 11:09:57 GMT
+                - Mon, 18 May 2026 13:37:38 GMT
             X-Amz-Id-2:
-                - txg1731cc92bb0243afa5b8-006a0af385
+                - txg098a243d8fe1476089ee-006a0b1622
             X-Amz-Request-Id:
-                - txg1731cc92bb0243afa5b8-006a0af385
+                - txg098a243d8fe1476089ee-006a0b1622
         status: 404 Not Found
         code: 404
-        duration: 50.538292ms
+        duration: 3.90735175s
     - id: 16
       request:
         proto: HTTP/1.1
@@ -845,7 +845,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -854,7 +854,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0fbc40d0-f787-469e-bbda-56b39ddff37a
+                - 5c6af7b8-f560-4501-99ee-b5bd40bbe966
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -862,8 +862,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T110957Z
-        url: https://tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud/
+                - 20260518T133738Z
+        url: https://tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -875,21 +875,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-6929862902340098161</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-3220788108341742018</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "277"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 11:09:57 GMT
+                - Mon, 18 May 2026 13:37:41 GMT
             X-Amz-Id-2:
-                - txg97977f2697944fac9519-006a0af385
+                - txg6c231735ea4741ccbedc-006a0b1625
             X-Amz-Request-Id:
-                - txg97977f2697944fac9519-006a0af385
+                - txg6c231735ea4741ccbedc-006a0b1625
         status: 200 OK
         code: 200
-        duration: 21.447875ms
+        duration: 104.9765ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -898,7 +898,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -907,7 +907,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ed6bd2f2-03ab-41aa-b9e5-52e3c2fd43e0
+                - 3884253a-8e4b-4aea-b491-7075d81a4c4a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -915,8 +915,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T110957Z
-        url: https://tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T133741Z
+        url: https://tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -926,21 +926,21 @@ interactions:
         trailer: {}
         content_length: 341
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgb557126e4f47468a9199-006a0af386</RequestId><HostId>txgb557126e4f47468a9199-006a0af386</HostId><Resource>/tf-tests-scaleway-object-bucket-6929862902340098161</Resource><BucketName>tf-tests-scaleway-object-bucket-6929862902340098161</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgc44553eeaada4c649e86-006a0b1626</RequestId><HostId>txgc44553eeaada4c649e86-006a0b1626</HostId><Resource>/tf-tests-scaleway-object-bucket-3220788108341742018</Resource><BucketName>tf-tests-scaleway-object-bucket-3220788108341742018</BucketName></Error>
         headers:
             Content-Length:
                 - "341"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 11:09:58 GMT
+                - Mon, 18 May 2026 13:37:42 GMT
             X-Amz-Id-2:
-                - txgb557126e4f47468a9199-006a0af386
+                - txgc44553eeaada4c649e86-006a0b1626
             X-Amz-Request-Id:
-                - txgb557126e4f47468a9199-006a0af386
+                - txgc44553eeaada4c649e86-006a0b1626
         status: 404 Not Found
         code: 404
-        duration: 88.592292ms
+        duration: 55.610334ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -949,7 +949,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -958,7 +958,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 81a04463-4873-4cc2-ad78-682d05985b04
+                - 578d3dde-fc1c-4564-b0d6-d7bd69f862ef
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -966,8 +966,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T110958Z
-        url: https://tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T133742Z
+        url: https://tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -977,21 +977,21 @@ interactions:
         trailer: {}
         content_length: 288
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg58b89810197f424c9ff2-006a0af386</RequestId><HostId>txg58b89810197f424c9ff2-006a0af386</HostId><Resource>/tf-tests-scaleway-object-bucket-6929862902340098161</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg70df675dca4147f4bf6e-006a0b1626</RequestId><HostId>txg70df675dca4147f4bf6e-006a0b1626</HostId><Resource>/tf-tests-scaleway-object-bucket-3220788108341742018</Resource></Error>
         headers:
             Content-Length:
                 - "288"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 11:09:58 GMT
+                - Mon, 18 May 2026 13:37:42 GMT
             X-Amz-Id-2:
-                - txg58b89810197f424c9ff2-006a0af386
+                - txg70df675dca4147f4bf6e-006a0b1626
             X-Amz-Request-Id:
-                - txg58b89810197f424c9ff2-006a0af386
+                - txg70df675dca4147f4bf6e-006a0b1626
         status: 404 Not Found
         code: 404
-        duration: 21.371834ms
+        duration: 103.910875ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -1000,7 +1000,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1009,7 +1009,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 1a5dd083-7949-4b40-9809-9a22868c49af
+                - 67b05e59-85fe-4c3e-84ef-79e87a876d85
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1017,8 +1017,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T110958Z
-        url: https://tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T133742Z
+        url: https://tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1037,14 +1037,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 11:09:58 GMT
+                - Mon, 18 May 2026 13:37:42 GMT
             X-Amz-Id-2:
-                - txga0c037c5fbb64ea8a9a2-006a0af386
+                - txg6f411e756b2146c289f3-006a0b1626
             X-Amz-Request-Id:
-                - txga0c037c5fbb64ea8a9a2-006a0af386
+                - txg6f411e756b2146c289f3-006a0b1626
         status: 200 OK
         code: 200
-        duration: 54.112709ms
+        duration: 34.921667ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1053,7 +1053,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1062,7 +1062,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 518fb079-234b-425d-885a-44ac50670aa2
+                - 56665122-84ff-491d-bc62-69f11d8b7241
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1070,8 +1070,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T110958Z
-        url: https://tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T133742Z
+        url: https://tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1090,14 +1090,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 11:09:58 GMT
+                - Mon, 18 May 2026 13:37:42 GMT
             X-Amz-Id-2:
-                - txg2eaa881ab36e4a44a2e3-006a0af386
+                - txgb1357bf001cc43098c00-006a0b1626
             X-Amz-Request-Id:
-                - txg2eaa881ab36e4a44a2e3-006a0af386
+                - txgb1357bf001cc43098c00-006a0b1626
         status: 200 OK
         code: 200
-        duration: 41.423792ms
+        duration: 124.190583ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1106,7 +1106,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1115,7 +1115,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 2dd08710-de5a-4fa8-87a6-7b6be0fe28a6
+                - dc5db3b5-e925-49e9-9dd1-ce59b395af60
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1123,8 +1123,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T110958Z
-        url: https://tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T133742Z
+        url: https://tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1143,14 +1143,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 11:09:58 GMT
+                - Mon, 18 May 2026 13:37:42 GMT
             X-Amz-Id-2:
-                - txg05d92fb01a8f47ce9d29-006a0af386
+                - txg5f146a3a5f9343fe925f-006a0b1626
             X-Amz-Request-Id:
-                - txg05d92fb01a8f47ce9d29-006a0af386
+                - txg5f146a3a5f9343fe925f-006a0b1626
         status: 200 OK
         code: 200
-        duration: 20.863042ms
+        duration: 60.48825ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1159,7 +1159,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1168,7 +1168,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 58d5831d-15ac-45c4-a035-20a68e474789
+                - 762956ca-3901-45fb-8081-1ea562f79bff
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1180,8 +1180,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T110958Z
-        url: https://tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T133742Z
+        url: https://tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud/?acl=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -1196,14 +1196,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 18 May 2026 11:09:58 GMT
+                - Mon, 18 May 2026 13:37:42 GMT
             X-Amz-Id-2:
-                - txg2d9c0139e92e48ebb1f4-006a0af386
+                - txg3fbb9a9476fb40e2b7c7-006a0b1626
             X-Amz-Request-Id:
-                - txg2d9c0139e92e48ebb1f4-006a0af386
+                - txg3fbb9a9476fb40e2b7c7-006a0b1626
         status: 200 OK
         code: 200
-        duration: 202.12475ms
+        duration: 451.690334ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1212,7 +1212,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1221,7 +1221,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e19cb65e-e259-4460-a699-b0273f05093d
+                - f70ce915-0e9d-4783-9f68-0dee2fe733bf
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1229,8 +1229,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T110958Z
-        url: https://tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud/
+                - 20260518T133743Z
+        url: https://tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud/
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1243,11 +1243,11 @@ interactions:
         body: ""
         headers:
             Date:
-                - Mon, 18 May 2026 11:09:58 GMT
+                - Mon, 18 May 2026 13:37:43 GMT
             X-Amz-Id-2:
-                - txg3803ccf7fefb414ca296-006a0af386
+                - txgbd08379dd8da493c8499-006a0b1627
             X-Amz-Request-Id:
-                - txg3803ccf7fefb414ca296-006a0af386
+                - txgbd08379dd8da493c8499-006a0b1627
         status: 204 No Content
         code: 204
-        duration: 237.970042ms
+        duration: 179.245667ms

--- a/internal/services/object/testdata/object-bucket-lifecycle-empty-filter-non-current-versions.cassette.yaml
+++ b/internal/services/object/testdata/object-bucket-lifecycle-empty-filter-non-current-versions.cassette.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-1434320673904442086.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -18,7 +18,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 2eca8314-8718-4e41-9a67-d5c5df23a04a
+                - 51ec1733-aabb-4ffe-bb72-d3e570c93343
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -26,8 +26,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133731Z
-        url: https://tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud/
+                - 20260518T140851Z
+        url: https://tf-tests-scaleway-object-bucket-1434320673904442086.s3.nl-ams.scw.cloud/
         method: PUT
       response:
         proto: HTTP/2.0
@@ -42,16 +42,16 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 18 May 2026 13:37:31 GMT
+                - Mon, 18 May 2026 14:08:51 GMT
             Location:
-                - /tf-tests-scaleway-object-bucket-3220788108341742018
+                - /tf-tests-scaleway-object-bucket-1434320673904442086
             X-Amz-Id-2:
-                - txg082b7c3b219c44a5827e-006a0b161b
+                - txg10439abb49734290afa3-006a0b1d73
             X-Amz-Request-Id:
-                - txg082b7c3b219c44a5827e-006a0b161b
+                - txg10439abb49734290afa3-006a0b1d73
         status: 200 OK
         code: 200
-        duration: 5.028012958s
+        duration: 4.955412458s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -60,7 +60,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-1434320673904442086.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -69,7 +69,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5ad7de37-e047-40a6-8b95-82bf2cd5dbd4
+                - 475358ca-b6f7-4a61-85f8-e06f8c6dcbd8
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -81,8 +81,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133736Z
-        url: https://tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T140856Z
+        url: https://tf-tests-scaleway-object-bucket-1434320673904442086.s3.nl-ams.scw.cloud/?acl=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -97,14 +97,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 18 May 2026 13:37:36 GMT
+                - Mon, 18 May 2026 14:08:56 GMT
             X-Amz-Id-2:
-                - txgf49d1acbcc8f4942b0e3-006a0b1620
+                - txg667c01db40ab4bd0b5ad-006a0b1d78
             X-Amz-Request-Id:
-                - txgf49d1acbcc8f4942b0e3-006a0b1620
+                - txg667c01db40ab4bd0b5ad-006a0b1d78
         status: 200 OK
         code: 200
-        duration: 111.953041ms
+        duration: 85.081833ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -113,7 +113,7 @@ interactions:
         content_length: 619
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-1434320673904442086.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Filter><And><ObjectSizeGreaterThan>30</ObjectSizeGreaterThan><ObjectSizeLessThan>500</ObjectSizeLessThan></And></Filter><ID>noncurrent_versions_rule</ID><NoncurrentVersionExpiration><NewerNoncurrentVersions>2</NewerNoncurrentVersions><NoncurrentDays>30</NoncurrentDays></NoncurrentVersionExpiration><NoncurrentVersionTransition><NewerNoncurrentVersions>5</NewerNoncurrentVersions><NoncurrentDays>40</NoncurrentDays><StorageClass>ONEZONE_IA</StorageClass></NoncurrentVersionTransition><Status>Enabled</Status></Rule></LifecycleConfiguration>
@@ -122,7 +122,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 993858a4-fa5a-47ee-b30f-f3fa6479fe54
+                - 3cedc18b-120f-460c-a0cb-2f6629fc3473
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
@@ -134,8 +134,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - 04a7e60965c971620ffc96e994ca50b76ab3e5f5528963e58fe2f99b47b7b217
             X-Amz-Date:
-                - 20260518T133736Z
-        url: https://tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T140856Z
+        url: https://tf-tests-scaleway-object-bucket-1434320673904442086.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -150,14 +150,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 18 May 2026 13:37:36 GMT
+                - Mon, 18 May 2026 14:08:56 GMT
             X-Amz-Id-2:
-                - txg5b74b647f0d7478a87f6-006a0b1620
+                - txg34f1082ad3b44c43befe-006a0b1d78
             X-Amz-Request-Id:
-                - txg5b74b647f0d7478a87f6-006a0b1620
+                - txg34f1082ad3b44c43befe-006a0b1d78
         status: 200 OK
         code: 200
-        duration: 105.815917ms
+        duration: 48.378333ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -166,7 +166,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-1434320673904442086.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -175,7 +175,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - dd0e4041-58ab-406b-8e07-3674dde77d43
+                - 74f91159-ce51-4c39-b1cd-7568fd9e89af
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -183,8 +183,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133736Z
-        url: https://tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T140856Z
+        url: https://tf-tests-scaleway-object-bucket-1434320673904442086.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -203,14 +203,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:37:36 GMT
+                - Mon, 18 May 2026 14:08:56 GMT
             X-Amz-Id-2:
-                - txgdc8e0ed268714f65af3d-006a0b1620
+                - txg75f8de7c8a194d848733-006a0b1d78
             X-Amz-Request-Id:
-                - txgdc8e0ed268714f65af3d-006a0b1620
+                - txg75f8de7c8a194d848733-006a0b1d78
         status: 200 OK
         code: 200
-        duration: 67.89025ms
+        duration: 64.158708ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -219,7 +219,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-1434320673904442086.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -228,7 +228,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 77633a0f-8277-4d0c-b6f3-752a91162306
+                - 2353cefd-25be-4302-9204-31b3b85cd814
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -236,8 +236,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133736Z
-        url: https://tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T140856Z
+        url: https://tf-tests-scaleway-object-bucket-1434320673904442086.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -247,21 +247,21 @@ interactions:
         trailer: {}
         content_length: 320
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg60f4ff3372f74e489980-006a0b1621</RequestId><HostId>txg60f4ff3372f74e489980-006a0b1621</HostId><Resource>/tf-tests-scaleway-object-bucket-3220788108341742018</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgdf2d741e5eaa4f518697-006a0b1d78</RequestId><HostId>txgdf2d741e5eaa4f518697-006a0b1d78</HostId><Resource>/tf-tests-scaleway-object-bucket-1434320673904442086</Resource></Error>
         headers:
             Content-Length:
                 - "320"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:37:37 GMT
+                - Mon, 18 May 2026 14:08:56 GMT
             X-Amz-Id-2:
-                - txg60f4ff3372f74e489980-006a0b1621
+                - txgdf2d741e5eaa4f518697-006a0b1d78
             X-Amz-Request-Id:
-                - txg60f4ff3372f74e489980-006a0b1621
+                - txgdf2d741e5eaa4f518697-006a0b1d78
         status: 404 Not Found
         code: 404
-        duration: 52.87475ms
+        duration: 37.478125ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -270,7 +270,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-1434320673904442086.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -279,7 +279,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9e7b7ff6-496d-4522-8556-ccd771a99274
+                - c20bb8b9-1cf1-4d2e-9348-0f14d54b6ddd
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -287,8 +287,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133737Z
-        url: https://tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud/
+                - 20260518T140856Z
+        url: https://tf-tests-scaleway-object-bucket-1434320673904442086.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -300,21 +300,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-3220788108341742018</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-1434320673904442086</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "277"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:37:37 GMT
+                - Mon, 18 May 2026 14:08:56 GMT
             X-Amz-Id-2:
-                - txg356faedfc0d248b6bf31-006a0b1621
+                - txg0b8949247db74342afc3-006a0b1d78
             X-Amz-Request-Id:
-                - txg356faedfc0d248b6bf31-006a0b1621
+                - txg0b8949247db74342afc3-006a0b1d78
         status: 200 OK
         code: 200
-        duration: 73.609333ms
+        duration: 45.429416ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -323,7 +323,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-1434320673904442086.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -332,7 +332,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d55963b7-a8e6-49e1-918c-5e32cc3481d3
+                - ebc305d3-8913-478a-beb0-9c8bc55753f3
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -340,8 +340,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133737Z
-        url: https://tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T140856Z
+        url: https://tf-tests-scaleway-object-bucket-1434320673904442086.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -351,21 +351,21 @@ interactions:
         trailer: {}
         content_length: 341
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg44d48ddc4ef34a3da1fa-006a0b1621</RequestId><HostId>txg44d48ddc4ef34a3da1fa-006a0b1621</HostId><Resource>/tf-tests-scaleway-object-bucket-3220788108341742018</Resource><BucketName>tf-tests-scaleway-object-bucket-3220788108341742018</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg4c89357b521e498fbc5e-006a0b1d78</RequestId><HostId>txg4c89357b521e498fbc5e-006a0b1d78</HostId><Resource>/tf-tests-scaleway-object-bucket-1434320673904442086</Resource><BucketName>tf-tests-scaleway-object-bucket-1434320673904442086</BucketName></Error>
         headers:
             Content-Length:
                 - "341"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:37:37 GMT
+                - Mon, 18 May 2026 14:08:56 GMT
             X-Amz-Id-2:
-                - txg44d48ddc4ef34a3da1fa-006a0b1621
+                - txg4c89357b521e498fbc5e-006a0b1d78
             X-Amz-Request-Id:
-                - txg44d48ddc4ef34a3da1fa-006a0b1621
+                - txg4c89357b521e498fbc5e-006a0b1d78
         status: 404 Not Found
         code: 404
-        duration: 36.364208ms
+        duration: 52.722959ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -374,7 +374,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-1434320673904442086.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -383,7 +383,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f7c57bbf-e545-45e7-8a7e-bea4401c0f4e
+                - 919b8a4d-b89c-4cb3-869a-f598fc350af9
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -391,8 +391,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133737Z
-        url: https://tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T140856Z
+        url: https://tf-tests-scaleway-object-bucket-1434320673904442086.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -402,21 +402,21 @@ interactions:
         trailer: {}
         content_length: 288
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg47f1baeeffe8451aaaba-006a0b1621</RequestId><HostId>txg47f1baeeffe8451aaaba-006a0b1621</HostId><Resource>/tf-tests-scaleway-object-bucket-3220788108341742018</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg070367cc7db345ba90c1-006a0b1d78</RequestId><HostId>txg070367cc7db345ba90c1-006a0b1d78</HostId><Resource>/tf-tests-scaleway-object-bucket-1434320673904442086</Resource></Error>
         headers:
             Content-Length:
                 - "288"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:37:37 GMT
+                - Mon, 18 May 2026 14:08:56 GMT
             X-Amz-Id-2:
-                - txg47f1baeeffe8451aaaba-006a0b1621
+                - txg070367cc7db345ba90c1-006a0b1d78
             X-Amz-Request-Id:
-                - txg47f1baeeffe8451aaaba-006a0b1621
+                - txg070367cc7db345ba90c1-006a0b1d78
         status: 404 Not Found
         code: 404
-        duration: 49.667208ms
+        duration: 40.066292ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -425,7 +425,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-1434320673904442086.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -434,7 +434,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0c7abb57-a99f-472e-a784-75615f846e65
+                - 0d4129cd-7f75-4048-aa88-0ec5ad580ca8
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -442,8 +442,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133737Z
-        url: https://tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T140856Z
+        url: https://tf-tests-scaleway-object-bucket-1434320673904442086.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -462,14 +462,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:37:37 GMT
+                - Mon, 18 May 2026 14:08:56 GMT
             X-Amz-Id-2:
-                - txg1fdd73ddf09846d0a4e5-006a0b1621
+                - txg165e16cae2194b9da9df-006a0b1d78
             X-Amz-Request-Id:
-                - txg1fdd73ddf09846d0a4e5-006a0b1621
+                - txg165e16cae2194b9da9df-006a0b1d78
         status: 200 OK
         code: 200
-        duration: 62.198167ms
+        duration: 37.879583ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -478,7 +478,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-1434320673904442086.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -487,7 +487,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ab326c85-1633-4b35-a99f-3cbea88ab9d0
+                - c1484c44-db00-41e8-bd7e-48422e12b487
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -495,8 +495,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133737Z
-        url: https://tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T140856Z
+        url: https://tf-tests-scaleway-object-bucket-1434320673904442086.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -515,14 +515,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:37:37 GMT
+                - Mon, 18 May 2026 14:08:56 GMT
             X-Amz-Id-2:
-                - txgc084b0d2b0484da88a4b-006a0b1621
+                - txgfb5ea9f3e6f7462292ed-006a0b1d78
             X-Amz-Request-Id:
-                - txgc084b0d2b0484da88a4b-006a0b1621
+                - txgfb5ea9f3e6f7462292ed-006a0b1d78
         status: 200 OK
         code: 200
-        duration: 34.529917ms
+        duration: 36.989542ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -531,7 +531,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-1434320673904442086.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -540,7 +540,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9d6ee84e-3d47-499b-a485-1a521d3d6994
+                - d9121e71-eff8-4f8b-b42c-6e8ea60172aa
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -552,8 +552,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133737Z
-        url: https://tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T140856Z
+        url: https://tf-tests-scaleway-object-bucket-1434320673904442086.s3.nl-ams.scw.cloud/?acl=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -568,14 +568,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 18 May 2026 13:37:37 GMT
+                - Mon, 18 May 2026 14:08:56 GMT
             X-Amz-Id-2:
-                - txg7b948bc8ce7d4cb0b454-006a0b1621
+                - txgf1dba9844e644683932e-006a0b1d78
             X-Amz-Request-Id:
-                - txg7b948bc8ce7d4cb0b454-006a0b1621
+                - txgf1dba9844e644683932e-006a0b1d78
         status: 200 OK
         code: 200
-        duration: 87.207292ms
+        duration: 63.47475ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -584,7 +584,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-1434320673904442086.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -593,7 +593,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f7063a7e-63cd-40a7-be8f-81bbd18e0e01
+                - ad004a00-285b-409f-8481-955d10495fc7
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -601,8 +601,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133737Z
-        url: https://tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T140856Z
+        url: https://tf-tests-scaleway-object-bucket-1434320673904442086.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -621,14 +621,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:37:37 GMT
+                - Mon, 18 May 2026 14:08:56 GMT
             X-Amz-Id-2:
-                - txgf78c770210e54013b864-006a0b1621
+                - txg74db730623ef43ba9679-006a0b1d78
             X-Amz-Request-Id:
-                - txgf78c770210e54013b864-006a0b1621
+                - txg74db730623ef43ba9679-006a0b1d78
         status: 200 OK
         code: 200
-        duration: 34.067125ms
+        duration: 33.562584ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -637,7 +637,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-1434320673904442086.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -646,7 +646,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - dfc9c533-75f8-4f1b-81bf-0467fb5e871f
+                - 2c256291-77cf-4f1d-9f00-ddbad0e3a94c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -654,8 +654,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133737Z
-        url: https://tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud/
+                - 20260518T140856Z
+        url: https://tf-tests-scaleway-object-bucket-1434320673904442086.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -670,16 +670,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:37:37 GMT
+                - Mon, 18 May 2026 14:08:57 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txg0cf17107a270480b85b8-006a0b1621
+                - txg5137a756279b437f9819-006a0b1d79
             X-Amz-Request-Id:
-                - txg0cf17107a270480b85b8-006a0b1621
+                - txg5137a756279b437f9819-006a0b1d79
         status: 200 OK
         code: 200
-        duration: 60.657375ms
+        duration: 53.912875ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -688,7 +688,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-1434320673904442086.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -697,7 +697,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0bab1ac7-3e1e-4fe8-9276-f46a44e834ba
+                - 6db5181d-7e85-4fd8-881c-5d755252551a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -705,8 +705,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133737Z
-        url: https://tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T140857Z
+        url: https://tf-tests-scaleway-object-bucket-1434320673904442086.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -725,14 +725,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:37:37 GMT
+                - Mon, 18 May 2026 14:08:57 GMT
             X-Amz-Id-2:
-                - txgda34d708d38648918d1c-006a0b1621
+                - txgb109615aafff46a68e7d-006a0b1d79
             X-Amz-Request-Id:
-                - txgda34d708d38648918d1c-006a0b1621
+                - txgb109615aafff46a68e7d-006a0b1d79
         status: 200 OK
         code: 200
-        duration: 51.592125ms
+        duration: 38.685917ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -741,7 +741,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-1434320673904442086.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -750,7 +750,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 2360fa70-a33d-4dec-b295-c8caee27ccf4
+                - 18682f31-416b-4afb-b313-0305e88175c4
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -758,8 +758,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133737Z
-        url: https://tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T140857Z
+        url: https://tf-tests-scaleway-object-bucket-1434320673904442086.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -778,14 +778,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:37:37 GMT
+                - Mon, 18 May 2026 14:08:57 GMT
             X-Amz-Id-2:
-                - txg670f8aabf754456eb4f2-006a0b1621
+                - txg6f1af3e552d94ffcae82-006a0b1d79
             X-Amz-Request-Id:
-                - txg670f8aabf754456eb4f2-006a0b1621
+                - txg6f1af3e552d94ffcae82-006a0b1d79
         status: 200 OK
         code: 200
-        duration: 52.078125ms
+        duration: 91.126084ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -794,7 +794,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-1434320673904442086.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -803,7 +803,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 73f09809-2f89-4509-8002-a51109f0e6be
+                - 423ba90f-4683-4d0e-8597-53a1418ce9fc
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -811,8 +811,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133737Z
-        url: https://tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T140857Z
+        url: https://tf-tests-scaleway-object-bucket-1434320673904442086.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -822,21 +822,21 @@ interactions:
         trailer: {}
         content_length: 320
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg098a243d8fe1476089ee-006a0b1622</RequestId><HostId>txg098a243d8fe1476089ee-006a0b1622</HostId><Resource>/tf-tests-scaleway-object-bucket-3220788108341742018</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg7156093bf65f47e1bec4-006a0b1d79</RequestId><HostId>txg7156093bf65f47e1bec4-006a0b1d79</HostId><Resource>/tf-tests-scaleway-object-bucket-1434320673904442086</Resource></Error>
         headers:
             Content-Length:
                 - "320"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:37:38 GMT
+                - Mon, 18 May 2026 14:08:57 GMT
             X-Amz-Id-2:
-                - txg098a243d8fe1476089ee-006a0b1622
+                - txg7156093bf65f47e1bec4-006a0b1d79
             X-Amz-Request-Id:
-                - txg098a243d8fe1476089ee-006a0b1622
+                - txg7156093bf65f47e1bec4-006a0b1d79
         status: 404 Not Found
         code: 404
-        duration: 3.90735175s
+        duration: 40.26675ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -845,7 +845,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-1434320673904442086.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -854,7 +854,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5c6af7b8-f560-4501-99ee-b5bd40bbe966
+                - 48e52b93-4e9e-4202-9b36-9633ac48ac45
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -862,8 +862,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133738Z
-        url: https://tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud/
+                - 20260518T140857Z
+        url: https://tf-tests-scaleway-object-bucket-1434320673904442086.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -875,21 +875,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-3220788108341742018</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-1434320673904442086</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "277"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:37:41 GMT
+                - Mon, 18 May 2026 14:08:57 GMT
             X-Amz-Id-2:
-                - txg6c231735ea4741ccbedc-006a0b1625
+                - txg260e81456dc14ef29ca6-006a0b1d79
             X-Amz-Request-Id:
-                - txg6c231735ea4741ccbedc-006a0b1625
+                - txg260e81456dc14ef29ca6-006a0b1d79
         status: 200 OK
         code: 200
-        duration: 104.9765ms
+        duration: 67.2055ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -898,7 +898,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-1434320673904442086.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -907,7 +907,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 3884253a-8e4b-4aea-b491-7075d81a4c4a
+                - 5034c612-713a-4fe4-a94b-40416d1aff11
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -915,8 +915,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133741Z
-        url: https://tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T140857Z
+        url: https://tf-tests-scaleway-object-bucket-1434320673904442086.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -926,21 +926,21 @@ interactions:
         trailer: {}
         content_length: 341
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgc44553eeaada4c649e86-006a0b1626</RequestId><HostId>txgc44553eeaada4c649e86-006a0b1626</HostId><Resource>/tf-tests-scaleway-object-bucket-3220788108341742018</Resource><BucketName>tf-tests-scaleway-object-bucket-3220788108341742018</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgd360bbeeba3f42dabf31-006a0b1d79</RequestId><HostId>txgd360bbeeba3f42dabf31-006a0b1d79</HostId><Resource>/tf-tests-scaleway-object-bucket-1434320673904442086</Resource><BucketName>tf-tests-scaleway-object-bucket-1434320673904442086</BucketName></Error>
         headers:
             Content-Length:
                 - "341"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:37:42 GMT
+                - Mon, 18 May 2026 14:08:57 GMT
             X-Amz-Id-2:
-                - txgc44553eeaada4c649e86-006a0b1626
+                - txgd360bbeeba3f42dabf31-006a0b1d79
             X-Amz-Request-Id:
-                - txgc44553eeaada4c649e86-006a0b1626
+                - txgd360bbeeba3f42dabf31-006a0b1d79
         status: 404 Not Found
         code: 404
-        duration: 55.610334ms
+        duration: 53.828834ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -949,7 +949,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-1434320673904442086.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -958,7 +958,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 578d3dde-fc1c-4564-b0d6-d7bd69f862ef
+                - 6d7b79db-ba17-497d-9875-80ac000c2b74
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -966,8 +966,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133742Z
-        url: https://tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T140857Z
+        url: https://tf-tests-scaleway-object-bucket-1434320673904442086.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -977,21 +977,21 @@ interactions:
         trailer: {}
         content_length: 288
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg70df675dca4147f4bf6e-006a0b1626</RequestId><HostId>txg70df675dca4147f4bf6e-006a0b1626</HostId><Resource>/tf-tests-scaleway-object-bucket-3220788108341742018</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgfbe6076b09c24afcad3e-006a0b1d79</RequestId><HostId>txgfbe6076b09c24afcad3e-006a0b1d79</HostId><Resource>/tf-tests-scaleway-object-bucket-1434320673904442086</Resource></Error>
         headers:
             Content-Length:
                 - "288"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:37:42 GMT
+                - Mon, 18 May 2026 14:08:57 GMT
             X-Amz-Id-2:
-                - txg70df675dca4147f4bf6e-006a0b1626
+                - txgfbe6076b09c24afcad3e-006a0b1d79
             X-Amz-Request-Id:
-                - txg70df675dca4147f4bf6e-006a0b1626
+                - txgfbe6076b09c24afcad3e-006a0b1d79
         status: 404 Not Found
         code: 404
-        duration: 103.910875ms
+        duration: 60.655292ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -1000,7 +1000,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-1434320673904442086.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1009,7 +1009,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 67b05e59-85fe-4c3e-84ef-79e87a876d85
+                - c50311bb-d76e-4b29-9a25-2a9b582bf14e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1017,8 +1017,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133742Z
-        url: https://tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T140857Z
+        url: https://tf-tests-scaleway-object-bucket-1434320673904442086.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1037,14 +1037,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:37:42 GMT
+                - Mon, 18 May 2026 14:08:57 GMT
             X-Amz-Id-2:
-                - txg6f411e756b2146c289f3-006a0b1626
+                - txgb862ad6d4747498da245-006a0b1d79
             X-Amz-Request-Id:
-                - txg6f411e756b2146c289f3-006a0b1626
+                - txgb862ad6d4747498da245-006a0b1d79
         status: 200 OK
         code: 200
-        duration: 34.921667ms
+        duration: 70.594292ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1053,7 +1053,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-1434320673904442086.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1062,7 +1062,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 56665122-84ff-491d-bc62-69f11d8b7241
+                - 6bd6d341-d16e-491a-8f3d-198c08c686f0
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1070,8 +1070,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133742Z
-        url: https://tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T140857Z
+        url: https://tf-tests-scaleway-object-bucket-1434320673904442086.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1090,14 +1090,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:37:42 GMT
+                - Mon, 18 May 2026 14:08:57 GMT
             X-Amz-Id-2:
-                - txgb1357bf001cc43098c00-006a0b1626
+                - txg02ccc86b82064afab705-006a0b1d79
             X-Amz-Request-Id:
-                - txgb1357bf001cc43098c00-006a0b1626
+                - txg02ccc86b82064afab705-006a0b1d79
         status: 200 OK
         code: 200
-        duration: 124.190583ms
+        duration: 55.505917ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1106,7 +1106,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-1434320673904442086.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1115,7 +1115,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - dc5db3b5-e925-49e9-9dd1-ce59b395af60
+                - 17457ef3-29bc-4803-b80e-fdba95471adc
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1123,8 +1123,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133742Z
-        url: https://tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T140857Z
+        url: https://tf-tests-scaleway-object-bucket-1434320673904442086.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1143,14 +1143,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:37:42 GMT
+                - Mon, 18 May 2026 14:08:57 GMT
             X-Amz-Id-2:
-                - txg5f146a3a5f9343fe925f-006a0b1626
+                - txga50d8bbc5fb7481097dd-006a0b1d79
             X-Amz-Request-Id:
-                - txg5f146a3a5f9343fe925f-006a0b1626
+                - txga50d8bbc5fb7481097dd-006a0b1d79
         status: 200 OK
         code: 200
-        duration: 60.48825ms
+        duration: 22.32125ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1159,7 +1159,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-1434320673904442086.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1168,7 +1168,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 762956ca-3901-45fb-8081-1ea562f79bff
+                - 822e1819-28fe-460d-9839-4b530c654dc8
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1180,8 +1180,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133742Z
-        url: https://tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T140858Z
+        url: https://tf-tests-scaleway-object-bucket-1434320673904442086.s3.nl-ams.scw.cloud/?acl=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -1196,14 +1196,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 18 May 2026 13:37:42 GMT
+                - Mon, 18 May 2026 14:08:58 GMT
             X-Amz-Id-2:
-                - txg3fbb9a9476fb40e2b7c7-006a0b1626
+                - txgea0721db5b8f4d3a8c7f-006a0b1d7a
             X-Amz-Request-Id:
-                - txg3fbb9a9476fb40e2b7c7-006a0b1626
+                - txgea0721db5b8f4d3a8c7f-006a0b1d7a
         status: 200 OK
         code: 200
-        duration: 451.690334ms
+        duration: 59.11ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1212,7 +1212,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-1434320673904442086.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1221,7 +1221,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f70ce915-0e9d-4783-9f68-0dee2fe733bf
+                - 6783e722-739e-4691-b8e7-e165a7f3f2b5
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1229,8 +1229,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133743Z
-        url: https://tf-tests-scaleway-object-bucket-3220788108341742018.s3.nl-ams.scw.cloud/
+                - 20260518T140858Z
+        url: https://tf-tests-scaleway-object-bucket-1434320673904442086.s3.nl-ams.scw.cloud/
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1243,11 +1243,11 @@ interactions:
         body: ""
         headers:
             Date:
-                - Mon, 18 May 2026 13:37:43 GMT
+                - Mon, 18 May 2026 14:08:58 GMT
             X-Amz-Id-2:
-                - txgbd08379dd8da493c8499-006a0b1627
+                - txgbed10c41a6bc419aaf1f-006a0b1d7a
             X-Amz-Request-Id:
-                - txgbd08379dd8da493c8499-006a0b1627
+                - txgbed10c41a6bc419aaf1f-006a0b1d7a
         status: 204 No Content
         code: 204
-        duration: 179.245667ms
+        duration: 207.406ms

--- a/internal/services/object/testdata/object-bucket-lifecycle-empty-filter-non-current-versions.cassette.yaml
+++ b/internal/services/object/testdata/object-bucket-lifecycle-empty-filter-non-current-versions.cassette.yaml
@@ -1,0 +1,835 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 0049d624-9753-43e7-9c8d-124460205d44
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T095110Z
+        url: https://tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud/
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Length:
+                - "0"
+            Date:
+                - Mon, 18 May 2026 09:51:10 GMT
+            Location:
+                - /tf-tests-scaleway-object-bucket-4578096170247254682
+            X-Amz-Id-2:
+                - txg92ab8b372ec3449ca2ac-006a0ae10e
+            X-Amz-Request-Id:
+                - txg92ab8b372ec3449ca2ac-006a0ae10e
+        status: 200 OK
+        code: 200
+        duration: 4.602258166s
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - c622fbe8-64c3-4007-b671-9380262485ab
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,Z,e
+            X-Amz-Acl:
+                - private
+            X-Amz-Checksum-Crc32:
+                - AAAAAA==
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T095114Z
+        url: https://tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud/?acl=
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Length:
+                - "0"
+            Date:
+                - Mon, 18 May 2026 09:51:14 GMT
+            X-Amz-Id-2:
+                - txg18ab3051203040e58e47-006a0ae112
+            X-Amz-Request-Id:
+                - txg18ab3051203040e58e47-006a0ae112
+        status: 200 OK
+        code: 200
+        duration: 122.149375ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 372
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><ExpiredObjectDeleteMarker>true</ExpiredObjectDeleteMarker></Expiration><Filter><And><ObjectSizeGreaterThan>30</ObjectSizeGreaterThan><ObjectSizeLessThan>500</ObjectSizeLessThan></And></Filter><ID>noncurrent_versions_rule</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 13a3d565-f3a8-4ec5-b2be-663de337b9df
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            Content-Type:
+                - application/xml
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,Z,e
+            X-Amz-Checksum-Crc32:
+                - DgTHAw==
+            X-Amz-Content-Sha256:
+                - 08fe4fcabdce3ca4a1cc3d41c8c0d330c8a19dfc1e61506e17442fa0b7d0ae69
+            X-Amz-Date:
+                - 20260518T095114Z
+        url: https://tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud/?lifecycle=
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Length:
+                - "0"
+            Date:
+                - Mon, 18 May 2026 09:51:14 GMT
+            X-Amz-Id-2:
+                - txg4dd3c5f2e67b4cc58649-006a0ae112
+            X-Amz-Request-Id:
+                - txg4dd3c5f2e67b4cc58649-006a0ae112
+        status: 200 OK
+        code: 200
+        duration: 67.203292ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 07e4ebc2-b7ff-4b89-87c3-ed9f8dbb1e46
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T095114Z
+        url: https://tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud/?acl=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 698
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+        headers:
+            Content-Length:
+                - "698"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Mon, 18 May 2026 09:51:15 GMT
+            X-Amz-Id-2:
+                - txgc6ec85cb0a5f4c769b27-006a0ae113
+            X-Amz-Request-Id:
+                - txgc6ec85cb0a5f4c769b27-006a0ae113
+        status: 200 OK
+        code: 200
+        duration: 53.156958ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 280624a1-c521-4ded-9fdb-f1c32108a347
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T095115Z
+        url: https://tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud/?object-lock=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 320
+        uncompressed: false
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg7c49a3f87e524332b6f8-006a0ae113</RequestId><HostId>txg7c49a3f87e524332b6f8-006a0ae113</HostId><Resource>/tf-tests-scaleway-object-bucket-4578096170247254682</Resource></Error>
+        headers:
+            Content-Length:
+                - "320"
+            Content-Type:
+                - application/xml
+            Date:
+                - Mon, 18 May 2026 09:51:15 GMT
+            X-Amz-Id-2:
+                - txg7c49a3f87e524332b6f8-006a0ae113
+            X-Amz-Request-Id:
+                - txg7c49a3f87e524332b6f8-006a0ae113
+        status: 404 Not Found
+        code: 404
+        duration: 52.862958ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 4a56d327-74c2-4e88-9db6-5f8443757f6f
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T095115Z
+        url: https://tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud/
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 277
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-4578096170247254682</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+        headers:
+            Content-Length:
+                - "277"
+            Content-Type:
+                - application/xml
+            Date:
+                - Mon, 18 May 2026 09:51:15 GMT
+            X-Amz-Id-2:
+                - txge9028c4c1e6143cfaebb-006a0ae113
+            X-Amz-Request-Id:
+                - txge9028c4c1e6143cfaebb-006a0ae113
+        status: 200 OK
+        code: 200
+        duration: 81.416708ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - e53765cd-68d8-42f6-a13c-06d12f44361b
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T095115Z
+        url: https://tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud/?tagging=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 341
+        uncompressed: false
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg8ffedff8e9a24de99157-006a0ae113</RequestId><HostId>txg8ffedff8e9a24de99157-006a0ae113</HostId><Resource>/tf-tests-scaleway-object-bucket-4578096170247254682</Resource><BucketName>tf-tests-scaleway-object-bucket-4578096170247254682</BucketName></Error>
+        headers:
+            Content-Length:
+                - "341"
+            Content-Type:
+                - application/xml
+            Date:
+                - Mon, 18 May 2026 09:51:15 GMT
+            X-Amz-Id-2:
+                - txg8ffedff8e9a24de99157-006a0ae113
+            X-Amz-Request-Id:
+                - txg8ffedff8e9a24de99157-006a0ae113
+        status: 404 Not Found
+        code: 404
+        duration: 65.130167ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 7c658d3b-d177-4c3d-9c4c-8cb88f1ef788
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T095115Z
+        url: https://tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud/?cors=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 288
+        uncompressed: false
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg5f8fe0959cf64511b0ba-006a0ae113</RequestId><HostId>txg5f8fe0959cf64511b0ba-006a0ae113</HostId><Resource>/tf-tests-scaleway-object-bucket-4578096170247254682</Resource></Error>
+        headers:
+            Content-Length:
+                - "288"
+            Content-Type:
+                - application/xml
+            Date:
+                - Mon, 18 May 2026 09:51:15 GMT
+            X-Amz-Id-2:
+                - txg5f8fe0959cf64511b0ba-006a0ae113
+            X-Amz-Request-Id:
+                - txg5f8fe0959cf64511b0ba-006a0ae113
+        status: 404 Not Found
+        code: 404
+        duration: 33.985083ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - dd509b2d-295c-4cd0-9c38-c5240eb479da
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T095115Z
+        url: https://tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud/?versioning=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 107
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <VersioningConfiguration><Status></Status></VersioningConfiguration>
+        headers:
+            Content-Length:
+                - "107"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Mon, 18 May 2026 09:51:15 GMT
+            X-Amz-Id-2:
+                - txgac962c2c969648c1b3a5-006a0ae113
+            X-Amz-Request-Id:
+                - txgac962c2c969648c1b3a5-006a0ae113
+        status: 200 OK
+        code: 200
+        duration: 66.008ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 50e14aa9-1dd5-4cc7-9541-14b453843306
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T095115Z
+        url: https://tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud/?lifecycle=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 345
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <Configuration><Rule><Expiration><ExpiredObjectDeleteMarker>true</ExpiredObjectDeleteMarker></Expiration><Filter><And><ObjectSizeGreaterThan>30</ObjectSizeGreaterThan><ObjectSizeLessThan>500</ObjectSizeLessThan></And></Filter><ID>noncurrent_versions_rule</ID><Status>Enabled</Status></Rule></Configuration>
+        headers:
+            Content-Length:
+                - "345"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Mon, 18 May 2026 09:51:15 GMT
+            X-Amz-Id-2:
+                - txgb2e5151996ac44cb855e-006a0ae113
+            X-Amz-Request-Id:
+                - txgb2e5151996ac44cb855e-006a0ae113
+        status: 200 OK
+        code: 200
+        duration: 37.355708ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - b0db91bf-c608-48f5-999c-bac4198f0e46
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,Z,e
+            X-Amz-Acl:
+                - private
+            X-Amz-Checksum-Crc32:
+                - AAAAAA==
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T095115Z
+        url: https://tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud/?acl=
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Length:
+                - "0"
+            Date:
+                - Mon, 18 May 2026 09:51:15 GMT
+            X-Amz-Id-2:
+                - txg0ab6d8f2ffc848b0b115-006a0ae113
+            X-Amz-Request-Id:
+                - txg0ab6d8f2ffc848b0b115-006a0ae113
+        status: 200 OK
+        code: 200
+        duration: 65.159833ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 1d4794c0-c45e-49d9-8a9d-2712cd4db0ff
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T095115Z
+        url: https://tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud/?acl=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 698
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+        headers:
+            Content-Length:
+                - "698"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Mon, 18 May 2026 09:51:15 GMT
+            X-Amz-Id-2:
+                - txg0a410e6efe88454a9105-006a0ae113
+            X-Amz-Request-Id:
+                - txg0a410e6efe88454a9105-006a0ae113
+        status: 200 OK
+        code: 200
+        duration: 75.743667ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 3416b2c8-a19d-44d2-b32e-adf1c9625783
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T095115Z
+        url: https://tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud/
+        method: HEAD
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Type:
+                - application/xml
+            Date:
+                - Mon, 18 May 2026 09:51:15 GMT
+            X-Amz-Bucket-Region:
+                - nl-ams
+            X-Amz-Id-2:
+                - txg4c1e3c92d9d3448c8289-006a0ae113
+            X-Amz-Request-Id:
+                - txg4c1e3c92d9d3448c8289-006a0ae113
+        status: 200 OK
+        code: 200
+        duration: 61.240333ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - ec0f46bc-cff9-437e-9d79-3bb3b0e17a8a
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T095115Z
+        url: https://tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud/?lifecycle=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 345
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <Configuration><Rule><Expiration><ExpiredObjectDeleteMarker>true</ExpiredObjectDeleteMarker></Expiration><Filter><And><ObjectSizeGreaterThan>30</ObjectSizeGreaterThan><ObjectSizeLessThan>500</ObjectSizeLessThan></And></Filter><ID>noncurrent_versions_rule</ID><Status>Enabled</Status></Rule></Configuration>
+        headers:
+            Content-Length:
+                - "345"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Mon, 18 May 2026 09:51:15 GMT
+            X-Amz-Id-2:
+                - txg910e9845a910495cbeae-006a0ae113
+            X-Amz-Request-Id:
+                - txg910e9845a910495cbeae-006a0ae113
+        status: 200 OK
+        code: 200
+        duration: 51.657792ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - cd726167-4966-48a6-bff0-df2c639b52c8
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,Z,e
+            X-Amz-Acl:
+                - private
+            X-Amz-Checksum-Crc32:
+                - AAAAAA==
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T095115Z
+        url: https://tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud/?acl=
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Length:
+                - "0"
+            Date:
+                - Mon, 18 May 2026 09:51:15 GMT
+            X-Amz-Id-2:
+                - txg6b79209c577b429ea877-006a0ae113
+            X-Amz-Request-Id:
+                - txg6b79209c577b429ea877-006a0ae113
+        status: 200 OK
+        code: 200
+        duration: 54.725042ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 5840e2ab-6ee0-4616-9264-6479304adbb4
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T095115Z
+        url: https://tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud/
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Date:
+                - Mon, 18 May 2026 09:51:16 GMT
+            X-Amz-Id-2:
+                - txg0cf1d180fd624850a259-006a0ae114
+            X-Amz-Request-Id:
+                - txg0cf1d180fd624850a259-006a0ae114
+        status: 204 No Content
+        code: 204
+        duration: 391.415083ms

--- a/internal/services/object/testdata/object-bucket-lifecycle-empty-filter-non-current-versions.cassette.yaml
+++ b/internal/services/object/testdata/object-bucket-lifecycle-empty-filter-non-current-versions.cassette.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -18,7 +18,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 14800cb1-850e-48b2-a538-83ee5f253b7a
+                - d65b23e8-70ff-4b6a-b5f0-3f72e3913685
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -26,8 +26,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T110158Z
-        url: https://tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud/
+                - 20260518T110951Z
+        url: https://tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud/
         method: PUT
       response:
         proto: HTTP/2.0
@@ -42,16 +42,16 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 18 May 2026 11:01:58 GMT
+                - Mon, 18 May 2026 11:09:51 GMT
             Location:
-                - /tf-tests-scaleway-object-bucket-7502770239130453132
+                - /tf-tests-scaleway-object-bucket-6929862902340098161
             X-Amz-Id-2:
-                - txg35e6d578b12a457780d6-006a0af1a6
+                - txg535469d35d584636b18b-006a0af37f
             X-Amz-Request-Id:
-                - txg35e6d578b12a457780d6-006a0af1a6
+                - txg535469d35d584636b18b-006a0af37f
         status: 200 OK
         code: 200
-        duration: 4.03953775s
+        duration: 4.918620583s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -60,7 +60,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -69,7 +69,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d793e2c1-27fb-4178-8d40-8f620d498255
+                - 04e37b61-d8f7-4446-bf11-648333f7a206
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -81,8 +81,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T110202Z
-        url: https://tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T110956Z
+        url: https://tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud/?acl=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -97,32 +97,32 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 18 May 2026 11:02:02 GMT
+                - Mon, 18 May 2026 11:09:56 GMT
             X-Amz-Id-2:
-                - txge5c407d37e094ea5af0e-006a0af1aa
+                - txg6740f02587394484b299-006a0af384
             X-Amz-Request-Id:
-                - txge5c407d37e094ea5af0e-006a0af1aa
+                - txg6740f02587394484b299-006a0af384
         status: 200 OK
         code: 200
-        duration: 120.857042ms
+        duration: 70.96325ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 567
+        content_length: 619
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
-        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Filter><And><ObjectSizeGreaterThan>30</ObjectSizeGreaterThan><ObjectSizeLessThan>500</ObjectSizeLessThan></And></Filter><ID>noncurrent_versions_rule</ID><NoncurrentVersionExpiration><NewerNoncurrentVersions>2</NewerNoncurrentVersions><NoncurrentDays>30</NoncurrentDays></NoncurrentVersionExpiration><NoncurrentVersionTransition><NoncurrentDays>40</NoncurrentDays><StorageClass>ONEZONE_IA</StorageClass></NoncurrentVersionTransition><Status>Enabled</Status></Rule></LifecycleConfiguration>
+        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Filter><And><ObjectSizeGreaterThan>30</ObjectSizeGreaterThan><ObjectSizeLessThan>500</ObjectSizeLessThan></And></Filter><ID>noncurrent_versions_rule</ID><NoncurrentVersionExpiration><NewerNoncurrentVersions>2</NewerNoncurrentVersions><NoncurrentDays>30</NoncurrentDays></NoncurrentVersionExpiration><NoncurrentVersionTransition><NewerNoncurrentVersions>5</NewerNoncurrentVersions><NoncurrentDays>40</NoncurrentDays><StorageClass>ONEZONE_IA</StorageClass></NoncurrentVersionTransition><Status>Enabled</Status></Rule></LifecycleConfiguration>
         form: {}
         headers:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 93a386b6-c068-4018-a880-aedb2b1f7654
+                - c3ea018b-0899-43d0-84ed-3463b622e346
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
@@ -130,12 +130,12 @@ interactions:
             User-Agent:
                 - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,Z,e
             X-Amz-Checksum-Crc32:
-                - o4mLhg==
+                - 6UPPsw==
             X-Amz-Content-Sha256:
-                - d18f8f4251f06bb287755ada136d188ea7efd85c7a8c883bd0b2fa51c48f54d0
+                - 04a7e60965c971620ffc96e994ca50b76ab3e5f5528963e58fe2f99b47b7b217
             X-Amz-Date:
-                - 20260518T110202Z
-        url: https://tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T110956Z
+        url: https://tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -150,14 +150,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 18 May 2026 11:02:02 GMT
+                - Mon, 18 May 2026 11:09:56 GMT
             X-Amz-Id-2:
-                - txgeed02f543e404758b935-006a0af1aa
+                - txg237bb5884cff454e89cd-006a0af384
             X-Amz-Request-Id:
-                - txgeed02f543e404758b935-006a0af1aa
+                - txg237bb5884cff454e89cd-006a0af384
         status: 200 OK
         code: 200
-        duration: 145.98175ms
+        duration: 89.779208ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -166,7 +166,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -175,7 +175,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 93044a36-ec09-4cab-a38a-6c3012201c5c
+                - 3f8fe9ec-4f0f-4268-a0f0-e89e3f572300
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -183,8 +183,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T110202Z
-        url: https://tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T110956Z
+        url: https://tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -203,14 +203,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 11:02:02 GMT
+                - Mon, 18 May 2026 11:09:56 GMT
             X-Amz-Id-2:
-                - txg58b52bda37ec43ff8783-006a0af1aa
+                - txgbea7cce1612a47d8baae-006a0af384
             X-Amz-Request-Id:
-                - txg58b52bda37ec43ff8783-006a0af1aa
+                - txgbea7cce1612a47d8baae-006a0af384
         status: 200 OK
         code: 200
-        duration: 53.170583ms
+        duration: 34.665416ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -219,7 +219,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -228,7 +228,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 15ac913a-fa3d-4dff-8b7a-b4def485d3b5
+                - dff504cf-c5ab-4e5c-86a7-d7dd042f630f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -236,8 +236,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T110202Z
-        url: https://tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T110956Z
+        url: https://tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -247,21 +247,21 @@ interactions:
         trailer: {}
         content_length: 320
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg14ffbb4b96ab4eb99937-006a0af1aa</RequestId><HostId>txg14ffbb4b96ab4eb99937-006a0af1aa</HostId><Resource>/tf-tests-scaleway-object-bucket-7502770239130453132</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg0acab65c84a741dab349-006a0af384</RequestId><HostId>txg0acab65c84a741dab349-006a0af384</HostId><Resource>/tf-tests-scaleway-object-bucket-6929862902340098161</Resource></Error>
         headers:
             Content-Length:
                 - "320"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 11:02:02 GMT
+                - Mon, 18 May 2026 11:09:56 GMT
             X-Amz-Id-2:
-                - txg14ffbb4b96ab4eb99937-006a0af1aa
+                - txg0acab65c84a741dab349-006a0af384
             X-Amz-Request-Id:
-                - txg14ffbb4b96ab4eb99937-006a0af1aa
+                - txg0acab65c84a741dab349-006a0af384
         status: 404 Not Found
         code: 404
-        duration: 32.816958ms
+        duration: 35.793083ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -270,7 +270,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -279,7 +279,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 18b30091-09c0-438c-9a22-3e87007c6643
+                - 0d9d6217-eabe-46ff-9328-4e37844b0545
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -287,8 +287,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T110202Z
-        url: https://tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud/
+                - 20260518T110956Z
+        url: https://tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -300,21 +300,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-7502770239130453132</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-6929862902340098161</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "277"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 11:02:02 GMT
+                - Mon, 18 May 2026 11:09:56 GMT
             X-Amz-Id-2:
-                - txgd5fcb369c38a436dbbe4-006a0af1aa
+                - txg925a2cb5c32944898b72-006a0af384
             X-Amz-Request-Id:
-                - txgd5fcb369c38a436dbbe4-006a0af1aa
+                - txg925a2cb5c32944898b72-006a0af384
         status: 200 OK
         code: 200
-        duration: 85.351083ms
+        duration: 96.603125ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -323,7 +323,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -332,7 +332,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 180e4e3b-8f39-436b-bd0e-1ba8703e2483
+                - 7a5a47ea-b4fa-4824-a3e0-9db41370c06f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -340,8 +340,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T110202Z
-        url: https://tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T110956Z
+        url: https://tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -351,21 +351,21 @@ interactions:
         trailer: {}
         content_length: 341
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgcaa3247d2107412cbafe-006a0af1aa</RequestId><HostId>txgcaa3247d2107412cbafe-006a0af1aa</HostId><Resource>/tf-tests-scaleway-object-bucket-7502770239130453132</Resource><BucketName>tf-tests-scaleway-object-bucket-7502770239130453132</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgbf925af64bc44a4ca9bb-006a0af384</RequestId><HostId>txgbf925af64bc44a4ca9bb-006a0af384</HostId><Resource>/tf-tests-scaleway-object-bucket-6929862902340098161</Resource><BucketName>tf-tests-scaleway-object-bucket-6929862902340098161</BucketName></Error>
         headers:
             Content-Length:
                 - "341"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 11:02:02 GMT
+                - Mon, 18 May 2026 11:09:56 GMT
             X-Amz-Id-2:
-                - txgcaa3247d2107412cbafe-006a0af1aa
+                - txgbf925af64bc44a4ca9bb-006a0af384
             X-Amz-Request-Id:
-                - txgcaa3247d2107412cbafe-006a0af1aa
+                - txgbf925af64bc44a4ca9bb-006a0af384
         status: 404 Not Found
         code: 404
-        duration: 58.894625ms
+        duration: 112.099209ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -374,7 +374,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -383,7 +383,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 04ed46d4-88ee-4797-8760-f2d25972765e
+                - b69cf94c-2435-44d8-9285-4cf120c2122d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -391,8 +391,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T110202Z
-        url: https://tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T110956Z
+        url: https://tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -402,21 +402,21 @@ interactions:
         trailer: {}
         content_length: 288
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg14e60116dd3a470e82af-006a0af1aa</RequestId><HostId>txg14e60116dd3a470e82af-006a0af1aa</HostId><Resource>/tf-tests-scaleway-object-bucket-7502770239130453132</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg8e9da3a9d8d14aa1a6f1-006a0af384</RequestId><HostId>txg8e9da3a9d8d14aa1a6f1-006a0af384</HostId><Resource>/tf-tests-scaleway-object-bucket-6929862902340098161</Resource></Error>
         headers:
             Content-Length:
                 - "288"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 11:02:02 GMT
+                - Mon, 18 May 2026 11:09:56 GMT
             X-Amz-Id-2:
-                - txg14e60116dd3a470e82af-006a0af1aa
+                - txg8e9da3a9d8d14aa1a6f1-006a0af384
             X-Amz-Request-Id:
-                - txg14e60116dd3a470e82af-006a0af1aa
+                - txg8e9da3a9d8d14aa1a6f1-006a0af384
         status: 404 Not Found
         code: 404
-        duration: 57.919625ms
+        duration: 50.991583ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -425,7 +425,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -434,7 +434,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 42473eb7-0992-4d72-add2-96ea7177400e
+                - 8445cace-931e-461f-aa4a-4b910216c049
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -442,8 +442,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T110202Z
-        url: https://tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T110956Z
+        url: https://tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -462,14 +462,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 11:02:02 GMT
+                - Mon, 18 May 2026 11:09:56 GMT
             X-Amz-Id-2:
-                - txg394b8e8a8165453a8a1d-006a0af1aa
+                - txg7bc410cbd54c4de891c4-006a0af384
             X-Amz-Request-Id:
-                - txg394b8e8a8165453a8a1d-006a0af1aa
+                - txg7bc410cbd54c4de891c4-006a0af384
         status: 200 OK
         code: 200
-        duration: 50.678542ms
+        duration: 35.0075ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -478,7 +478,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -487,7 +487,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 97ca7891-f8dc-4a85-9ea4-8b3c4f0d497d
+                - 95cbbaff-c09a-400e-b3dd-f4e52f58c5f1
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -495,8 +495,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T110202Z
-        url: https://tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T110956Z
+        url: https://tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -504,25 +504,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 540
+        content_length: 592
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Filter><And><ObjectSizeGreaterThan>30</ObjectSizeGreaterThan><ObjectSizeLessThan>500</ObjectSizeLessThan></And></Filter><ID>noncurrent_versions_rule</ID><NoncurrentVersionExpiration><NewerNoncurrentVersions>2</NewerNoncurrentVersions><NoncurrentDays>30</NoncurrentDays></NoncurrentVersionExpiration><NoncurrentVersionTransition><NoncurrentDays>40</NoncurrentDays><StorageClass>ONEZONE_IA</StorageClass></NoncurrentVersionTransition><Status>Enabled</Status></Rule></Configuration>
+            <Configuration><Rule><Filter><And><ObjectSizeGreaterThan>30</ObjectSizeGreaterThan><ObjectSizeLessThan>500</ObjectSizeLessThan></And></Filter><ID>noncurrent_versions_rule</ID><NoncurrentVersionExpiration><NewerNoncurrentVersions>2</NewerNoncurrentVersions><NoncurrentDays>30</NoncurrentDays></NoncurrentVersionExpiration><NoncurrentVersionTransition><NewerNoncurrentVersions>5</NewerNoncurrentVersions><NoncurrentDays>40</NoncurrentDays><StorageClass>ONEZONE_IA</StorageClass></NoncurrentVersionTransition><Status>Enabled</Status></Rule></Configuration>
         headers:
             Content-Length:
-                - "540"
+                - "592"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 11:02:02 GMT
+                - Mon, 18 May 2026 11:09:56 GMT
             X-Amz-Id-2:
-                - txg21f18d354b4f43218bce-006a0af1aa
+                - txg18936e7708564bfebdc8-006a0af384
             X-Amz-Request-Id:
-                - txg21f18d354b4f43218bce-006a0af1aa
+                - txg18936e7708564bfebdc8-006a0af384
         status: 200 OK
         code: 200
-        duration: 31.352291ms
+        duration: 30.498084ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -531,7 +531,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -540,7 +540,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e37dc083-fa7a-4500-aad9-a2f246bbaeda
+                - 426ecc05-f2b9-4ff7-ae03-ecf9443b617f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -552,8 +552,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T110202Z
-        url: https://tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T110956Z
+        url: https://tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud/?acl=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -568,14 +568,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 18 May 2026 11:02:02 GMT
+                - Mon, 18 May 2026 11:09:56 GMT
             X-Amz-Id-2:
-                - txg4572cf34ec76478ab6e2-006a0af1aa
+                - txg4c72445540a14f77b640-006a0af384
             X-Amz-Request-Id:
-                - txg4572cf34ec76478ab6e2-006a0af1aa
+                - txg4c72445540a14f77b640-006a0af384
         status: 200 OK
         code: 200
-        duration: 209.620042ms
+        duration: 400.286166ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -584,7 +584,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -593,7 +593,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 2696cf4b-3e03-405a-8f1a-dd9d531bc6b7
+                - d7661e98-5892-459f-b84d-b8d0846e8855
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -601,8 +601,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T110203Z
-        url: https://tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T110957Z
+        url: https://tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -621,14 +621,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 11:02:03 GMT
+                - Mon, 18 May 2026 11:09:57 GMT
             X-Amz-Id-2:
-                - txgc99303ffd823411b93f4-006a0af1ab
+                - txgce0090b2fcf743e692eb-006a0af385
             X-Amz-Request-Id:
-                - txgc99303ffd823411b93f4-006a0af1ab
+                - txgce0090b2fcf743e692eb-006a0af385
         status: 200 OK
         code: 200
-        duration: 55.857167ms
+        duration: 37.993667ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -637,7 +637,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -646,7 +646,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 3ec5e2f5-a7e0-43db-b4b9-265f4b67094c
+                - e8e47d60-afb3-49a8-96a9-f8a7b39f8c78
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -654,8 +654,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T110203Z
-        url: https://tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud/
+                - 20260518T110957Z
+        url: https://tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -670,16 +670,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 11:02:03 GMT
+                - Mon, 18 May 2026 11:09:57 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txge6db156d74374493a012-006a0af1ab
+                - txg0c731d8f8c054bcbb4ab-006a0af385
             X-Amz-Request-Id:
-                - txge6db156d74374493a012-006a0af1ab
+                - txg0c731d8f8c054bcbb4ab-006a0af385
         status: 200 OK
         code: 200
-        duration: 168.739541ms
+        duration: 62.326417ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -688,7 +688,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -697,7 +697,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 98628684-261a-4faf-a613-20dddcb21735
+                - c29ca9e7-ed0a-43eb-a773-d1a88c1e9be4
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -705,8 +705,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T110203Z
-        url: https://tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T110957Z
+        url: https://tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -714,25 +714,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 540
+        content_length: 592
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Filter><And><ObjectSizeGreaterThan>30</ObjectSizeGreaterThan><ObjectSizeLessThan>500</ObjectSizeLessThan></And></Filter><ID>noncurrent_versions_rule</ID><NoncurrentVersionExpiration><NewerNoncurrentVersions>2</NewerNoncurrentVersions><NoncurrentDays>30</NoncurrentDays></NoncurrentVersionExpiration><NoncurrentVersionTransition><NoncurrentDays>40</NoncurrentDays><StorageClass>ONEZONE_IA</StorageClass></NoncurrentVersionTransition><Status>Enabled</Status></Rule></Configuration>
+            <Configuration><Rule><Filter><And><ObjectSizeGreaterThan>30</ObjectSizeGreaterThan><ObjectSizeLessThan>500</ObjectSizeLessThan></And></Filter><ID>noncurrent_versions_rule</ID><NoncurrentVersionExpiration><NewerNoncurrentVersions>2</NewerNoncurrentVersions><NoncurrentDays>30</NoncurrentDays></NoncurrentVersionExpiration><NoncurrentVersionTransition><NewerNoncurrentVersions>5</NewerNoncurrentVersions><NoncurrentDays>40</NoncurrentDays><StorageClass>ONEZONE_IA</StorageClass></NoncurrentVersionTransition><Status>Enabled</Status></Rule></Configuration>
         headers:
             Content-Length:
-                - "540"
+                - "592"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 11:02:03 GMT
+                - Mon, 18 May 2026 11:09:57 GMT
             X-Amz-Id-2:
-                - txge150584dad574071b665-006a0af1ab
+                - txg549e17861dfa48169f52-006a0af385
             X-Amz-Request-Id:
-                - txge150584dad574071b665-006a0af1ab
+                - txg549e17861dfa48169f52-006a0af385
         status: 200 OK
         code: 200
-        duration: 22.704083ms
+        duration: 53.528ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -741,7 +741,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -750,7 +750,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7bcd7e95-31f3-44a1-a350-a1f20c7a159f
+                - 4e7b299b-64a1-4d95-831c-41df758b264e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -758,8 +758,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T110203Z
-        url: https://tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T110957Z
+        url: https://tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -778,14 +778,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 11:02:03 GMT
+                - Mon, 18 May 2026 11:09:57 GMT
             X-Amz-Id-2:
-                - txgbad57e0514c54947af7b-006a0af1ab
+                - txgdbf5ac18ab0041e5b819-006a0af385
             X-Amz-Request-Id:
-                - txgbad57e0514c54947af7b-006a0af1ab
+                - txgdbf5ac18ab0041e5b819-006a0af385
         status: 200 OK
         code: 200
-        duration: 61.5ms
+        duration: 44.456459ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -794,7 +794,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -803,7 +803,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 024c36e7-ffd7-4779-9063-8b952aad05d1
+                - 8ff462d1-a5c2-4c00-9e6c-847c8a528df9
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -811,8 +811,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T110203Z
-        url: https://tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T110957Z
+        url: https://tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -822,21 +822,21 @@ interactions:
         trailer: {}
         content_length: 320
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgc917855a702b4b4f97ad-006a0af1ab</RequestId><HostId>txgc917855a702b4b4f97ad-006a0af1ab</HostId><Resource>/tf-tests-scaleway-object-bucket-7502770239130453132</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg1731cc92bb0243afa5b8-006a0af385</RequestId><HostId>txg1731cc92bb0243afa5b8-006a0af385</HostId><Resource>/tf-tests-scaleway-object-bucket-6929862902340098161</Resource></Error>
         headers:
             Content-Length:
                 - "320"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 11:02:03 GMT
+                - Mon, 18 May 2026 11:09:57 GMT
             X-Amz-Id-2:
-                - txgc917855a702b4b4f97ad-006a0af1ab
+                - txg1731cc92bb0243afa5b8-006a0af385
             X-Amz-Request-Id:
-                - txgc917855a702b4b4f97ad-006a0af1ab
+                - txg1731cc92bb0243afa5b8-006a0af385
         status: 404 Not Found
         code: 404
-        duration: 55.300208ms
+        duration: 50.538292ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -845,7 +845,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -854,7 +854,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 20f2fe5e-5e13-4c01-b901-500fae9fffde
+                - 0fbc40d0-f787-469e-bbda-56b39ddff37a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -862,8 +862,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T110203Z
-        url: https://tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud/
+                - 20260518T110957Z
+        url: https://tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -875,21 +875,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-7502770239130453132</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-6929862902340098161</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "277"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 11:02:03 GMT
+                - Mon, 18 May 2026 11:09:57 GMT
             X-Amz-Id-2:
-                - txg1251772311e9485e8371-006a0af1ab
+                - txg97977f2697944fac9519-006a0af385
             X-Amz-Request-Id:
-                - txg1251772311e9485e8371-006a0af1ab
+                - txg97977f2697944fac9519-006a0af385
         status: 200 OK
         code: 200
-        duration: 89.009167ms
+        duration: 21.447875ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -898,7 +898,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -907,7 +907,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 3cf85ec8-d01a-4e80-812e-cb31ff404e36
+                - ed6bd2f2-03ab-41aa-b9e5-52e3c2fd43e0
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -915,8 +915,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T110203Z
-        url: https://tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T110957Z
+        url: https://tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -926,21 +926,21 @@ interactions:
         trailer: {}
         content_length: 341
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg4b956316e13442a0969a-006a0af1ab</RequestId><HostId>txg4b956316e13442a0969a-006a0af1ab</HostId><Resource>/tf-tests-scaleway-object-bucket-7502770239130453132</Resource><BucketName>tf-tests-scaleway-object-bucket-7502770239130453132</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgb557126e4f47468a9199-006a0af386</RequestId><HostId>txgb557126e4f47468a9199-006a0af386</HostId><Resource>/tf-tests-scaleway-object-bucket-6929862902340098161</Resource><BucketName>tf-tests-scaleway-object-bucket-6929862902340098161</BucketName></Error>
         headers:
             Content-Length:
                 - "341"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 11:02:03 GMT
+                - Mon, 18 May 2026 11:09:58 GMT
             X-Amz-Id-2:
-                - txg4b956316e13442a0969a-006a0af1ab
+                - txgb557126e4f47468a9199-006a0af386
             X-Amz-Request-Id:
-                - txg4b956316e13442a0969a-006a0af1ab
+                - txgb557126e4f47468a9199-006a0af386
         status: 404 Not Found
         code: 404
-        duration: 71.787542ms
+        duration: 88.592292ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -949,7 +949,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -958,7 +958,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 3c875bbf-79a0-4c4c-9699-1e8c052cad42
+                - 81a04463-4873-4cc2-ad78-682d05985b04
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -966,8 +966,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T110203Z
-        url: https://tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T110958Z
+        url: https://tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -977,21 +977,21 @@ interactions:
         trailer: {}
         content_length: 288
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg937d24d696204bc79932-006a0af1ab</RequestId><HostId>txg937d24d696204bc79932-006a0af1ab</HostId><Resource>/tf-tests-scaleway-object-bucket-7502770239130453132</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg58b89810197f424c9ff2-006a0af386</RequestId><HostId>txg58b89810197f424c9ff2-006a0af386</HostId><Resource>/tf-tests-scaleway-object-bucket-6929862902340098161</Resource></Error>
         headers:
             Content-Length:
                 - "288"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 11:02:03 GMT
+                - Mon, 18 May 2026 11:09:58 GMT
             X-Amz-Id-2:
-                - txg937d24d696204bc79932-006a0af1ab
+                - txg58b89810197f424c9ff2-006a0af386
             X-Amz-Request-Id:
-                - txg937d24d696204bc79932-006a0af1ab
+                - txg58b89810197f424c9ff2-006a0af386
         status: 404 Not Found
         code: 404
-        duration: 54.842042ms
+        duration: 21.371834ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -1000,7 +1000,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1009,7 +1009,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4e63ba1b-08e0-4315-8ccc-79d4984ee391
+                - 1a5dd083-7949-4b40-9809-9a22868c49af
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1017,8 +1017,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T110203Z
-        url: https://tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T110958Z
+        url: https://tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1037,14 +1037,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 11:02:04 GMT
+                - Mon, 18 May 2026 11:09:58 GMT
             X-Amz-Id-2:
-                - txg9253d31681e34176b9f0-006a0af1ac
+                - txga0c037c5fbb64ea8a9a2-006a0af386
             X-Amz-Request-Id:
-                - txg9253d31681e34176b9f0-006a0af1ac
+                - txga0c037c5fbb64ea8a9a2-006a0af386
         status: 200 OK
         code: 200
-        duration: 124.74275ms
+        duration: 54.112709ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1053,7 +1053,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1062,7 +1062,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e2599658-afea-4f38-be3c-15ec20bd42c4
+                - 518fb079-234b-425d-885a-44ac50670aa2
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1070,8 +1070,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T110204Z
-        url: https://tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T110958Z
+        url: https://tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1079,25 +1079,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 540
+        content_length: 592
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Filter><And><ObjectSizeGreaterThan>30</ObjectSizeGreaterThan><ObjectSizeLessThan>500</ObjectSizeLessThan></And></Filter><ID>noncurrent_versions_rule</ID><NoncurrentVersionExpiration><NewerNoncurrentVersions>2</NewerNoncurrentVersions><NoncurrentDays>30</NoncurrentDays></NoncurrentVersionExpiration><NoncurrentVersionTransition><NoncurrentDays>40</NoncurrentDays><StorageClass>ONEZONE_IA</StorageClass></NoncurrentVersionTransition><Status>Enabled</Status></Rule></Configuration>
+            <Configuration><Rule><Filter><And><ObjectSizeGreaterThan>30</ObjectSizeGreaterThan><ObjectSizeLessThan>500</ObjectSizeLessThan></And></Filter><ID>noncurrent_versions_rule</ID><NoncurrentVersionExpiration><NewerNoncurrentVersions>2</NewerNoncurrentVersions><NoncurrentDays>30</NoncurrentDays></NoncurrentVersionExpiration><NoncurrentVersionTransition><NewerNoncurrentVersions>5</NewerNoncurrentVersions><NoncurrentDays>40</NoncurrentDays><StorageClass>ONEZONE_IA</StorageClass></NoncurrentVersionTransition><Status>Enabled</Status></Rule></Configuration>
         headers:
             Content-Length:
-                - "540"
+                - "592"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 11:02:04 GMT
+                - Mon, 18 May 2026 11:09:58 GMT
             X-Amz-Id-2:
-                - txga3b8719064904c83968f-006a0af1ac
+                - txg2eaa881ab36e4a44a2e3-006a0af386
             X-Amz-Request-Id:
-                - txga3b8719064904c83968f-006a0af1ac
+                - txg2eaa881ab36e4a44a2e3-006a0af386
         status: 200 OK
         code: 200
-        duration: 35.048667ms
+        duration: 41.423792ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1106,7 +1106,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1115,7 +1115,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - afdb1942-f882-4c83-9f18-2b3c4375ca00
+                - 2dd08710-de5a-4fa8-87a6-7b6be0fe28a6
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1123,8 +1123,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T110204Z
-        url: https://tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T110958Z
+        url: https://tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1143,14 +1143,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 11:02:04 GMT
+                - Mon, 18 May 2026 11:09:58 GMT
             X-Amz-Id-2:
-                - txg52d47f7c1c724d66ad96-006a0af1ac
+                - txg05d92fb01a8f47ce9d29-006a0af386
             X-Amz-Request-Id:
-                - txg52d47f7c1c724d66ad96-006a0af1ac
+                - txg05d92fb01a8f47ce9d29-006a0af386
         status: 200 OK
         code: 200
-        duration: 55.22925ms
+        duration: 20.863042ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1159,7 +1159,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1168,7 +1168,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 327a4c45-c8e4-4660-9c05-48a7970691b9
+                - 58d5831d-15ac-45c4-a035-20a68e474789
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1180,8 +1180,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T110204Z
-        url: https://tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T110958Z
+        url: https://tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud/?acl=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -1196,14 +1196,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 18 May 2026 11:02:04 GMT
+                - Mon, 18 May 2026 11:09:58 GMT
             X-Amz-Id-2:
-                - txg2496c5fc86804885a73c-006a0af1ac
+                - txg2d9c0139e92e48ebb1f4-006a0af386
             X-Amz-Request-Id:
-                - txg2496c5fc86804885a73c-006a0af1ac
+                - txg2d9c0139e92e48ebb1f4-006a0af386
         status: 200 OK
         code: 200
-        duration: 121.258625ms
+        duration: 202.12475ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1212,7 +1212,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1221,7 +1221,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4ee154ed-5de7-465c-afb7-4b3b8654219a
+                - e19cb65e-e259-4460-a699-b0273f05093d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1229,8 +1229,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T110204Z
-        url: https://tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud/
+                - 20260518T110958Z
+        url: https://tf-tests-scaleway-object-bucket-6929862902340098161.s3.nl-ams.scw.cloud/
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1243,11 +1243,11 @@ interactions:
         body: ""
         headers:
             Date:
-                - Mon, 18 May 2026 11:02:04 GMT
+                - Mon, 18 May 2026 11:09:58 GMT
             X-Amz-Id-2:
-                - txgf5a609fae8de40b6aa0a-006a0af1ac
+                - txg3803ccf7fefb414ca296-006a0af386
             X-Amz-Request-Id:
-                - txgf5a609fae8de40b6aa0a-006a0af1ac
+                - txg3803ccf7fefb414ca296-006a0af386
         status: 204 No Content
         code: 204
-        duration: 250.06925ms
+        duration: 237.970042ms

--- a/internal/services/object/testdata/object-bucket-lifecycle-empty-filter-non-current-versions.cassette.yaml
+++ b/internal/services/object/testdata/object-bucket-lifecycle-empty-filter-non-current-versions.cassette.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -18,7 +18,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0049d624-9753-43e7-9c8d-124460205d44
+                - 14800cb1-850e-48b2-a538-83ee5f253b7a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -26,8 +26,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T095110Z
-        url: https://tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud/
+                - 20260518T110158Z
+        url: https://tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud/
         method: PUT
       response:
         proto: HTTP/2.0
@@ -42,16 +42,16 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 18 May 2026 09:51:10 GMT
+                - Mon, 18 May 2026 11:01:58 GMT
             Location:
-                - /tf-tests-scaleway-object-bucket-4578096170247254682
+                - /tf-tests-scaleway-object-bucket-7502770239130453132
             X-Amz-Id-2:
-                - txg92ab8b372ec3449ca2ac-006a0ae10e
+                - txg35e6d578b12a457780d6-006a0af1a6
             X-Amz-Request-Id:
-                - txg92ab8b372ec3449ca2ac-006a0ae10e
+                - txg35e6d578b12a457780d6-006a0af1a6
         status: 200 OK
         code: 200
-        duration: 4.602258166s
+        duration: 4.03953775s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -60,7 +60,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -69,7 +69,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c622fbe8-64c3-4007-b671-9380262485ab
+                - d793e2c1-27fb-4178-8d40-8f620d498255
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -81,8 +81,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T095114Z
-        url: https://tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T110202Z
+        url: https://tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud/?acl=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -97,32 +97,32 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 18 May 2026 09:51:14 GMT
+                - Mon, 18 May 2026 11:02:02 GMT
             X-Amz-Id-2:
-                - txg18ab3051203040e58e47-006a0ae112
+                - txge5c407d37e094ea5af0e-006a0af1aa
             X-Amz-Request-Id:
-                - txg18ab3051203040e58e47-006a0ae112
+                - txge5c407d37e094ea5af0e-006a0af1aa
         status: 200 OK
         code: 200
-        duration: 122.149375ms
+        duration: 120.857042ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 372
+        content_length: 567
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
-        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><ExpiredObjectDeleteMarker>true</ExpiredObjectDeleteMarker></Expiration><Filter><And><ObjectSizeGreaterThan>30</ObjectSizeGreaterThan><ObjectSizeLessThan>500</ObjectSizeLessThan></And></Filter><ID>noncurrent_versions_rule</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
+        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Filter><And><ObjectSizeGreaterThan>30</ObjectSizeGreaterThan><ObjectSizeLessThan>500</ObjectSizeLessThan></And></Filter><ID>noncurrent_versions_rule</ID><NoncurrentVersionExpiration><NewerNoncurrentVersions>2</NewerNoncurrentVersions><NoncurrentDays>30</NoncurrentDays></NoncurrentVersionExpiration><NoncurrentVersionTransition><NoncurrentDays>40</NoncurrentDays><StorageClass>ONEZONE_IA</StorageClass></NoncurrentVersionTransition><Status>Enabled</Status></Rule></LifecycleConfiguration>
         form: {}
         headers:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 13a3d565-f3a8-4ec5-b2be-663de337b9df
+                - 93a386b6-c068-4018-a880-aedb2b1f7654
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
@@ -130,12 +130,12 @@ interactions:
             User-Agent:
                 - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,Z,e
             X-Amz-Checksum-Crc32:
-                - DgTHAw==
+                - o4mLhg==
             X-Amz-Content-Sha256:
-                - 08fe4fcabdce3ca4a1cc3d41c8c0d330c8a19dfc1e61506e17442fa0b7d0ae69
+                - d18f8f4251f06bb287755ada136d188ea7efd85c7a8c883bd0b2fa51c48f54d0
             X-Amz-Date:
-                - 20260518T095114Z
-        url: https://tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T110202Z
+        url: https://tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -150,14 +150,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 18 May 2026 09:51:14 GMT
+                - Mon, 18 May 2026 11:02:02 GMT
             X-Amz-Id-2:
-                - txg4dd3c5f2e67b4cc58649-006a0ae112
+                - txgeed02f543e404758b935-006a0af1aa
             X-Amz-Request-Id:
-                - txg4dd3c5f2e67b4cc58649-006a0ae112
+                - txgeed02f543e404758b935-006a0af1aa
         status: 200 OK
         code: 200
-        duration: 67.203292ms
+        duration: 145.98175ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -166,7 +166,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -175,7 +175,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 07e4ebc2-b7ff-4b89-87c3-ed9f8dbb1e46
+                - 93044a36-ec09-4cab-a38a-6c3012201c5c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -183,8 +183,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T095114Z
-        url: https://tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T110202Z
+        url: https://tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -203,14 +203,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 09:51:15 GMT
+                - Mon, 18 May 2026 11:02:02 GMT
             X-Amz-Id-2:
-                - txgc6ec85cb0a5f4c769b27-006a0ae113
+                - txg58b52bda37ec43ff8783-006a0af1aa
             X-Amz-Request-Id:
-                - txgc6ec85cb0a5f4c769b27-006a0ae113
+                - txg58b52bda37ec43ff8783-006a0af1aa
         status: 200 OK
         code: 200
-        duration: 53.156958ms
+        duration: 53.170583ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -219,7 +219,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -228,7 +228,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 280624a1-c521-4ded-9fdb-f1c32108a347
+                - 15ac913a-fa3d-4dff-8b7a-b4def485d3b5
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -236,8 +236,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T095115Z
-        url: https://tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T110202Z
+        url: https://tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -247,21 +247,21 @@ interactions:
         trailer: {}
         content_length: 320
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg7c49a3f87e524332b6f8-006a0ae113</RequestId><HostId>txg7c49a3f87e524332b6f8-006a0ae113</HostId><Resource>/tf-tests-scaleway-object-bucket-4578096170247254682</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg14ffbb4b96ab4eb99937-006a0af1aa</RequestId><HostId>txg14ffbb4b96ab4eb99937-006a0af1aa</HostId><Resource>/tf-tests-scaleway-object-bucket-7502770239130453132</Resource></Error>
         headers:
             Content-Length:
                 - "320"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 09:51:15 GMT
+                - Mon, 18 May 2026 11:02:02 GMT
             X-Amz-Id-2:
-                - txg7c49a3f87e524332b6f8-006a0ae113
+                - txg14ffbb4b96ab4eb99937-006a0af1aa
             X-Amz-Request-Id:
-                - txg7c49a3f87e524332b6f8-006a0ae113
+                - txg14ffbb4b96ab4eb99937-006a0af1aa
         status: 404 Not Found
         code: 404
-        duration: 52.862958ms
+        duration: 32.816958ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -270,7 +270,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -279,7 +279,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4a56d327-74c2-4e88-9db6-5f8443757f6f
+                - 18b30091-09c0-438c-9a22-3e87007c6643
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -287,8 +287,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T095115Z
-        url: https://tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud/
+                - 20260518T110202Z
+        url: https://tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -300,21 +300,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-4578096170247254682</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-7502770239130453132</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "277"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 09:51:15 GMT
+                - Mon, 18 May 2026 11:02:02 GMT
             X-Amz-Id-2:
-                - txge9028c4c1e6143cfaebb-006a0ae113
+                - txgd5fcb369c38a436dbbe4-006a0af1aa
             X-Amz-Request-Id:
-                - txge9028c4c1e6143cfaebb-006a0ae113
+                - txgd5fcb369c38a436dbbe4-006a0af1aa
         status: 200 OK
         code: 200
-        duration: 81.416708ms
+        duration: 85.351083ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -323,7 +323,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -332,7 +332,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e53765cd-68d8-42f6-a13c-06d12f44361b
+                - 180e4e3b-8f39-436b-bd0e-1ba8703e2483
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -340,8 +340,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T095115Z
-        url: https://tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T110202Z
+        url: https://tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -351,21 +351,21 @@ interactions:
         trailer: {}
         content_length: 341
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg8ffedff8e9a24de99157-006a0ae113</RequestId><HostId>txg8ffedff8e9a24de99157-006a0ae113</HostId><Resource>/tf-tests-scaleway-object-bucket-4578096170247254682</Resource><BucketName>tf-tests-scaleway-object-bucket-4578096170247254682</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgcaa3247d2107412cbafe-006a0af1aa</RequestId><HostId>txgcaa3247d2107412cbafe-006a0af1aa</HostId><Resource>/tf-tests-scaleway-object-bucket-7502770239130453132</Resource><BucketName>tf-tests-scaleway-object-bucket-7502770239130453132</BucketName></Error>
         headers:
             Content-Length:
                 - "341"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 09:51:15 GMT
+                - Mon, 18 May 2026 11:02:02 GMT
             X-Amz-Id-2:
-                - txg8ffedff8e9a24de99157-006a0ae113
+                - txgcaa3247d2107412cbafe-006a0af1aa
             X-Amz-Request-Id:
-                - txg8ffedff8e9a24de99157-006a0ae113
+                - txgcaa3247d2107412cbafe-006a0af1aa
         status: 404 Not Found
         code: 404
-        duration: 65.130167ms
+        duration: 58.894625ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -374,7 +374,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -383,7 +383,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7c658d3b-d177-4c3d-9c4c-8cb88f1ef788
+                - 04ed46d4-88ee-4797-8760-f2d25972765e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -391,8 +391,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T095115Z
-        url: https://tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T110202Z
+        url: https://tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -402,21 +402,21 @@ interactions:
         trailer: {}
         content_length: 288
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg5f8fe0959cf64511b0ba-006a0ae113</RequestId><HostId>txg5f8fe0959cf64511b0ba-006a0ae113</HostId><Resource>/tf-tests-scaleway-object-bucket-4578096170247254682</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg14e60116dd3a470e82af-006a0af1aa</RequestId><HostId>txg14e60116dd3a470e82af-006a0af1aa</HostId><Resource>/tf-tests-scaleway-object-bucket-7502770239130453132</Resource></Error>
         headers:
             Content-Length:
                 - "288"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 09:51:15 GMT
+                - Mon, 18 May 2026 11:02:02 GMT
             X-Amz-Id-2:
-                - txg5f8fe0959cf64511b0ba-006a0ae113
+                - txg14e60116dd3a470e82af-006a0af1aa
             X-Amz-Request-Id:
-                - txg5f8fe0959cf64511b0ba-006a0ae113
+                - txg14e60116dd3a470e82af-006a0af1aa
         status: 404 Not Found
         code: 404
-        duration: 33.985083ms
+        duration: 57.919625ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -425,7 +425,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -434,7 +434,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - dd509b2d-295c-4cd0-9c38-c5240eb479da
+                - 42473eb7-0992-4d72-add2-96ea7177400e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -442,8 +442,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T095115Z
-        url: https://tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T110202Z
+        url: https://tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -462,14 +462,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 09:51:15 GMT
+                - Mon, 18 May 2026 11:02:02 GMT
             X-Amz-Id-2:
-                - txgac962c2c969648c1b3a5-006a0ae113
+                - txg394b8e8a8165453a8a1d-006a0af1aa
             X-Amz-Request-Id:
-                - txgac962c2c969648c1b3a5-006a0ae113
+                - txg394b8e8a8165453a8a1d-006a0af1aa
         status: 200 OK
         code: 200
-        duration: 66.008ms
+        duration: 50.678542ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -478,7 +478,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -487,7 +487,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 50e14aa9-1dd5-4cc7-9541-14b453843306
+                - 97ca7891-f8dc-4a85-9ea4-8b3c4f0d497d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -495,8 +495,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T095115Z
-        url: https://tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T110202Z
+        url: https://tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -504,25 +504,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 345
+        content_length: 540
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><ExpiredObjectDeleteMarker>true</ExpiredObjectDeleteMarker></Expiration><Filter><And><ObjectSizeGreaterThan>30</ObjectSizeGreaterThan><ObjectSizeLessThan>500</ObjectSizeLessThan></And></Filter><ID>noncurrent_versions_rule</ID><Status>Enabled</Status></Rule></Configuration>
+            <Configuration><Rule><Filter><And><ObjectSizeGreaterThan>30</ObjectSizeGreaterThan><ObjectSizeLessThan>500</ObjectSizeLessThan></And></Filter><ID>noncurrent_versions_rule</ID><NoncurrentVersionExpiration><NewerNoncurrentVersions>2</NewerNoncurrentVersions><NoncurrentDays>30</NoncurrentDays></NoncurrentVersionExpiration><NoncurrentVersionTransition><NoncurrentDays>40</NoncurrentDays><StorageClass>ONEZONE_IA</StorageClass></NoncurrentVersionTransition><Status>Enabled</Status></Rule></Configuration>
         headers:
             Content-Length:
-                - "345"
+                - "540"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 09:51:15 GMT
+                - Mon, 18 May 2026 11:02:02 GMT
             X-Amz-Id-2:
-                - txgb2e5151996ac44cb855e-006a0ae113
+                - txg21f18d354b4f43218bce-006a0af1aa
             X-Amz-Request-Id:
-                - txgb2e5151996ac44cb855e-006a0ae113
+                - txg21f18d354b4f43218bce-006a0af1aa
         status: 200 OK
         code: 200
-        duration: 37.355708ms
+        duration: 31.352291ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -531,7 +531,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -540,7 +540,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b0db91bf-c608-48f5-999c-bac4198f0e46
+                - e37dc083-fa7a-4500-aad9-a2f246bbaeda
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -552,8 +552,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T095115Z
-        url: https://tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T110202Z
+        url: https://tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud/?acl=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -568,14 +568,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 18 May 2026 09:51:15 GMT
+                - Mon, 18 May 2026 11:02:02 GMT
             X-Amz-Id-2:
-                - txg0ab6d8f2ffc848b0b115-006a0ae113
+                - txg4572cf34ec76478ab6e2-006a0af1aa
             X-Amz-Request-Id:
-                - txg0ab6d8f2ffc848b0b115-006a0ae113
+                - txg4572cf34ec76478ab6e2-006a0af1aa
         status: 200 OK
         code: 200
-        duration: 65.159833ms
+        duration: 209.620042ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -584,7 +584,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -593,7 +593,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 1d4794c0-c45e-49d9-8a9d-2712cd4db0ff
+                - 2696cf4b-3e03-405a-8f1a-dd9d531bc6b7
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -601,8 +601,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T095115Z
-        url: https://tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T110203Z
+        url: https://tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -621,14 +621,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 09:51:15 GMT
+                - Mon, 18 May 2026 11:02:03 GMT
             X-Amz-Id-2:
-                - txg0a410e6efe88454a9105-006a0ae113
+                - txgc99303ffd823411b93f4-006a0af1ab
             X-Amz-Request-Id:
-                - txg0a410e6efe88454a9105-006a0ae113
+                - txgc99303ffd823411b93f4-006a0af1ab
         status: 200 OK
         code: 200
-        duration: 75.743667ms
+        duration: 55.857167ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -637,7 +637,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -646,7 +646,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 3416b2c8-a19d-44d2-b32e-adf1c9625783
+                - 3ec5e2f5-a7e0-43db-b4b9-265f4b67094c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -654,8 +654,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T095115Z
-        url: https://tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud/
+                - 20260518T110203Z
+        url: https://tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -670,16 +670,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 09:51:15 GMT
+                - Mon, 18 May 2026 11:02:03 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txg4c1e3c92d9d3448c8289-006a0ae113
+                - txge6db156d74374493a012-006a0af1ab
             X-Amz-Request-Id:
-                - txg4c1e3c92d9d3448c8289-006a0ae113
+                - txge6db156d74374493a012-006a0af1ab
         status: 200 OK
         code: 200
-        duration: 61.240333ms
+        duration: 168.739541ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -688,7 +688,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -697,7 +697,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ec0f46bc-cff9-437e-9d79-3bb3b0e17a8a
+                - 98628684-261a-4faf-a613-20dddcb21735
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -705,8 +705,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T095115Z
-        url: https://tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T110203Z
+        url: https://tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -714,25 +714,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 345
+        content_length: 540
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><ExpiredObjectDeleteMarker>true</ExpiredObjectDeleteMarker></Expiration><Filter><And><ObjectSizeGreaterThan>30</ObjectSizeGreaterThan><ObjectSizeLessThan>500</ObjectSizeLessThan></And></Filter><ID>noncurrent_versions_rule</ID><Status>Enabled</Status></Rule></Configuration>
+            <Configuration><Rule><Filter><And><ObjectSizeGreaterThan>30</ObjectSizeGreaterThan><ObjectSizeLessThan>500</ObjectSizeLessThan></And></Filter><ID>noncurrent_versions_rule</ID><NoncurrentVersionExpiration><NewerNoncurrentVersions>2</NewerNoncurrentVersions><NoncurrentDays>30</NoncurrentDays></NoncurrentVersionExpiration><NoncurrentVersionTransition><NoncurrentDays>40</NoncurrentDays><StorageClass>ONEZONE_IA</StorageClass></NoncurrentVersionTransition><Status>Enabled</Status></Rule></Configuration>
         headers:
             Content-Length:
-                - "345"
+                - "540"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 09:51:15 GMT
+                - Mon, 18 May 2026 11:02:03 GMT
             X-Amz-Id-2:
-                - txg910e9845a910495cbeae-006a0ae113
+                - txge150584dad574071b665-006a0af1ab
             X-Amz-Request-Id:
-                - txg910e9845a910495cbeae-006a0ae113
+                - txge150584dad574071b665-006a0af1ab
         status: 200 OK
         code: 200
-        duration: 51.657792ms
+        duration: 22.704083ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -741,7 +741,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -750,7 +750,425 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - cd726167-4966-48a6-bff0-df2c639b52c8
+                - 7bcd7e95-31f3-44a1-a350-a1f20c7a159f
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T110203Z
+        url: https://tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud/?acl=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 698
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+        headers:
+            Content-Length:
+                - "698"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Mon, 18 May 2026 11:02:03 GMT
+            X-Amz-Id-2:
+                - txgbad57e0514c54947af7b-006a0af1ab
+            X-Amz-Request-Id:
+                - txgbad57e0514c54947af7b-006a0af1ab
+        status: 200 OK
+        code: 200
+        duration: 61.5ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 024c36e7-ffd7-4779-9063-8b952aad05d1
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T110203Z
+        url: https://tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud/?object-lock=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 320
+        uncompressed: false
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgc917855a702b4b4f97ad-006a0af1ab</RequestId><HostId>txgc917855a702b4b4f97ad-006a0af1ab</HostId><Resource>/tf-tests-scaleway-object-bucket-7502770239130453132</Resource></Error>
+        headers:
+            Content-Length:
+                - "320"
+            Content-Type:
+                - application/xml
+            Date:
+                - Mon, 18 May 2026 11:02:03 GMT
+            X-Amz-Id-2:
+                - txgc917855a702b4b4f97ad-006a0af1ab
+            X-Amz-Request-Id:
+                - txgc917855a702b4b4f97ad-006a0af1ab
+        status: 404 Not Found
+        code: 404
+        duration: 55.300208ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 20f2fe5e-5e13-4c01-b901-500fae9fffde
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T110203Z
+        url: https://tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud/
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 277
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-7502770239130453132</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+        headers:
+            Content-Length:
+                - "277"
+            Content-Type:
+                - application/xml
+            Date:
+                - Mon, 18 May 2026 11:02:03 GMT
+            X-Amz-Id-2:
+                - txg1251772311e9485e8371-006a0af1ab
+            X-Amz-Request-Id:
+                - txg1251772311e9485e8371-006a0af1ab
+        status: 200 OK
+        code: 200
+        duration: 89.009167ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 3cf85ec8-d01a-4e80-812e-cb31ff404e36
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T110203Z
+        url: https://tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud/?tagging=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 341
+        uncompressed: false
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg4b956316e13442a0969a-006a0af1ab</RequestId><HostId>txg4b956316e13442a0969a-006a0af1ab</HostId><Resource>/tf-tests-scaleway-object-bucket-7502770239130453132</Resource><BucketName>tf-tests-scaleway-object-bucket-7502770239130453132</BucketName></Error>
+        headers:
+            Content-Length:
+                - "341"
+            Content-Type:
+                - application/xml
+            Date:
+                - Mon, 18 May 2026 11:02:03 GMT
+            X-Amz-Id-2:
+                - txg4b956316e13442a0969a-006a0af1ab
+            X-Amz-Request-Id:
+                - txg4b956316e13442a0969a-006a0af1ab
+        status: 404 Not Found
+        code: 404
+        duration: 71.787542ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 3c875bbf-79a0-4c4c-9699-1e8c052cad42
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T110203Z
+        url: https://tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud/?cors=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 288
+        uncompressed: false
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg937d24d696204bc79932-006a0af1ab</RequestId><HostId>txg937d24d696204bc79932-006a0af1ab</HostId><Resource>/tf-tests-scaleway-object-bucket-7502770239130453132</Resource></Error>
+        headers:
+            Content-Length:
+                - "288"
+            Content-Type:
+                - application/xml
+            Date:
+                - Mon, 18 May 2026 11:02:03 GMT
+            X-Amz-Id-2:
+                - txg937d24d696204bc79932-006a0af1ab
+            X-Amz-Request-Id:
+                - txg937d24d696204bc79932-006a0af1ab
+        status: 404 Not Found
+        code: 404
+        duration: 54.842042ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 4e63ba1b-08e0-4315-8ccc-79d4984ee391
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T110203Z
+        url: https://tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud/?versioning=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 107
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <VersioningConfiguration><Status></Status></VersioningConfiguration>
+        headers:
+            Content-Length:
+                - "107"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Mon, 18 May 2026 11:02:04 GMT
+            X-Amz-Id-2:
+                - txg9253d31681e34176b9f0-006a0af1ac
+            X-Amz-Request-Id:
+                - txg9253d31681e34176b9f0-006a0af1ac
+        status: 200 OK
+        code: 200
+        duration: 124.74275ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - e2599658-afea-4f38-be3c-15ec20bd42c4
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T110204Z
+        url: https://tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud/?lifecycle=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 540
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <Configuration><Rule><Filter><And><ObjectSizeGreaterThan>30</ObjectSizeGreaterThan><ObjectSizeLessThan>500</ObjectSizeLessThan></And></Filter><ID>noncurrent_versions_rule</ID><NoncurrentVersionExpiration><NewerNoncurrentVersions>2</NewerNoncurrentVersions><NoncurrentDays>30</NoncurrentDays></NoncurrentVersionExpiration><NoncurrentVersionTransition><NoncurrentDays>40</NoncurrentDays><StorageClass>ONEZONE_IA</StorageClass></NoncurrentVersionTransition><Status>Enabled</Status></Rule></Configuration>
+        headers:
+            Content-Length:
+                - "540"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Mon, 18 May 2026 11:02:04 GMT
+            X-Amz-Id-2:
+                - txga3b8719064904c83968f-006a0af1ac
+            X-Amz-Request-Id:
+                - txga3b8719064904c83968f-006a0af1ac
+        status: 200 OK
+        code: 200
+        duration: 35.048667ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - afdb1942-f882-4c83-9f18-2b3c4375ca00
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260518T110204Z
+        url: https://tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud/?acl=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 698
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+        headers:
+            Content-Length:
+                - "698"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Mon, 18 May 2026 11:02:04 GMT
+            X-Amz-Id-2:
+                - txg52d47f7c1c724d66ad96-006a0af1ac
+            X-Amz-Request-Id:
+                - txg52d47f7c1c724d66ad96-006a0af1ac
+        status: 200 OK
+        code: 200
+        duration: 55.22925ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 327a4c45-c8e4-4660-9c05-48a7970691b9
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -762,8 +1180,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T095115Z
-        url: https://tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T110204Z
+        url: https://tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud/?acl=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -778,15 +1196,15 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 18 May 2026 09:51:15 GMT
+                - Mon, 18 May 2026 11:02:04 GMT
             X-Amz-Id-2:
-                - txg6b79209c577b429ea877-006a0ae113
+                - txg2496c5fc86804885a73c-006a0af1ac
             X-Amz-Request-Id:
-                - txg6b79209c577b429ea877-006a0ae113
+                - txg2496c5fc86804885a73c-006a0af1ac
         status: 200 OK
         code: 200
-        duration: 54.725042ms
-    - id: 15
+        duration: 121.258625ms
+    - id: 23
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -794,7 +1212,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -803,7 +1221,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5840e2ab-6ee0-4616-9264-6479304adbb4
+                - 4ee154ed-5de7-465c-afb7-4b3b8654219a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -811,8 +1229,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T095115Z
-        url: https://tf-tests-scaleway-object-bucket-4578096170247254682.s3.nl-ams.scw.cloud/
+                - 20260518T110204Z
+        url: https://tf-tests-scaleway-object-bucket-7502770239130453132.s3.nl-ams.scw.cloud/
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -825,11 +1243,11 @@ interactions:
         body: ""
         headers:
             Date:
-                - Mon, 18 May 2026 09:51:16 GMT
+                - Mon, 18 May 2026 11:02:04 GMT
             X-Amz-Id-2:
-                - txg0cf1d180fd624850a259-006a0ae114
+                - txgf5a609fae8de40b6aa0a-006a0af1ac
             X-Amz-Request-Id:
-                - txg0cf1d180fd624850a259-006a0ae114
+                - txgf5a609fae8de40b6aa0a-006a0af1ac
         status: 204 No Content
         code: 204
-        duration: 391.415083ms
+        duration: 250.06925ms

--- a/internal/services/object/testdata/object-bucket-lifecycle-remove-rule.cassette.yaml
+++ b/internal/services/object/testdata/object-bucket-lifecycle-remove-rule.cassette.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -18,7 +18,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5f03d08c-27f6-46e1-9346-8c42d6d0010b
+                - 824dec4e-fd38-44c6-882f-bdcb6afbe2b2
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -26,8 +26,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T153254Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud/
+                - 20260513T160103Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/
         method: PUT
       response:
         proto: HTTP/2.0
@@ -42,16 +42,16 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Wed, 13 May 2026 15:32:54 GMT
+                - Wed, 13 May 2026 16:01:04 GMT
             Location:
-                - /tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805
+                - /tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618
             X-Amz-Id-2:
-                - txge0d274788b1a43c090d7-006a0499a6
+                - txgd146c944b86f426a9e89-006a04a040
             X-Amz-Request-Id:
-                - txge0d274788b1a43c090d7-006a0499a6
+                - txgd146c944b86f426a9e89-006a04a040
         status: 200 OK
         code: 200
-        duration: 3.942176334s
+        duration: 556.340209ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -60,7 +60,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -69,7 +69,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 6485da5d-0e4f-4393-b71a-566f424ae6fa
+                - 9af7badf-d230-4f71-be53-33e8e500a313
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -81,8 +81,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T153258Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud/?acl=
+                - 20260513T160104Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?acl=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -97,32 +97,32 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Wed, 13 May 2026 15:32:58 GMT
+                - Wed, 13 May 2026 16:01:04 GMT
             X-Amz-Id-2:
-                - txg9a8adb3e506a406f9221-006a0499aa
+                - txgc45cf0e40559477a90c5-006a04a040
             X-Amz-Request-Id:
-                - txg9a8adb3e506a406f9221-006a0499aa
+                - txgc45cf0e40559477a90c5-006a04a040
         status: 200 OK
         code: 200
-        duration: 96.847ms
+        duration: 183.361542ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 265
+        content_length: 460
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
-        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><ExpiredObjectDeleteMarker>true</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>expire delete markers</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
+        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>prefix/</Prefix></Filter><ID>to delete</ID><Status>Enabled</Status></Rule><Rule><Expiration><ExpiredObjectDeleteMarker>true</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>expire delete markers</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
         form: {}
         headers:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 6cce23b6-df9c-4465-8e75-f16fca75f3e0
+                - 3669c9a3-22f2-41fa-a99a-e874afbc3c1a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
@@ -130,12 +130,12 @@ interactions:
             User-Agent:
                 - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,Z,e
             X-Amz-Checksum-Crc32:
-                - NdscUw==
+                - kRgv3g==
             X-Amz-Content-Sha256:
-                - fd28d6105facd58e0708118f811178b230c443b5cac5e2f9bb6714a806f344e0
+                - be82f5350a9f62e9880e1d0bfb67fee8cb072fff45d9d7171711c16a6b0dbbb2
             X-Amz-Date:
-                - 20260513T153258Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260513T160104Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -150,14 +150,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Wed, 13 May 2026 15:32:58 GMT
+                - Wed, 13 May 2026 16:01:04 GMT
             X-Amz-Id-2:
-                - txgd4a5975d6e634f8ba651-006a0499aa
+                - txg928927fa84304c71a204-006a04a040
             X-Amz-Request-Id:
-                - txgd4a5975d6e634f8ba651-006a0499aa
+                - txg928927fa84304c71a204-006a04a040
         status: 200 OK
         code: 200
-        duration: 83.63875ms
+        duration: 70.780417ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -166,7 +166,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -175,7 +175,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 514cc3f5-9635-4a10-8c7d-049fd809290f
+                - 016b1be5-fbc5-4350-9df2-77d6d8169713
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -183,8 +183,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T153258Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud/?acl=
+                - 20260513T160104Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -203,14 +203,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 15:32:58 GMT
+                - Wed, 13 May 2026 16:01:04 GMT
             X-Amz-Id-2:
-                - txg7a3c68a91b5846cf8caf-006a0499aa
+                - txg2a99a7cf706648cc8cd6-006a04a040
             X-Amz-Request-Id:
-                - txg7a3c68a91b5846cf8caf-006a0499aa
+                - txg2a99a7cf706648cc8cd6-006a04a040
         status: 200 OK
         code: 200
-        duration: 136.169583ms
+        duration: 57.00325ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -219,7 +219,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -228,7 +228,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 8bec365f-c56c-4600-9cbb-72c11e80eba8
+                - acad42f8-4253-4911-a303-e916c5a99685
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -236,8 +236,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T153258Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260513T160104Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -247,21 +247,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgaa5d9fca42b741f78a8b-006a0499aa</RequestId><HostId>txgaa5d9fca42b741f78a8b-006a0499aa</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg059d73a4a0854041ae0e-006a04a040</RequestId><HostId>txg059d73a4a0854041ae0e-006a04a040</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 15:32:58 GMT
+                - Wed, 13 May 2026 16:01:04 GMT
             X-Amz-Id-2:
-                - txgaa5d9fca42b741f78a8b-006a0499aa
+                - txg059d73a4a0854041ae0e-006a04a040
             X-Amz-Request-Id:
-                - txgaa5d9fca42b741f78a8b-006a0499aa
+                - txg059d73a4a0854041ae0e-006a04a040
         status: 404 Not Found
         code: 404
-        duration: 57.13425ms
+        duration: 61.710583ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -270,7 +270,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -279,7 +279,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f9072d8c-0746-4138-b56b-ad108c130771
+                - 701f172e-defd-44d8-94eb-9f78950b8370
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -287,8 +287,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T153258Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud/
+                - 20260513T160104Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -300,21 +300,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 15:32:58 GMT
+                - Wed, 13 May 2026 16:01:04 GMT
             X-Amz-Id-2:
-                - txgbaf7fe8b899641cab057-006a0499aa
+                - txg8a8eb54cd46242de9942-006a04a040
             X-Amz-Request-Id:
-                - txgbaf7fe8b899641cab057-006a0499aa
+                - txg8a8eb54cd46242de9942-006a04a040
         status: 200 OK
         code: 200
-        duration: 173.758458ms
+        duration: 150.122084ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -323,7 +323,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -332,7 +332,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - be5fbcb9-a26e-4ac2-9833-31c96286cd74
+                - 2dfb9d0b-991f-4381-921c-17467af5130c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -340,8 +340,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T153258Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud/?tagging=
+                - 20260513T160104Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -351,21 +351,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg6c9492427fb04a10b43a-006a0499aa</RequestId><HostId>txg6c9492427fb04a10b43a-006a0499aa</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg1fac07eb079e4e40b783-006a04a041</RequestId><HostId>txg1fac07eb079e4e40b783-006a04a041</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 15:32:58 GMT
+                - Wed, 13 May 2026 16:01:05 GMT
             X-Amz-Id-2:
-                - txg6c9492427fb04a10b43a-006a0499aa
+                - txg1fac07eb079e4e40b783-006a04a041
             X-Amz-Request-Id:
-                - txg6c9492427fb04a10b43a-006a0499aa
+                - txg1fac07eb079e4e40b783-006a04a041
         status: 404 Not Found
         code: 404
-        duration: 33.261458ms
+        duration: 63.058375ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -374,7 +374,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -383,7 +383,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 65109d9e-ae3e-41ab-abea-12d8171f6bf6
+                - 29e86611-1d43-4f04-a914-a90df661bbd1
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -391,8 +391,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T153258Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud/?cors=
+                - 20260513T160105Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -402,21 +402,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg7ed6d32b2d924735b438-006a0499aa</RequestId><HostId>txg7ed6d32b2d924735b438-006a0499aa</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg0118e366c00d4ae8b3f6-006a04a041</RequestId><HostId>txg0118e366c00d4ae8b3f6-006a04a041</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 15:32:58 GMT
+                - Wed, 13 May 2026 16:01:05 GMT
             X-Amz-Id-2:
-                - txg7ed6d32b2d924735b438-006a0499aa
+                - txg0118e366c00d4ae8b3f6-006a04a041
             X-Amz-Request-Id:
-                - txg7ed6d32b2d924735b438-006a0499aa
+                - txg0118e366c00d4ae8b3f6-006a04a041
         status: 404 Not Found
         code: 404
-        duration: 179.863917ms
+        duration: 63.749125ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -425,7 +425,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -434,7 +434,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 2de84dd4-4bb6-41aa-9e5f-08c37180b91d
+                - 60edeac4-47c8-4c0c-bbaf-feceed871418
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -442,8 +442,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T153258Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud/?versioning=
+                - 20260513T160105Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -462,14 +462,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 15:32:58 GMT
+                - Wed, 13 May 2026 16:01:05 GMT
             X-Amz-Id-2:
-                - txg1efe1fb51b654f58b741-006a0499aa
+                - txg6ee31d36cdb94bb1b6e3-006a04a041
             X-Amz-Request-Id:
-                - txg1efe1fb51b654f58b741-006a0499aa
+                - txg6ee31d36cdb94bb1b6e3-006a04a041
         status: 200 OK
         code: 200
-        duration: 298.135083ms
+        duration: 23.094416ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -478,7 +478,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -487,7 +487,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d10628c6-fc57-4b1d-a0f5-4fda302ee1d1
+                - 51715fbe-bd0c-434d-8497-46f840341697
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -495,8 +495,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T153258Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260513T160105Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -504,25 +504,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 238
+        content_length: 433
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><ExpiredObjectDeleteMarker>true</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>expire delete markers</ID><Status>Enabled</Status></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>prefix/</Prefix></Filter><ID>to delete</ID><Status>Enabled</Status></Rule><Rule><Expiration><ExpiredObjectDeleteMarker>true</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>expire delete markers</ID><Status>Enabled</Status></Rule></Configuration>
         headers:
             Content-Length:
-                - "238"
+                - "433"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 15:32:59 GMT
+                - Wed, 13 May 2026 16:01:05 GMT
             X-Amz-Id-2:
-                - txgd6e729390c4f4d9aabeb-006a0499ab
+                - txg39a650d9bbd34749bda4-006a04a041
             X-Amz-Request-Id:
-                - txgd6e729390c4f4d9aabeb-006a0499ab
+                - txg39a650d9bbd34749bda4-006a04a041
         status: 200 OK
         code: 200
-        duration: 72.234167ms
+        duration: 62.703875ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -531,7 +531,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -540,7 +540,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e63d1868-3a04-4c90-be87-2454d66c0a70
+                - 743865b4-675c-41d1-9bce-e7fce27a2d0f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -548,8 +548,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T153259Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud/
+                - 20260513T160105Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -564,16 +564,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 15:32:59 GMT
+                - Wed, 13 May 2026 16:01:05 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txg7c0b4240e1c94e649b15-006a0499ab
+                - txg09d509f89bf64bdea980-006a04a041
             X-Amz-Request-Id:
-                - txg7c0b4240e1c94e649b15-006a0499ab
+                - txg09d509f89bf64bdea980-006a04a041
         status: 200 OK
         code: 200
-        duration: 296.053375ms
+        duration: 148.703ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -582,7 +582,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -591,7 +591,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 3b827017-a7be-4f79-929b-cc3806a8369a
+                - da92deea-2d7f-4196-8278-7fc6dbf1a539
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -599,8 +599,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T153259Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260513T160105Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -608,25 +608,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 238
+        content_length: 433
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><ExpiredObjectDeleteMarker>true</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>expire delete markers</ID><Status>Enabled</Status></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>prefix/</Prefix></Filter><ID>to delete</ID><Status>Enabled</Status></Rule><Rule><Expiration><ExpiredObjectDeleteMarker>true</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>expire delete markers</ID><Status>Enabled</Status></Rule></Configuration>
         headers:
             Content-Length:
-                - "238"
+                - "433"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 15:32:59 GMT
+                - Wed, 13 May 2026 16:01:05 GMT
             X-Amz-Id-2:
-                - txgea6396b59a0141ae8dcd-006a0499ab
+                - txg5c3d0704a1114f6ab44a-006a04a041
             X-Amz-Request-Id:
-                - txgea6396b59a0141ae8dcd-006a0499ab
+                - txg5c3d0704a1114f6ab44a-006a04a041
         status: 200 OK
         code: 200
-        duration: 23.425834ms
+        duration: 50.845291ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -635,7 +635,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -644,7 +644,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7d8c3cdc-f8cf-46b9-8499-f5bb6d6b80b8
+                - 01f8c0df-b6bc-4a63-9d4b-66d814f4db38
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -652,8 +652,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T153300Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud/?acl=
+                - 20260513T160105Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -672,14 +672,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 15:33:00 GMT
+                - Wed, 13 May 2026 16:01:05 GMT
             X-Amz-Id-2:
-                - txg3b01328401c3416bb686-006a0499ac
+                - txgb00d27b48af2461585a5-006a04a041
             X-Amz-Request-Id:
-                - txg3b01328401c3416bb686-006a0499ac
+                - txgb00d27b48af2461585a5-006a04a041
         status: 200 OK
         code: 200
-        duration: 211.570667ms
+        duration: 70.276584ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -688,7 +688,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -697,7 +697,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 25ae0b35-6c69-4b01-b516-adc29b214971
+                - 7b2615a5-46c6-4ee2-a95c-49ca839d0bc3
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -705,8 +705,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T153300Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260513T160105Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -716,21 +716,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgf88dc3c1cb8b481199a0-006a0499ac</RequestId><HostId>txgf88dc3c1cb8b481199a0-006a0499ac</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg4c27343df2624df4b10b-006a04a041</RequestId><HostId>txg4c27343df2624df4b10b-006a04a041</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 15:33:00 GMT
+                - Wed, 13 May 2026 16:01:05 GMT
             X-Amz-Id-2:
-                - txgf88dc3c1cb8b481199a0-006a0499ac
+                - txg4c27343df2624df4b10b-006a04a041
             X-Amz-Request-Id:
-                - txgf88dc3c1cb8b481199a0-006a0499ac
+                - txg4c27343df2624df4b10b-006a04a041
         status: 404 Not Found
         code: 404
-        duration: 241.590542ms
+        duration: 62.271333ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -739,7 +739,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -748,7 +748,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - a5b79608-cb34-445a-8b2c-2447a40b4764
+                - de8c60af-4e6d-4fc2-b3c9-063d99609ccc
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -756,8 +756,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T153300Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud/
+                - 20260513T160105Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -769,21 +769,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 15:33:00 GMT
+                - Wed, 13 May 2026 16:01:05 GMT
             X-Amz-Id-2:
-                - txg4d6df495347b45a6be92-006a0499ac
+                - txg9ef43289a1f54604bc0e-006a04a041
             X-Amz-Request-Id:
-                - txg4d6df495347b45a6be92-006a0499ac
+                - txg9ef43289a1f54604bc0e-006a04a041
         status: 200 OK
         code: 200
-        duration: 244.314709ms
+        duration: 151.942916ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -792,7 +792,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -801,7 +801,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 30a6312f-a76a-40fd-8bd6-a756fab8ecb8
+                - ecdf29e7-4d14-46f6-8a29-8ca0fa5b91fc
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -809,8 +809,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T153300Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud/?tagging=
+                - 20260513T160105Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -820,21 +820,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg1f282bd683f34f45a477-006a0499ac</RequestId><HostId>txg1f282bd683f34f45a477-006a0499ac</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgc805c76a9d4e46989d44-006a04a042</RequestId><HostId>txgc805c76a9d4e46989d44-006a04a042</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 15:33:00 GMT
+                - Wed, 13 May 2026 16:01:06 GMT
             X-Amz-Id-2:
-                - txg1f282bd683f34f45a477-006a0499ac
+                - txgc805c76a9d4e46989d44-006a04a042
             X-Amz-Request-Id:
-                - txg1f282bd683f34f45a477-006a0499ac
+                - txgc805c76a9d4e46989d44-006a04a042
         status: 404 Not Found
         code: 404
-        duration: 235.939042ms
+        duration: 54.986209ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -843,7 +843,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -852,7 +852,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - fc76786f-13c3-44d7-8020-ade899645aca
+                - c0b414c2-36ab-4955-8d14-15c0351df9f5
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -860,8 +860,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T153300Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud/?cors=
+                - 20260513T160106Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -871,21 +871,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg9f5f247055644348aa14-006a0499ac</RequestId><HostId>txg9f5f247055644348aa14-006a0499ac</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg9017ef0b66924464b64d-006a04a042</RequestId><HostId>txg9017ef0b66924464b64d-006a04a042</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 15:33:00 GMT
+                - Wed, 13 May 2026 16:01:06 GMT
             X-Amz-Id-2:
-                - txg9f5f247055644348aa14-006a0499ac
+                - txg9017ef0b66924464b64d-006a04a042
             X-Amz-Request-Id:
-                - txg9f5f247055644348aa14-006a0499ac
+                - txg9017ef0b66924464b64d-006a04a042
         status: 404 Not Found
         code: 404
-        duration: 96.513667ms
+        duration: 66.268584ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -894,7 +894,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -903,7 +903,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 59b1125d-6ef4-4763-9850-90df7b25a86b
+                - 4d9acfe4-eb2b-4dfd-bb57-b1b2ed05539b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -911,8 +911,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T153300Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud/?versioning=
+                - 20260513T160106Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -931,14 +931,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 15:33:01 GMT
+                - Wed, 13 May 2026 16:01:06 GMT
             X-Amz-Id-2:
-                - txg1950ea1156a345f0aa11-006a0499ad
+                - txg444001b0cce9463980ea-006a04a042
             X-Amz-Request-Id:
-                - txg1950ea1156a345f0aa11-006a0499ad
+                - txg444001b0cce9463980ea-006a04a042
         status: 200 OK
         code: 200
-        duration: 400.492458ms
+        duration: 71.043709ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -947,7 +947,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -956,7 +956,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 05637caf-e72e-437d-9729-93b723474ab0
+                - 176a1693-98e7-4e95-bbd7-1459c4811cfe
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -964,8 +964,791 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T153301Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260513T160106Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?lifecycle=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 433
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <Configuration><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>prefix/</Prefix></Filter><ID>to delete</ID><Status>Enabled</Status></Rule><Rule><Expiration><ExpiredObjectDeleteMarker>true</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>expire delete markers</ID><Status>Enabled</Status></Rule></Configuration>
+        headers:
+            Content-Length:
+                - "433"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Wed, 13 May 2026 16:01:06 GMT
+            X-Amz-Id-2:
+                - txgb4387584cf344ef48356-006a04a042
+            X-Amz-Request-Id:
+                - txgb4387584cf344ef48356-006a04a042
+        status: 200 OK
+        code: 200
+        duration: 37.898458ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - c98ad764-7bba-444e-bcab-864cb0a7340c
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260513T160106Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?acl=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 698
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+        headers:
+            Content-Length:
+                - "698"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Wed, 13 May 2026 16:01:06 GMT
+            X-Amz-Id-2:
+                - txg4e68debdc480457e82af-006a04a042
+            X-Amz-Request-Id:
+                - txg4e68debdc480457e82af-006a04a042
+        status: 200 OK
+        code: 200
+        duration: 64.875625ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - be5a7823-8be5-4f69-98e3-99185e58edc0
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260513T160106Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?object-lock=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 330
+        uncompressed: false
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txge508aeacbaae4d45b5a2-006a04a042</RequestId><HostId>txge508aeacbaae4d45b5a2-006a04a042</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618</Resource></Error>
+        headers:
+            Content-Length:
+                - "330"
+            Content-Type:
+                - application/xml
+            Date:
+                - Wed, 13 May 2026 16:01:06 GMT
+            X-Amz-Id-2:
+                - txge508aeacbaae4d45b5a2-006a04a042
+            X-Amz-Request-Id:
+                - txge508aeacbaae4d45b5a2-006a04a042
+        status: 404 Not Found
+        code: 404
+        duration: 96.277416ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 9ec8d5ac-20fe-40cc-967e-50e92523c98f
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260513T160106Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 287
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+        headers:
+            Content-Length:
+                - "287"
+            Content-Type:
+                - application/xml
+            Date:
+                - Wed, 13 May 2026 16:01:06 GMT
+            X-Amz-Id-2:
+                - txg6ee57b77f62c48b8bb0e-006a04a042
+            X-Amz-Request-Id:
+                - txg6ee57b77f62c48b8bb0e-006a04a042
+        status: 200 OK
+        code: 200
+        duration: 38.449084ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - e1fbac7b-9172-46ea-8588-9c00e32a11d1
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260513T160106Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?tagging=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 361
+        uncompressed: false
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg28d1014ffb394345baa9-006a04a042</RequestId><HostId>txg28d1014ffb394345baa9-006a04a042</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618</BucketName></Error>
+        headers:
+            Content-Length:
+                - "361"
+            Content-Type:
+                - application/xml
+            Date:
+                - Wed, 13 May 2026 16:01:06 GMT
+            X-Amz-Id-2:
+                - txg28d1014ffb394345baa9-006a04a042
+            X-Amz-Request-Id:
+                - txg28d1014ffb394345baa9-006a04a042
+        status: 404 Not Found
+        code: 404
+        duration: 22.870958ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 7944839c-16e6-4187-aa38-0293ac63224f
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260513T160106Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?cors=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 298
+        uncompressed: false
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg2f70a80044e543fcbcfb-006a04a042</RequestId><HostId>txg2f70a80044e543fcbcfb-006a04a042</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618</Resource></Error>
+        headers:
+            Content-Length:
+                - "298"
+            Content-Type:
+                - application/xml
+            Date:
+                - Wed, 13 May 2026 16:01:06 GMT
+            X-Amz-Id-2:
+                - txg2f70a80044e543fcbcfb-006a04a042
+            X-Amz-Request-Id:
+                - txg2f70a80044e543fcbcfb-006a04a042
+        status: 404 Not Found
+        code: 404
+        duration: 62.019875ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 354b1480-21d8-458b-b299-93d54b961ab4
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260513T160106Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?versioning=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 107
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <VersioningConfiguration><Status></Status></VersioningConfiguration>
+        headers:
+            Content-Length:
+                - "107"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Wed, 13 May 2026 16:01:06 GMT
+            X-Amz-Id-2:
+                - txgf8a3fad41edc4f659d91-006a04a042
+            X-Amz-Request-Id:
+                - txgf8a3fad41edc4f659d91-006a04a042
+        status: 200 OK
+        code: 200
+        duration: 52.124125ms
+    - id: 25
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 88abcf3b-d223-4683-9d6d-192aee8ae0dc
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260513T160106Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?lifecycle=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 433
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <Configuration><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>prefix/</Prefix></Filter><ID>to delete</ID><Status>Enabled</Status></Rule><Rule><Expiration><ExpiredObjectDeleteMarker>true</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>expire delete markers</ID><Status>Enabled</Status></Rule></Configuration>
+        headers:
+            Content-Length:
+                - "433"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Wed, 13 May 2026 16:01:06 GMT
+            X-Amz-Id-2:
+                - txg07a95a22c84e4bc9874d-006a04a042
+            X-Amz-Request-Id:
+                - txg07a95a22c84e4bc9874d-006a04a042
+        status: 200 OK
+        code: 200
+        duration: 75.145292ms
+    - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 265
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><ExpiredObjectDeleteMarker>true</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>expire delete markers</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - ee2dcc31-988a-4ac0-8fc1-168f28e7622c
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            Content-Type:
+                - application/xml
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,Z,e
+            X-Amz-Checksum-Crc32:
+                - NdscUw==
+            X-Amz-Content-Sha256:
+                - fd28d6105facd58e0708118f811178b230c443b5cac5e2f9bb6714a806f344e0
+            X-Amz-Date:
+                - 20260513T160107Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?lifecycle=
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Length:
+                - "0"
+            Date:
+                - Wed, 13 May 2026 16:01:07 GMT
+            X-Amz-Id-2:
+                - txgc5c68da5f2a64feb87a3-006a04a043
+            X-Amz-Request-Id:
+                - txgc5c68da5f2a64feb87a3-006a04a043
+        status: 200 OK
+        code: 200
+        duration: 144.387792ms
+    - id: 27
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - bfd56644-2021-43c8-9429-18f699cef2f3
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260513T160107Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?acl=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 698
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+        headers:
+            Content-Length:
+                - "698"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Wed, 13 May 2026 16:01:07 GMT
+            X-Amz-Id-2:
+                - txg936a3afa5c234ea28dfb-006a04a043
+            X-Amz-Request-Id:
+                - txg936a3afa5c234ea28dfb-006a04a043
+        status: 200 OK
+        code: 200
+        duration: 39.887667ms
+    - id: 28
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 9308c72b-8a6b-45b2-9811-9c537d6ee090
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260513T160107Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?object-lock=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 330
+        uncompressed: false
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg0679b8b4f01c4c2a9307-006a04a043</RequestId><HostId>txg0679b8b4f01c4c2a9307-006a04a043</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618</Resource></Error>
+        headers:
+            Content-Length:
+                - "330"
+            Content-Type:
+                - application/xml
+            Date:
+                - Wed, 13 May 2026 16:01:07 GMT
+            X-Amz-Id-2:
+                - txg0679b8b4f01c4c2a9307-006a04a043
+            X-Amz-Request-Id:
+                - txg0679b8b4f01c4c2a9307-006a04a043
+        status: 404 Not Found
+        code: 404
+        duration: 53.758792ms
+    - id: 29
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 5fc60821-135e-4a7c-891b-1b50e7728aa7
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260513T160107Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 287
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+        headers:
+            Content-Length:
+                - "287"
+            Content-Type:
+                - application/xml
+            Date:
+                - Wed, 13 May 2026 16:01:07 GMT
+            X-Amz-Id-2:
+                - txgdd212351099644139c35-006a04a043
+            X-Amz-Request-Id:
+                - txgdd212351099644139c35-006a04a043
+        status: 200 OK
+        code: 200
+        duration: 61.386916ms
+    - id: 30
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 39c27822-4946-4d96-9571-d8afd40251f2
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260513T160107Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?tagging=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 361
+        uncompressed: false
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg285eda49f5cb494f833b-006a04a043</RequestId><HostId>txg285eda49f5cb494f833b-006a04a043</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618</BucketName></Error>
+        headers:
+            Content-Length:
+                - "361"
+            Content-Type:
+                - application/xml
+            Date:
+                - Wed, 13 May 2026 16:01:07 GMT
+            X-Amz-Id-2:
+                - txg285eda49f5cb494f833b-006a04a043
+            X-Amz-Request-Id:
+                - txg285eda49f5cb494f833b-006a04a043
+        status: 404 Not Found
+        code: 404
+        duration: 22.412458ms
+    - id: 31
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - fe46586a-cf29-4d07-9d0a-b3a0e22b91dd
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260513T160107Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?cors=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 298
+        uncompressed: false
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg1533250aa3ed4c9db69f-006a04a043</RequestId><HostId>txg1533250aa3ed4c9db69f-006a04a043</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618</Resource></Error>
+        headers:
+            Content-Length:
+                - "298"
+            Content-Type:
+                - application/xml
+            Date:
+                - Wed, 13 May 2026 16:01:07 GMT
+            X-Amz-Id-2:
+                - txg1533250aa3ed4c9db69f-006a04a043
+            X-Amz-Request-Id:
+                - txg1533250aa3ed4c9db69f-006a04a043
+        status: 404 Not Found
+        code: 404
+        duration: 22.456375ms
+    - id: 32
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - cd074dad-e11f-46cf-bd1d-dc7741a50ad6
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260513T160107Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?versioning=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 107
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <VersioningConfiguration><Status></Status></VersioningConfiguration>
+        headers:
+            Content-Length:
+                - "107"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Wed, 13 May 2026 16:01:07 GMT
+            X-Amz-Id-2:
+                - txg60f7b3822a4a4fbaa49a-006a04a043
+            X-Amz-Request-Id:
+                - txg60f7b3822a4a4fbaa49a-006a04a043
+        status: 200 OK
+        code: 200
+        duration: 145.784416ms
+    - id: 33
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 9c2f12e5-5eed-47f7-8a10-99471cbba8ae
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260513T160107Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -984,15 +1767,15 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 15:33:01 GMT
+                - Wed, 13 May 2026 16:01:07 GMT
             X-Amz-Id-2:
-                - txge87191201bc6438885d0-006a0499ad
+                - txgd42412a2a0eb4d9396e7-006a04a043
             X-Amz-Request-Id:
-                - txge87191201bc6438885d0-006a0499ad
+                - txgd42412a2a0eb4d9396e7-006a04a043
         status: 200 OK
         code: 200
-        duration: 64.295417ms
-    - id: 19
+        duration: 92.883666ms
+    - id: 34
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1000,7 +1783,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1009,7 +1792,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c91492ac-5a77-4ecc-9c4f-3728c4610072
+                - 5d924599-7078-4d1f-ab1d-d7d5e60535a6
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1017,8 +1800,477 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T153301Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud/
+                - 20260513T160107Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/
+        method: HEAD
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Type:
+                - application/xml
+            Date:
+                - Wed, 13 May 2026 16:01:07 GMT
+            X-Amz-Bucket-Region:
+                - nl-ams
+            X-Amz-Id-2:
+                - txg4642fb3e296a4c179262-006a04a043
+            X-Amz-Request-Id:
+                - txg4642fb3e296a4c179262-006a04a043
+        status: 200 OK
+        code: 200
+        duration: 34.583791ms
+    - id: 35
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 4bc662e5-5bac-478f-a3be-b797fe7e6f30
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260513T160107Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?lifecycle=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 238
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <Configuration><Rule><Expiration><ExpiredObjectDeleteMarker>true</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>expire delete markers</ID><Status>Enabled</Status></Rule></Configuration>
+        headers:
+            Content-Length:
+                - "238"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Wed, 13 May 2026 16:01:07 GMT
+            X-Amz-Id-2:
+                - txg39dac2ec18bf418195b2-006a04a043
+            X-Amz-Request-Id:
+                - txg39dac2ec18bf418195b2-006a04a043
+        status: 200 OK
+        code: 200
+        duration: 61.314041ms
+    - id: 36
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 4d40bd18-4fd2-461e-9ead-8c03ec6c3fed
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260513T160108Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?acl=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 698
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+        headers:
+            Content-Length:
+                - "698"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Wed, 13 May 2026 16:01:08 GMT
+            X-Amz-Id-2:
+                - txg4d9488a2bbed472bac96-006a04a044
+            X-Amz-Request-Id:
+                - txg4d9488a2bbed472bac96-006a04a044
+        status: 200 OK
+        code: 200
+        duration: 38.630166ms
+    - id: 37
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - b529986f-158c-4688-a3be-e67d3c526f29
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260513T160108Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?object-lock=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 330
+        uncompressed: false
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg66f4932fb8f047b8ae05-006a04a044</RequestId><HostId>txg66f4932fb8f047b8ae05-006a04a044</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618</Resource></Error>
+        headers:
+            Content-Length:
+                - "330"
+            Content-Type:
+                - application/xml
+            Date:
+                - Wed, 13 May 2026 16:01:08 GMT
+            X-Amz-Id-2:
+                - txg66f4932fb8f047b8ae05-006a04a044
+            X-Amz-Request-Id:
+                - txg66f4932fb8f047b8ae05-006a04a044
+        status: 404 Not Found
+        code: 404
+        duration: 73.978083ms
+    - id: 38
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 3608bd40-fecd-4831-96cf-58880ef043c8
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260513T160108Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 287
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+        headers:
+            Content-Length:
+                - "287"
+            Content-Type:
+                - application/xml
+            Date:
+                - Wed, 13 May 2026 16:01:08 GMT
+            X-Amz-Id-2:
+                - txg94b8142b44c14b5eb8d7-006a04a044
+            X-Amz-Request-Id:
+                - txg94b8142b44c14b5eb8d7-006a04a044
+        status: 200 OK
+        code: 200
+        duration: 23.36675ms
+    - id: 39
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 4da3b0b3-839c-4dc1-ab28-628d9eee489a
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260513T160108Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?tagging=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 361
+        uncompressed: false
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg65d72744f8bd4e74a0de-006a04a044</RequestId><HostId>txg65d72744f8bd4e74a0de-006a04a044</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618</BucketName></Error>
+        headers:
+            Content-Length:
+                - "361"
+            Content-Type:
+                - application/xml
+            Date:
+                - Wed, 13 May 2026 16:01:08 GMT
+            X-Amz-Id-2:
+                - txg65d72744f8bd4e74a0de-006a04a044
+            X-Amz-Request-Id:
+                - txg65d72744f8bd4e74a0de-006a04a044
+        status: 404 Not Found
+        code: 404
+        duration: 54.407666ms
+    - id: 40
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - f619a5d5-e9b1-41c1-95ec-e1d781bae6b7
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260513T160108Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?cors=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 298
+        uncompressed: false
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg0bf8f041556d4737b84c-006a04a044</RequestId><HostId>txg0bf8f041556d4737b84c-006a04a044</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618</Resource></Error>
+        headers:
+            Content-Length:
+                - "298"
+            Content-Type:
+                - application/xml
+            Date:
+                - Wed, 13 May 2026 16:01:08 GMT
+            X-Amz-Id-2:
+                - txg0bf8f041556d4737b84c-006a04a044
+            X-Amz-Request-Id:
+                - txg0bf8f041556d4737b84c-006a04a044
+        status: 404 Not Found
+        code: 404
+        duration: 53.690333ms
+    - id: 41
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 0fd53d38-28c8-463e-ae07-f3ee87d59b0f
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260513T160108Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?versioning=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 107
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <VersioningConfiguration><Status></Status></VersioningConfiguration>
+        headers:
+            Content-Length:
+                - "107"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Wed, 13 May 2026 16:01:08 GMT
+            X-Amz-Id-2:
+                - txg568a75ac90334cd691b7-006a04a044
+            X-Amz-Request-Id:
+                - txg568a75ac90334cd691b7-006a04a044
+        status: 200 OK
+        code: 200
+        duration: 23.277958ms
+    - id: 42
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - e17fe07e-2d8e-4708-9e07-53b20ced74e2
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260513T160108Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?lifecycle=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 238
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <Configuration><Rule><Expiration><ExpiredObjectDeleteMarker>true</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>expire delete markers</ID><Status>Enabled</Status></Rule></Configuration>
+        headers:
+            Content-Length:
+                - "238"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Wed, 13 May 2026 16:01:08 GMT
+            X-Amz-Id-2:
+                - txg94e3503cf07a4ee7b318-006a04a044
+            X-Amz-Request-Id:
+                - txg94e3503cf07a4ee7b318-006a04a044
+        status: 200 OK
+        code: 200
+        duration: 55.406792ms
+    - id: 43
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - fb9031c6-be9b-40e3-aa1a-48fe1ceb4e5e
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260513T160108Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1031,11 +2283,11 @@ interactions:
         body: ""
         headers:
             Date:
-                - Wed, 13 May 2026 15:33:01 GMT
+                - Wed, 13 May 2026 16:01:08 GMT
             X-Amz-Id-2:
-                - txgf83674c43a3b4066a5fc-006a0499ad
+                - txg45ed2f23152a4b37961d-006a04a044
             X-Amz-Request-Id:
-                - txgf83674c43a3b4066a5fc-006a0499ad
+                - txg45ed2f23152a4b37961d-006a04a044
         status: 204 No Content
         code: 204
-        duration: 548.86275ms
+        duration: 210.741ms

--- a/internal/services/object/testdata/object-bucket-lifecycle-remove-rule.cassette.yaml
+++ b/internal/services/object/testdata/object-bucket-lifecycle-remove-rule.cassette.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -18,7 +18,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 824dec4e-fd38-44c6-882f-bdcb6afbe2b2
+                - 0d28e553-e269-4883-821c-b66fdf46fec3
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -26,8 +26,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T160103Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/
+                - 20260518T103914Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/
         method: PUT
       response:
         proto: HTTP/2.0
@@ -42,16 +42,16 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Wed, 13 May 2026 16:01:04 GMT
+                - Mon, 18 May 2026 10:39:14 GMT
             Location:
-                - /tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618
+                - /tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505
             X-Amz-Id-2:
-                - txgd146c944b86f426a9e89-006a04a040
+                - txg1ce7650356414fbf8fe7-006a0aec52
             X-Amz-Request-Id:
-                - txgd146c944b86f426a9e89-006a04a040
+                - txg1ce7650356414fbf8fe7-006a0aec52
         status: 200 OK
         code: 200
-        duration: 556.340209ms
+        duration: 4.159323792s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -60,7 +60,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -69,7 +69,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9af7badf-d230-4f71-be53-33e8e500a313
+                - 34f0698e-5e9e-4f38-8683-eb76ee4d1e98
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -81,8 +81,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T160104Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T103918Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?acl=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -97,14 +97,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Wed, 13 May 2026 16:01:04 GMT
+                - Mon, 18 May 2026 10:39:18 GMT
             X-Amz-Id-2:
-                - txgc45cf0e40559477a90c5-006a04a040
+                - txg5b961224fd55410dbe7d-006a0aec56
             X-Amz-Request-Id:
-                - txgc45cf0e40559477a90c5-006a04a040
+                - txg5b961224fd55410dbe7d-006a0aec56
         status: 200 OK
         code: 200
-        duration: 183.361542ms
+        duration: 244.549958ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -113,7 +113,7 @@ interactions:
         content_length: 460
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>prefix/</Prefix></Filter><ID>to delete</ID><Status>Enabled</Status></Rule><Rule><Expiration><ExpiredObjectDeleteMarker>true</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>expire delete markers</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
@@ -122,7 +122,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 3669c9a3-22f2-41fa-a99a-e874afbc3c1a
+                - 31d8cddd-9033-420b-842f-6f3f13ef5b1a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
@@ -134,8 +134,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - be82f5350a9f62e9880e1d0bfb67fee8cb072fff45d9d7171711c16a6b0dbbb2
             X-Amz-Date:
-                - 20260513T160104Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T103918Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -150,14 +150,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Wed, 13 May 2026 16:01:04 GMT
+                - Mon, 18 May 2026 10:39:18 GMT
             X-Amz-Id-2:
-                - txg928927fa84304c71a204-006a04a040
+                - txg8f44a8fea0b94a72ab5b-006a0aec56
             X-Amz-Request-Id:
-                - txg928927fa84304c71a204-006a04a040
+                - txg8f44a8fea0b94a72ab5b-006a0aec56
         status: 200 OK
         code: 200
-        duration: 70.780417ms
+        duration: 182.690917ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -166,7 +166,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -175,7 +175,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 016b1be5-fbc5-4350-9df2-77d6d8169713
+                - 45ff1dde-085a-45d9-9eea-25258d621461
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -183,8 +183,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T160104Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T103918Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -203,14 +203,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 16:01:04 GMT
+                - Mon, 18 May 2026 10:39:18 GMT
             X-Amz-Id-2:
-                - txg2a99a7cf706648cc8cd6-006a04a040
+                - txg1b154aee968745b79a1f-006a0aec56
             X-Amz-Request-Id:
-                - txg2a99a7cf706648cc8cd6-006a04a040
+                - txg1b154aee968745b79a1f-006a0aec56
         status: 200 OK
         code: 200
-        duration: 57.00325ms
+        duration: 182.750917ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -219,7 +219,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -228,7 +228,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - acad42f8-4253-4911-a303-e916c5a99685
+                - b90eae83-f885-4e74-be26-813e3fd16c54
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -236,8 +236,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T160104Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T103918Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -247,21 +247,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg059d73a4a0854041ae0e-006a04a040</RequestId><HostId>txg059d73a4a0854041ae0e-006a04a040</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg0d5272160bd24ea6a9a1-006a0aec57</RequestId><HostId>txg0d5272160bd24ea6a9a1-006a0aec57</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 16:01:04 GMT
+                - Mon, 18 May 2026 10:39:19 GMT
             X-Amz-Id-2:
-                - txg059d73a4a0854041ae0e-006a04a040
+                - txg0d5272160bd24ea6a9a1-006a0aec57
             X-Amz-Request-Id:
-                - txg059d73a4a0854041ae0e-006a04a040
+                - txg0d5272160bd24ea6a9a1-006a0aec57
         status: 404 Not Found
         code: 404
-        duration: 61.710583ms
+        duration: 122.402542ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -270,7 +270,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -279,7 +279,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 701f172e-defd-44d8-94eb-9f78950b8370
+                - 0c38e138-2f19-4a54-9170-611d90bcedae
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -287,8 +287,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T160104Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/
+                - 20260518T103919Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -300,21 +300,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 16:01:04 GMT
+                - Mon, 18 May 2026 10:39:19 GMT
             X-Amz-Id-2:
-                - txg8a8eb54cd46242de9942-006a04a040
+                - txg4224f89b82f043648de3-006a0aec57
             X-Amz-Request-Id:
-                - txg8a8eb54cd46242de9942-006a04a040
+                - txg4224f89b82f043648de3-006a0aec57
         status: 200 OK
         code: 200
-        duration: 150.122084ms
+        duration: 121.805875ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -323,7 +323,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -332,7 +332,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 2dfb9d0b-991f-4381-921c-17467af5130c
+                - 322c2e95-396e-45fc-a674-93e2e1048bc7
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -340,8 +340,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T160104Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T103919Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -351,21 +351,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg1fac07eb079e4e40b783-006a04a041</RequestId><HostId>txg1fac07eb079e4e40b783-006a04a041</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg7bfee7fa3c8e49a994db-006a0aec57</RequestId><HostId>txg7bfee7fa3c8e49a994db-006a0aec57</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 16:01:05 GMT
+                - Mon, 18 May 2026 10:39:19 GMT
             X-Amz-Id-2:
-                - txg1fac07eb079e4e40b783-006a04a041
+                - txg7bfee7fa3c8e49a994db-006a0aec57
             X-Amz-Request-Id:
-                - txg1fac07eb079e4e40b783-006a04a041
+                - txg7bfee7fa3c8e49a994db-006a0aec57
         status: 404 Not Found
         code: 404
-        duration: 63.058375ms
+        duration: 68.117083ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -374,7 +374,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -383,7 +383,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 29e86611-1d43-4f04-a914-a90df661bbd1
+                - 30271d57-19fd-4dd9-9733-ce9a2ab3f116
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -391,8 +391,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T160105Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T103919Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -402,21 +402,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg0118e366c00d4ae8b3f6-006a04a041</RequestId><HostId>txg0118e366c00d4ae8b3f6-006a04a041</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txga6bb8fa6ae7148b1a255-006a0aec57</RequestId><HostId>txga6bb8fa6ae7148b1a255-006a0aec57</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 16:01:05 GMT
+                - Mon, 18 May 2026 10:39:19 GMT
             X-Amz-Id-2:
-                - txg0118e366c00d4ae8b3f6-006a04a041
+                - txga6bb8fa6ae7148b1a255-006a0aec57
             X-Amz-Request-Id:
-                - txg0118e366c00d4ae8b3f6-006a04a041
+                - txga6bb8fa6ae7148b1a255-006a0aec57
         status: 404 Not Found
         code: 404
-        duration: 63.749125ms
+        duration: 416.791ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -425,7 +425,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -434,7 +434,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 60edeac4-47c8-4c0c-bbaf-feceed871418
+                - 8ab84e84-66c5-40f2-a914-ea026eefcb54
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -442,8 +442,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T160105Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T103919Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -462,14 +462,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 16:01:05 GMT
+                - Mon, 18 May 2026 10:39:19 GMT
             X-Amz-Id-2:
-                - txg6ee31d36cdb94bb1b6e3-006a04a041
+                - txg928406dca3f940a2beb4-006a0aec57
             X-Amz-Request-Id:
-                - txg6ee31d36cdb94bb1b6e3-006a04a041
+                - txg928406dca3f940a2beb4-006a0aec57
         status: 200 OK
         code: 200
-        duration: 23.094416ms
+        duration: 35.376167ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -478,7 +478,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -487,7 +487,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 51715fbe-bd0c-434d-8497-46f840341697
+                - 2bac31fd-62e8-4e10-8f18-d0a84edf1358
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -495,8 +495,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T160105Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T103919Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -515,14 +515,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 16:01:05 GMT
+                - Mon, 18 May 2026 10:39:19 GMT
             X-Amz-Id-2:
-                - txg39a650d9bbd34749bda4-006a04a041
+                - txg290be1056ca74d58aa15-006a0aec57
             X-Amz-Request-Id:
-                - txg39a650d9bbd34749bda4-006a04a041
+                - txg290be1056ca74d58aa15-006a0aec57
         status: 200 OK
         code: 200
-        duration: 62.703875ms
+        duration: 131.069375ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -531,7 +531,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -540,7 +540,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 743865b4-675c-41d1-9bce-e7fce27a2d0f
+                - 201319ce-e55d-48ed-b412-aa11b90094fd
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -548,8 +548,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T160105Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/
+                - 20260518T103920Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -564,16 +564,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 16:01:05 GMT
+                - Mon, 18 May 2026 10:39:20 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txg09d509f89bf64bdea980-006a04a041
+                - txged90f74b2fc84843bb3f-006a0aec58
             X-Amz-Request-Id:
-                - txg09d509f89bf64bdea980-006a04a041
+                - txged90f74b2fc84843bb3f-006a0aec58
         status: 200 OK
         code: 200
-        duration: 148.703ms
+        duration: 76.984917ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -582,7 +582,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -591,7 +591,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - da92deea-2d7f-4196-8278-7fc6dbf1a539
+                - 35478f6f-fd4f-4ac7-86dc-e353b1d4e7cb
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -599,8 +599,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T160105Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T103920Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -619,14 +619,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 16:01:05 GMT
+                - Mon, 18 May 2026 10:39:20 GMT
             X-Amz-Id-2:
-                - txg5c3d0704a1114f6ab44a-006a04a041
+                - txg466fb7d7b98c4d68a6d6-006a0aec58
             X-Amz-Request-Id:
-                - txg5c3d0704a1114f6ab44a-006a04a041
+                - txg466fb7d7b98c4d68a6d6-006a0aec58
         status: 200 OK
         code: 200
-        duration: 50.845291ms
+        duration: 76.815875ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -635,7 +635,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -644,7 +644,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 01f8c0df-b6bc-4a63-9d4b-66d814f4db38
+                - 1c031e87-7b90-400e-aa39-1b5b94b9b689
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -652,8 +652,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T160105Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T103920Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -672,14 +672,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 16:01:05 GMT
+                - Mon, 18 May 2026 10:39:20 GMT
             X-Amz-Id-2:
-                - txgb00d27b48af2461585a5-006a04a041
+                - txg5d0492891e3549f48b8b-006a0aec58
             X-Amz-Request-Id:
-                - txgb00d27b48af2461585a5-006a04a041
+                - txg5d0492891e3549f48b8b-006a0aec58
         status: 200 OK
         code: 200
-        duration: 70.276584ms
+        duration: 37.577625ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -688,7 +688,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -697,7 +697,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7b2615a5-46c6-4ee2-a95c-49ca839d0bc3
+                - cb8695e0-8fd5-440d-9415-19e10fe3eec6
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -705,8 +705,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T160105Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T103920Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -716,21 +716,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg4c27343df2624df4b10b-006a04a041</RequestId><HostId>txg4c27343df2624df4b10b-006a04a041</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgd1a70331b37d4f538eb6-006a0aec58</RequestId><HostId>txgd1a70331b37d4f538eb6-006a0aec58</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 16:01:05 GMT
+                - Mon, 18 May 2026 10:39:20 GMT
             X-Amz-Id-2:
-                - txg4c27343df2624df4b10b-006a04a041
+                - txgd1a70331b37d4f538eb6-006a0aec58
             X-Amz-Request-Id:
-                - txg4c27343df2624df4b10b-006a04a041
+                - txgd1a70331b37d4f538eb6-006a0aec58
         status: 404 Not Found
         code: 404
-        duration: 62.271333ms
+        duration: 67.804083ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -739,7 +739,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -748,7 +748,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - de8c60af-4e6d-4fc2-b3c9-063d99609ccc
+                - 74989da9-3c69-4a4c-a37a-a50db07d5a08
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -756,8 +756,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T160105Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/
+                - 20260518T103920Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -769,21 +769,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 16:01:05 GMT
+                - Mon, 18 May 2026 10:39:20 GMT
             X-Amz-Id-2:
-                - txg9ef43289a1f54604bc0e-006a04a041
+                - txg407776e9583a4e019a1f-006a0aec58
             X-Amz-Request-Id:
-                - txg9ef43289a1f54604bc0e-006a04a041
+                - txg407776e9583a4e019a1f-006a0aec58
         status: 200 OK
         code: 200
-        duration: 151.942916ms
+        duration: 62.625583ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -792,7 +792,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -801,7 +801,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ecdf29e7-4d14-46f6-8a29-8ca0fa5b91fc
+                - cadb29bc-fed2-4a81-92a0-1ae3c4f46fd5
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -809,8 +809,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T160105Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T103920Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -820,21 +820,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgc805c76a9d4e46989d44-006a04a042</RequestId><HostId>txgc805c76a9d4e46989d44-006a04a042</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgf5d4a56ac6db4eeea3f8-006a0aec58</RequestId><HostId>txgf5d4a56ac6db4eeea3f8-006a0aec58</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 16:01:06 GMT
+                - Mon, 18 May 2026 10:39:20 GMT
             X-Amz-Id-2:
-                - txgc805c76a9d4e46989d44-006a04a042
+                - txgf5d4a56ac6db4eeea3f8-006a0aec58
             X-Amz-Request-Id:
-                - txgc805c76a9d4e46989d44-006a04a042
+                - txgf5d4a56ac6db4eeea3f8-006a0aec58
         status: 404 Not Found
         code: 404
-        duration: 54.986209ms
+        duration: 139.437583ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -843,7 +843,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -852,7 +852,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c0b414c2-36ab-4955-8d14-15c0351df9f5
+                - e7ccc199-070d-4fd1-bb54-30a38539dd8b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -860,8 +860,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T160106Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T103920Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -871,21 +871,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg9017ef0b66924464b64d-006a04a042</RequestId><HostId>txg9017ef0b66924464b64d-006a04a042</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg56db86c481c14b19943f-006a0aec58</RequestId><HostId>txg56db86c481c14b19943f-006a0aec58</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 16:01:06 GMT
+                - Mon, 18 May 2026 10:39:20 GMT
             X-Amz-Id-2:
-                - txg9017ef0b66924464b64d-006a04a042
+                - txg56db86c481c14b19943f-006a0aec58
             X-Amz-Request-Id:
-                - txg9017ef0b66924464b64d-006a04a042
+                - txg56db86c481c14b19943f-006a0aec58
         status: 404 Not Found
         code: 404
-        duration: 66.268584ms
+        duration: 57.974333ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -894,7 +894,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -903,7 +903,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4d9acfe4-eb2b-4dfd-bb57-b1b2ed05539b
+                - 1cf517eb-7c6b-49cc-a272-ce1581757e3e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -911,8 +911,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T160106Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T103920Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -931,14 +931,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 16:01:06 GMT
+                - Mon, 18 May 2026 10:39:20 GMT
             X-Amz-Id-2:
-                - txg444001b0cce9463980ea-006a04a042
+                - txgcc90681030184ba4a28e-006a0aec58
             X-Amz-Request-Id:
-                - txg444001b0cce9463980ea-006a04a042
+                - txgcc90681030184ba4a28e-006a0aec58
         status: 200 OK
         code: 200
-        duration: 71.043709ms
+        duration: 1.374400208s
     - id: 18
       request:
         proto: HTTP/1.1
@@ -947,7 +947,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -956,7 +956,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 176a1693-98e7-4e95-bbd7-1459c4811cfe
+                - d676e8cd-61ce-493e-bbca-dea4ec197c79
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -964,8 +964,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T160106Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T103920Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -984,14 +984,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 16:01:06 GMT
+                - Mon, 18 May 2026 10:39:22 GMT
             X-Amz-Id-2:
-                - txgb4387584cf344ef48356-006a04a042
+                - txg40c9803c4e9342778305-006a0aec5a
             X-Amz-Request-Id:
-                - txgb4387584cf344ef48356-006a04a042
+                - txg40c9803c4e9342778305-006a0aec5a
         status: 200 OK
         code: 200
-        duration: 37.898458ms
+        duration: 216.03025ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -1000,7 +1000,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1009,7 +1009,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c98ad764-7bba-444e-bcab-864cb0a7340c
+                - 758afbed-67f4-484f-85f6-a1d2319f06fa
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1017,8 +1017,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T160106Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T103922Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1037,14 +1037,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 16:01:06 GMT
+                - Mon, 18 May 2026 10:39:22 GMT
             X-Amz-Id-2:
-                - txg4e68debdc480457e82af-006a04a042
+                - txg5a08eaf2d604483fa258-006a0aec5a
             X-Amz-Request-Id:
-                - txg4e68debdc480457e82af-006a04a042
+                - txg5a08eaf2d604483fa258-006a0aec5a
         status: 200 OK
         code: 200
-        duration: 64.875625ms
+        duration: 141.156875ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1053,7 +1053,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1062,7 +1062,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - be5a7823-8be5-4f69-98e3-99185e58edc0
+                - 518c984d-c44d-4861-a604-e379053ad2e4
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1070,8 +1070,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T160106Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T103922Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1081,21 +1081,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txge508aeacbaae4d45b5a2-006a04a042</RequestId><HostId>txge508aeacbaae4d45b5a2-006a04a042</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgb9756a7754254183893a-006a0aec5a</RequestId><HostId>txgb9756a7754254183893a-006a0aec5a</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 16:01:06 GMT
+                - Mon, 18 May 2026 10:39:22 GMT
             X-Amz-Id-2:
-                - txge508aeacbaae4d45b5a2-006a04a042
+                - txgb9756a7754254183893a-006a0aec5a
             X-Amz-Request-Id:
-                - txge508aeacbaae4d45b5a2-006a04a042
+                - txgb9756a7754254183893a-006a0aec5a
         status: 404 Not Found
         code: 404
-        duration: 96.277416ms
+        duration: 68.950459ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1104,7 +1104,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1113,7 +1113,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9ec8d5ac-20fe-40cc-967e-50e92523c98f
+                - 8e6e9142-ebdf-4f32-966a-5d9c381f3a2d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1121,8 +1121,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T160106Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/
+                - 20260518T103922Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -1134,21 +1134,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 16:01:06 GMT
+                - Mon, 18 May 2026 10:39:22 GMT
             X-Amz-Id-2:
-                - txg6ee57b77f62c48b8bb0e-006a04a042
+                - txg5fbd817516df46caa6f9-006a0aec5a
             X-Amz-Request-Id:
-                - txg6ee57b77f62c48b8bb0e-006a04a042
+                - txg5fbd817516df46caa6f9-006a0aec5a
         status: 200 OK
         code: 200
-        duration: 38.449084ms
+        duration: 176.76725ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1157,7 +1157,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1166,7 +1166,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e1fbac7b-9172-46ea-8588-9c00e32a11d1
+                - c118fae5-b161-4e5a-a868-a12531534f9d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1174,8 +1174,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T160106Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T103922Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1185,21 +1185,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg28d1014ffb394345baa9-006a04a042</RequestId><HostId>txg28d1014ffb394345baa9-006a04a042</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgc742c99f82dc47949aa8-006a0aec5b</RequestId><HostId>txgc742c99f82dc47949aa8-006a0aec5b</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 16:01:06 GMT
+                - Mon, 18 May 2026 10:39:23 GMT
             X-Amz-Id-2:
-                - txg28d1014ffb394345baa9-006a04a042
+                - txgc742c99f82dc47949aa8-006a0aec5b
             X-Amz-Request-Id:
-                - txg28d1014ffb394345baa9-006a04a042
+                - txgc742c99f82dc47949aa8-006a0aec5b
         status: 404 Not Found
         code: 404
-        duration: 22.870958ms
+        duration: 88.831375ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1208,7 +1208,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1217,7 +1217,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7944839c-16e6-4187-aa38-0293ac63224f
+                - ab8bcce1-da9f-4647-85a8-ef0187503bab
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1225,8 +1225,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T160106Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T103923Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1236,21 +1236,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg2f70a80044e543fcbcfb-006a04a042</RequestId><HostId>txg2f70a80044e543fcbcfb-006a04a042</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgcac60e9da2534fc8b32f-006a0aec5b</RequestId><HostId>txgcac60e9da2534fc8b32f-006a0aec5b</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 16:01:06 GMT
+                - Mon, 18 May 2026 10:39:23 GMT
             X-Amz-Id-2:
-                - txg2f70a80044e543fcbcfb-006a04a042
+                - txgcac60e9da2534fc8b32f-006a0aec5b
             X-Amz-Request-Id:
-                - txg2f70a80044e543fcbcfb-006a04a042
+                - txgcac60e9da2534fc8b32f-006a0aec5b
         status: 404 Not Found
         code: 404
-        duration: 62.019875ms
+        duration: 70.461667ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1259,7 +1259,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1268,7 +1268,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 354b1480-21d8-458b-b299-93d54b961ab4
+                - 549ea9ef-ce9e-4d76-bc0d-ddd93bfdcbc8
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1276,8 +1276,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T160106Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T103923Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1296,14 +1296,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 16:01:06 GMT
+                - Mon, 18 May 2026 10:39:23 GMT
             X-Amz-Id-2:
-                - txgf8a3fad41edc4f659d91-006a04a042
+                - txg51f6342a04c64bf6a29d-006a0aec5b
             X-Amz-Request-Id:
-                - txgf8a3fad41edc4f659d91-006a04a042
+                - txg51f6342a04c64bf6a29d-006a0aec5b
         status: 200 OK
         code: 200
-        duration: 52.124125ms
+        duration: 154.270209ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1312,7 +1312,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1321,7 +1321,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 88abcf3b-d223-4683-9d6d-192aee8ae0dc
+                - e1fff0ef-5c37-4d61-820e-104660f21591
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1329,8 +1329,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T160106Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T103923Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1349,14 +1349,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 16:01:06 GMT
+                - Mon, 18 May 2026 10:39:23 GMT
             X-Amz-Id-2:
-                - txg07a95a22c84e4bc9874d-006a04a042
+                - txgdca2630371de48a6b9fe-006a0aec5b
             X-Amz-Request-Id:
-                - txg07a95a22c84e4bc9874d-006a04a042
+                - txgdca2630371de48a6b9fe-006a0aec5b
         status: 200 OK
         code: 200
-        duration: 75.145292ms
+        duration: 57.502417ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1365,7 +1365,7 @@ interactions:
         content_length: 265
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><ExpiredObjectDeleteMarker>true</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>expire delete markers</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
@@ -1374,7 +1374,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ee2dcc31-988a-4ac0-8fc1-168f28e7622c
+                - ce095ff3-3962-4419-87db-25b2f4073fef
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
@@ -1386,8 +1386,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - fd28d6105facd58e0708118f811178b230c443b5cac5e2f9bb6714a806f344e0
             X-Amz-Date:
-                - 20260513T160107Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T103923Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -1402,14 +1402,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Wed, 13 May 2026 16:01:07 GMT
+                - Mon, 18 May 2026 10:39:23 GMT
             X-Amz-Id-2:
-                - txgc5c68da5f2a64feb87a3-006a04a043
+                - txga4a4b96a04734d5fb851-006a0aec5b
             X-Amz-Request-Id:
-                - txgc5c68da5f2a64feb87a3-006a04a043
+                - txga4a4b96a04734d5fb851-006a0aec5b
         status: 200 OK
         code: 200
-        duration: 144.387792ms
+        duration: 334.699459ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1418,7 +1418,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1427,7 +1427,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - bfd56644-2021-43c8-9429-18f699cef2f3
+                - 8af7f929-6763-4b24-9622-c6f68e051f04
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1435,8 +1435,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T160107Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T103923Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1455,14 +1455,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 16:01:07 GMT
+                - Mon, 18 May 2026 10:39:23 GMT
             X-Amz-Id-2:
-                - txg936a3afa5c234ea28dfb-006a04a043
+                - txg0fad32e2b41b4a119d29-006a0aec5b
             X-Amz-Request-Id:
-                - txg936a3afa5c234ea28dfb-006a04a043
+                - txg0fad32e2b41b4a119d29-006a0aec5b
         status: 200 OK
         code: 200
-        duration: 39.887667ms
+        duration: 167.1795ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1471,7 +1471,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1480,7 +1480,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9308c72b-8a6b-45b2-9811-9c537d6ee090
+                - 3673c7fb-b995-41c9-b0b4-b965b775f047
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1488,8 +1488,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T160107Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T103923Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1499,21 +1499,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg0679b8b4f01c4c2a9307-006a04a043</RequestId><HostId>txg0679b8b4f01c4c2a9307-006a04a043</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg3205402f167343d78576-006a0aec5c</RequestId><HostId>txg3205402f167343d78576-006a0aec5c</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 16:01:07 GMT
+                - Mon, 18 May 2026 10:39:24 GMT
             X-Amz-Id-2:
-                - txg0679b8b4f01c4c2a9307-006a04a043
+                - txg3205402f167343d78576-006a0aec5c
             X-Amz-Request-Id:
-                - txg0679b8b4f01c4c2a9307-006a04a043
+                - txg3205402f167343d78576-006a0aec5c
         status: 404 Not Found
         code: 404
-        duration: 53.758792ms
+        duration: 117.834709ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1522,7 +1522,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1531,7 +1531,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5fc60821-135e-4a7c-891b-1b50e7728aa7
+                - 435c077a-5a80-472a-a3ff-4ff5c5743b67
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1539,8 +1539,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T160107Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/
+                - 20260518T103924Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -1552,21 +1552,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 16:01:07 GMT
+                - Mon, 18 May 2026 10:39:24 GMT
             X-Amz-Id-2:
-                - txgdd212351099644139c35-006a04a043
+                - txg159a617f8b014b9cb51b-006a0aec5c
             X-Amz-Request-Id:
-                - txgdd212351099644139c35-006a04a043
+                - txg159a617f8b014b9cb51b-006a0aec5c
         status: 200 OK
         code: 200
-        duration: 61.386916ms
+        duration: 158.418ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1575,7 +1575,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1584,7 +1584,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 39c27822-4946-4d96-9571-d8afd40251f2
+                - 5d381247-6918-4d06-8017-3b5b5e8d0e7a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1592,8 +1592,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T160107Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T103924Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1603,21 +1603,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg285eda49f5cb494f833b-006a04a043</RequestId><HostId>txg285eda49f5cb494f833b-006a04a043</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg93df32e32ee04c789cf0-006a0aec5c</RequestId><HostId>txg93df32e32ee04c789cf0-006a0aec5c</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 16:01:07 GMT
+                - Mon, 18 May 2026 10:39:24 GMT
             X-Amz-Id-2:
-                - txg285eda49f5cb494f833b-006a04a043
+                - txg93df32e32ee04c789cf0-006a0aec5c
             X-Amz-Request-Id:
-                - txg285eda49f5cb494f833b-006a04a043
+                - txg93df32e32ee04c789cf0-006a0aec5c
         status: 404 Not Found
         code: 404
-        duration: 22.412458ms
+        duration: 60.70725ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1626,7 +1626,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1635,7 +1635,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - fe46586a-cf29-4d07-9d0a-b3a0e22b91dd
+                - 48c9d05d-c4c0-411b-ab86-113157ee0660
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1643,8 +1643,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T160107Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T103924Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1654,21 +1654,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg1533250aa3ed4c9db69f-006a04a043</RequestId><HostId>txg1533250aa3ed4c9db69f-006a04a043</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg88506e816c6142e29516-006a0aec5c</RequestId><HostId>txg88506e816c6142e29516-006a0aec5c</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 16:01:07 GMT
+                - Mon, 18 May 2026 10:39:24 GMT
             X-Amz-Id-2:
-                - txg1533250aa3ed4c9db69f-006a04a043
+                - txg88506e816c6142e29516-006a0aec5c
             X-Amz-Request-Id:
-                - txg1533250aa3ed4c9db69f-006a04a043
+                - txg88506e816c6142e29516-006a0aec5c
         status: 404 Not Found
         code: 404
-        duration: 22.456375ms
+        duration: 168.031417ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1677,7 +1677,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1686,7 +1686,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - cd074dad-e11f-46cf-bd1d-dc7741a50ad6
+                - 3afc43dc-fd48-49b4-a4f5-bd9b235d8890
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1694,8 +1694,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T160107Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T103924Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1714,14 +1714,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 16:01:07 GMT
+                - Mon, 18 May 2026 10:39:24 GMT
             X-Amz-Id-2:
-                - txg60f7b3822a4a4fbaa49a-006a04a043
+                - txg8f829e668dc84bc7be2f-006a0aec5c
             X-Amz-Request-Id:
-                - txg60f7b3822a4a4fbaa49a-006a04a043
+                - txg8f829e668dc84bc7be2f-006a0aec5c
         status: 200 OK
         code: 200
-        duration: 145.784416ms
+        duration: 169.416458ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1730,7 +1730,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1739,7 +1739,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9c2f12e5-5eed-47f7-8a10-99471cbba8ae
+                - 42d2816a-11fd-4ebc-a3cb-6aba38130621
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1747,8 +1747,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T160107Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T103924Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1767,14 +1767,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 16:01:07 GMT
+                - Mon, 18 May 2026 10:39:24 GMT
             X-Amz-Id-2:
-                - txgd42412a2a0eb4d9396e7-006a04a043
+                - txg521c32a0ca284984a3e2-006a0aec5c
             X-Amz-Request-Id:
-                - txgd42412a2a0eb4d9396e7-006a04a043
+                - txg521c32a0ca284984a3e2-006a0aec5c
         status: 200 OK
         code: 200
-        duration: 92.883666ms
+        duration: 172.199292ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1783,7 +1783,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1792,7 +1792,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5d924599-7078-4d1f-ab1d-d7d5e60535a6
+                - 644730f0-b276-4319-a172-7f6db45a8915
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1800,8 +1800,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T160107Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/
+                - 20260518T103925Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -1816,16 +1816,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 16:01:07 GMT
+                - Mon, 18 May 2026 10:39:25 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txg4642fb3e296a4c179262-006a04a043
+                - txg3f1ac4e5dddd4e909222-006a0aec5d
             X-Amz-Request-Id:
-                - txg4642fb3e296a4c179262-006a04a043
+                - txg3f1ac4e5dddd4e909222-006a0aec5d
         status: 200 OK
         code: 200
-        duration: 34.583791ms
+        duration: 26.412833ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1834,7 +1834,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1843,7 +1843,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4bc662e5-5bac-478f-a3be-b797fe7e6f30
+                - cbedc925-b05e-4c7c-9c62-38135cdbb501
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1851,8 +1851,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T160107Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T103925Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1871,14 +1871,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 16:01:07 GMT
+                - Mon, 18 May 2026 10:39:25 GMT
             X-Amz-Id-2:
-                - txg39dac2ec18bf418195b2-006a04a043
+                - txg897ce6d4d7454db882f3-006a0aec5d
             X-Amz-Request-Id:
-                - txg39dac2ec18bf418195b2-006a04a043
+                - txg897ce6d4d7454db882f3-006a0aec5d
         status: 200 OK
         code: 200
-        duration: 61.314041ms
+        duration: 77.74525ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1887,7 +1887,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1896,7 +1896,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4d40bd18-4fd2-461e-9ead-8c03ec6c3fed
+                - fb776ef4-3ae3-4ae5-adf3-0f25fd4e5a01
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1904,8 +1904,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T160108Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T103925Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1924,14 +1924,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 16:01:08 GMT
+                - Mon, 18 May 2026 10:39:25 GMT
             X-Amz-Id-2:
-                - txg4d9488a2bbed472bac96-006a04a044
+                - txgdbaae15b7529427ebafd-006a0aec5d
             X-Amz-Request-Id:
-                - txg4d9488a2bbed472bac96-006a04a044
+                - txgdbaae15b7529427ebafd-006a0aec5d
         status: 200 OK
         code: 200
-        duration: 38.630166ms
+        duration: 75.221334ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1940,7 +1940,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1949,7 +1949,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b529986f-158c-4688-a3be-e67d3c526f29
+                - 8d2ed9f4-598d-40ca-9739-f35258eec109
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1957,8 +1957,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T160108Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T103925Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1968,21 +1968,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg66f4932fb8f047b8ae05-006a04a044</RequestId><HostId>txg66f4932fb8f047b8ae05-006a04a044</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txga260d3d59e0a4067b0ca-006a0aec5d</RequestId><HostId>txga260d3d59e0a4067b0ca-006a0aec5d</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 16:01:08 GMT
+                - Mon, 18 May 2026 10:39:25 GMT
             X-Amz-Id-2:
-                - txg66f4932fb8f047b8ae05-006a04a044
+                - txga260d3d59e0a4067b0ca-006a0aec5d
             X-Amz-Request-Id:
-                - txg66f4932fb8f047b8ae05-006a04a044
+                - txga260d3d59e0a4067b0ca-006a0aec5d
         status: 404 Not Found
         code: 404
-        duration: 73.978083ms
+        duration: 59.496542ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1991,7 +1991,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2000,7 +2000,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 3608bd40-fecd-4831-96cf-58880ef043c8
+                - 78db42d1-6411-4375-8050-498eb85ceecc
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2008,8 +2008,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T160108Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/
+                - 20260518T103925Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -2021,21 +2021,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 16:01:08 GMT
+                - Mon, 18 May 2026 10:39:25 GMT
             X-Amz-Id-2:
-                - txg94b8142b44c14b5eb8d7-006a04a044
+                - txg7a5fd112d71b4f23b31c-006a0aec5d
             X-Amz-Request-Id:
-                - txg94b8142b44c14b5eb8d7-006a04a044
+                - txg7a5fd112d71b4f23b31c-006a0aec5d
         status: 200 OK
         code: 200
-        duration: 23.36675ms
+        duration: 53.091667ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -2044,7 +2044,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2053,7 +2053,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4da3b0b3-839c-4dc1-ab28-628d9eee489a
+                - 0127211b-0faf-4dad-98f1-97dab8d2a675
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2061,8 +2061,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T160108Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T103925Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2072,21 +2072,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg65d72744f8bd4e74a0de-006a04a044</RequestId><HostId>txg65d72744f8bd4e74a0de-006a04a044</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg2e27846bdd60412c89be-006a0aec5d</RequestId><HostId>txg2e27846bdd60412c89be-006a0aec5d</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 16:01:08 GMT
+                - Mon, 18 May 2026 10:39:25 GMT
             X-Amz-Id-2:
-                - txg65d72744f8bd4e74a0de-006a04a044
+                - txg2e27846bdd60412c89be-006a0aec5d
             X-Amz-Request-Id:
-                - txg65d72744f8bd4e74a0de-006a04a044
+                - txg2e27846bdd60412c89be-006a0aec5d
         status: 404 Not Found
         code: 404
-        duration: 54.407666ms
+        duration: 64.315458ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -2095,7 +2095,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2104,7 +2104,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f619a5d5-e9b1-41c1-95ec-e1d781bae6b7
+                - 31659530-8218-493e-abc2-da6478784d0e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2112,8 +2112,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T160108Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T103925Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2123,21 +2123,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg0bf8f041556d4737b84c-006a04a044</RequestId><HostId>txg0bf8f041556d4737b84c-006a04a044</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg354e7bca4cf4412bb31d-006a0aec5d</RequestId><HostId>txg354e7bca4cf4412bb31d-006a0aec5d</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 16:01:08 GMT
+                - Mon, 18 May 2026 10:39:25 GMT
             X-Amz-Id-2:
-                - txg0bf8f041556d4737b84c-006a04a044
+                - txg354e7bca4cf4412bb31d-006a0aec5d
             X-Amz-Request-Id:
-                - txg0bf8f041556d4737b84c-006a04a044
+                - txg354e7bca4cf4412bb31d-006a0aec5d
         status: 404 Not Found
         code: 404
-        duration: 53.690333ms
+        duration: 129.981166ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -2146,7 +2146,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2155,7 +2155,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0fd53d38-28c8-463e-ae07-f3ee87d59b0f
+                - c295f31d-4c91-44b3-9709-0fe998976585
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2163,8 +2163,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T160108Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T103925Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2183,14 +2183,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 16:01:08 GMT
+                - Mon, 18 May 2026 10:39:25 GMT
             X-Amz-Id-2:
-                - txg568a75ac90334cd691b7-006a04a044
+                - txgeedcf3842f704429824e-006a0aec5d
             X-Amz-Request-Id:
-                - txg568a75ac90334cd691b7-006a04a044
+                - txgeedcf3842f704429824e-006a0aec5d
         status: 200 OK
         code: 200
-        duration: 23.277958ms
+        duration: 222.745875ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -2199,7 +2199,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2208,7 +2208,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e17fe07e-2d8e-4708-9e07-53b20ced74e2
+                - b9af8784-974c-492b-9500-83c655b0446f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2216,8 +2216,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T160108Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T103925Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2236,14 +2236,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 16:01:08 GMT
+                - Mon, 18 May 2026 10:39:26 GMT
             X-Amz-Id-2:
-                - txg94e3503cf07a4ee7b318-006a04a044
+                - txgae7d7f3ba5ac4cf6b918-006a0aec5e
             X-Amz-Request-Id:
-                - txg94e3503cf07a4ee7b318-006a04a044
+                - txgae7d7f3ba5ac4cf6b918-006a0aec5e
         status: 200 OK
         code: 200
-        duration: 55.406792ms
+        duration: 41.098292ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -2252,7 +2252,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2261,7 +2261,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - fb9031c6-be9b-40e3-aa1a-48fe1ceb4e5e
+                - d465120c-a41d-4c19-aa5f-4cc4d925c554
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2269,8 +2269,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T160108Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8637116572947427618.s3.nl-ams.scw.cloud/
+                - 20260518T103926Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2283,11 +2283,11 @@ interactions:
         body: ""
         headers:
             Date:
-                - Wed, 13 May 2026 16:01:08 GMT
+                - Mon, 18 May 2026 10:39:26 GMT
             X-Amz-Id-2:
-                - txg45ed2f23152a4b37961d-006a04a044
+                - txgf6908e5d83db441995a5-006a0aec5e
             X-Amz-Request-Id:
-                - txg45ed2f23152a4b37961d-006a04a044
+                - txgf6908e5d83db441995a5-006a0aec5e
         status: 204 No Content
         code: 204
-        duration: 210.741ms
+        duration: 352.592084ms

--- a/internal/services/object/testdata/object-bucket-lifecycle-remove-rule.cassette.yaml
+++ b/internal/services/object/testdata/object-bucket-lifecycle-remove-rule.cassette.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -18,7 +18,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0d28e553-e269-4883-821c-b66fdf46fec3
+                - 962d684e-d7e2-47a6-85ec-a8b6d0d57531
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -26,8 +26,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103914Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/
+                - 20260518T133715Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/
         method: PUT
       response:
         proto: HTTP/2.0
@@ -42,16 +42,16 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 18 May 2026 10:39:14 GMT
+                - Mon, 18 May 2026 13:37:16 GMT
             Location:
-                - /tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505
+                - /tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655
             X-Amz-Id-2:
-                - txg1ce7650356414fbf8fe7-006a0aec52
+                - txgbb6800e8e46f4978a308-006a0b160c
             X-Amz-Request-Id:
-                - txg1ce7650356414fbf8fe7-006a0aec52
+                - txgbb6800e8e46f4978a308-006a0b160c
         status: 200 OK
         code: 200
-        duration: 4.159323792s
+        duration: 4.78261575s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -60,7 +60,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -69,7 +69,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 34f0698e-5e9e-4f38-8683-eb76ee4d1e98
+                - c353fd3e-aa15-4163-80b6-501dfd0f3822
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -81,8 +81,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103918Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T133720Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?acl=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -97,14 +97,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 18 May 2026 10:39:18 GMT
+                - Mon, 18 May 2026 13:37:20 GMT
             X-Amz-Id-2:
-                - txg5b961224fd55410dbe7d-006a0aec56
+                - txgafb5438e9e6242caa082-006a0b1610
             X-Amz-Request-Id:
-                - txg5b961224fd55410dbe7d-006a0aec56
+                - txgafb5438e9e6242caa082-006a0b1610
         status: 200 OK
         code: 200
-        duration: 244.549958ms
+        duration: 80.522167ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -113,7 +113,7 @@ interactions:
         content_length: 460
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>prefix/</Prefix></Filter><ID>to delete</ID><Status>Enabled</Status></Rule><Rule><Expiration><ExpiredObjectDeleteMarker>true</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>expire delete markers</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
@@ -122,7 +122,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 31d8cddd-9033-420b-842f-6f3f13ef5b1a
+                - 1f8e5da2-11bf-4e97-b008-622e160d38ea
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
@@ -134,8 +134,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - be82f5350a9f62e9880e1d0bfb67fee8cb072fff45d9d7171711c16a6b0dbbb2
             X-Amz-Date:
-                - 20260518T103918Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T133720Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -150,14 +150,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 18 May 2026 10:39:18 GMT
+                - Mon, 18 May 2026 13:37:20 GMT
             X-Amz-Id-2:
-                - txg8f44a8fea0b94a72ab5b-006a0aec56
+                - txgd1a8fc9e1d0e4303b180-006a0b1610
             X-Amz-Request-Id:
-                - txg8f44a8fea0b94a72ab5b-006a0aec56
+                - txgd1a8fc9e1d0e4303b180-006a0b1610
         status: 200 OK
         code: 200
-        duration: 182.690917ms
+        duration: 132.02225ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -166,7 +166,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -175,7 +175,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 45ff1dde-085a-45d9-9eea-25258d621461
+                - f0f580b6-9b24-469e-9f20-ad5234ed5c7d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -183,8 +183,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103918Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T133720Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -203,14 +203,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:39:18 GMT
+                - Mon, 18 May 2026 13:37:21 GMT
             X-Amz-Id-2:
-                - txg1b154aee968745b79a1f-006a0aec56
+                - txg5d9fcc8616da40ee9581-006a0b1611
             X-Amz-Request-Id:
-                - txg1b154aee968745b79a1f-006a0aec56
+                - txg5d9fcc8616da40ee9581-006a0b1611
         status: 200 OK
         code: 200
-        duration: 182.750917ms
+        duration: 54.802209ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -219,7 +219,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -228,7 +228,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b90eae83-f885-4e74-be26-813e3fd16c54
+                - 588053c6-7483-4487-9792-68613f9ee3ca
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -236,8 +236,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103918Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T133721Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -247,21 +247,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg0d5272160bd24ea6a9a1-006a0aec57</RequestId><HostId>txg0d5272160bd24ea6a9a1-006a0aec57</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg9dc7337cad0e4590aff2-006a0b1611</RequestId><HostId>txg9dc7337cad0e4590aff2-006a0b1611</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:39:19 GMT
+                - Mon, 18 May 2026 13:37:21 GMT
             X-Amz-Id-2:
-                - txg0d5272160bd24ea6a9a1-006a0aec57
+                - txg9dc7337cad0e4590aff2-006a0b1611
             X-Amz-Request-Id:
-                - txg0d5272160bd24ea6a9a1-006a0aec57
+                - txg9dc7337cad0e4590aff2-006a0b1611
         status: 404 Not Found
         code: 404
-        duration: 122.402542ms
+        duration: 685.988958ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -270,7 +270,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -279,7 +279,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0c38e138-2f19-4a54-9170-611d90bcedae
+                - a086af17-04b0-4ec1-a755-6ee0899dec17
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -287,8 +287,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103919Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/
+                - 20260518T133721Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -300,21 +300,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:39:19 GMT
+                - Mon, 18 May 2026 13:37:21 GMT
             X-Amz-Id-2:
-                - txg4224f89b82f043648de3-006a0aec57
+                - txg60b5c3654fd44b238b07-006a0b1611
             X-Amz-Request-Id:
-                - txg4224f89b82f043648de3-006a0aec57
+                - txg60b5c3654fd44b238b07-006a0b1611
         status: 200 OK
         code: 200
-        duration: 121.805875ms
+        duration: 65.281833ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -323,7 +323,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -332,7 +332,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 322c2e95-396e-45fc-a674-93e2e1048bc7
+                - 6cbf9192-f653-41d4-aea9-464386bd63fb
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -340,8 +340,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103919Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T133721Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -351,21 +351,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg7bfee7fa3c8e49a994db-006a0aec57</RequestId><HostId>txg7bfee7fa3c8e49a994db-006a0aec57</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgb99aea70c361450a88d1-006a0b1611</RequestId><HostId>txgb99aea70c361450a88d1-006a0b1611</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:39:19 GMT
+                - Mon, 18 May 2026 13:37:21 GMT
             X-Amz-Id-2:
-                - txg7bfee7fa3c8e49a994db-006a0aec57
+                - txgb99aea70c361450a88d1-006a0b1611
             X-Amz-Request-Id:
-                - txg7bfee7fa3c8e49a994db-006a0aec57
+                - txgb99aea70c361450a88d1-006a0b1611
         status: 404 Not Found
         code: 404
-        duration: 68.117083ms
+        duration: 34.163792ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -374,7 +374,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -383,7 +383,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 30271d57-19fd-4dd9-9733-ce9a2ab3f116
+                - b472dd1a-32a0-44fb-b92b-0a8eac563c23
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -391,8 +391,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103919Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T133721Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -402,21 +402,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txga6bb8fa6ae7148b1a255-006a0aec57</RequestId><HostId>txga6bb8fa6ae7148b1a255-006a0aec57</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg2cd99303583140f0b3e8-006a0b1611</RequestId><HostId>txg2cd99303583140f0b3e8-006a0b1611</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:39:19 GMT
+                - Mon, 18 May 2026 13:37:21 GMT
             X-Amz-Id-2:
-                - txga6bb8fa6ae7148b1a255-006a0aec57
+                - txg2cd99303583140f0b3e8-006a0b1611
             X-Amz-Request-Id:
-                - txga6bb8fa6ae7148b1a255-006a0aec57
+                - txg2cd99303583140f0b3e8-006a0b1611
         status: 404 Not Found
         code: 404
-        duration: 416.791ms
+        duration: 54.189125ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -425,7 +425,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -434,7 +434,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 8ab84e84-66c5-40f2-a914-ea026eefcb54
+                - 5701192f-e02c-4e80-94ac-6035bbf4aa10
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -442,8 +442,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103919Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T133721Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -462,14 +462,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:39:19 GMT
+                - Mon, 18 May 2026 13:37:21 GMT
             X-Amz-Id-2:
-                - txg928406dca3f940a2beb4-006a0aec57
+                - txg50ae64a8c2c74acfaf74-006a0b1611
             X-Amz-Request-Id:
-                - txg928406dca3f940a2beb4-006a0aec57
+                - txg50ae64a8c2c74acfaf74-006a0b1611
         status: 200 OK
         code: 200
-        duration: 35.376167ms
+        duration: 72.628959ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -478,7 +478,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -487,7 +487,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 2bac31fd-62e8-4e10-8f18-d0a84edf1358
+                - 9eb400bb-c4c8-418f-afbf-cf914676b5b4
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -495,8 +495,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103919Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T133721Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -515,14 +515,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:39:19 GMT
+                - Mon, 18 May 2026 13:37:21 GMT
             X-Amz-Id-2:
-                - txg290be1056ca74d58aa15-006a0aec57
+                - txg003cd11bf799481f8fc1-006a0b1611
             X-Amz-Request-Id:
-                - txg290be1056ca74d58aa15-006a0aec57
+                - txg003cd11bf799481f8fc1-006a0b1611
         status: 200 OK
         code: 200
-        duration: 131.069375ms
+        duration: 71.7905ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -531,7 +531,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -540,7 +540,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 201319ce-e55d-48ed-b412-aa11b90094fd
+                - 3d0beb89-f04d-4fbd-aaea-4137db74bbd1
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -548,8 +548,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103920Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/
+                - 20260518T133722Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -564,16 +564,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:39:20 GMT
+                - Mon, 18 May 2026 13:37:22 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txged90f74b2fc84843bb3f-006a0aec58
+                - txgfe8223b861524c48933f-006a0b1612
             X-Amz-Request-Id:
-                - txged90f74b2fc84843bb3f-006a0aec58
+                - txgfe8223b861524c48933f-006a0b1612
         status: 200 OK
         code: 200
-        duration: 76.984917ms
+        duration: 63.734833ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -582,7 +582,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -591,7 +591,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 35478f6f-fd4f-4ac7-86dc-e353b1d4e7cb
+                - 9ab10941-0d98-41cc-b021-af206956e50f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -599,8 +599,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103920Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T133722Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -619,14 +619,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:39:20 GMT
+                - Mon, 18 May 2026 13:37:22 GMT
             X-Amz-Id-2:
-                - txg466fb7d7b98c4d68a6d6-006a0aec58
+                - txgf1c004b7d48f41fa986b-006a0b1612
             X-Amz-Request-Id:
-                - txg466fb7d7b98c4d68a6d6-006a0aec58
+                - txgf1c004b7d48f41fa986b-006a0b1612
         status: 200 OK
         code: 200
-        duration: 76.815875ms
+        duration: 53.346ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -635,7 +635,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -644,7 +644,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 1c031e87-7b90-400e-aa39-1b5b94b9b689
+                - dbe73d14-8ba2-446e-9628-e3a14b53d88c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -652,8 +652,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103920Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T133722Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -672,14 +672,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:39:20 GMT
+                - Mon, 18 May 2026 13:37:22 GMT
             X-Amz-Id-2:
-                - txg5d0492891e3549f48b8b-006a0aec58
+                - txg6e6d851591f443ea8635-006a0b1612
             X-Amz-Request-Id:
-                - txg5d0492891e3549f48b8b-006a0aec58
+                - txg6e6d851591f443ea8635-006a0b1612
         status: 200 OK
         code: 200
-        duration: 37.577625ms
+        duration: 204.707125ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -688,7 +688,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -697,7 +697,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - cb8695e0-8fd5-440d-9415-19e10fe3eec6
+                - 165bdfc5-3b35-4384-8c09-954437549257
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -705,8 +705,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103920Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T133722Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -716,21 +716,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgd1a70331b37d4f538eb6-006a0aec58</RequestId><HostId>txgd1a70331b37d4f538eb6-006a0aec58</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg5d4660538aa84f769fc4-006a0b1612</RequestId><HostId>txg5d4660538aa84f769fc4-006a0b1612</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:39:20 GMT
+                - Mon, 18 May 2026 13:37:22 GMT
             X-Amz-Id-2:
-                - txgd1a70331b37d4f538eb6-006a0aec58
+                - txg5d4660538aa84f769fc4-006a0b1612
             X-Amz-Request-Id:
-                - txgd1a70331b37d4f538eb6-006a0aec58
+                - txg5d4660538aa84f769fc4-006a0b1612
         status: 404 Not Found
         code: 404
-        duration: 67.804083ms
+        duration: 36.459625ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -739,7 +739,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -748,7 +748,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 74989da9-3c69-4a4c-a37a-a50db07d5a08
+                - ea4f2d78-936f-410a-80ec-992e038797f2
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -756,8 +756,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103920Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/
+                - 20260518T133722Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -769,21 +769,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:39:20 GMT
+                - Mon, 18 May 2026 13:37:22 GMT
             X-Amz-Id-2:
-                - txg407776e9583a4e019a1f-006a0aec58
+                - txg4a0f7bf9e2f34b4280a5-006a0b1612
             X-Amz-Request-Id:
-                - txg407776e9583a4e019a1f-006a0aec58
+                - txg4a0f7bf9e2f34b4280a5-006a0b1612
         status: 200 OK
         code: 200
-        duration: 62.625583ms
+        duration: 40.130333ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -792,7 +792,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -801,7 +801,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - cadb29bc-fed2-4a81-92a0-1ae3c4f46fd5
+                - ad3d01f6-e893-4c86-ba70-acc8495d45e6
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -809,8 +809,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103920Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T133722Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -820,21 +820,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgf5d4a56ac6db4eeea3f8-006a0aec58</RequestId><HostId>txgf5d4a56ac6db4eeea3f8-006a0aec58</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg576f5f3eed9d4c7896b7-006a0b1612</RequestId><HostId>txg576f5f3eed9d4c7896b7-006a0b1612</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:39:20 GMT
+                - Mon, 18 May 2026 13:37:22 GMT
             X-Amz-Id-2:
-                - txgf5d4a56ac6db4eeea3f8-006a0aec58
+                - txg576f5f3eed9d4c7896b7-006a0b1612
             X-Amz-Request-Id:
-                - txgf5d4a56ac6db4eeea3f8-006a0aec58
+                - txg576f5f3eed9d4c7896b7-006a0b1612
         status: 404 Not Found
         code: 404
-        duration: 139.437583ms
+        duration: 39.796209ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -843,7 +843,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -852,7 +852,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e7ccc199-070d-4fd1-bb54-30a38539dd8b
+                - 06364116-7dab-4792-ade7-b430c2ad2aaa
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -860,8 +860,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103920Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T133722Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -871,21 +871,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg56db86c481c14b19943f-006a0aec58</RequestId><HostId>txg56db86c481c14b19943f-006a0aec58</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgb98fe98a9ac246119f47-006a0b1612</RequestId><HostId>txgb98fe98a9ac246119f47-006a0b1612</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:39:20 GMT
+                - Mon, 18 May 2026 13:37:22 GMT
             X-Amz-Id-2:
-                - txg56db86c481c14b19943f-006a0aec58
+                - txgb98fe98a9ac246119f47-006a0b1612
             X-Amz-Request-Id:
-                - txg56db86c481c14b19943f-006a0aec58
+                - txgb98fe98a9ac246119f47-006a0b1612
         status: 404 Not Found
         code: 404
-        duration: 57.974333ms
+        duration: 61.186667ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -894,7 +894,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -903,7 +903,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 1cf517eb-7c6b-49cc-a272-ce1581757e3e
+                - 3de24d7b-1a6e-4732-a4c2-faf16010e122
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -911,8 +911,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103920Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T133722Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -931,14 +931,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:39:20 GMT
+                - Mon, 18 May 2026 13:37:22 GMT
             X-Amz-Id-2:
-                - txgcc90681030184ba4a28e-006a0aec58
+                - txg41168af261a04e43ba2e-006a0b1612
             X-Amz-Request-Id:
-                - txgcc90681030184ba4a28e-006a0aec58
+                - txg41168af261a04e43ba2e-006a0b1612
         status: 200 OK
         code: 200
-        duration: 1.374400208s
+        duration: 52.61ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -947,7 +947,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -956,7 +956,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d676e8cd-61ce-493e-bbca-dea4ec197c79
+                - 56b33d0a-26ff-4551-8f70-6506498a03ee
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -964,8 +964,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103920Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T133722Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -984,14 +984,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:39:22 GMT
+                - Mon, 18 May 2026 13:37:22 GMT
             X-Amz-Id-2:
-                - txg40c9803c4e9342778305-006a0aec5a
+                - txg07138c3a65e8404bb243-006a0b1612
             X-Amz-Request-Id:
-                - txg40c9803c4e9342778305-006a0aec5a
+                - txg07138c3a65e8404bb243-006a0b1612
         status: 200 OK
         code: 200
-        duration: 216.03025ms
+        duration: 55.897917ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -1000,7 +1000,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1009,7 +1009,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 758afbed-67f4-484f-85f6-a1d2319f06fa
+                - 7b49ca8b-4841-42ab-8dd3-5b4ecdc2ffd4
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1017,8 +1017,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103922Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T133723Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1037,14 +1037,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:39:22 GMT
+                - Mon, 18 May 2026 13:37:23 GMT
             X-Amz-Id-2:
-                - txg5a08eaf2d604483fa258-006a0aec5a
+                - txg0fee9aeaf0244b12aa23-006a0b1613
             X-Amz-Request-Id:
-                - txg5a08eaf2d604483fa258-006a0aec5a
+                - txg0fee9aeaf0244b12aa23-006a0b1613
         status: 200 OK
         code: 200
-        duration: 141.156875ms
+        duration: 62.99875ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1053,7 +1053,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1062,7 +1062,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 518c984d-c44d-4861-a604-e379053ad2e4
+                - 87ece195-1920-4e70-b048-22e6084098ae
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1070,8 +1070,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103922Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T133723Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1081,21 +1081,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgb9756a7754254183893a-006a0aec5a</RequestId><HostId>txgb9756a7754254183893a-006a0aec5a</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg43a939099e3040669ef0-006a0b1613</RequestId><HostId>txg43a939099e3040669ef0-006a0b1613</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:39:22 GMT
+                - Mon, 18 May 2026 13:37:23 GMT
             X-Amz-Id-2:
-                - txgb9756a7754254183893a-006a0aec5a
+                - txg43a939099e3040669ef0-006a0b1613
             X-Amz-Request-Id:
-                - txgb9756a7754254183893a-006a0aec5a
+                - txg43a939099e3040669ef0-006a0b1613
         status: 404 Not Found
         code: 404
-        duration: 68.950459ms
+        duration: 38.950417ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1104,7 +1104,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1113,7 +1113,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 8e6e9142-ebdf-4f32-966a-5d9c381f3a2d
+                - 26412df6-0b87-4091-93a8-48c1daa0fd0c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1121,8 +1121,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103922Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/
+                - 20260518T133723Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -1134,21 +1134,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:39:22 GMT
+                - Mon, 18 May 2026 13:37:23 GMT
             X-Amz-Id-2:
-                - txg5fbd817516df46caa6f9-006a0aec5a
+                - txgd76dc95d3e5849e28fd7-006a0b1613
             X-Amz-Request-Id:
-                - txg5fbd817516df46caa6f9-006a0aec5a
+                - txgd76dc95d3e5849e28fd7-006a0b1613
         status: 200 OK
         code: 200
-        duration: 176.76725ms
+        duration: 229.270292ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1157,7 +1157,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1166,7 +1166,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c118fae5-b161-4e5a-a868-a12531534f9d
+                - 4247b47d-74e8-42c8-ae85-6005c99562b7
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1174,8 +1174,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103922Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T133723Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1185,21 +1185,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgc742c99f82dc47949aa8-006a0aec5b</RequestId><HostId>txgc742c99f82dc47949aa8-006a0aec5b</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg7624757984db4121bb24-006a0b1613</RequestId><HostId>txg7624757984db4121bb24-006a0b1613</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:39:23 GMT
+                - Mon, 18 May 2026 13:37:23 GMT
             X-Amz-Id-2:
-                - txgc742c99f82dc47949aa8-006a0aec5b
+                - txg7624757984db4121bb24-006a0b1613
             X-Amz-Request-Id:
-                - txgc742c99f82dc47949aa8-006a0aec5b
+                - txg7624757984db4121bb24-006a0b1613
         status: 404 Not Found
         code: 404
-        duration: 88.831375ms
+        duration: 53.167ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1208,7 +1208,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1217,7 +1217,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ab8bcce1-da9f-4647-85a8-ef0187503bab
+                - e685defb-5d9f-4d93-a14c-3199d528ed9b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1225,8 +1225,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103923Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T133723Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1236,21 +1236,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgcac60e9da2534fc8b32f-006a0aec5b</RequestId><HostId>txgcac60e9da2534fc8b32f-006a0aec5b</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg9a993c8da26c4ed89b74-006a0b1613</RequestId><HostId>txg9a993c8da26c4ed89b74-006a0b1613</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:39:23 GMT
+                - Mon, 18 May 2026 13:37:23 GMT
             X-Amz-Id-2:
-                - txgcac60e9da2534fc8b32f-006a0aec5b
+                - txg9a993c8da26c4ed89b74-006a0b1613
             X-Amz-Request-Id:
-                - txgcac60e9da2534fc8b32f-006a0aec5b
+                - txg9a993c8da26c4ed89b74-006a0b1613
         status: 404 Not Found
         code: 404
-        duration: 70.461667ms
+        duration: 34.948708ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1259,7 +1259,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1268,7 +1268,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 549ea9ef-ce9e-4d76-bc0d-ddd93bfdcbc8
+                - 9c863182-e3a6-4f99-b67b-5e9b65ee3ee6
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1276,8 +1276,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103923Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T133723Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1296,14 +1296,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:39:23 GMT
+                - Mon, 18 May 2026 13:37:23 GMT
             X-Amz-Id-2:
-                - txg51f6342a04c64bf6a29d-006a0aec5b
+                - txg371f683cca9f4e6d91a4-006a0b1613
             X-Amz-Request-Id:
-                - txg51f6342a04c64bf6a29d-006a0aec5b
+                - txg371f683cca9f4e6d91a4-006a0b1613
         status: 200 OK
         code: 200
-        duration: 154.270209ms
+        duration: 52.211083ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1312,7 +1312,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1321,7 +1321,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e1fff0ef-5c37-4d61-820e-104660f21591
+                - dd14964a-1de2-40aa-9ad2-621fc30c2555
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1329,8 +1329,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103923Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T133723Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1349,14 +1349,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:39:23 GMT
+                - Mon, 18 May 2026 13:37:23 GMT
             X-Amz-Id-2:
-                - txgdca2630371de48a6b9fe-006a0aec5b
+                - txg2457b57c9e414c9a80e1-006a0b1613
             X-Amz-Request-Id:
-                - txgdca2630371de48a6b9fe-006a0aec5b
+                - txg2457b57c9e414c9a80e1-006a0b1613
         status: 200 OK
         code: 200
-        duration: 57.502417ms
+        duration: 22.925334ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1365,7 +1365,7 @@ interactions:
         content_length: 265
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><ExpiredObjectDeleteMarker>true</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>expire delete markers</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
@@ -1374,7 +1374,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ce095ff3-3962-4419-87db-25b2f4073fef
+                - 7d1065b1-f6b7-4812-b508-c6b0f52ca58f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
@@ -1386,8 +1386,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - fd28d6105facd58e0708118f811178b230c443b5cac5e2f9bb6714a806f344e0
             X-Amz-Date:
-                - 20260518T103923Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T133723Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -1402,14 +1402,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 18 May 2026 10:39:23 GMT
+                - Mon, 18 May 2026 13:37:23 GMT
             X-Amz-Id-2:
-                - txga4a4b96a04734d5fb851-006a0aec5b
+                - txg17a6a9a5f74342fabe5c-006a0b1613
             X-Amz-Request-Id:
-                - txga4a4b96a04734d5fb851-006a0aec5b
+                - txg17a6a9a5f74342fabe5c-006a0b1613
         status: 200 OK
         code: 200
-        duration: 334.699459ms
+        duration: 122.384625ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1418,7 +1418,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1427,7 +1427,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 8af7f929-6763-4b24-9622-c6f68e051f04
+                - c18f1046-7e15-445b-a79f-268b7000cd7e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1435,8 +1435,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103923Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T133724Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1455,14 +1455,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:39:23 GMT
+                - Mon, 18 May 2026 13:37:24 GMT
             X-Amz-Id-2:
-                - txg0fad32e2b41b4a119d29-006a0aec5b
+                - txg91908b9e6d3846bc8931-006a0b1614
             X-Amz-Request-Id:
-                - txg0fad32e2b41b4a119d29-006a0aec5b
+                - txg91908b9e6d3846bc8931-006a0b1614
         status: 200 OK
         code: 200
-        duration: 167.1795ms
+        duration: 64.324041ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1471,7 +1471,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1480,7 +1480,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 3673c7fb-b995-41c9-b0b4-b965b775f047
+                - db2e4e18-1a70-4d60-90d8-47071bf11486
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1488,8 +1488,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103923Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T133724Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1499,21 +1499,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg3205402f167343d78576-006a0aec5c</RequestId><HostId>txg3205402f167343d78576-006a0aec5c</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgae58c50c376143bf8130-006a0b1614</RequestId><HostId>txgae58c50c376143bf8130-006a0b1614</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:39:24 GMT
+                - Mon, 18 May 2026 13:37:24 GMT
             X-Amz-Id-2:
-                - txg3205402f167343d78576-006a0aec5c
+                - txgae58c50c376143bf8130-006a0b1614
             X-Amz-Request-Id:
-                - txg3205402f167343d78576-006a0aec5c
+                - txgae58c50c376143bf8130-006a0b1614
         status: 404 Not Found
         code: 404
-        duration: 117.834709ms
+        duration: 81.664167ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1522,7 +1522,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1531,7 +1531,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 435c077a-5a80-472a-a3ff-4ff5c5743b67
+                - 5965e39a-b301-450a-ad56-4c6138fd60fa
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1539,8 +1539,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103924Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/
+                - 20260518T133724Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -1552,21 +1552,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:39:24 GMT
+                - Mon, 18 May 2026 13:37:24 GMT
             X-Amz-Id-2:
-                - txg159a617f8b014b9cb51b-006a0aec5c
+                - txg8c02350a0fd74b489b00-006a0b1614
             X-Amz-Request-Id:
-                - txg159a617f8b014b9cb51b-006a0aec5c
+                - txg8c02350a0fd74b489b00-006a0b1614
         status: 200 OK
         code: 200
-        duration: 158.418ms
+        duration: 1.040641166s
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1575,7 +1575,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1584,7 +1584,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5d381247-6918-4d06-8017-3b5b5e8d0e7a
+                - 70dfdaec-9bb3-41c1-bd93-382d77580bad
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1592,8 +1592,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103924Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T133724Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1603,21 +1603,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg93df32e32ee04c789cf0-006a0aec5c</RequestId><HostId>txg93df32e32ee04c789cf0-006a0aec5c</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgaa4274dda34d4d6ba5e9-006a0b1615</RequestId><HostId>txgaa4274dda34d4d6ba5e9-006a0b1615</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:39:24 GMT
+                - Mon, 18 May 2026 13:37:25 GMT
             X-Amz-Id-2:
-                - txg93df32e32ee04c789cf0-006a0aec5c
+                - txgaa4274dda34d4d6ba5e9-006a0b1615
             X-Amz-Request-Id:
-                - txg93df32e32ee04c789cf0-006a0aec5c
+                - txgaa4274dda34d4d6ba5e9-006a0b1615
         status: 404 Not Found
         code: 404
-        duration: 60.70725ms
+        duration: 62.404208ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1626,7 +1626,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1635,7 +1635,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 48c9d05d-c4c0-411b-ab86-113157ee0660
+                - 209b0229-e7cf-4996-bcf0-adc15a9063fe
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1643,8 +1643,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103924Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T133725Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1654,21 +1654,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg88506e816c6142e29516-006a0aec5c</RequestId><HostId>txg88506e816c6142e29516-006a0aec5c</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgdf3dfd88533845a1ae8f-006a0b1615</RequestId><HostId>txgdf3dfd88533845a1ae8f-006a0b1615</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:39:24 GMT
+                - Mon, 18 May 2026 13:37:25 GMT
             X-Amz-Id-2:
-                - txg88506e816c6142e29516-006a0aec5c
+                - txgdf3dfd88533845a1ae8f-006a0b1615
             X-Amz-Request-Id:
-                - txg88506e816c6142e29516-006a0aec5c
+                - txgdf3dfd88533845a1ae8f-006a0b1615
         status: 404 Not Found
         code: 404
-        duration: 168.031417ms
+        duration: 31.101042ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1677,7 +1677,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1686,7 +1686,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 3afc43dc-fd48-49b4-a4f5-bd9b235d8890
+                - 1ac478f1-8ce6-4822-a18f-334e73d3f940
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1694,8 +1694,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103924Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T133725Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1714,14 +1714,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:39:24 GMT
+                - Mon, 18 May 2026 13:37:25 GMT
             X-Amz-Id-2:
-                - txg8f829e668dc84bc7be2f-006a0aec5c
+                - txge6bb225f57e1432aa0c7-006a0b1615
             X-Amz-Request-Id:
-                - txg8f829e668dc84bc7be2f-006a0aec5c
+                - txge6bb225f57e1432aa0c7-006a0b1615
         status: 200 OK
         code: 200
-        duration: 169.416458ms
+        duration: 61.937916ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1730,7 +1730,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1739,7 +1739,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 42d2816a-11fd-4ebc-a3cb-6aba38130621
+                - 988267d7-3c49-47e7-8e2c-730c6084be62
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1747,8 +1747,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103924Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T133725Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1767,14 +1767,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:39:24 GMT
+                - Mon, 18 May 2026 13:37:25 GMT
             X-Amz-Id-2:
-                - txg521c32a0ca284984a3e2-006a0aec5c
+                - txgc52734107d124552a5b5-006a0b1615
             X-Amz-Request-Id:
-                - txg521c32a0ca284984a3e2-006a0aec5c
+                - txgc52734107d124552a5b5-006a0b1615
         status: 200 OK
         code: 200
-        duration: 172.199292ms
+        duration: 62.222667ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1783,7 +1783,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1792,7 +1792,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 644730f0-b276-4319-a172-7f6db45a8915
+                - 47c1fe9e-8928-4919-ab5e-e0540c71da0b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1800,8 +1800,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103925Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/
+                - 20260518T133725Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -1816,16 +1816,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:39:25 GMT
+                - Mon, 18 May 2026 13:37:25 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txg3f1ac4e5dddd4e909222-006a0aec5d
+                - txgabd4f4a59ec440b89cd4-006a0b1615
             X-Amz-Request-Id:
-                - txg3f1ac4e5dddd4e909222-006a0aec5d
+                - txgabd4f4a59ec440b89cd4-006a0b1615
         status: 200 OK
         code: 200
-        duration: 26.412833ms
+        duration: 28.86575ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1834,7 +1834,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1843,7 +1843,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - cbedc925-b05e-4c7c-9c62-38135cdbb501
+                - 680cd577-b709-4d8f-b5dc-eb0f891ab5dd
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1851,8 +1851,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103925Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T133725Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1871,14 +1871,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:39:25 GMT
+                - Mon, 18 May 2026 13:37:25 GMT
             X-Amz-Id-2:
-                - txg897ce6d4d7454db882f3-006a0aec5d
+                - txg643ff80c29be4be8a52d-006a0b1615
             X-Amz-Request-Id:
-                - txg897ce6d4d7454db882f3-006a0aec5d
+                - txg643ff80c29be4be8a52d-006a0b1615
         status: 200 OK
         code: 200
-        duration: 77.74525ms
+        duration: 190.763791ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1887,7 +1887,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1896,7 +1896,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - fb776ef4-3ae3-4ae5-adf3-0f25fd4e5a01
+                - 16d9280d-1c62-4eae-b441-c307c88aa4ac
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1904,8 +1904,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103925Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T133726Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1924,14 +1924,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:39:25 GMT
+                - Mon, 18 May 2026 13:37:26 GMT
             X-Amz-Id-2:
-                - txgdbaae15b7529427ebafd-006a0aec5d
+                - txg880f710f5d954041a88b-006a0b1616
             X-Amz-Request-Id:
-                - txgdbaae15b7529427ebafd-006a0aec5d
+                - txg880f710f5d954041a88b-006a0b1616
         status: 200 OK
         code: 200
-        duration: 75.221334ms
+        duration: 35.601791ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1940,7 +1940,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1949,7 +1949,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 8d2ed9f4-598d-40ca-9739-f35258eec109
+                - 71de461d-b42a-4f58-8fb1-e423f561a1b8
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1957,8 +1957,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103925Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T133726Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1968,21 +1968,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txga260d3d59e0a4067b0ca-006a0aec5d</RequestId><HostId>txga260d3d59e0a4067b0ca-006a0aec5d</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg7277a28e235240d4877f-006a0b1616</RequestId><HostId>txg7277a28e235240d4877f-006a0b1616</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:39:25 GMT
+                - Mon, 18 May 2026 13:37:26 GMT
             X-Amz-Id-2:
-                - txga260d3d59e0a4067b0ca-006a0aec5d
+                - txg7277a28e235240d4877f-006a0b1616
             X-Amz-Request-Id:
-                - txga260d3d59e0a4067b0ca-006a0aec5d
+                - txg7277a28e235240d4877f-006a0b1616
         status: 404 Not Found
         code: 404
-        duration: 59.496542ms
+        duration: 33.222541ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1991,7 +1991,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2000,7 +2000,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 78db42d1-6411-4375-8050-498eb85ceecc
+                - f7af4f64-2444-4181-90e8-e598439aae17
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2008,8 +2008,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103925Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/
+                - 20260518T133726Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -2021,21 +2021,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:39:25 GMT
+                - Mon, 18 May 2026 13:37:26 GMT
             X-Amz-Id-2:
-                - txg7a5fd112d71b4f23b31c-006a0aec5d
+                - txg3b59e941295d4f168f71-006a0b1616
             X-Amz-Request-Id:
-                - txg7a5fd112d71b4f23b31c-006a0aec5d
+                - txg3b59e941295d4f168f71-006a0b1616
         status: 200 OK
         code: 200
-        duration: 53.091667ms
+        duration: 39.058458ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -2044,7 +2044,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2053,7 +2053,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0127211b-0faf-4dad-98f1-97dab8d2a675
+                - 74cc2fbd-aafd-40dd-86c3-2cb86ddb371e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2061,8 +2061,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103925Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T133726Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2072,21 +2072,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg2e27846bdd60412c89be-006a0aec5d</RequestId><HostId>txg2e27846bdd60412c89be-006a0aec5d</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg8b6cd215895c491fbc20-006a0b1616</RequestId><HostId>txg8b6cd215895c491fbc20-006a0b1616</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:39:25 GMT
+                - Mon, 18 May 2026 13:37:26 GMT
             X-Amz-Id-2:
-                - txg2e27846bdd60412c89be-006a0aec5d
+                - txg8b6cd215895c491fbc20-006a0b1616
             X-Amz-Request-Id:
-                - txg2e27846bdd60412c89be-006a0aec5d
+                - txg8b6cd215895c491fbc20-006a0b1616
         status: 404 Not Found
         code: 404
-        duration: 64.315458ms
+        duration: 20.804542ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -2095,7 +2095,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2104,7 +2104,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 31659530-8218-493e-abc2-da6478784d0e
+                - bc49ec4c-3376-4389-83de-b2aae27a9e52
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2112,8 +2112,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103925Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T133726Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2123,21 +2123,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg354e7bca4cf4412bb31d-006a0aec5d</RequestId><HostId>txg354e7bca4cf4412bb31d-006a0aec5d</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg7271e54bfe5240548722-006a0b1616</RequestId><HostId>txg7271e54bfe5240548722-006a0b1616</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:39:25 GMT
+                - Mon, 18 May 2026 13:37:26 GMT
             X-Amz-Id-2:
-                - txg354e7bca4cf4412bb31d-006a0aec5d
+                - txg7271e54bfe5240548722-006a0b1616
             X-Amz-Request-Id:
-                - txg354e7bca4cf4412bb31d-006a0aec5d
+                - txg7271e54bfe5240548722-006a0b1616
         status: 404 Not Found
         code: 404
-        duration: 129.981166ms
+        duration: 21.738625ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -2146,7 +2146,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2155,7 +2155,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c295f31d-4c91-44b3-9709-0fe998976585
+                - eebee72d-0c5c-4855-ab9c-a25fb20d317d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2163,8 +2163,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103925Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T133726Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2183,14 +2183,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:39:25 GMT
+                - Mon, 18 May 2026 13:37:26 GMT
             X-Amz-Id-2:
-                - txgeedcf3842f704429824e-006a0aec5d
+                - txgf0be23ac533741fd8d01-006a0b1616
             X-Amz-Request-Id:
-                - txgeedcf3842f704429824e-006a0aec5d
+                - txgf0be23ac533741fd8d01-006a0b1616
         status: 200 OK
         code: 200
-        duration: 222.745875ms
+        duration: 55.171334ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -2199,7 +2199,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2208,7 +2208,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b9af8784-974c-492b-9500-83c655b0446f
+                - 31ca1b34-999c-482e-8420-8d71ca1f1705
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2216,8 +2216,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103925Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T133726Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2236,14 +2236,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:39:26 GMT
+                - Mon, 18 May 2026 13:37:26 GMT
             X-Amz-Id-2:
-                - txgae7d7f3ba5ac4cf6b918-006a0aec5e
+                - txg6bb2cb64e6fa47e0adf2-006a0b1616
             X-Amz-Request-Id:
-                - txgae7d7f3ba5ac4cf6b918-006a0aec5e
+                - txg6bb2cb64e6fa47e0adf2-006a0b1616
         status: 200 OK
         code: 200
-        duration: 41.098292ms
+        duration: 53.465459ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -2252,7 +2252,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2261,7 +2261,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d465120c-a41d-4c19-aa5f-4cc4d925c554
+                - cfe99d6e-9082-45a5-adb8-e0ee1efd4202
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2269,8 +2269,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103926Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1946076572531615505.s3.nl-ams.scw.cloud/
+                - 20260518T133726Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2283,11 +2283,11 @@ interactions:
         body: ""
         headers:
             Date:
-                - Mon, 18 May 2026 10:39:26 GMT
+                - Mon, 18 May 2026 13:37:26 GMT
             X-Amz-Id-2:
-                - txgf6908e5d83db441995a5-006a0aec5e
+                - txg5088dda52e5440038721-006a0b1616
             X-Amz-Request-Id:
-                - txgf6908e5d83db441995a5-006a0aec5e
+                - txg5088dda52e5440038721-006a0b1616
         status: 204 No Content
         code: 204
-        duration: 352.592084ms
+        duration: 212.13025ms

--- a/internal/services/object/testdata/object-bucket-lifecycle-remove-rule.cassette.yaml
+++ b/internal/services/object/testdata/object-bucket-lifecycle-remove-rule.cassette.yaml
@@ -1,0 +1,1041 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 5f03d08c-27f6-46e1-9346-8c42d6d0010b
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260513T153254Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud/
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Length:
+                - "0"
+            Date:
+                - Wed, 13 May 2026 15:32:54 GMT
+            Location:
+                - /tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805
+            X-Amz-Id-2:
+                - txge0d274788b1a43c090d7-006a0499a6
+            X-Amz-Request-Id:
+                - txge0d274788b1a43c090d7-006a0499a6
+        status: 200 OK
+        code: 200
+        duration: 3.942176334s
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 6485da5d-0e4f-4393-b71a-566f424ae6fa
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,Z,e
+            X-Amz-Acl:
+                - private
+            X-Amz-Checksum-Crc32:
+                - AAAAAA==
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260513T153258Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud/?acl=
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Length:
+                - "0"
+            Date:
+                - Wed, 13 May 2026 15:32:58 GMT
+            X-Amz-Id-2:
+                - txg9a8adb3e506a406f9221-006a0499aa
+            X-Amz-Request-Id:
+                - txg9a8adb3e506a406f9221-006a0499aa
+        status: 200 OK
+        code: 200
+        duration: 96.847ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 265
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><ExpiredObjectDeleteMarker>true</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>expire delete markers</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 6cce23b6-df9c-4465-8e75-f16fca75f3e0
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            Content-Type:
+                - application/xml
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,Z,e
+            X-Amz-Checksum-Crc32:
+                - NdscUw==
+            X-Amz-Content-Sha256:
+                - fd28d6105facd58e0708118f811178b230c443b5cac5e2f9bb6714a806f344e0
+            X-Amz-Date:
+                - 20260513T153258Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud/?lifecycle=
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Length:
+                - "0"
+            Date:
+                - Wed, 13 May 2026 15:32:58 GMT
+            X-Amz-Id-2:
+                - txgd4a5975d6e634f8ba651-006a0499aa
+            X-Amz-Request-Id:
+                - txgd4a5975d6e634f8ba651-006a0499aa
+        status: 200 OK
+        code: 200
+        duration: 83.63875ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 514cc3f5-9635-4a10-8c7d-049fd809290f
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260513T153258Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud/?acl=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 698
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+        headers:
+            Content-Length:
+                - "698"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Wed, 13 May 2026 15:32:58 GMT
+            X-Amz-Id-2:
+                - txg7a3c68a91b5846cf8caf-006a0499aa
+            X-Amz-Request-Id:
+                - txg7a3c68a91b5846cf8caf-006a0499aa
+        status: 200 OK
+        code: 200
+        duration: 136.169583ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 8bec365f-c56c-4600-9cbb-72c11e80eba8
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260513T153258Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud/?object-lock=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 330
+        uncompressed: false
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgaa5d9fca42b741f78a8b-006a0499aa</RequestId><HostId>txgaa5d9fca42b741f78a8b-006a0499aa</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805</Resource></Error>
+        headers:
+            Content-Length:
+                - "330"
+            Content-Type:
+                - application/xml
+            Date:
+                - Wed, 13 May 2026 15:32:58 GMT
+            X-Amz-Id-2:
+                - txgaa5d9fca42b741f78a8b-006a0499aa
+            X-Amz-Request-Id:
+                - txgaa5d9fca42b741f78a8b-006a0499aa
+        status: 404 Not Found
+        code: 404
+        duration: 57.13425ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - f9072d8c-0746-4138-b56b-ad108c130771
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260513T153258Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud/
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 287
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+        headers:
+            Content-Length:
+                - "287"
+            Content-Type:
+                - application/xml
+            Date:
+                - Wed, 13 May 2026 15:32:58 GMT
+            X-Amz-Id-2:
+                - txgbaf7fe8b899641cab057-006a0499aa
+            X-Amz-Request-Id:
+                - txgbaf7fe8b899641cab057-006a0499aa
+        status: 200 OK
+        code: 200
+        duration: 173.758458ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - be5fbcb9-a26e-4ac2-9833-31c96286cd74
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260513T153258Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud/?tagging=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 361
+        uncompressed: false
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg6c9492427fb04a10b43a-006a0499aa</RequestId><HostId>txg6c9492427fb04a10b43a-006a0499aa</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805</BucketName></Error>
+        headers:
+            Content-Length:
+                - "361"
+            Content-Type:
+                - application/xml
+            Date:
+                - Wed, 13 May 2026 15:32:58 GMT
+            X-Amz-Id-2:
+                - txg6c9492427fb04a10b43a-006a0499aa
+            X-Amz-Request-Id:
+                - txg6c9492427fb04a10b43a-006a0499aa
+        status: 404 Not Found
+        code: 404
+        duration: 33.261458ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 65109d9e-ae3e-41ab-abea-12d8171f6bf6
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260513T153258Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud/?cors=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 298
+        uncompressed: false
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg7ed6d32b2d924735b438-006a0499aa</RequestId><HostId>txg7ed6d32b2d924735b438-006a0499aa</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805</Resource></Error>
+        headers:
+            Content-Length:
+                - "298"
+            Content-Type:
+                - application/xml
+            Date:
+                - Wed, 13 May 2026 15:32:58 GMT
+            X-Amz-Id-2:
+                - txg7ed6d32b2d924735b438-006a0499aa
+            X-Amz-Request-Id:
+                - txg7ed6d32b2d924735b438-006a0499aa
+        status: 404 Not Found
+        code: 404
+        duration: 179.863917ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 2de84dd4-4bb6-41aa-9e5f-08c37180b91d
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260513T153258Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud/?versioning=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 107
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <VersioningConfiguration><Status></Status></VersioningConfiguration>
+        headers:
+            Content-Length:
+                - "107"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Wed, 13 May 2026 15:32:58 GMT
+            X-Amz-Id-2:
+                - txg1efe1fb51b654f58b741-006a0499aa
+            X-Amz-Request-Id:
+                - txg1efe1fb51b654f58b741-006a0499aa
+        status: 200 OK
+        code: 200
+        duration: 298.135083ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - d10628c6-fc57-4b1d-a0f5-4fda302ee1d1
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260513T153258Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud/?lifecycle=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 238
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <Configuration><Rule><Expiration><ExpiredObjectDeleteMarker>true</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>expire delete markers</ID><Status>Enabled</Status></Rule></Configuration>
+        headers:
+            Content-Length:
+                - "238"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Wed, 13 May 2026 15:32:59 GMT
+            X-Amz-Id-2:
+                - txgd6e729390c4f4d9aabeb-006a0499ab
+            X-Amz-Request-Id:
+                - txgd6e729390c4f4d9aabeb-006a0499ab
+        status: 200 OK
+        code: 200
+        duration: 72.234167ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - e63d1868-3a04-4c90-be87-2454d66c0a70
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260513T153259Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud/
+        method: HEAD
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Type:
+                - application/xml
+            Date:
+                - Wed, 13 May 2026 15:32:59 GMT
+            X-Amz-Bucket-Region:
+                - nl-ams
+            X-Amz-Id-2:
+                - txg7c0b4240e1c94e649b15-006a0499ab
+            X-Amz-Request-Id:
+                - txg7c0b4240e1c94e649b15-006a0499ab
+        status: 200 OK
+        code: 200
+        duration: 296.053375ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 3b827017-a7be-4f79-929b-cc3806a8369a
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260513T153259Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud/?lifecycle=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 238
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <Configuration><Rule><Expiration><ExpiredObjectDeleteMarker>true</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>expire delete markers</ID><Status>Enabled</Status></Rule></Configuration>
+        headers:
+            Content-Length:
+                - "238"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Wed, 13 May 2026 15:32:59 GMT
+            X-Amz-Id-2:
+                - txgea6396b59a0141ae8dcd-006a0499ab
+            X-Amz-Request-Id:
+                - txgea6396b59a0141ae8dcd-006a0499ab
+        status: 200 OK
+        code: 200
+        duration: 23.425834ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 7d8c3cdc-f8cf-46b9-8499-f5bb6d6b80b8
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260513T153300Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud/?acl=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 698
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+        headers:
+            Content-Length:
+                - "698"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Wed, 13 May 2026 15:33:00 GMT
+            X-Amz-Id-2:
+                - txg3b01328401c3416bb686-006a0499ac
+            X-Amz-Request-Id:
+                - txg3b01328401c3416bb686-006a0499ac
+        status: 200 OK
+        code: 200
+        duration: 211.570667ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 25ae0b35-6c69-4b01-b516-adc29b214971
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260513T153300Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud/?object-lock=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 330
+        uncompressed: false
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgf88dc3c1cb8b481199a0-006a0499ac</RequestId><HostId>txgf88dc3c1cb8b481199a0-006a0499ac</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805</Resource></Error>
+        headers:
+            Content-Length:
+                - "330"
+            Content-Type:
+                - application/xml
+            Date:
+                - Wed, 13 May 2026 15:33:00 GMT
+            X-Amz-Id-2:
+                - txgf88dc3c1cb8b481199a0-006a0499ac
+            X-Amz-Request-Id:
+                - txgf88dc3c1cb8b481199a0-006a0499ac
+        status: 404 Not Found
+        code: 404
+        duration: 241.590542ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - a5b79608-cb34-445a-8b2c-2447a40b4764
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260513T153300Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud/
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 287
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+        headers:
+            Content-Length:
+                - "287"
+            Content-Type:
+                - application/xml
+            Date:
+                - Wed, 13 May 2026 15:33:00 GMT
+            X-Amz-Id-2:
+                - txg4d6df495347b45a6be92-006a0499ac
+            X-Amz-Request-Id:
+                - txg4d6df495347b45a6be92-006a0499ac
+        status: 200 OK
+        code: 200
+        duration: 244.314709ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 30a6312f-a76a-40fd-8bd6-a756fab8ecb8
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260513T153300Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud/?tagging=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 361
+        uncompressed: false
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg1f282bd683f34f45a477-006a0499ac</RequestId><HostId>txg1f282bd683f34f45a477-006a0499ac</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805</BucketName></Error>
+        headers:
+            Content-Length:
+                - "361"
+            Content-Type:
+                - application/xml
+            Date:
+                - Wed, 13 May 2026 15:33:00 GMT
+            X-Amz-Id-2:
+                - txg1f282bd683f34f45a477-006a0499ac
+            X-Amz-Request-Id:
+                - txg1f282bd683f34f45a477-006a0499ac
+        status: 404 Not Found
+        code: 404
+        duration: 235.939042ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - fc76786f-13c3-44d7-8020-ade899645aca
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260513T153300Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud/?cors=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 298
+        uncompressed: false
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg9f5f247055644348aa14-006a0499ac</RequestId><HostId>txg9f5f247055644348aa14-006a0499ac</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805</Resource></Error>
+        headers:
+            Content-Length:
+                - "298"
+            Content-Type:
+                - application/xml
+            Date:
+                - Wed, 13 May 2026 15:33:00 GMT
+            X-Amz-Id-2:
+                - txg9f5f247055644348aa14-006a0499ac
+            X-Amz-Request-Id:
+                - txg9f5f247055644348aa14-006a0499ac
+        status: 404 Not Found
+        code: 404
+        duration: 96.513667ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 59b1125d-6ef4-4763-9850-90df7b25a86b
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260513T153300Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud/?versioning=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 107
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <VersioningConfiguration><Status></Status></VersioningConfiguration>
+        headers:
+            Content-Length:
+                - "107"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Wed, 13 May 2026 15:33:01 GMT
+            X-Amz-Id-2:
+                - txg1950ea1156a345f0aa11-006a0499ad
+            X-Amz-Request-Id:
+                - txg1950ea1156a345f0aa11-006a0499ad
+        status: 200 OK
+        code: 200
+        duration: 400.492458ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 05637caf-e72e-437d-9729-93b723474ab0
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260513T153301Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud/?lifecycle=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 238
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <Configuration><Rule><Expiration><ExpiredObjectDeleteMarker>true</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>expire delete markers</ID><Status>Enabled</Status></Rule></Configuration>
+        headers:
+            Content-Length:
+                - "238"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Wed, 13 May 2026 15:33:01 GMT
+            X-Amz-Id-2:
+                - txge87191201bc6438885d0-006a0499ad
+            X-Amz-Request-Id:
+                - txge87191201bc6438885d0-006a0499ad
+        status: 200 OK
+        code: 200
+        duration: 64.295417ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - c91492ac-5a77-4ecc-9c4f-3728c4610072
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260513T153301Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-2644150182178468805.s3.nl-ams.scw.cloud/
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Date:
+                - Wed, 13 May 2026 15:33:01 GMT
+            X-Amz-Id-2:
+                - txgf83674c43a3b4066a5fc-006a0499ad
+            X-Amz-Request-Id:
+                - txgf83674c43a3b4066a5fc-006a0499ad
+        status: 204 No Content
+        code: 204
+        duration: 548.86275ms

--- a/internal/services/object/testdata/object-bucket-lifecycle-remove-rule.cassette.yaml
+++ b/internal/services/object/testdata/object-bucket-lifecycle-remove-rule.cassette.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -18,7 +18,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 962d684e-d7e2-47a6-85ec-a8b6d0d57531
+                - 4409d30f-a3fd-4477-9762-3e1173b45aaa
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -26,8 +26,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133715Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/
+                - 20260518T140826Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud/
         method: PUT
       response:
         proto: HTTP/2.0
@@ -42,16 +42,16 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 18 May 2026 13:37:16 GMT
+                - Mon, 18 May 2026 14:08:26 GMT
             Location:
-                - /tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655
+                - /tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767
             X-Amz-Id-2:
-                - txgbb6800e8e46f4978a308-006a0b160c
+                - txgb81507bf2eb6441ea8ba-006a0b1d5a
             X-Amz-Request-Id:
-                - txgbb6800e8e46f4978a308-006a0b160c
+                - txgb81507bf2eb6441ea8ba-006a0b1d5a
         status: 200 OK
         code: 200
-        duration: 4.78261575s
+        duration: 5.150312333s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -60,7 +60,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -69,7 +69,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c353fd3e-aa15-4163-80b6-501dfd0f3822
+                - 23a86053-4176-4880-a868-4c4bf1c0f1c3
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -81,8 +81,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133720Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T140831Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud/?acl=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -97,14 +97,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 18 May 2026 13:37:20 GMT
+                - Mon, 18 May 2026 14:08:31 GMT
             X-Amz-Id-2:
-                - txgafb5438e9e6242caa082-006a0b1610
+                - txg4811c6f13c424baf8353-006a0b1d5f
             X-Amz-Request-Id:
-                - txgafb5438e9e6242caa082-006a0b1610
+                - txg4811c6f13c424baf8353-006a0b1d5f
         status: 200 OK
         code: 200
-        duration: 80.522167ms
+        duration: 281.15325ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -113,7 +113,7 @@ interactions:
         content_length: 460
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>prefix/</Prefix></Filter><ID>to delete</ID><Status>Enabled</Status></Rule><Rule><Expiration><ExpiredObjectDeleteMarker>true</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>expire delete markers</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
@@ -122,7 +122,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 1f8e5da2-11bf-4e97-b008-622e160d38ea
+                - 74609fbb-cd28-4bb6-82e4-14881ccd8701
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
@@ -134,8 +134,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - be82f5350a9f62e9880e1d0bfb67fee8cb072fff45d9d7171711c16a6b0dbbb2
             X-Amz-Date:
-                - 20260518T133720Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T140831Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -150,14 +150,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 18 May 2026 13:37:20 GMT
+                - Mon, 18 May 2026 14:08:32 GMT
             X-Amz-Id-2:
-                - txgd1a8fc9e1d0e4303b180-006a0b1610
+                - txga2b80f67636848e3b1ac-006a0b1d60
             X-Amz-Request-Id:
-                - txgd1a8fc9e1d0e4303b180-006a0b1610
+                - txga2b80f67636848e3b1ac-006a0b1d60
         status: 200 OK
         code: 200
-        duration: 132.02225ms
+        duration: 96.400667ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -166,7 +166,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -175,7 +175,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f0f580b6-9b24-469e-9f20-ad5234ed5c7d
+                - 5d2e446d-16f7-4fe9-8d55-648103f48919
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -183,8 +183,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133720Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T140832Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -203,14 +203,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:37:21 GMT
+                - Mon, 18 May 2026 14:08:32 GMT
             X-Amz-Id-2:
-                - txg5d9fcc8616da40ee9581-006a0b1611
+                - txg552aecf3964d4f5dad5f-006a0b1d60
             X-Amz-Request-Id:
-                - txg5d9fcc8616da40ee9581-006a0b1611
+                - txg552aecf3964d4f5dad5f-006a0b1d60
         status: 200 OK
         code: 200
-        duration: 54.802209ms
+        duration: 191.747459ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -219,7 +219,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -228,7 +228,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 588053c6-7483-4487-9792-68613f9ee3ca
+                - 234a8840-2e4e-4921-b97e-54c5d4473c87
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -236,8 +236,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133721Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T140832Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -247,21 +247,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg9dc7337cad0e4590aff2-006a0b1611</RequestId><HostId>txg9dc7337cad0e4590aff2-006a0b1611</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg6a4474ba51734dff83c7-006a0b1d60</RequestId><HostId>txg6a4474ba51734dff83c7-006a0b1d60</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:37:21 GMT
+                - Mon, 18 May 2026 14:08:32 GMT
             X-Amz-Id-2:
-                - txg9dc7337cad0e4590aff2-006a0b1611
+                - txg6a4474ba51734dff83c7-006a0b1d60
             X-Amz-Request-Id:
-                - txg9dc7337cad0e4590aff2-006a0b1611
+                - txg6a4474ba51734dff83c7-006a0b1d60
         status: 404 Not Found
         code: 404
-        duration: 685.988958ms
+        duration: 3.38942925s
     - id: 5
       request:
         proto: HTTP/1.1
@@ -270,7 +270,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -279,7 +279,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - a086af17-04b0-4ec1-a755-6ee0899dec17
+                - a89dbba5-46ee-44dd-8681-06bc84e72e48
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -287,8 +287,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133721Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/
+                - 20260518T140832Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -300,21 +300,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:37:21 GMT
+                - Mon, 18 May 2026 14:08:35 GMT
             X-Amz-Id-2:
-                - txg60b5c3654fd44b238b07-006a0b1611
+                - txg19c5a1673b4e40859192-006a0b1d63
             X-Amz-Request-Id:
-                - txg60b5c3654fd44b238b07-006a0b1611
+                - txg19c5a1673b4e40859192-006a0b1d63
         status: 200 OK
         code: 200
-        duration: 65.281833ms
+        duration: 280.897416ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -323,7 +323,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -332,7 +332,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 6cbf9192-f653-41d4-aea9-464386bd63fb
+                - 21b63ed9-d787-453f-a403-d558198176a5
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -340,8 +340,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133721Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T140835Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -351,21 +351,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgb99aea70c361450a88d1-006a0b1611</RequestId><HostId>txgb99aea70c361450a88d1-006a0b1611</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg6483ba94f98747aea2a1-006a0b1d64</RequestId><HostId>txg6483ba94f98747aea2a1-006a0b1d64</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:37:21 GMT
+                - Mon, 18 May 2026 14:08:36 GMT
             X-Amz-Id-2:
-                - txgb99aea70c361450a88d1-006a0b1611
+                - txg6483ba94f98747aea2a1-006a0b1d64
             X-Amz-Request-Id:
-                - txgb99aea70c361450a88d1-006a0b1611
+                - txg6483ba94f98747aea2a1-006a0b1d64
         status: 404 Not Found
         code: 404
-        duration: 34.163792ms
+        duration: 73.521083ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -374,7 +374,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -383,7 +383,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b472dd1a-32a0-44fb-b92b-0a8eac563c23
+                - 7f103923-5465-4179-aff0-1fd21cd06eb4
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -391,8 +391,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133721Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T140836Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -402,21 +402,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg2cd99303583140f0b3e8-006a0b1611</RequestId><HostId>txg2cd99303583140f0b3e8-006a0b1611</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg8986ab08ceda493e9058-006a0b1d64</RequestId><HostId>txg8986ab08ceda493e9058-006a0b1d64</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:37:21 GMT
+                - Mon, 18 May 2026 14:08:36 GMT
             X-Amz-Id-2:
-                - txg2cd99303583140f0b3e8-006a0b1611
+                - txg8986ab08ceda493e9058-006a0b1d64
             X-Amz-Request-Id:
-                - txg2cd99303583140f0b3e8-006a0b1611
+                - txg8986ab08ceda493e9058-006a0b1d64
         status: 404 Not Found
         code: 404
-        duration: 54.189125ms
+        duration: 75.801375ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -425,7 +425,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -434,7 +434,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5701192f-e02c-4e80-94ac-6035bbf4aa10
+                - 6882081a-af50-44da-935a-f3fc3739ce2a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -442,8 +442,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133721Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T140836Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -462,14 +462,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:37:21 GMT
+                - Mon, 18 May 2026 14:08:36 GMT
             X-Amz-Id-2:
-                - txg50ae64a8c2c74acfaf74-006a0b1611
+                - txgcf5efdeba1fe4befa7f2-006a0b1d64
             X-Amz-Request-Id:
-                - txg50ae64a8c2c74acfaf74-006a0b1611
+                - txgcf5efdeba1fe4befa7f2-006a0b1d64
         status: 200 OK
         code: 200
-        duration: 72.628959ms
+        duration: 57.261459ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -478,7 +478,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -487,7 +487,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9eb400bb-c4c8-418f-afbf-cf914676b5b4
+                - 04cf55a4-d52d-48d8-8e08-45361a815152
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -495,8 +495,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133721Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T140836Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -515,14 +515,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:37:21 GMT
+                - Mon, 18 May 2026 14:08:36 GMT
             X-Amz-Id-2:
-                - txg003cd11bf799481f8fc1-006a0b1611
+                - txg0ff5258c8c764ee78119-006a0b1d64
             X-Amz-Request-Id:
-                - txg003cd11bf799481f8fc1-006a0b1611
+                - txg0ff5258c8c764ee78119-006a0b1d64
         status: 200 OK
         code: 200
-        duration: 71.7905ms
+        duration: 45.591625ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -531,7 +531,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -540,7 +540,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 3d0beb89-f04d-4fbd-aaea-4137db74bbd1
+                - d71f62f8-51fe-4c6c-b207-d4c8d2bea107
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -548,8 +548,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133722Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/
+                - 20260518T140836Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -564,16 +564,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:37:22 GMT
+                - Mon, 18 May 2026 14:08:36 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txgfe8223b861524c48933f-006a0b1612
+                - txgddd099a65a4b4432be58-006a0b1d64
             X-Amz-Request-Id:
-                - txgfe8223b861524c48933f-006a0b1612
+                - txgddd099a65a4b4432be58-006a0b1d64
         status: 200 OK
         code: 200
-        duration: 63.734833ms
+        duration: 165.926833ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -582,7 +582,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -591,7 +591,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9ab10941-0d98-41cc-b021-af206956e50f
+                - 545708fa-2c00-4c63-abdd-edf0aebd6b8c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -599,8 +599,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133722Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T140836Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -619,14 +619,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:37:22 GMT
+                - Mon, 18 May 2026 14:08:36 GMT
             X-Amz-Id-2:
-                - txgf1c004b7d48f41fa986b-006a0b1612
+                - txga9c3a4a0f66b4f7d9f6c-006a0b1d64
             X-Amz-Request-Id:
-                - txgf1c004b7d48f41fa986b-006a0b1612
+                - txga9c3a4a0f66b4f7d9f6c-006a0b1d64
         status: 200 OK
         code: 200
-        duration: 53.346ms
+        duration: 345.794125ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -635,7 +635,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -644,7 +644,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - dbe73d14-8ba2-446e-9628-e3a14b53d88c
+                - b0e12859-87ca-4307-87b9-a3471def18ed
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -652,8 +652,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133722Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T140837Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -672,14 +672,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:37:22 GMT
+                - Mon, 18 May 2026 14:08:37 GMT
             X-Amz-Id-2:
-                - txg6e6d851591f443ea8635-006a0b1612
+                - txg37dc0393ad6e4e6089a0-006a0b1d65
             X-Amz-Request-Id:
-                - txg6e6d851591f443ea8635-006a0b1612
+                - txg37dc0393ad6e4e6089a0-006a0b1d65
         status: 200 OK
         code: 200
-        duration: 204.707125ms
+        duration: 79.261709ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -688,7 +688,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -697,7 +697,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 165bdfc5-3b35-4384-8c09-954437549257
+                - 1ec7ffe7-94ec-402e-ae9b-dc05d8e1be74
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -705,8 +705,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133722Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T140837Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -716,21 +716,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg5d4660538aa84f769fc4-006a0b1612</RequestId><HostId>txg5d4660538aa84f769fc4-006a0b1612</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg04f62ec12ba04a388201-006a0b1d65</RequestId><HostId>txg04f62ec12ba04a388201-006a0b1d65</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:37:22 GMT
+                - Mon, 18 May 2026 14:08:37 GMT
             X-Amz-Id-2:
-                - txg5d4660538aa84f769fc4-006a0b1612
+                - txg04f62ec12ba04a388201-006a0b1d65
             X-Amz-Request-Id:
-                - txg5d4660538aa84f769fc4-006a0b1612
+                - txg04f62ec12ba04a388201-006a0b1d65
         status: 404 Not Found
         code: 404
-        duration: 36.459625ms
+        duration: 1.897813917s
     - id: 14
       request:
         proto: HTTP/1.1
@@ -739,7 +739,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -748,7 +748,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ea4f2d78-936f-410a-80ec-992e038797f2
+                - 3ae6b185-c95f-4f8c-a4c9-fcaf82099ca7
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -756,8 +756,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133722Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/
+                - 20260518T140837Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -769,21 +769,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:37:22 GMT
+                - Mon, 18 May 2026 14:08:39 GMT
             X-Amz-Id-2:
-                - txg4a0f7bf9e2f34b4280a5-006a0b1612
+                - txgc34e0653ff984f038c8d-006a0b1d67
             X-Amz-Request-Id:
-                - txg4a0f7bf9e2f34b4280a5-006a0b1612
+                - txgc34e0653ff984f038c8d-006a0b1d67
         status: 200 OK
         code: 200
-        duration: 40.130333ms
+        duration: 1.812340459s
     - id: 15
       request:
         proto: HTTP/1.1
@@ -792,7 +792,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -801,7 +801,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ad3d01f6-e893-4c86-ba70-acc8495d45e6
+                - edb3c5e6-56c2-4ad5-93a9-739659cc68fe
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -809,8 +809,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133722Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T140839Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -820,21 +820,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg576f5f3eed9d4c7896b7-006a0b1612</RequestId><HostId>txg576f5f3eed9d4c7896b7-006a0b1612</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgf42d9257fed94d9e9873-006a0b1d69</RequestId><HostId>txgf42d9257fed94d9e9873-006a0b1d69</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:37:22 GMT
+                - Mon, 18 May 2026 14:08:41 GMT
             X-Amz-Id-2:
-                - txg576f5f3eed9d4c7896b7-006a0b1612
+                - txgf42d9257fed94d9e9873-006a0b1d69
             X-Amz-Request-Id:
-                - txg576f5f3eed9d4c7896b7-006a0b1612
+                - txgf42d9257fed94d9e9873-006a0b1d69
         status: 404 Not Found
         code: 404
-        duration: 39.796209ms
+        duration: 59.429916ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -843,7 +843,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -852,7 +852,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 06364116-7dab-4792-ade7-b430c2ad2aaa
+                - 19893bd8-304e-41d4-b202-9188016861ca
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -860,8 +860,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133722Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T140841Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -871,21 +871,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgb98fe98a9ac246119f47-006a0b1612</RequestId><HostId>txgb98fe98a9ac246119f47-006a0b1612</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg45fb64b5a3584692acd2-006a0b1d69</RequestId><HostId>txg45fb64b5a3584692acd2-006a0b1d69</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:37:22 GMT
+                - Mon, 18 May 2026 14:08:41 GMT
             X-Amz-Id-2:
-                - txgb98fe98a9ac246119f47-006a0b1612
+                - txg45fb64b5a3584692acd2-006a0b1d69
             X-Amz-Request-Id:
-                - txgb98fe98a9ac246119f47-006a0b1612
+                - txg45fb64b5a3584692acd2-006a0b1d69
         status: 404 Not Found
         code: 404
-        duration: 61.186667ms
+        duration: 113.767833ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -894,7 +894,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -903,7 +903,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 3de24d7b-1a6e-4732-a4c2-faf16010e122
+                - a51af70c-b5d8-4861-b70d-db4797c3c1b1
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -911,8 +911,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133722Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T140841Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -931,14 +931,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:37:22 GMT
+                - Mon, 18 May 2026 14:08:41 GMT
             X-Amz-Id-2:
-                - txg41168af261a04e43ba2e-006a0b1612
+                - txgc40983da427d495b9741-006a0b1d69
             X-Amz-Request-Id:
-                - txg41168af261a04e43ba2e-006a0b1612
+                - txgc40983da427d495b9741-006a0b1d69
         status: 200 OK
         code: 200
-        duration: 52.61ms
+        duration: 61.312583ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -947,7 +947,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -956,7 +956,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 56b33d0a-26ff-4551-8f70-6506498a03ee
+                - 7904c03c-879a-4b05-87fa-db93a66ed622
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -964,8 +964,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133722Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T140841Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -984,14 +984,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:37:22 GMT
+                - Mon, 18 May 2026 14:08:41 GMT
             X-Amz-Id-2:
-                - txg07138c3a65e8404bb243-006a0b1612
+                - txgcb297cc4a5bc481ea217-006a0b1d69
             X-Amz-Request-Id:
-                - txg07138c3a65e8404bb243-006a0b1612
+                - txgcb297cc4a5bc481ea217-006a0b1d69
         status: 200 OK
         code: 200
-        duration: 55.897917ms
+        duration: 189.173334ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -1000,7 +1000,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1009,7 +1009,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7b49ca8b-4841-42ab-8dd3-5b4ecdc2ffd4
+                - 99362cd8-554c-49be-8f4f-e8f7fa4e1c58
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1017,8 +1017,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133723Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T140841Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1037,14 +1037,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:37:23 GMT
+                - Mon, 18 May 2026 14:08:41 GMT
             X-Amz-Id-2:
-                - txg0fee9aeaf0244b12aa23-006a0b1613
+                - txgca251a6141ab42c1a9f6-006a0b1d69
             X-Amz-Request-Id:
-                - txg0fee9aeaf0244b12aa23-006a0b1613
+                - txgca251a6141ab42c1a9f6-006a0b1d69
         status: 200 OK
         code: 200
-        duration: 62.99875ms
+        duration: 74.575458ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1053,7 +1053,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1062,7 +1062,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 87ece195-1920-4e70-b048-22e6084098ae
+                - 45b497f2-d74c-4420-9a89-7af7e858661f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1070,8 +1070,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133723Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T140841Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1081,21 +1081,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg43a939099e3040669ef0-006a0b1613</RequestId><HostId>txg43a939099e3040669ef0-006a0b1613</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg0091cd9a028346e0b5d0-006a0b1d69</RequestId><HostId>txg0091cd9a028346e0b5d0-006a0b1d69</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:37:23 GMT
+                - Mon, 18 May 2026 14:08:41 GMT
             X-Amz-Id-2:
-                - txg43a939099e3040669ef0-006a0b1613
+                - txg0091cd9a028346e0b5d0-006a0b1d69
             X-Amz-Request-Id:
-                - txg43a939099e3040669ef0-006a0b1613
+                - txg0091cd9a028346e0b5d0-006a0b1d69
         status: 404 Not Found
         code: 404
-        duration: 38.950417ms
+        duration: 107.035542ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1104,7 +1104,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1113,7 +1113,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 26412df6-0b87-4091-93a8-48c1daa0fd0c
+                - 108df887-e78b-4f63-995e-cd2a40982393
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1121,8 +1121,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133723Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/
+                - 20260518T140841Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -1134,21 +1134,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:37:23 GMT
+                - Mon, 18 May 2026 14:08:41 GMT
             X-Amz-Id-2:
-                - txgd76dc95d3e5849e28fd7-006a0b1613
+                - txg2bf9146876ae4849aca7-006a0b1d69
             X-Amz-Request-Id:
-                - txgd76dc95d3e5849e28fd7-006a0b1613
+                - txg2bf9146876ae4849aca7-006a0b1d69
         status: 200 OK
         code: 200
-        duration: 229.270292ms
+        duration: 123.722209ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1157,7 +1157,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1166,7 +1166,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4247b47d-74e8-42c8-ae85-6005c99562b7
+                - 9f978553-d49a-45cd-88b1-29f2fa631c02
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1174,8 +1174,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133723Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T140841Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1185,21 +1185,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg7624757984db4121bb24-006a0b1613</RequestId><HostId>txg7624757984db4121bb24-006a0b1613</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgddedf25ba2384f94b0cb-006a0b1d69</RequestId><HostId>txgddedf25ba2384f94b0cb-006a0b1d69</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:37:23 GMT
+                - Mon, 18 May 2026 14:08:41 GMT
             X-Amz-Id-2:
-                - txg7624757984db4121bb24-006a0b1613
+                - txgddedf25ba2384f94b0cb-006a0b1d69
             X-Amz-Request-Id:
-                - txg7624757984db4121bb24-006a0b1613
+                - txgddedf25ba2384f94b0cb-006a0b1d69
         status: 404 Not Found
         code: 404
-        duration: 53.167ms
+        duration: 26.7315ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1208,7 +1208,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1217,7 +1217,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e685defb-5d9f-4d93-a14c-3199d528ed9b
+                - 859b4c45-f888-4042-8e0b-70e1629dd99d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1225,8 +1225,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133723Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T140841Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1236,21 +1236,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg9a993c8da26c4ed89b74-006a0b1613</RequestId><HostId>txg9a993c8da26c4ed89b74-006a0b1613</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg9b3d10871ef04eb187fb-006a0b1d69</RequestId><HostId>txg9b3d10871ef04eb187fb-006a0b1d69</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:37:23 GMT
+                - Mon, 18 May 2026 14:08:41 GMT
             X-Amz-Id-2:
-                - txg9a993c8da26c4ed89b74-006a0b1613
+                - txg9b3d10871ef04eb187fb-006a0b1d69
             X-Amz-Request-Id:
-                - txg9a993c8da26c4ed89b74-006a0b1613
+                - txg9b3d10871ef04eb187fb-006a0b1d69
         status: 404 Not Found
         code: 404
-        duration: 34.948708ms
+        duration: 62.436666ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1259,7 +1259,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1268,7 +1268,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9c863182-e3a6-4f99-b67b-5e9b65ee3ee6
+                - 33a37c0c-2f22-4c9f-99ca-182860eb817c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1276,8 +1276,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133723Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T140841Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1296,14 +1296,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:37:23 GMT
+                - Mon, 18 May 2026 14:08:42 GMT
             X-Amz-Id-2:
-                - txg371f683cca9f4e6d91a4-006a0b1613
+                - txg72dec24f66d74f4c9f6b-006a0b1d6a
             X-Amz-Request-Id:
-                - txg371f683cca9f4e6d91a4-006a0b1613
+                - txg72dec24f66d74f4c9f6b-006a0b1d6a
         status: 200 OK
         code: 200
-        duration: 52.211083ms
+        duration: 194.310083ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1312,7 +1312,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1321,7 +1321,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - dd14964a-1de2-40aa-9ad2-621fc30c2555
+                - 6f0841ff-c9a0-43c5-9023-726d2c7b4317
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1329,8 +1329,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133723Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T140842Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1349,14 +1349,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:37:23 GMT
+                - Mon, 18 May 2026 14:08:42 GMT
             X-Amz-Id-2:
-                - txg2457b57c9e414c9a80e1-006a0b1613
+                - txg6caedb28173541529adf-006a0b1d6a
             X-Amz-Request-Id:
-                - txg2457b57c9e414c9a80e1-006a0b1613
+                - txg6caedb28173541529adf-006a0b1d6a
         status: 200 OK
         code: 200
-        duration: 22.925334ms
+        duration: 167.482292ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1365,7 +1365,7 @@ interactions:
         content_length: 265
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><ExpiredObjectDeleteMarker>true</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>expire delete markers</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
@@ -1374,7 +1374,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7d1065b1-f6b7-4812-b508-c6b0f52ca58f
+                - 759824e1-b8fb-4bf9-bd57-3670735a46f9
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
@@ -1386,8 +1386,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - fd28d6105facd58e0708118f811178b230c443b5cac5e2f9bb6714a806f344e0
             X-Amz-Date:
-                - 20260518T133723Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T140842Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -1402,14 +1402,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 18 May 2026 13:37:23 GMT
+                - Mon, 18 May 2026 14:08:42 GMT
             X-Amz-Id-2:
-                - txg17a6a9a5f74342fabe5c-006a0b1613
+                - txg6f8211acc82e4ed9b877-006a0b1d6a
             X-Amz-Request-Id:
-                - txg17a6a9a5f74342fabe5c-006a0b1613
+                - txg6f8211acc82e4ed9b877-006a0b1d6a
         status: 200 OK
         code: 200
-        duration: 122.384625ms
+        duration: 272.042875ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1418,7 +1418,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1427,7 +1427,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c18f1046-7e15-445b-a79f-268b7000cd7e
+                - d790aeef-110d-49e3-98b1-0b85d13b386a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1435,8 +1435,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133724Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T140842Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1455,14 +1455,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:37:24 GMT
+                - Mon, 18 May 2026 14:08:42 GMT
             X-Amz-Id-2:
-                - txg91908b9e6d3846bc8931-006a0b1614
+                - txgc0ca111ddb784febb93f-006a0b1d6a
             X-Amz-Request-Id:
-                - txg91908b9e6d3846bc8931-006a0b1614
+                - txgc0ca111ddb784febb93f-006a0b1d6a
         status: 200 OK
         code: 200
-        duration: 64.324041ms
+        duration: 29.201959ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1471,7 +1471,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1480,7 +1480,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - db2e4e18-1a70-4d60-90d8-47071bf11486
+                - dcd2e3fe-8399-41f9-8c04-fff352dd3b63
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1488,8 +1488,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133724Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T140842Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1499,21 +1499,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgae58c50c376143bf8130-006a0b1614</RequestId><HostId>txgae58c50c376143bf8130-006a0b1614</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgd32d04e5b7b54c529e20-006a0b1d6a</RequestId><HostId>txgd32d04e5b7b54c529e20-006a0b1d6a</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:37:24 GMT
+                - Mon, 18 May 2026 14:08:42 GMT
             X-Amz-Id-2:
-                - txgae58c50c376143bf8130-006a0b1614
+                - txgd32d04e5b7b54c529e20-006a0b1d6a
             X-Amz-Request-Id:
-                - txgae58c50c376143bf8130-006a0b1614
+                - txgd32d04e5b7b54c529e20-006a0b1d6a
         status: 404 Not Found
         code: 404
-        duration: 81.664167ms
+        duration: 78.132208ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1522,7 +1522,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1531,7 +1531,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5965e39a-b301-450a-ad56-4c6138fd60fa
+                - e6a9aaf9-5b23-4460-ac10-c51652796d31
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1539,8 +1539,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133724Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/
+                - 20260518T140842Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -1552,21 +1552,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:37:24 GMT
+                - Mon, 18 May 2026 14:08:42 GMT
             X-Amz-Id-2:
-                - txg8c02350a0fd74b489b00-006a0b1614
+                - txga315e85606604212beea-006a0b1d6a
             X-Amz-Request-Id:
-                - txg8c02350a0fd74b489b00-006a0b1614
+                - txga315e85606604212beea-006a0b1d6a
         status: 200 OK
         code: 200
-        duration: 1.040641166s
+        duration: 223.463959ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1575,7 +1575,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1584,7 +1584,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 70dfdaec-9bb3-41c1-bd93-382d77580bad
+                - 901da3b5-2057-497f-b78a-97bfd0408018
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1592,8 +1592,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133724Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T140842Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1603,21 +1603,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgaa4274dda34d4d6ba5e9-006a0b1615</RequestId><HostId>txgaa4274dda34d4d6ba5e9-006a0b1615</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg0cce547c3f6b4171a4a6-006a0b1d6b</RequestId><HostId>txg0cce547c3f6b4171a4a6-006a0b1d6b</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:37:25 GMT
+                - Mon, 18 May 2026 14:08:43 GMT
             X-Amz-Id-2:
-                - txgaa4274dda34d4d6ba5e9-006a0b1615
+                - txg0cce547c3f6b4171a4a6-006a0b1d6b
             X-Amz-Request-Id:
-                - txgaa4274dda34d4d6ba5e9-006a0b1615
+                - txg0cce547c3f6b4171a4a6-006a0b1d6b
         status: 404 Not Found
         code: 404
-        duration: 62.404208ms
+        duration: 62.793667ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1626,7 +1626,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1635,7 +1635,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 209b0229-e7cf-4996-bcf0-adc15a9063fe
+                - d91dabf1-e77a-412f-bd73-d06888455286
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1643,8 +1643,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133725Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T140843Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1654,21 +1654,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgdf3dfd88533845a1ae8f-006a0b1615</RequestId><HostId>txgdf3dfd88533845a1ae8f-006a0b1615</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgb48eca4c91d944e3a5d5-006a0b1d6b</RequestId><HostId>txgb48eca4c91d944e3a5d5-006a0b1d6b</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:37:25 GMT
+                - Mon, 18 May 2026 14:08:43 GMT
             X-Amz-Id-2:
-                - txgdf3dfd88533845a1ae8f-006a0b1615
+                - txgb48eca4c91d944e3a5d5-006a0b1d6b
             X-Amz-Request-Id:
-                - txgdf3dfd88533845a1ae8f-006a0b1615
+                - txgb48eca4c91d944e3a5d5-006a0b1d6b
         status: 404 Not Found
         code: 404
-        duration: 31.101042ms
+        duration: 58.149458ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1677,7 +1677,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1686,7 +1686,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 1ac478f1-8ce6-4822-a18f-334e73d3f940
+                - c9a419d1-1ead-4710-bf3c-aae29b778313
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1694,8 +1694,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133725Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T140843Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1714,14 +1714,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:37:25 GMT
+                - Mon, 18 May 2026 14:08:43 GMT
             X-Amz-Id-2:
-                - txge6bb225f57e1432aa0c7-006a0b1615
+                - txg6d91d290e8554183a3e2-006a0b1d6b
             X-Amz-Request-Id:
-                - txge6bb225f57e1432aa0c7-006a0b1615
+                - txg6d91d290e8554183a3e2-006a0b1d6b
         status: 200 OK
         code: 200
-        duration: 61.937916ms
+        duration: 236.738667ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1730,7 +1730,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1739,7 +1739,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 988267d7-3c49-47e7-8e2c-730c6084be62
+                - 088fd8f4-ebb0-47b3-ae7d-57304b17365b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1747,8 +1747,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133725Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T140843Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1767,14 +1767,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:37:25 GMT
+                - Mon, 18 May 2026 14:08:43 GMT
             X-Amz-Id-2:
-                - txgc52734107d124552a5b5-006a0b1615
+                - txg101d63223ce4483591fe-006a0b1d6b
             X-Amz-Request-Id:
-                - txgc52734107d124552a5b5-006a0b1615
+                - txg101d63223ce4483591fe-006a0b1d6b
         status: 200 OK
         code: 200
-        duration: 62.222667ms
+        duration: 27.486458ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1783,7 +1783,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1792,7 +1792,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 47c1fe9e-8928-4919-ab5e-e0540c71da0b
+                - 39fbbadd-c3aa-4be3-922a-202cac50d3cd
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1800,8 +1800,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133725Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/
+                - 20260518T140843Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -1816,16 +1816,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:37:25 GMT
+                - Mon, 18 May 2026 14:08:43 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txgabd4f4a59ec440b89cd4-006a0b1615
+                - txgd298d2f0deaa4d86ac2e-006a0b1d6b
             X-Amz-Request-Id:
-                - txgabd4f4a59ec440b89cd4-006a0b1615
+                - txgd298d2f0deaa4d86ac2e-006a0b1d6b
         status: 200 OK
         code: 200
-        duration: 28.86575ms
+        duration: 68.531208ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1834,7 +1834,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1843,7 +1843,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 680cd577-b709-4d8f-b5dc-eb0f891ab5dd
+                - f1b230a4-5105-4fdf-93f1-132c7e992ba4
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1851,8 +1851,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133725Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T140843Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1871,14 +1871,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:37:25 GMT
+                - Mon, 18 May 2026 14:08:43 GMT
             X-Amz-Id-2:
-                - txg643ff80c29be4be8a52d-006a0b1615
+                - txg5e0a1955317d42159b8b-006a0b1d6b
             X-Amz-Request-Id:
-                - txg643ff80c29be4be8a52d-006a0b1615
+                - txg5e0a1955317d42159b8b-006a0b1d6b
         status: 200 OK
         code: 200
-        duration: 190.763791ms
+        duration: 35.563542ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1887,7 +1887,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1896,7 +1896,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 16d9280d-1c62-4eae-b441-c307c88aa4ac
+                - 402e13db-e4ec-4c82-b459-e9d3ca670a48
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1904,8 +1904,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133726Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T140843Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1924,14 +1924,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:37:26 GMT
+                - Mon, 18 May 2026 14:08:44 GMT
             X-Amz-Id-2:
-                - txg880f710f5d954041a88b-006a0b1616
+                - txgee053d6be9cb473ab3ce-006a0b1d6c
             X-Amz-Request-Id:
-                - txg880f710f5d954041a88b-006a0b1616
+                - txgee053d6be9cb473ab3ce-006a0b1d6c
         status: 200 OK
         code: 200
-        duration: 35.601791ms
+        duration: 255.104458ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1940,7 +1940,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1949,7 +1949,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 71de461d-b42a-4f58-8fb1-e423f561a1b8
+                - 9910d556-04f6-4ed1-9e68-24339568898e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1957,8 +1957,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133726Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T140844Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1968,21 +1968,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg7277a28e235240d4877f-006a0b1616</RequestId><HostId>txg7277a28e235240d4877f-006a0b1616</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txga43740a7a37e4069aea3-006a0b1d6c</RequestId><HostId>txga43740a7a37e4069aea3-006a0b1d6c</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:37:26 GMT
+                - Mon, 18 May 2026 14:08:44 GMT
             X-Amz-Id-2:
-                - txg7277a28e235240d4877f-006a0b1616
+                - txga43740a7a37e4069aea3-006a0b1d6c
             X-Amz-Request-Id:
-                - txg7277a28e235240d4877f-006a0b1616
+                - txga43740a7a37e4069aea3-006a0b1d6c
         status: 404 Not Found
         code: 404
-        duration: 33.222541ms
+        duration: 224.764875ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1991,7 +1991,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2000,7 +2000,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f7af4f64-2444-4181-90e8-e598439aae17
+                - c4eeb151-3077-4ff6-91ab-37448546552c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2008,8 +2008,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133726Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/
+                - 20260518T140844Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -2021,21 +2021,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:37:26 GMT
+                - Mon, 18 May 2026 14:08:44 GMT
             X-Amz-Id-2:
-                - txg3b59e941295d4f168f71-006a0b1616
+                - txg8f0793f4415d4867a027-006a0b1d6c
             X-Amz-Request-Id:
-                - txg3b59e941295d4f168f71-006a0b1616
+                - txg8f0793f4415d4867a027-006a0b1d6c
         status: 200 OK
         code: 200
-        duration: 39.058458ms
+        duration: 92.546458ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -2044,7 +2044,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2053,7 +2053,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 74cc2fbd-aafd-40dd-86c3-2cb86ddb371e
+                - 5fec5f22-4fc5-496b-8aa2-5750491ed08b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2061,8 +2061,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133726Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T140844Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2072,21 +2072,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg8b6cd215895c491fbc20-006a0b1616</RequestId><HostId>txg8b6cd215895c491fbc20-006a0b1616</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txge5aba99b122d49fa8257-006a0b1d6c</RequestId><HostId>txge5aba99b122d49fa8257-006a0b1d6c</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:37:26 GMT
+                - Mon, 18 May 2026 14:08:44 GMT
             X-Amz-Id-2:
-                - txg8b6cd215895c491fbc20-006a0b1616
+                - txge5aba99b122d49fa8257-006a0b1d6c
             X-Amz-Request-Id:
-                - txg8b6cd215895c491fbc20-006a0b1616
+                - txge5aba99b122d49fa8257-006a0b1d6c
         status: 404 Not Found
         code: 404
-        duration: 20.804542ms
+        duration: 125.5585ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -2095,7 +2095,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2104,7 +2104,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - bc49ec4c-3376-4389-83de-b2aae27a9e52
+                - fe0aee00-e542-4aea-90a5-3c8f2b9d2681
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2112,8 +2112,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133726Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T140844Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2123,21 +2123,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg7271e54bfe5240548722-006a0b1616</RequestId><HostId>txg7271e54bfe5240548722-006a0b1616</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg2bb60215fed2475dbc89-006a0b1d6c</RequestId><HostId>txg2bb60215fed2475dbc89-006a0b1d6c</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:37:26 GMT
+                - Mon, 18 May 2026 14:08:44 GMT
             X-Amz-Id-2:
-                - txg7271e54bfe5240548722-006a0b1616
+                - txg2bb60215fed2475dbc89-006a0b1d6c
             X-Amz-Request-Id:
-                - txg7271e54bfe5240548722-006a0b1616
+                - txg2bb60215fed2475dbc89-006a0b1d6c
         status: 404 Not Found
         code: 404
-        duration: 21.738625ms
+        duration: 1.450405792s
     - id: 41
       request:
         proto: HTTP/1.1
@@ -2146,7 +2146,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2155,7 +2155,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - eebee72d-0c5c-4855-ab9c-a25fb20d317d
+                - d1158c49-61f5-43e9-8087-682156fdbaf4
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2163,8 +2163,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133726Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T140844Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2183,14 +2183,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:37:26 GMT
+                - Mon, 18 May 2026 14:08:46 GMT
             X-Amz-Id-2:
-                - txgf0be23ac533741fd8d01-006a0b1616
+                - txg2a6fac4a92b84c009a92-006a0b1d6e
             X-Amz-Request-Id:
-                - txgf0be23ac533741fd8d01-006a0b1616
+                - txg2a6fac4a92b84c009a92-006a0b1d6e
         status: 200 OK
         code: 200
-        duration: 55.171334ms
+        duration: 70.375333ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -2199,7 +2199,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2208,7 +2208,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 31ca1b34-999c-482e-8420-8d71ca1f1705
+                - 2d537d87-4e1c-468a-9d10-4a4df369ac76
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2216,8 +2216,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133726Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T140846Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2236,14 +2236,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:37:26 GMT
+                - Mon, 18 May 2026 14:08:46 GMT
             X-Amz-Id-2:
-                - txg6bb2cb64e6fa47e0adf2-006a0b1616
+                - txga184f16e44b449ca8653-006a0b1d6e
             X-Amz-Request-Id:
-                - txg6bb2cb64e6fa47e0adf2-006a0b1616
+                - txga184f16e44b449ca8653-006a0b1d6e
         status: 200 OK
         code: 200
-        duration: 53.465459ms
+        duration: 104.968458ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -2252,7 +2252,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2261,7 +2261,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - cfe99d6e-9082-45a5-adb8-e0ee1efd4202
+                - b33163fc-9496-407c-9f18-162507a2ef1c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2269,8 +2269,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133726Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-8618527379460918655.s3.nl-ams.scw.cloud/
+                - 20260518T140846Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-9051092854446712767.s3.nl-ams.scw.cloud/
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2283,11 +2283,11 @@ interactions:
         body: ""
         headers:
             Date:
-                - Mon, 18 May 2026 13:37:26 GMT
+                - Mon, 18 May 2026 14:08:46 GMT
             X-Amz-Id-2:
-                - txg5088dda52e5440038721-006a0b1616
+                - txgac88c4345c484823b432-006a0b1d6e
             X-Amz-Request-Id:
-                - txg5088dda52e5440038721-006a0b1616
+                - txgac88c4345c484823b432-006a0b1d6e
         status: 204 No Content
         code: 204
-        duration: 212.13025ms
+        duration: 269.490417ms

--- a/internal/services/object/testdata/object-bucket-lifecycle.cassette.yaml
+++ b/internal/services/object/testdata/object-bucket-lifecycle.cassette.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -18,7 +18,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 82b72117-7c13-45c6-bf5c-3c5f6b0e1952
+                - 4c7e7527-c2dd-452a-b810-95930308ec2a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -26,8 +26,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103241Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
+                - 20260518T133548Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
         method: PUT
       response:
         proto: HTTP/2.0
@@ -42,16 +42,16 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 18 May 2026 10:32:41 GMT
+                - Mon, 18 May 2026 13:35:49 GMT
             Location:
-                - /tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018
+                - /tf-tests-scaleway-object-bucket-lifecycle-361671012043732063
             X-Amz-Id-2:
-                - txg0c6784e7608247f5b2d1-006a0aeac9
+                - txg95d5e938f1394555a771-006a0b15b5
             X-Amz-Request-Id:
-                - txg0c6784e7608247f5b2d1-006a0aeac9
+                - txg95d5e938f1394555a771-006a0b15b5
         status: 200 OK
         code: 200
-        duration: 4.429925417s
+        duration: 7.733313583s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -60,7 +60,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -69,7 +69,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - dd2b87c9-77fd-42b8-8a09-c9aecf4cc87d
+                - 45e29889-18e8-4943-a07d-62637dd6432e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -81,8 +81,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103246Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T133556Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?acl=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -97,14 +97,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 18 May 2026 10:32:46 GMT
+                - Mon, 18 May 2026 13:35:56 GMT
             X-Amz-Id-2:
-                - txgb21d590faf814d408be9-006a0aeace
+                - txg3e7f2be80bf6460fb05d-006a0b15bc
             X-Amz-Request-Id:
-                - txgb21d590faf814d408be9-006a0aeace
+                - txg3e7f2be80bf6460fb05d-006a0b15bc
         status: 200 OK
         code: 200
-        duration: 244.391667ms
+        duration: 78.903167ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -113,7 +113,7 @@ interactions:
         content_length: 363
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></LifecycleConfiguration>
@@ -122,7 +122,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4d4590c6-beda-4851-9a58-b4c044084c09
+                - 0d4b9e8a-def9-4332-aa76-adf3e70f9933
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
@@ -134,8 +134,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - 512733381e697ad60e3f974cfb76a92f1c9d2b97cb251bdf165a2579d5e88cd5
             X-Amz-Date:
-                - 20260518T103246Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T133556Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -150,14 +150,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 18 May 2026 10:32:46 GMT
+                - Mon, 18 May 2026 13:35:56 GMT
             X-Amz-Id-2:
-                - txgb1265fa5b66146c4aba0-006a0aeace
+                - txg8223dcafbad94185a53f-006a0b15bc
             X-Amz-Request-Id:
-                - txgb1265fa5b66146c4aba0-006a0aeace
+                - txg8223dcafbad94185a53f-006a0b15bc
         status: 200 OK
         code: 200
-        duration: 366.095625ms
+        duration: 114.8165ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -166,7 +166,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -175,7 +175,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 572f6a27-339c-4b50-b2b2-52e0bab9cd62
+                - 0ef5a8f7-df20-4a20-9a8e-3ac25a784674
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -183,8 +183,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103246Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T133556Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -203,14 +203,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:32:46 GMT
+                - Mon, 18 May 2026 13:35:56 GMT
             X-Amz-Id-2:
-                - txg27237383edc0475daa48-006a0aeace
+                - txgba0dd215ff6f49ada4b1-006a0b15bc
             X-Amz-Request-Id:
-                - txg27237383edc0475daa48-006a0aeace
+                - txgba0dd215ff6f49ada4b1-006a0b15bc
         status: 200 OK
         code: 200
-        duration: 72.83875ms
+        duration: 59.738583ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -219,7 +219,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -228,7 +228,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - a20bc075-86e7-4f5f-9663-ae9d57f93070
+                - f70d2f11-4ef7-4511-add6-5bcfc9fa0aba
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -236,8 +236,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103246Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T133556Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -245,23 +245,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 330
+        content_length: 329
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg866d9aebda1e46fba840-006a0aeace</RequestId><HostId>txg866d9aebda1e46fba840-006a0aeace</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg25385c9803f340109e77-006a0b15bd</RequestId><HostId>txg25385c9803f340109e77-006a0b15bd</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
         headers:
             Content-Length:
-                - "330"
+                - "329"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:32:46 GMT
+                - Mon, 18 May 2026 13:35:57 GMT
             X-Amz-Id-2:
-                - txg866d9aebda1e46fba840-006a0aeace
+                - txg25385c9803f340109e77-006a0b15bd
             X-Amz-Request-Id:
-                - txg866d9aebda1e46fba840-006a0aeace
+                - txg25385c9803f340109e77-006a0b15bd
         status: 404 Not Found
         code: 404
-        duration: 292.820625ms
+        duration: 30.0745ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -270,7 +270,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -279,7 +279,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c47d9d41-c84b-40cf-8ba1-18f0f1791c85
+                - cd76900b-1cca-43df-9d81-b772e6794e01
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -287,8 +287,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103246Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
+                - 20260518T133557Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -296,25 +296,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 287
+        content_length: 286
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "287"
+                - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:32:47 GMT
+                - Mon, 18 May 2026 13:35:57 GMT
             X-Amz-Id-2:
-                - txgbe057b70305746758658-006a0aeacf
+                - txg952917af00b844228635-006a0b15bd
             X-Amz-Request-Id:
-                - txgbe057b70305746758658-006a0aeacf
+                - txg952917af00b844228635-006a0b15bd
         status: 200 OK
         code: 200
-        duration: 245.360291ms
+        duration: 132.859583ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -323,7 +323,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -332,7 +332,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - df570571-4fa2-4e19-9d88-85ea40fc4429
+                - 5cd17394-93fb-427b-8df1-7b4e120edc5a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -340,8 +340,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103247Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T133557Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -349,23 +349,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 361
+        content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg26f07190c14d44cb9661-006a0aeacf</RequestId><HostId>txg26f07190c14d44cb9661-006a0aeacf</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg8f0f25b64aa44ab69f3c-006a0b15bd</RequestId><HostId>txg8f0f25b64aa44ab69f3c-006a0b15bd</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</BucketName></Error>
         headers:
             Content-Length:
-                - "361"
+                - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:32:47 GMT
+                - Mon, 18 May 2026 13:35:57 GMT
             X-Amz-Id-2:
-                - txg26f07190c14d44cb9661-006a0aeacf
+                - txg8f0f25b64aa44ab69f3c-006a0b15bd
             X-Amz-Request-Id:
-                - txg26f07190c14d44cb9661-006a0aeacf
+                - txg8f0f25b64aa44ab69f3c-006a0b15bd
         status: 404 Not Found
         code: 404
-        duration: 245.323458ms
+        duration: 42.316667ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -374,7 +374,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -383,7 +383,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 53036375-199d-4d06-932d-8aeb2c8eeb4c
+                - 8b701384-cdf0-4142-b2f6-e0aba4256d70
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -391,8 +391,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103247Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T133557Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -400,23 +400,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 298
+        content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg1b636d1afca24110a7b3-006a0aeacf</RequestId><HostId>txg1b636d1afca24110a7b3-006a0aeacf</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg9e8f757f68754b94aaac-006a0b15bd</RequestId><HostId>txg9e8f757f68754b94aaac-006a0b15bd</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
         headers:
             Content-Length:
-                - "298"
+                - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:32:47 GMT
+                - Mon, 18 May 2026 13:35:57 GMT
             X-Amz-Id-2:
-                - txg1b636d1afca24110a7b3-006a0aeacf
+                - txg9e8f757f68754b94aaac-006a0b15bd
             X-Amz-Request-Id:
-                - txg1b636d1afca24110a7b3-006a0aeacf
+                - txg9e8f757f68754b94aaac-006a0b15bd
         status: 404 Not Found
         code: 404
-        duration: 20.636209ms
+        duration: 62.203042ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -425,7 +425,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -434,7 +434,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b28f9e5f-83bc-4be3-8695-4e02afb8193b
+                - 9013d6ca-bf6c-42e0-9329-c72e32bfea0d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -442,8 +442,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103247Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T133557Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -462,14 +462,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:32:47 GMT
+                - Mon, 18 May 2026 13:35:57 GMT
             X-Amz-Id-2:
-                - txgbf962414710d40c09cf3-006a0aeacf
+                - txg99fcaade7ddf4abea9f0-006a0b15bd
             X-Amz-Request-Id:
-                - txgbf962414710d40c09cf3-006a0aeacf
+                - txg99fcaade7ddf4abea9f0-006a0b15bd
         status: 200 OK
         code: 200
-        duration: 151.986375ms
+        duration: 48.296583ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -478,7 +478,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -487,7 +487,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0ad4e03b-666e-480b-b141-a5cf4035a295
+                - f36767f5-7ae8-44b8-bfba-52861820f4d4
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -495,8 +495,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103247Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T133557Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -515,14 +515,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:32:47 GMT
+                - Mon, 18 May 2026 13:35:57 GMT
             X-Amz-Id-2:
-                - txgbcd70dba7bd54cc49cde-006a0aeacf
+                - txgc81b4c5bc31140b2b49d-006a0b15bd
             X-Amz-Request-Id:
-                - txgbcd70dba7bd54cc49cde-006a0aeacf
+                - txgc81b4c5bc31140b2b49d-006a0b15bd
         status: 200 OK
         code: 200
-        duration: 33.783ms
+        duration: 31.688833ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -531,7 +531,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -540,7 +540,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - db2e474e-2a49-4b1f-8f07-9345f3a6c9dd
+                - 4d8fc812-0e5d-4495-9f0d-c202fa52ae78
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -548,8 +548,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103248Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
+                - 20260518T133557Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -564,16 +564,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:32:48 GMT
+                - Mon, 18 May 2026 13:35:57 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txg29d1d519413f48818501-006a0aead0
+                - txg927c1a37e2c04fff8660-006a0b15bd
             X-Amz-Request-Id:
-                - txg29d1d519413f48818501-006a0aead0
+                - txg927c1a37e2c04fff8660-006a0b15bd
         status: 200 OK
         code: 200
-        duration: 44.730583ms
+        duration: 65.517209ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -582,7 +582,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -591,7 +591,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - a7195225-330d-4efa-a06e-b6a99feb8b03
+                - 5f03d4f7-fcad-405e-a9ef-8af968a22693
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -599,8 +599,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103248Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T133557Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -619,14 +619,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:32:48 GMT
+                - Mon, 18 May 2026 13:35:57 GMT
             X-Amz-Id-2:
-                - txg3238d8e0fcc547b58b0b-006a0aead0
+                - txg5a871d29c9514d1f831f-006a0b15bd
             X-Amz-Request-Id:
-                - txg3238d8e0fcc547b58b0b-006a0aead0
+                - txg5a871d29c9514d1f831f-006a0b15bd
         status: 200 OK
         code: 200
-        duration: 127.678959ms
+        duration: 62.234542ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -635,7 +635,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -644,7 +644,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 03e94647-1724-41c5-88ca-e8bb796db3fc
+                - 7b26db91-ba1e-4d9d-bb4f-2eee2f594e82
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -652,8 +652,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103248Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T133557Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -672,14 +672,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:32:48 GMT
+                - Mon, 18 May 2026 13:35:57 GMT
             X-Amz-Id-2:
-                - txg6b8d31365c0f4c5496e3-006a0aead0
+                - txg3b492b54f4654eaebbb9-006a0b15bd
             X-Amz-Request-Id:
-                - txg6b8d31365c0f4c5496e3-006a0aead0
+                - txg3b492b54f4654eaebbb9-006a0b15bd
         status: 200 OK
         code: 200
-        duration: 33.367167ms
+        duration: 49.610125ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -688,7 +688,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -697,7 +697,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 13ad3fe4-5707-4883-b335-0a3dccb23dcd
+                - 73ce7d03-e7c9-4101-a407-f302e7203edc
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -705,8 +705,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103248Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T133557Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -714,23 +714,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 330
+        content_length: 329
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgbda0eb8be8684c7c93b4-006a0aead0</RequestId><HostId>txgbda0eb8be8684c7c93b4-006a0aead0</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txga2087e1a754d4f3c9ba9-006a0b15bd</RequestId><HostId>txga2087e1a754d4f3c9ba9-006a0b15bd</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
         headers:
             Content-Length:
-                - "330"
+                - "329"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:32:48 GMT
+                - Mon, 18 May 2026 13:35:57 GMT
             X-Amz-Id-2:
-                - txgbda0eb8be8684c7c93b4-006a0aead0
+                - txga2087e1a754d4f3c9ba9-006a0b15bd
             X-Amz-Request-Id:
-                - txgbda0eb8be8684c7c93b4-006a0aead0
+                - txga2087e1a754d4f3c9ba9-006a0b15bd
         status: 404 Not Found
         code: 404
-        duration: 55.058958ms
+        duration: 63.871959ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -739,7 +739,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -748,7 +748,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 62ca2241-ce59-4f33-b4dd-356129d02f59
+                - b8faaec4-da89-46bd-aac0-403d1a9d5932
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -756,8 +756,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103248Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
+                - 20260518T133557Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -765,25 +765,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 287
+        content_length: 286
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "287"
+                - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:32:48 GMT
+                - Mon, 18 May 2026 13:35:57 GMT
             X-Amz-Id-2:
-                - txgab28bcdf47f94ba688d6-006a0aead0
+                - txg4252db8d38be47459a59-006a0b15bd
             X-Amz-Request-Id:
-                - txgab28bcdf47f94ba688d6-006a0aead0
+                - txg4252db8d38be47459a59-006a0b15bd
         status: 200 OK
         code: 200
-        duration: 234.491042ms
+        duration: 106.266792ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -792,7 +792,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -801,7 +801,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 00c19340-7cc7-4b00-a39c-3b1b3787ebaf
+                - c94e4b7b-1558-40b9-b5fd-41ec3846431f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -809,8 +809,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103248Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T133557Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -818,23 +818,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 361
+        content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg0239a20eb15d47bdb5fe-006a0aead0</RequestId><HostId>txg0239a20eb15d47bdb5fe-006a0aead0</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg566ca844e56d415f82bd-006a0b15be</RequestId><HostId>txg566ca844e56d415f82bd-006a0b15be</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</BucketName></Error>
         headers:
             Content-Length:
-                - "361"
+                - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:32:48 GMT
+                - Mon, 18 May 2026 13:35:58 GMT
             X-Amz-Id-2:
-                - txg0239a20eb15d47bdb5fe-006a0aead0
+                - txg566ca844e56d415f82bd-006a0b15be
             X-Amz-Request-Id:
-                - txg0239a20eb15d47bdb5fe-006a0aead0
+                - txg566ca844e56d415f82bd-006a0b15be
         status: 404 Not Found
         code: 404
-        duration: 367.03425ms
+        duration: 21.226958ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -843,7 +843,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -852,7 +852,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 98fa3c6f-fc63-4cf9-8a2e-76619fa097bf
+                - 572de172-ee4a-489b-b8cc-ab18cf2a6c40
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -860,8 +860,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103248Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T133558Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -869,23 +869,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 298
+        content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txge6279517fe8b452bb75e-006a0aead1</RequestId><HostId>txge6279517fe8b452bb75e-006a0aead1</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgc5bf42b388064a62ae42-006a0b15be</RequestId><HostId>txgc5bf42b388064a62ae42-006a0b15be</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
         headers:
             Content-Length:
-                - "298"
+                - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:32:49 GMT
+                - Mon, 18 May 2026 13:35:58 GMT
             X-Amz-Id-2:
-                - txge6279517fe8b452bb75e-006a0aead1
+                - txgc5bf42b388064a62ae42-006a0b15be
             X-Amz-Request-Id:
-                - txge6279517fe8b452bb75e-006a0aead1
+                - txgc5bf42b388064a62ae42-006a0b15be
         status: 404 Not Found
         code: 404
-        duration: 61.131375ms
+        duration: 52.750917ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -894,7 +894,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -903,7 +903,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 04e1012b-2839-4c11-bf4c-2473095e8711
+                - ff43b1f1-3e67-4379-ac9b-c4aee69316d6
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -911,8 +911,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103249Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T133558Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -931,14 +931,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:32:49 GMT
+                - Mon, 18 May 2026 13:35:58 GMT
             X-Amz-Id-2:
-                - txg5bcaaee1e09d44218928-006a0aead1
+                - txg5623adee56924833846e-006a0b15be
             X-Amz-Request-Id:
-                - txg5bcaaee1e09d44218928-006a0aead1
+                - txg5623adee56924833846e-006a0b15be
         status: 200 OK
         code: 200
-        duration: 34.146ms
+        duration: 79.133541ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -947,7 +947,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -956,7 +956,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - aa2675b0-f6db-4249-966a-4e9c150e9f93
+                - f0b4f58b-6512-450f-9fb4-4224c2a0a53b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -964,8 +964,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103249Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T133558Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -984,14 +984,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:32:49 GMT
+                - Mon, 18 May 2026 13:35:58 GMT
             X-Amz-Id-2:
-                - txg6efa458e7be043e8a726-006a0aead1
+                - txg49feaa0c30f4417d9a89-006a0b15be
             X-Amz-Request-Id:
-                - txg6efa458e7be043e8a726-006a0aead1
+                - txg49feaa0c30f4417d9a89-006a0b15be
         status: 200 OK
         code: 200
-        duration: 71.9115ms
+        duration: 48.709125ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -1000,7 +1000,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1009,7 +1009,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 626aaab6-46f3-40bf-b961-fcfc48b76896
+                - d3451f3a-f198-47aa-a589-45c3514ec42c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1017,8 +1017,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103249Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T133558Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1037,14 +1037,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:32:49 GMT
+                - Mon, 18 May 2026 13:35:58 GMT
             X-Amz-Id-2:
-                - txgade9dc219b98448982d3-006a0aead1
+                - txgeca0adc147e34107b9b9-006a0b15be
             X-Amz-Request-Id:
-                - txgade9dc219b98448982d3-006a0aead1
+                - txgeca0adc147e34107b9b9-006a0b15be
         status: 200 OK
         code: 200
-        duration: 277.251ms
+        duration: 33.171833ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1053,7 +1053,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1062,7 +1062,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f2c586b9-1cbb-4e7a-b065-c4eadb61027d
+                - a1ea5dcd-8b35-4c18-b9d1-f0f20f9ec5ca
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1070,8 +1070,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103249Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T133558Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1079,23 +1079,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 330
+        content_length: 329
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg8f8fee6776564d75a989-006a0aead1</RequestId><HostId>txg8f8fee6776564d75a989-006a0aead1</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg31ddbc57ad9340d1a586-006a0b15be</RequestId><HostId>txg31ddbc57ad9340d1a586-006a0b15be</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
         headers:
             Content-Length:
-                - "330"
+                - "329"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:32:49 GMT
+                - Mon, 18 May 2026 13:35:58 GMT
             X-Amz-Id-2:
-                - txg8f8fee6776564d75a989-006a0aead1
+                - txg31ddbc57ad9340d1a586-006a0b15be
             X-Amz-Request-Id:
-                - txg8f8fee6776564d75a989-006a0aead1
+                - txg31ddbc57ad9340d1a586-006a0b15be
         status: 404 Not Found
         code: 404
-        duration: 22.1165ms
+        duration: 36.44275ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1104,7 +1104,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1113,7 +1113,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 019936d0-7c3c-4241-ba20-6aabbb4e1c3b
+                - 29afad61-5e6b-4dc6-ad91-719e456dd1f2
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1121,8 +1121,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103249Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
+                - 20260518T133558Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -1130,25 +1130,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 287
+        content_length: 286
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "287"
+                - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:32:49 GMT
+                - Mon, 18 May 2026 13:35:58 GMT
             X-Amz-Id-2:
-                - txg84c01b94d9e947d6b9ae-006a0aead1
+                - txg69ccfcdc8734482e8f76-006a0b15be
             X-Amz-Request-Id:
-                - txg84c01b94d9e947d6b9ae-006a0aead1
+                - txg69ccfcdc8734482e8f76-006a0b15be
         status: 200 OK
         code: 200
-        duration: 141.653625ms
+        duration: 51.824375ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1157,7 +1157,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1166,7 +1166,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - bfe35906-f9c9-48aa-a5ce-4a838f282833
+                - d27b5479-e421-417c-95d6-9ba303ab026a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1174,8 +1174,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103249Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T133558Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1183,23 +1183,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 361
+        content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgd67336f463704a5898c8-006a0aead1</RequestId><HostId>txgd67336f463704a5898c8-006a0aead1</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg08e9adc0bc7e4f6c855d-006a0b15be</RequestId><HostId>txg08e9adc0bc7e4f6c855d-006a0b15be</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</BucketName></Error>
         headers:
             Content-Length:
-                - "361"
+                - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:32:49 GMT
+                - Mon, 18 May 2026 13:35:58 GMT
             X-Amz-Id-2:
-                - txgd67336f463704a5898c8-006a0aead1
+                - txg08e9adc0bc7e4f6c855d-006a0b15be
             X-Amz-Request-Id:
-                - txgd67336f463704a5898c8-006a0aead1
+                - txg08e9adc0bc7e4f6c855d-006a0b15be
         status: 404 Not Found
         code: 404
-        duration: 21.083792ms
+        duration: 35.38125ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1208,7 +1208,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1217,7 +1217,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 2e0140da-15e1-46ed-89de-802f2fa621d1
+                - 92ca5056-078a-45e6-8a38-c1c534d81dea
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1225,8 +1225,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103249Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T133558Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1234,23 +1234,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 298
+        content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg3c06ba3b76e245769381-006a0aead1</RequestId><HostId>txg3c06ba3b76e245769381-006a0aead1</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg4be503d61c684cefaf95-006a0b15be</RequestId><HostId>txg4be503d61c684cefaf95-006a0b15be</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
         headers:
             Content-Length:
-                - "298"
+                - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:32:49 GMT
+                - Mon, 18 May 2026 13:35:58 GMT
             X-Amz-Id-2:
-                - txg3c06ba3b76e245769381-006a0aead1
+                - txg4be503d61c684cefaf95-006a0b15be
             X-Amz-Request-Id:
-                - txg3c06ba3b76e245769381-006a0aead1
+                - txg4be503d61c684cefaf95-006a0b15be
         status: 404 Not Found
         code: 404
-        duration: 171.111167ms
+        duration: 57.986834ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1259,7 +1259,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1268,7 +1268,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 8e7405d6-a64f-4afa-a3c3-75828c7beb5e
+                - f7bfdd56-d79d-4fa1-9cd7-5838a7fe855d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1276,8 +1276,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103249Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T133558Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1296,14 +1296,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:32:50 GMT
+                - Mon, 18 May 2026 13:35:58 GMT
             X-Amz-Id-2:
-                - txgf7182e5decbb46e8bac0-006a0aead2
+                - txg116573d3e3a44c39841f-006a0b15be
             X-Amz-Request-Id:
-                - txgf7182e5decbb46e8bac0-006a0aead2
+                - txg116573d3e3a44c39841f-006a0b15be
         status: 200 OK
         code: 200
-        duration: 234.10325ms
+        duration: 19.425083ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1312,7 +1312,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1321,7 +1321,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 571073ec-106c-4934-bef4-82e6d47e2724
+                - f219c0a8-0556-478e-b857-3eda4db47bd8
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1329,8 +1329,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103250Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T133558Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1349,14 +1349,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:32:50 GMT
+                - Mon, 18 May 2026 13:35:58 GMT
             X-Amz-Id-2:
-                - txg5d51303425734880b8b0-006a0aead2
+                - txgdfed9b4b1090448c9923-006a0b15be
             X-Amz-Request-Id:
-                - txg5d51303425734880b8b0-006a0aead2
+                - txgdfed9b4b1090448c9923-006a0b15be
         status: 200 OK
         code: 200
-        duration: 246.733333ms
+        duration: 74.490875ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1365,7 +1365,7 @@ interactions:
         content_length: 366
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition></Rule></LifecycleConfiguration>
@@ -1374,7 +1374,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 79b48293-5891-47d3-ad45-8639693ba4ee
+                - 2f4e8e40-7f08-495d-b9a4-4769aed5ca0f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
@@ -1386,8 +1386,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - 1695287f0c18bfb8c0d3d10989fec9b3e430afbc2914de7c50f434a75491894c
             X-Amz-Date:
-                - 20260518T103250Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T133558Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -1402,14 +1402,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 18 May 2026 10:32:50 GMT
+                - Mon, 18 May 2026 13:35:58 GMT
             X-Amz-Id-2:
-                - txg432d8011dca1463bb4a0-006a0aead2
+                - txg85abb7ed93224b44b486-006a0b15be
             X-Amz-Request-Id:
-                - txg432d8011dca1463bb4a0-006a0aead2
+                - txg85abb7ed93224b44b486-006a0b15be
         status: 200 OK
         code: 200
-        duration: 202.804958ms
+        duration: 63.122333ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1418,7 +1418,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1427,7 +1427,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 51b0ae9e-b2a9-4415-8569-a8fa99292cdf
+                - c6b4a30b-9210-4346-adfd-47773f1005e1
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1435,8 +1435,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103251Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T133559Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1455,14 +1455,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:32:51 GMT
+                - Mon, 18 May 2026 13:35:59 GMT
             X-Amz-Id-2:
-                - txgff29fb772237453a831f-006a0aead3
+                - txg2d2bc01238794a5799b9-006a0b15bf
             X-Amz-Request-Id:
-                - txgff29fb772237453a831f-006a0aead3
+                - txg2d2bc01238794a5799b9-006a0b15bf
         status: 200 OK
         code: 200
-        duration: 244.522875ms
+        duration: 31.601833ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1471,7 +1471,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1480,7 +1480,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e33a87ae-0f72-4661-b408-b602f287ae00
+                - c5e2597a-86d7-427b-9bb8-ef87eed2d6fb
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1488,8 +1488,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103251Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T133559Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1497,23 +1497,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 330
+        content_length: 329
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgd23dcd26e1124340aa75-006a0aead3</RequestId><HostId>txgd23dcd26e1124340aa75-006a0aead3</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg7ff6b92af4244057ad3c-006a0b15bf</RequestId><HostId>txg7ff6b92af4244057ad3c-006a0b15bf</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
         headers:
             Content-Length:
-                - "330"
+                - "329"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:32:51 GMT
+                - Mon, 18 May 2026 13:35:59 GMT
             X-Amz-Id-2:
-                - txgd23dcd26e1124340aa75-006a0aead3
+                - txg7ff6b92af4244057ad3c-006a0b15bf
             X-Amz-Request-Id:
-                - txgd23dcd26e1124340aa75-006a0aead3
+                - txg7ff6b92af4244057ad3c-006a0b15bf
         status: 404 Not Found
         code: 404
-        duration: 95.062458ms
+        duration: 31.844333ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1522,7 +1522,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1531,7 +1531,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 25f561cc-7e22-465b-a8cf-dc7f31786446
+                - 114d0593-d98a-438b-bc1b-e19cfd3a93b3
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1539,8 +1539,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103251Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
+                - 20260518T133559Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -1548,25 +1548,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 287
+        content_length: 286
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "287"
+                - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:32:51 GMT
+                - Mon, 18 May 2026 13:35:59 GMT
             X-Amz-Id-2:
-                - txg53eaa81254df4f9ebe64-006a0aead3
+                - txgd46ce7ebb4a54e328597-006a0b15bf
             X-Amz-Request-Id:
-                - txg53eaa81254df4f9ebe64-006a0aead3
+                - txgd46ce7ebb4a54e328597-006a0b15bf
         status: 200 OK
         code: 200
-        duration: 269.791584ms
+        duration: 29.2935ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1575,7 +1575,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1584,7 +1584,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 55395e45-c6ee-44df-ab32-8f67f6aca0c4
+                - 505f5f4f-8c70-4206-bbe9-c23c1726a1d7
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1592,8 +1592,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103251Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T133559Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1601,23 +1601,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 361
+        content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg462c977d16a94e8682e7-006a0aead3</RequestId><HostId>txg462c977d16a94e8682e7-006a0aead3</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg4cfd89bdfcfc451dab80-006a0b15bf</RequestId><HostId>txg4cfd89bdfcfc451dab80-006a0b15bf</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</BucketName></Error>
         headers:
             Content-Length:
-                - "361"
+                - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:32:51 GMT
+                - Mon, 18 May 2026 13:35:59 GMT
             X-Amz-Id-2:
-                - txg462c977d16a94e8682e7-006a0aead3
+                - txg4cfd89bdfcfc451dab80-006a0b15bf
             X-Amz-Request-Id:
-                - txg462c977d16a94e8682e7-006a0aead3
+                - txg4cfd89bdfcfc451dab80-006a0b15bf
         status: 404 Not Found
         code: 404
-        duration: 58.46775ms
+        duration: 18.752ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1626,7 +1626,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1635,7 +1635,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 3920a164-f3bf-4a54-b783-74c6d7b1cb58
+                - c8b73fe2-a3ef-4279-8d00-122f26ec5587
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1643,8 +1643,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103251Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T133559Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1652,23 +1652,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 298
+        content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg5c83968383534081b0a3-006a0aead3</RequestId><HostId>txg5c83968383534081b0a3-006a0aead3</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg6312263a8ad648b49799-006a0b15bf</RequestId><HostId>txg6312263a8ad648b49799-006a0b15bf</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
         headers:
             Content-Length:
-                - "298"
+                - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:32:51 GMT
+                - Mon, 18 May 2026 13:35:59 GMT
             X-Amz-Id-2:
-                - txg5c83968383534081b0a3-006a0aead3
+                - txg6312263a8ad648b49799-006a0b15bf
             X-Amz-Request-Id:
-                - txg5c83968383534081b0a3-006a0aead3
+                - txg6312263a8ad648b49799-006a0b15bf
         status: 404 Not Found
         code: 404
-        duration: 54.368042ms
+        duration: 61.025042ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1677,7 +1677,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1686,7 +1686,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ecb6c00f-face-45de-be99-ef2f62d5ae2a
+                - 45b66c7a-190a-4864-b244-4baa31dcfdbd
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1694,8 +1694,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103251Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T133559Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1714,14 +1714,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:32:51 GMT
+                - Mon, 18 May 2026 13:35:59 GMT
             X-Amz-Id-2:
-                - txgce71d52724864949bac8-006a0aead3
+                - txgaa9733d8453c495b87fd-006a0b15bf
             X-Amz-Request-Id:
-                - txgce71d52724864949bac8-006a0aead3
+                - txgaa9733d8453c495b87fd-006a0b15bf
         status: 200 OK
         code: 200
-        duration: 150.142083ms
+        duration: 33.189584ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1730,7 +1730,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1739,7 +1739,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 560b423d-6add-4f72-9b0f-049a6ed16284
+                - dfcd926d-75d7-47fc-888f-2042e5a600d5
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1747,8 +1747,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103251Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T133559Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1767,14 +1767,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:32:51 GMT
+                - Mon, 18 May 2026 13:35:59 GMT
             X-Amz-Id-2:
-                - txg8b4dca0edc2046aabd00-006a0aead3
+                - txg84a78b112aa64dc2876b-006a0b15bf
             X-Amz-Request-Id:
-                - txg8b4dca0edc2046aabd00-006a0aead3
+                - txg84a78b112aa64dc2876b-006a0b15bf
         status: 200 OK
         code: 200
-        duration: 163.643875ms
+        duration: 47.729042ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1783,7 +1783,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1792,7 +1792,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c2ca17fb-b66c-4a41-816b-2638e98343ce
+                - 292561fd-fc9c-46e3-8b33-4a819dc582ec
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1800,8 +1800,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103252Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
+                - 20260518T133559Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -1816,16 +1816,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:32:52 GMT
+                - Mon, 18 May 2026 13:35:59 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txge9ff9b7d98554508b97a-006a0aead4
+                - txg45bdff0158264a82b917-006a0b15bf
             X-Amz-Request-Id:
-                - txge9ff9b7d98554508b97a-006a0aead4
+                - txg45bdff0158264a82b917-006a0b15bf
         status: 200 OK
         code: 200
-        duration: 331.380083ms
+        duration: 35.383333ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1834,7 +1834,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1843,7 +1843,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 1912a7c2-2d4f-44ef-8dce-5ed344cb8a83
+                - 31509049-43d9-40f3-b189-2c13cb83acb5
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1851,8 +1851,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103252Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T133559Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1871,14 +1871,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:32:52 GMT
+                - Mon, 18 May 2026 13:35:59 GMT
             X-Amz-Id-2:
-                - txg46f3b99539864a0486f3-006a0aead4
+                - txgbc07c46e7ee14e9bbcf1-006a0b15bf
             X-Amz-Request-Id:
-                - txg46f3b99539864a0486f3-006a0aead4
+                - txgbc07c46e7ee14e9bbcf1-006a0b15bf
         status: 200 OK
         code: 200
-        duration: 38.739833ms
+        duration: 58.54025ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1887,7 +1887,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1896,7 +1896,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 48ccd124-43c4-47e0-949b-ba92c3e760e4
+                - f35f7d5a-0d72-41aa-9fa0-4783ea1de93d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1904,8 +1904,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103252Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T133559Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1924,14 +1924,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:32:52 GMT
+                - Mon, 18 May 2026 13:35:59 GMT
             X-Amz-Id-2:
-                - txgb6ddd244e0bc4df08dbc-006a0aead4
+                - txg420d3b14b68745b09b2b-006a0b15bf
             X-Amz-Request-Id:
-                - txgb6ddd244e0bc4df08dbc-006a0aead4
+                - txg420d3b14b68745b09b2b-006a0b15bf
         status: 200 OK
         code: 200
-        duration: 108.29975ms
+        duration: 64.338959ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1940,7 +1940,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1949,7 +1949,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0c22799b-8697-4479-af11-2a3394c2b623
+                - 4bb3b75e-a085-4e26-9476-cca6ecb2ddef
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1957,8 +1957,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103252Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T133559Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1966,23 +1966,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 330
+        content_length: 329
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg6407ee196a8647d7bcd0-006a0aead4</RequestId><HostId>txg6407ee196a8647d7bcd0-006a0aead4</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg920c84f45816478ab67b-006a0b15bf</RequestId><HostId>txg920c84f45816478ab67b-006a0b15bf</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
         headers:
             Content-Length:
-                - "330"
+                - "329"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:32:52 GMT
+                - Mon, 18 May 2026 13:35:59 GMT
             X-Amz-Id-2:
-                - txg6407ee196a8647d7bcd0-006a0aead4
+                - txg920c84f45816478ab67b-006a0b15bf
             X-Amz-Request-Id:
-                - txg6407ee196a8647d7bcd0-006a0aead4
+                - txg920c84f45816478ab67b-006a0b15bf
         status: 404 Not Found
         code: 404
-        duration: 185.254417ms
+        duration: 50.502167ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1991,7 +1991,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2000,7 +2000,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7be5f8cd-f5ac-4cbd-8e4a-604b26cdb2db
+                - 5ea7f7f4-1817-4992-91eb-962a2e8cb4e2
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2008,8 +2008,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103252Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
+                - 20260518T133559Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -2017,25 +2017,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 287
+        content_length: 286
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "287"
+                - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:32:53 GMT
+                - Mon, 18 May 2026 13:35:59 GMT
             X-Amz-Id-2:
-                - txg3b31223a73284934a776-006a0aead5
+                - txgbe4360aa6085456498b3-006a0b15bf
             X-Amz-Request-Id:
-                - txg3b31223a73284934a776-006a0aead5
+                - txgbe4360aa6085456498b3-006a0b15bf
         status: 200 OK
         code: 200
-        duration: 78.224ms
+        duration: 20.805292ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -2044,7 +2044,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2053,7 +2053,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 74922969-0c8f-46b1-8319-20fb06ab6bf7
+                - 653e829d-e5c6-4b8b-996b-3cfb50cd46e2
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2061,8 +2061,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103253Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T133559Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2070,23 +2070,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 361
+        content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg396ee12162d54811a10c-006a0aead5</RequestId><HostId>txg396ee12162d54811a10c-006a0aead5</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg678514fed7614fc89b1c-006a0b15bf</RequestId><HostId>txg678514fed7614fc89b1c-006a0b15bf</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</BucketName></Error>
         headers:
             Content-Length:
-                - "361"
+                - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:32:53 GMT
+                - Mon, 18 May 2026 13:35:59 GMT
             X-Amz-Id-2:
-                - txg396ee12162d54811a10c-006a0aead5
+                - txg678514fed7614fc89b1c-006a0b15bf
             X-Amz-Request-Id:
-                - txg396ee12162d54811a10c-006a0aead5
+                - txg678514fed7614fc89b1c-006a0b15bf
         status: 404 Not Found
         code: 404
-        duration: 159.608916ms
+        duration: 61.166417ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -2095,7 +2095,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2104,7 +2104,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - a86315ce-1a67-49d4-a8bd-ae185b637086
+                - 7377f5fb-db48-47ec-a8a3-d50e8f7121e3
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2112,8 +2112,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103253Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T133559Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2121,23 +2121,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 298
+        content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgfd162e75241f40b58237-006a0aead5</RequestId><HostId>txgfd162e75241f40b58237-006a0aead5</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txge0a3ea1e2cb44294af00-006a0b15bf</RequestId><HostId>txge0a3ea1e2cb44294af00-006a0b15bf</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
         headers:
             Content-Length:
-                - "298"
+                - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:32:53 GMT
+                - Mon, 18 May 2026 13:35:59 GMT
             X-Amz-Id-2:
-                - txgfd162e75241f40b58237-006a0aead5
+                - txge0a3ea1e2cb44294af00-006a0b15bf
             X-Amz-Request-Id:
-                - txgfd162e75241f40b58237-006a0aead5
+                - txge0a3ea1e2cb44294af00-006a0b15bf
         status: 404 Not Found
         code: 404
-        duration: 250.430625ms
+        duration: 20.850709ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -2146,7 +2146,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2155,7 +2155,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - afce0431-b4c6-43b6-b154-fdd793457114
+                - 3325555a-1257-4f71-bd8d-591e417fb017
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2163,8 +2163,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103253Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T133559Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2183,14 +2183,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:32:53 GMT
+                - Mon, 18 May 2026 13:35:59 GMT
             X-Amz-Id-2:
-                - txgf1290f69a7724bcfab84-006a0aead5
+                - txg8e510b8c57844e1fa687-006a0b15bf
             X-Amz-Request-Id:
-                - txgf1290f69a7724bcfab84-006a0aead5
+                - txg8e510b8c57844e1fa687-006a0b15bf
         status: 200 OK
         code: 200
-        duration: 21.416584ms
+        duration: 60.918708ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -2199,7 +2199,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2208,7 +2208,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7c918243-9830-4c80-9dcd-9f667ff4e87e
+                - 7d6c617d-7e97-4f07-936a-cdd8cfe1aeab
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2216,8 +2216,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103253Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T133559Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2236,14 +2236,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:32:53 GMT
+                - Mon, 18 May 2026 13:36:00 GMT
             X-Amz-Id-2:
-                - txg9a06c08796c849499d5a-006a0aead5
+                - txgba9a2c461b114ff79b1e-006a0b15c0
             X-Amz-Request-Id:
-                - txg9a06c08796c849499d5a-006a0aead5
+                - txgba9a2c461b114ff79b1e-006a0b15c0
         status: 200 OK
         code: 200
-        duration: 90.827ms
+        duration: 20.514875ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -2252,7 +2252,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2261,7 +2261,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 46fbb1e0-2823-47d5-9014-0635bfbbe6af
+                - 7b899472-7724-412a-a65a-4374da4ddf63
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2269,8 +2269,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103253Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T133600Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2289,14 +2289,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:32:53 GMT
+                - Mon, 18 May 2026 13:36:00 GMT
             X-Amz-Id-2:
-                - txg0f806fd1ccf04a83aa09-006a0aead5
+                - txg1fce40260d5e46d6a268-006a0b15c0
             X-Amz-Request-Id:
-                - txg0f806fd1ccf04a83aa09-006a0aead5
+                - txg1fce40260d5e46d6a268-006a0b15c0
         status: 200 OK
         code: 200
-        duration: 146.175917ms
+        duration: 20.321583ms
     - id: 44
       request:
         proto: HTTP/1.1
@@ -2305,7 +2305,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2314,7 +2314,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 6a7269c4-5c33-4b84-9bfe-d4ddf67cb2a3
+                - 85a9b849-f45b-42a5-a473-92c1b4597a00
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2322,8 +2322,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103253Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T133600Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2331,23 +2331,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 330
+        content_length: 329
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txge842802ca2c04ce095cf-006a0aead6</RequestId><HostId>txge842802ca2c04ce095cf-006a0aead6</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg97b4a35719df4769b7b3-006a0b15c0</RequestId><HostId>txg97b4a35719df4769b7b3-006a0b15c0</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
         headers:
             Content-Length:
-                - "330"
+                - "329"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:32:54 GMT
+                - Mon, 18 May 2026 13:36:00 GMT
             X-Amz-Id-2:
-                - txge842802ca2c04ce095cf-006a0aead6
+                - txg97b4a35719df4769b7b3-006a0b15c0
             X-Amz-Request-Id:
-                - txge842802ca2c04ce095cf-006a0aead6
+                - txg97b4a35719df4769b7b3-006a0b15c0
         status: 404 Not Found
         code: 404
-        duration: 176.987291ms
+        duration: 82.519083ms
     - id: 45
       request:
         proto: HTTP/1.1
@@ -2356,7 +2356,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2365,7 +2365,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 66d32cd5-9083-4835-8c0e-ee104e93e708
+                - f98a83ad-9269-4392-a65b-f35134515edb
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2373,8 +2373,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103254Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
+                - 20260518T133600Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -2382,25 +2382,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 287
+        content_length: 286
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "287"
+                - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:32:54 GMT
+                - Mon, 18 May 2026 13:36:00 GMT
             X-Amz-Id-2:
-                - txg3ca87414e0354b5e8a2a-006a0aead6
+                - txg8426e91605314618bb2c-006a0b15c0
             X-Amz-Request-Id:
-                - txg3ca87414e0354b5e8a2a-006a0aead6
+                - txg8426e91605314618bb2c-006a0b15c0
         status: 200 OK
         code: 200
-        duration: 293.15475ms
+        duration: 95.0265ms
     - id: 46
       request:
         proto: HTTP/1.1
@@ -2409,7 +2409,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2418,7 +2418,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 8b6fd264-bc57-4744-942b-243c630e9690
+                - b10285a3-e2e7-4996-aff7-0a6c1ebb44c7
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2426,8 +2426,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103254Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T133600Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2435,23 +2435,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 361
+        content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgfbb18a9aaef143a1a202-006a0aead6</RequestId><HostId>txgfbb18a9aaef143a1a202-006a0aead6</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg375e22b29c59463c9ba6-006a0b15c0</RequestId><HostId>txg375e22b29c59463c9ba6-006a0b15c0</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</BucketName></Error>
         headers:
             Content-Length:
-                - "361"
+                - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:32:54 GMT
+                - Mon, 18 May 2026 13:36:00 GMT
             X-Amz-Id-2:
-                - txgfbb18a9aaef143a1a202-006a0aead6
+                - txg375e22b29c59463c9ba6-006a0b15c0
             X-Amz-Request-Id:
-                - txgfbb18a9aaef143a1a202-006a0aead6
+                - txg375e22b29c59463c9ba6-006a0b15c0
         status: 404 Not Found
         code: 404
-        duration: 133.114667ms
+        duration: 30.652167ms
     - id: 47
       request:
         proto: HTTP/1.1
@@ -2460,7 +2460,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2469,7 +2469,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0be3c1f6-a2b0-4433-bbf7-ee11919e508f
+                - 0bab10c3-a3fe-4f22-9529-a67b4231b697
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2477,8 +2477,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103254Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T133600Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2486,23 +2486,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 298
+        content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg6e03d694589f42e1a36e-006a0aead6</RequestId><HostId>txg6e03d694589f42e1a36e-006a0aead6</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txge908319b63a74f81861d-006a0b15c0</RequestId><HostId>txge908319b63a74f81861d-006a0b15c0</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
         headers:
             Content-Length:
-                - "298"
+                - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:32:54 GMT
+                - Mon, 18 May 2026 13:36:00 GMT
             X-Amz-Id-2:
-                - txg6e03d694589f42e1a36e-006a0aead6
+                - txge908319b63a74f81861d-006a0b15c0
             X-Amz-Request-Id:
-                - txg6e03d694589f42e1a36e-006a0aead6
+                - txge908319b63a74f81861d-006a0b15c0
         status: 404 Not Found
         code: 404
-        duration: 308.198041ms
+        duration: 50.60525ms
     - id: 48
       request:
         proto: HTTP/1.1
@@ -2511,7 +2511,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2520,7 +2520,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 3d8de7d6-996a-47d4-9224-117a8879caf7
+                - 604f8f45-45e1-44e0-a0a9-88562608de72
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2528,8 +2528,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103254Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T133600Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2548,14 +2548,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:32:54 GMT
+                - Mon, 18 May 2026 13:36:00 GMT
             X-Amz-Id-2:
-                - txg4a3bce12d0ad41b3aade-006a0aead6
+                - txgcc7f8ca0c4e04b0aa841-006a0b15c0
             X-Amz-Request-Id:
-                - txg4a3bce12d0ad41b3aade-006a0aead6
+                - txgcc7f8ca0c4e04b0aa841-006a0b15c0
         status: 200 OK
         code: 200
-        duration: 112.336417ms
+        duration: 39.1305ms
     - id: 49
       request:
         proto: HTTP/1.1
@@ -2564,7 +2564,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2573,7 +2573,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e3d611e4-d57c-460f-bbed-fb6f949ef1b4
+                - 17356a66-ce84-46ae-b024-92cb6ca59994
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2581,8 +2581,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103254Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T133600Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2601,14 +2601,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:32:55 GMT
+                - Mon, 18 May 2026 13:36:00 GMT
             X-Amz-Id-2:
-                - txgefcbca56168a465897c7-006a0aead7
+                - txg7c7634e5725e40bc9292-006a0b15c0
             X-Amz-Request-Id:
-                - txgefcbca56168a465897c7-006a0aead7
+                - txg7c7634e5725e40bc9292-006a0b15c0
         status: 200 OK
         code: 200
-        duration: 21.312166ms
+        duration: 36.392708ms
     - id: 50
       request:
         proto: HTTP/1.1
@@ -2617,16 +2617,16 @@ interactions:
         content_length: 1312
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
-        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></LifecycleConfiguration>
+        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></LifecycleConfiguration>
         form: {}
         headers:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 99676815-f6e3-42b3-9eda-205ba0fd4bb4
+                - 9f64d105-8a87-4260-97d7-b698b84a03af
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
@@ -2634,12 +2634,12 @@ interactions:
             User-Agent:
                 - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,Z,e
             X-Amz-Checksum-Crc32:
-                - 4NH0sw==
+                - uMAwFg==
             X-Amz-Content-Sha256:
-                - 26f747e15ce1a1b780c6752abe8ce8948c374f5a893f30d1d89454d547619049
+                - 45868aab6daf1016fee02a51a4a72191a7d55026e146191922aab1a4acb0706f
             X-Amz-Date:
-                - 20260518T103255Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T133600Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -2654,14 +2654,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 18 May 2026 10:32:55 GMT
+                - Mon, 18 May 2026 13:36:00 GMT
             X-Amz-Id-2:
-                - txg0a198e39bdbf46208696-006a0aead7
+                - txg7abd36328efd423880a1-006a0b15c0
             X-Amz-Request-Id:
-                - txg0a198e39bdbf46208696-006a0aead7
+                - txg7abd36328efd423880a1-006a0b15c0
         status: 200 OK
         code: 200
-        duration: 420.2105ms
+        duration: 39.960042ms
     - id: 51
       request:
         proto: HTTP/1.1
@@ -2670,7 +2670,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2679,7 +2679,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c5c78f68-2357-41d9-9b09-ded7795e0559
+                - caa90fa4-efb1-43bc-a414-fee20565dc70
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2687,8 +2687,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103255Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T133600Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2707,14 +2707,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:32:55 GMT
+                - Mon, 18 May 2026 13:36:00 GMT
             X-Amz-Id-2:
-                - txgbf2bb6b13d5b486785ba-006a0aead7
+                - txgc89d7cf8d5154be49de4-006a0b15c0
             X-Amz-Request-Id:
-                - txgbf2bb6b13d5b486785ba-006a0aead7
+                - txgc89d7cf8d5154be49de4-006a0b15c0
         status: 200 OK
         code: 200
-        duration: 50.600083ms
+        duration: 23.012583ms
     - id: 52
       request:
         proto: HTTP/1.1
@@ -2723,7 +2723,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2732,7 +2732,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d9021281-31fc-4afd-bd6c-20b940c23c99
+                - bc8811ab-2ce1-4b64-8de1-aa3f8954d82a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2740,8 +2740,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103255Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T133600Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2749,23 +2749,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 330
+        content_length: 329
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg4c1be19708ed45d9bb82-006a0aead7</RequestId><HostId>txg4c1be19708ed45d9bb82-006a0aead7</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg107e42c0680a4ceaa019-006a0b15c0</RequestId><HostId>txg107e42c0680a4ceaa019-006a0b15c0</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
         headers:
             Content-Length:
-                - "330"
+                - "329"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:32:55 GMT
+                - Mon, 18 May 2026 13:36:00 GMT
             X-Amz-Id-2:
-                - txg4c1be19708ed45d9bb82-006a0aead7
+                - txg107e42c0680a4ceaa019-006a0b15c0
             X-Amz-Request-Id:
-                - txg4c1be19708ed45d9bb82-006a0aead7
+                - txg107e42c0680a4ceaa019-006a0b15c0
         status: 404 Not Found
         code: 404
-        duration: 121.003333ms
+        duration: 36.825416ms
     - id: 53
       request:
         proto: HTTP/1.1
@@ -2774,7 +2774,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2783,7 +2783,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 46fc5f68-b626-4d7f-8550-420f8ea90d02
+                - 705ee487-3caa-4655-9c40-b8ca9734e74d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2791,8 +2791,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103255Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
+                - 20260518T133600Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -2800,25 +2800,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 287
+        content_length: 286
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "287"
+                - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:32:55 GMT
+                - Mon, 18 May 2026 13:36:00 GMT
             X-Amz-Id-2:
-                - txg9775a63bee30423bac76-006a0aead7
+                - txgd718c5303e8f4fe7a262-006a0b15c0
             X-Amz-Request-Id:
-                - txg9775a63bee30423bac76-006a0aead7
+                - txgd718c5303e8f4fe7a262-006a0b15c0
         status: 200 OK
         code: 200
-        duration: 79.175875ms
+        duration: 91.468541ms
     - id: 54
       request:
         proto: HTTP/1.1
@@ -2827,7 +2827,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2836,7 +2836,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 6d077fdc-100c-4362-9319-2779bc2ba3aa
+                - 00b86f0d-0f98-40b6-bb57-329b422df0b6
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2844,8 +2844,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103255Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T133600Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2853,23 +2853,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 361
+        content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg636db28b8c9c41438c7a-006a0aead7</RequestId><HostId>txg636db28b8c9c41438c7a-006a0aead7</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txge6333df19adf48e7a2db-006a0b15c0</RequestId><HostId>txge6333df19adf48e7a2db-006a0b15c0</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</BucketName></Error>
         headers:
             Content-Length:
-                - "361"
+                - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:32:55 GMT
+                - Mon, 18 May 2026 13:36:00 GMT
             X-Amz-Id-2:
-                - txg636db28b8c9c41438c7a-006a0aead7
+                - txge6333df19adf48e7a2db-006a0b15c0
             X-Amz-Request-Id:
-                - txg636db28b8c9c41438c7a-006a0aead7
+                - txge6333df19adf48e7a2db-006a0b15c0
         status: 404 Not Found
         code: 404
-        duration: 234.09925ms
+        duration: 21.006791ms
     - id: 55
       request:
         proto: HTTP/1.1
@@ -2878,7 +2878,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2887,7 +2887,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c06b3580-eb77-4f02-abb0-a650f41932a9
+                - 7d764301-af1b-4c01-978e-5af924c1c3ee
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2895,8 +2895,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103255Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T133600Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2904,23 +2904,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 298
+        content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg128e35a677aa49eda80a-006a0aead8</RequestId><HostId>txg128e35a677aa49eda80a-006a0aead8</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txga1a7dbf1527045f7ab74-006a0b15c0</RequestId><HostId>txga1a7dbf1527045f7ab74-006a0b15c0</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
         headers:
             Content-Length:
-                - "298"
+                - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:32:56 GMT
+                - Mon, 18 May 2026 13:36:00 GMT
             X-Amz-Id-2:
-                - txg128e35a677aa49eda80a-006a0aead8
+                - txga1a7dbf1527045f7ab74-006a0b15c0
             X-Amz-Request-Id:
-                - txg128e35a677aa49eda80a-006a0aead8
+                - txga1a7dbf1527045f7ab74-006a0b15c0
         status: 404 Not Found
         code: 404
-        duration: 90.021ms
+        duration: 61.679125ms
     - id: 56
       request:
         proto: HTTP/1.1
@@ -2929,7 +2929,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2938,7 +2938,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 86a8a0bf-8d68-49b4-a7b4-ba75f6130db8
+                - b988adb3-219f-4254-b7cc-5bbf07d0b307
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2946,8 +2946,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103256Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T133600Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2966,14 +2966,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:32:56 GMT
+                - Mon, 18 May 2026 13:36:01 GMT
             X-Amz-Id-2:
-                - txg61ecc483729d4d60be05-006a0aead8
+                - txge3af76b19a0242af8f4a-006a0b15c1
             X-Amz-Request-Id:
-                - txg61ecc483729d4d60be05-006a0aead8
+                - txge3af76b19a0242af8f4a-006a0b15c1
         status: 200 OK
         code: 200
-        duration: 21.898542ms
+        duration: 19.865541ms
     - id: 57
       request:
         proto: HTTP/1.1
@@ -2982,7 +2982,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2991,7 +2991,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4b59f6f3-8067-41d2-b0ac-4a730e94f11c
+                - 91a39df0-7a5c-412c-a8db-74c58e85675f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2999,8 +2999,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103256Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T133601Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3012,21 +3012,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
                 - "1285"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:32:56 GMT
+                - Mon, 18 May 2026 13:36:01 GMT
             X-Amz-Id-2:
-                - txg8fab7dcff0cf4432a47d-006a0aead8
+                - txg80d5c65bd850455bb84c-006a0b15c1
             X-Amz-Request-Id:
-                - txg8fab7dcff0cf4432a47d-006a0aead8
+                - txg80d5c65bd850455bb84c-006a0b15c1
         status: 200 OK
         code: 200
-        duration: 125.052375ms
+        duration: 18.810208ms
     - id: 58
       request:
         proto: HTTP/1.1
@@ -3035,7 +3035,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3044,7 +3044,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c655fbae-c7bf-46c9-b05e-bb593d5f2040
+                - e818d9a6-8793-4676-8bf8-a498fcd74547
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3052,8 +3052,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103256Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
+                - 20260518T133601Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -3068,16 +3068,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:32:56 GMT
+                - Mon, 18 May 2026 13:36:01 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txg05920a8065bb461aa719-006a0aead8
+                - txg7f3412ba12c441ce866b-006a0b15c1
             X-Amz-Request-Id:
-                - txg05920a8065bb461aa719-006a0aead8
+                - txg7f3412ba12c441ce866b-006a0b15c1
         status: 200 OK
         code: 200
-        duration: 30.58825ms
+        duration: 34.768541ms
     - id: 59
       request:
         proto: HTTP/1.1
@@ -3086,7 +3086,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3095,7 +3095,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9e91fe46-8a51-4f1f-913c-a17bf150d409
+                - 483155e2-624b-4da5-b512-e1c0d0a29045
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3103,8 +3103,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103256Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T133601Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3116,21 +3116,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
                 - "1285"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:32:56 GMT
+                - Mon, 18 May 2026 13:36:01 GMT
             X-Amz-Id-2:
-                - txg21cd5c90571d4c0cb3ea-006a0aead8
+                - txg9b9bd5a4e307421bac2f-006a0b15c1
             X-Amz-Request-Id:
-                - txg21cd5c90571d4c0cb3ea-006a0aead8
+                - txg9b9bd5a4e307421bac2f-006a0b15c1
         status: 200 OK
         code: 200
-        duration: 53.564791ms
+        duration: 34.856291ms
     - id: 60
       request:
         proto: HTTP/1.1
@@ -3139,7 +3139,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3148,7 +3148,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e0578d94-1b1f-417c-8110-153c36aed10d
+                - 0901da06-f3f8-4d65-875f-29a75c2b5fb4
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3156,8 +3156,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103256Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T133601Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3176,14 +3176,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:32:56 GMT
+                - Mon, 18 May 2026 13:36:01 GMT
             X-Amz-Id-2:
-                - txg2900cc0280814d40aba8-006a0aead8
+                - txge61a7b68c13b40bdbbc1-006a0b15c1
             X-Amz-Request-Id:
-                - txg2900cc0280814d40aba8-006a0aead8
+                - txge61a7b68c13b40bdbbc1-006a0b15c1
         status: 200 OK
         code: 200
-        duration: 22.627542ms
+        duration: 33.21475ms
     - id: 61
       request:
         proto: HTTP/1.1
@@ -3192,7 +3192,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3201,7 +3201,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5967e5b6-898d-459a-834f-2f854bfdf8a5
+                - dd3068f0-c28c-4c40-b4c4-8c1d9fbb1006
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3209,8 +3209,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103256Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T133601Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3218,23 +3218,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 330
+        content_length: 329
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txge7ecc7e9160b4ad3a1ae-006a0aead8</RequestId><HostId>txge7ecc7e9160b4ad3a1ae-006a0aead8</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg8358bed674364cf7b78f-006a0b15c1</RequestId><HostId>txg8358bed674364cf7b78f-006a0b15c1</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
         headers:
             Content-Length:
-                - "330"
+                - "329"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:32:56 GMT
+                - Mon, 18 May 2026 13:36:01 GMT
             X-Amz-Id-2:
-                - txge7ecc7e9160b4ad3a1ae-006a0aead8
+                - txg8358bed674364cf7b78f-006a0b15c1
             X-Amz-Request-Id:
-                - txge7ecc7e9160b4ad3a1ae-006a0aead8
+                - txg8358bed674364cf7b78f-006a0b15c1
         status: 404 Not Found
         code: 404
-        duration: 58.60875ms
+        duration: 37.71325ms
     - id: 62
       request:
         proto: HTTP/1.1
@@ -3243,7 +3243,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3252,7 +3252,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 772b91d7-43cb-4446-84f0-d5219304ddf9
+                - f9860c8c-9f3e-4fa0-b618-343bbd27ab8f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3260,8 +3260,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103256Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
+                - 20260518T133601Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -3269,25 +3269,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 287
+        content_length: 286
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "287"
+                - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:32:56 GMT
+                - Mon, 18 May 2026 13:36:01 GMT
             X-Amz-Id-2:
-                - txg39646da1b4f54500bb33-006a0aead8
+                - txg67613cdd10cc443a84cb-006a0b15c1
             X-Amz-Request-Id:
-                - txg39646da1b4f54500bb33-006a0aead8
+                - txg67613cdd10cc443a84cb-006a0b15c1
         status: 200 OK
         code: 200
-        duration: 330.737083ms
+        duration: 30.323708ms
     - id: 63
       request:
         proto: HTTP/1.1
@@ -3296,7 +3296,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3305,7 +3305,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - baa9987d-16a0-4698-b6f6-286d1ede1fd8
+                - a9dbe0bd-7181-4f52-8658-c07a995f2c15
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3313,8 +3313,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103256Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T133601Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3322,23 +3322,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 361
+        content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg88a897369b33421fa86d-006a0aead9</RequestId><HostId>txg88a897369b33421fa86d-006a0aead9</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgc3d9aa03942d4eccafdc-006a0b15c1</RequestId><HostId>txgc3d9aa03942d4eccafdc-006a0b15c1</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</BucketName></Error>
         headers:
             Content-Length:
-                - "361"
+                - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:32:57 GMT
+                - Mon, 18 May 2026 13:36:01 GMT
             X-Amz-Id-2:
-                - txg88a897369b33421fa86d-006a0aead9
+                - txgc3d9aa03942d4eccafdc-006a0b15c1
             X-Amz-Request-Id:
-                - txg88a897369b33421fa86d-006a0aead9
+                - txgc3d9aa03942d4eccafdc-006a0b15c1
         status: 404 Not Found
         code: 404
-        duration: 21.180417ms
+        duration: 19.769916ms
     - id: 64
       request:
         proto: HTTP/1.1
@@ -3347,7 +3347,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3356,7 +3356,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 6d4fb60d-6d97-4c41-8c14-5722de3fa3e3
+                - 8175fe4d-a694-49b8-b391-b6a020ced508
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3364,8 +3364,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103257Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T133601Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3373,23 +3373,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 298
+        content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg0d72fc0b5c4745759e68-006a0aead9</RequestId><HostId>txg0d72fc0b5c4745759e68-006a0aead9</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txga138f5ddc8a44fa29b34-006a0b15c1</RequestId><HostId>txga138f5ddc8a44fa29b34-006a0b15c1</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
         headers:
             Content-Length:
-                - "298"
+                - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:32:57 GMT
+                - Mon, 18 May 2026 13:36:01 GMT
             X-Amz-Id-2:
-                - txg0d72fc0b5c4745759e68-006a0aead9
+                - txga138f5ddc8a44fa29b34-006a0b15c1
             X-Amz-Request-Id:
-                - txg0d72fc0b5c4745759e68-006a0aead9
+                - txga138f5ddc8a44fa29b34-006a0b15c1
         status: 404 Not Found
         code: 404
-        duration: 20.472875ms
+        duration: 107.336042ms
     - id: 65
       request:
         proto: HTTP/1.1
@@ -3398,7 +3398,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3407,7 +3407,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d2c13169-9f3c-4edf-8585-a1384493ffe9
+                - 47c9553d-aa58-490c-ab8b-c0db415d570e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3415,8 +3415,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103257Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T133601Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3435,14 +3435,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:32:57 GMT
+                - Mon, 18 May 2026 13:36:01 GMT
             X-Amz-Id-2:
-                - txg4e9c53e70c1643838309-006a0aead9
+                - txg096dc48c8bb2479999de-006a0b15c1
             X-Amz-Request-Id:
-                - txg4e9c53e70c1643838309-006a0aead9
+                - txg096dc48c8bb2479999de-006a0b15c1
         status: 200 OK
         code: 200
-        duration: 224.113958ms
+        duration: 59.704ms
     - id: 66
       request:
         proto: HTTP/1.1
@@ -3451,7 +3451,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3460,7 +3460,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4cfd68c6-0f16-4783-bb10-591492a97758
+                - b9870707-ed32-4629-8292-5bccb825e7ac
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3468,8 +3468,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103257Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T133601Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3481,21 +3481,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
                 - "1285"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:32:57 GMT
+                - Mon, 18 May 2026 13:36:01 GMT
             X-Amz-Id-2:
-                - txg474e2192a0d749bca73b-006a0aead9
+                - txg401c8deae34e4638a463-006a0b15c1
             X-Amz-Request-Id:
-                - txg474e2192a0d749bca73b-006a0aead9
+                - txg401c8deae34e4638a463-006a0b15c1
         status: 200 OK
         code: 200
-        duration: 137.442125ms
+        duration: 34.210125ms
     - id: 67
       request:
         proto: HTTP/1.1
@@ -3504,7 +3504,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3513,7 +3513,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 888bb445-3325-4641-8c01-4f500e2d4749
+                - e3e213ac-311d-4e4a-8acd-f2b69acecc81
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3521,8 +3521,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103257Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T133601Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3541,14 +3541,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:32:57 GMT
+                - Mon, 18 May 2026 13:36:02 GMT
             X-Amz-Id-2:
-                - txg47f3dab0f92f4b919f49-006a0aead9
+                - txgb38778d22b3e48eabe5d-006a0b15c2
             X-Amz-Request-Id:
-                - txg47f3dab0f92f4b919f49-006a0aead9
+                - txgb38778d22b3e48eabe5d-006a0b15c2
         status: 200 OK
         code: 200
-        duration: 24.121959ms
+        duration: 18.305291ms
     - id: 68
       request:
         proto: HTTP/1.1
@@ -3557,7 +3557,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3566,7 +3566,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0a080c59-188c-4e01-8a6b-1d3f199b498b
+                - d84fbf70-d8f4-44da-b060-2e3fa8f14cc4
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3574,8 +3574,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103257Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T133602Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3583,23 +3583,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 330
+        content_length: 329
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgdf937c4bf38f4f1c9942-006a0aead9</RequestId><HostId>txgdf937c4bf38f4f1c9942-006a0aead9</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg9bd094d885824d5183a0-006a0b15c2</RequestId><HostId>txg9bd094d885824d5183a0-006a0b15c2</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
         headers:
             Content-Length:
-                - "330"
+                - "329"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:32:57 GMT
+                - Mon, 18 May 2026 13:36:02 GMT
             X-Amz-Id-2:
-                - txgdf937c4bf38f4f1c9942-006a0aead9
+                - txg9bd094d885824d5183a0-006a0b15c2
             X-Amz-Request-Id:
-                - txgdf937c4bf38f4f1c9942-006a0aead9
+                - txg9bd094d885824d5183a0-006a0b15c2
         status: 404 Not Found
         code: 404
-        duration: 88.717417ms
+        duration: 52.663916ms
     - id: 69
       request:
         proto: HTTP/1.1
@@ -3608,7 +3608,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3617,7 +3617,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 375bb115-4297-4476-8bf9-77e57e679e97
+                - b428458b-e670-48db-af0e-cc34c4060a6e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3625,8 +3625,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103257Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
+                - 20260518T133602Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -3634,25 +3634,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 287
+        content_length: 286
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "287"
+                - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:32:57 GMT
+                - Mon, 18 May 2026 13:36:02 GMT
             X-Amz-Id-2:
-                - txg4464d712945c4e798433-006a0aead9
+                - txg1258b35d1a6447ec8784-006a0b15c2
             X-Amz-Request-Id:
-                - txg4464d712945c4e798433-006a0aead9
+                - txg1258b35d1a6447ec8784-006a0b15c2
         status: 200 OK
         code: 200
-        duration: 48.316ms
+        duration: 21.28475ms
     - id: 70
       request:
         proto: HTTP/1.1
@@ -3661,7 +3661,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3670,7 +3670,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 1949a122-a160-4dec-abf0-2c3682a965b7
+                - 8dd63355-4141-483a-8ae5-670031cbf33d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3678,8 +3678,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103257Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T133602Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3687,23 +3687,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 361
+        content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg793ef4e69a5c46d3981c-006a0aeada</RequestId><HostId>txg793ef4e69a5c46d3981c-006a0aeada</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg460252d27eaa4fde8581-006a0b15c2</RequestId><HostId>txg460252d27eaa4fde8581-006a0b15c2</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</BucketName></Error>
         headers:
             Content-Length:
-                - "361"
+                - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:32:58 GMT
+                - Mon, 18 May 2026 13:36:02 GMT
             X-Amz-Id-2:
-                - txg793ef4e69a5c46d3981c-006a0aeada
+                - txg460252d27eaa4fde8581-006a0b15c2
             X-Amz-Request-Id:
-                - txg793ef4e69a5c46d3981c-006a0aeada
+                - txg460252d27eaa4fde8581-006a0b15c2
         status: 404 Not Found
         code: 404
-        duration: 85.764375ms
+        duration: 84.369083ms
     - id: 71
       request:
         proto: HTTP/1.1
@@ -3712,7 +3712,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3721,7 +3721,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 60b7c1e6-f31c-4733-baaf-42847fa0dee8
+                - ef2ce59c-efdc-42cd-8312-4edd9a712b38
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3729,8 +3729,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103258Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T133602Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3738,23 +3738,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 298
+        content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg3c6a6e7efc474751974c-006a0aeada</RequestId><HostId>txg3c6a6e7efc474751974c-006a0aeada</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgd9478a46620c48edadd3-006a0b15c2</RequestId><HostId>txgd9478a46620c48edadd3-006a0b15c2</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
         headers:
             Content-Length:
-                - "298"
+                - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:32:58 GMT
+                - Mon, 18 May 2026 13:36:02 GMT
             X-Amz-Id-2:
-                - txg3c6a6e7efc474751974c-006a0aeada
+                - txgd9478a46620c48edadd3-006a0b15c2
             X-Amz-Request-Id:
-                - txg3c6a6e7efc474751974c-006a0aeada
+                - txgd9478a46620c48edadd3-006a0b15c2
         status: 404 Not Found
         code: 404
-        duration: 20.851209ms
+        duration: 58.836958ms
     - id: 72
       request:
         proto: HTTP/1.1
@@ -3763,7 +3763,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3772,7 +3772,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 6624d4c4-053b-493e-a7e1-bd2089553736
+                - 539de228-a52e-4429-ab31-d2e2d5463fb4
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3780,8 +3780,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103258Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T133602Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3800,14 +3800,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:32:58 GMT
+                - Mon, 18 May 2026 13:36:02 GMT
             X-Amz-Id-2:
-                - txgb71d4714c4cf4533a347-006a0aeada
+                - txg1f442b018f7f44789f0d-006a0b15c2
             X-Amz-Request-Id:
-                - txgb71d4714c4cf4533a347-006a0aeada
+                - txg1f442b018f7f44789f0d-006a0b15c2
         status: 200 OK
         code: 200
-        duration: 20.152ms
+        duration: 171.952958ms
     - id: 73
       request:
         proto: HTTP/1.1
@@ -3816,7 +3816,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3825,7 +3825,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - a526c22c-d486-4d25-8f04-6164853dd77e
+                - ff1cedb6-a57a-4354-b4d7-c0bc9fd8f071
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3833,8 +3833,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103258Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T133602Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3846,21 +3846,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
                 - "1285"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:32:58 GMT
+                - Mon, 18 May 2026 13:36:02 GMT
             X-Amz-Id-2:
-                - txg4790979463504821a4c0-006a0aeada
+                - txgeaf8387d98ac4f78b029-006a0b15c2
             X-Amz-Request-Id:
-                - txg4790979463504821a4c0-006a0aeada
+                - txgeaf8387d98ac4f78b029-006a0b15c2
         status: 200 OK
         code: 200
-        duration: 153.723042ms
+        duration: 20.733208ms
     - id: 74
       request:
         proto: HTTP/1.1
@@ -3869,7 +3869,7 @@ interactions:
         content_length: 296
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
@@ -3878,7 +3878,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 6b1ce1b9-ae7e-45da-a753-6171f3578b1f
+                - 6c0a83da-899e-4e5f-ba7f-93174106a992
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
@@ -3890,8 +3890,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - 7756d51b786b61edff20b7957d22346417f85f71d19eeca0d6d28d6df7b15bbc
             X-Amz-Date:
-                - 20260518T103258Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T133602Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -3906,14 +3906,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 18 May 2026 10:32:58 GMT
+                - Mon, 18 May 2026 13:36:02 GMT
             X-Amz-Id-2:
-                - txgdb8a362ebdae44ee9bc0-006a0aeada
+                - txgc3fe67db41944847a326-006a0b15c2
             X-Amz-Request-Id:
-                - txgdb8a362ebdae44ee9bc0-006a0aeada
+                - txgc3fe67db41944847a326-006a0b15c2
         status: 200 OK
         code: 200
-        duration: 39.499ms
+        duration: 22.204042ms
     - id: 75
       request:
         proto: HTTP/1.1
@@ -3922,7 +3922,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3931,7 +3931,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 723af911-494b-49eb-a4b0-3e7d31cf9d67
+                - b0262691-186a-4dda-87ee-c257263da6a8
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3939,8 +3939,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103258Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T133602Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3959,14 +3959,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:32:58 GMT
+                - Mon, 18 May 2026 13:36:02 GMT
             X-Amz-Id-2:
-                - txg23037ffd73d446699a41-006a0aeada
+                - txg5ed619075ac64062a89e-006a0b15c2
             X-Amz-Request-Id:
-                - txg23037ffd73d446699a41-006a0aeada
+                - txg5ed619075ac64062a89e-006a0b15c2
         status: 200 OK
         code: 200
-        duration: 114.08325ms
+        duration: 22.008875ms
     - id: 76
       request:
         proto: HTTP/1.1
@@ -3975,7 +3975,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3984,7 +3984,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 03595ad7-dd53-4ca6-b4f2-c93a8e859ae4
+                - af3210b9-f6df-47d6-9baa-60e573b3d34e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3992,8 +3992,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103258Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T133602Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4001,23 +4001,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 330
+        content_length: 329
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgf89beebe8af94e4a9a93-006a0aeada</RequestId><HostId>txgf89beebe8af94e4a9a93-006a0aeada</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg8c0cd459f62f43b68041-006a0b15c2</RequestId><HostId>txg8c0cd459f62f43b68041-006a0b15c2</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
         headers:
             Content-Length:
-                - "330"
+                - "329"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:32:58 GMT
+                - Mon, 18 May 2026 13:36:02 GMT
             X-Amz-Id-2:
-                - txgf89beebe8af94e4a9a93-006a0aeada
+                - txg8c0cd459f62f43b68041-006a0b15c2
             X-Amz-Request-Id:
-                - txgf89beebe8af94e4a9a93-006a0aeada
+                - txg8c0cd459f62f43b68041-006a0b15c2
         status: 404 Not Found
         code: 404
-        duration: 179.164125ms
+        duration: 59.14125ms
     - id: 77
       request:
         proto: HTTP/1.1
@@ -4026,7 +4026,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4035,7 +4035,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 6a5ac5c1-c7aa-497b-87da-50718e60fa84
+                - 821d5e5b-12d5-4694-89f8-aa9faa67a3c5
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4043,8 +4043,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103258Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
+                - 20260518T133602Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -4052,25 +4052,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 287
+        content_length: 286
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "287"
+                - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:32:58 GMT
+                - Mon, 18 May 2026 13:36:02 GMT
             X-Amz-Id-2:
-                - txgfc94f35b7f934e928f9c-006a0aeada
+                - txga759d844c6354cddb6ce-006a0b15c2
             X-Amz-Request-Id:
-                - txgfc94f35b7f934e928f9c-006a0aeada
+                - txga759d844c6354cddb6ce-006a0b15c2
         status: 200 OK
         code: 200
-        duration: 158.856209ms
+        duration: 19.257291ms
     - id: 78
       request:
         proto: HTTP/1.1
@@ -4079,7 +4079,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4088,7 +4088,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7292236c-0a7d-491f-b783-c633ea27cfec
+                - 4caf6fe3-c107-454c-b8c3-676f2c01436e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4096,8 +4096,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103258Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T133602Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4105,23 +4105,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 361
+        content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txge0e58f0b17ed48ee93cc-006a0aeadb</RequestId><HostId>txge0e58f0b17ed48ee93cc-006a0aeadb</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgcc36082bea9e4fd399be-006a0b15c2</RequestId><HostId>txgcc36082bea9e4fd399be-006a0b15c2</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</BucketName></Error>
         headers:
             Content-Length:
-                - "361"
+                - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:32:59 GMT
+                - Mon, 18 May 2026 13:36:02 GMT
             X-Amz-Id-2:
-                - txge0e58f0b17ed48ee93cc-006a0aeadb
+                - txgcc36082bea9e4fd399be-006a0b15c2
             X-Amz-Request-Id:
-                - txge0e58f0b17ed48ee93cc-006a0aeadb
+                - txgcc36082bea9e4fd399be-006a0b15c2
         status: 404 Not Found
         code: 404
-        duration: 247.005834ms
+        duration: 58.403334ms
     - id: 79
       request:
         proto: HTTP/1.1
@@ -4130,7 +4130,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4139,7 +4139,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 29996280-82d1-42e6-be2c-228b56303057
+                - bce0ec15-e790-436b-bc3b-07c668306c79
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4147,8 +4147,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103259Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T133602Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4156,23 +4156,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 298
+        content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txga3e45d5d6db04998b09b-006a0aeadb</RequestId><HostId>txga3e45d5d6db04998b09b-006a0aeadb</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg6fc7045ddcbf4c6a92b2-006a0b15c2</RequestId><HostId>txg6fc7045ddcbf4c6a92b2-006a0b15c2</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
         headers:
             Content-Length:
-                - "298"
+                - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:32:59 GMT
+                - Mon, 18 May 2026 13:36:02 GMT
             X-Amz-Id-2:
-                - txga3e45d5d6db04998b09b-006a0aeadb
+                - txg6fc7045ddcbf4c6a92b2-006a0b15c2
             X-Amz-Request-Id:
-                - txga3e45d5d6db04998b09b-006a0aeadb
+                - txg6fc7045ddcbf4c6a92b2-006a0b15c2
         status: 404 Not Found
         code: 404
-        duration: 52.133083ms
+        duration: 18.891583ms
     - id: 80
       request:
         proto: HTTP/1.1
@@ -4181,7 +4181,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4190,7 +4190,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 2fec7c55-167c-4f84-b6f4-9882b2ecc937
+                - f8f28038-346c-4ee2-bd0c-feea98ef53fe
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4198,8 +4198,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103259Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T133602Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4218,14 +4218,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:32:59 GMT
+                - Mon, 18 May 2026 13:36:02 GMT
             X-Amz-Id-2:
-                - txgdbb37ac0faa540348e34-006a0aeadb
+                - txg2e06b36763644c6d899b-006a0b15c2
             X-Amz-Request-Id:
-                - txgdbb37ac0faa540348e34-006a0aeadb
+                - txg2e06b36763644c6d899b-006a0b15c2
         status: 200 OK
         code: 200
-        duration: 20.43225ms
+        duration: 51.0555ms
     - id: 81
       request:
         proto: HTTP/1.1
@@ -4234,7 +4234,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4243,7 +4243,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0b484fc7-97bd-4bb2-8d6f-797fce4faeae
+                - 97b96b6e-e330-474b-a1ed-75a122178f0d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4251,8 +4251,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103259Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T133602Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4271,14 +4271,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:32:59 GMT
+                - Mon, 18 May 2026 13:36:02 GMT
             X-Amz-Id-2:
-                - txg8a210cfd92844672a969-006a0aeadb
+                - txg1503fa18959b462882f7-006a0b15c2
             X-Amz-Request-Id:
-                - txg8a210cfd92844672a969-006a0aeadb
+                - txg1503fa18959b462882f7-006a0b15c2
         status: 200 OK
         code: 200
-        duration: 27.17725ms
+        duration: 18.257583ms
     - id: 82
       request:
         proto: HTTP/1.1
@@ -4287,7 +4287,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4296,7 +4296,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - fa7a0c90-2043-435a-98f1-ddc47b210303
+                - 2dfd2a8b-02d7-4993-9a6a-0f68a8a1c4a1
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4304,8 +4304,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103259Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
+                - 20260518T133603Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -4320,16 +4320,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:32:59 GMT
+                - Mon, 18 May 2026 13:36:03 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txg9f3de97c87a94f698a3b-006a0aeadb
+                - txg4eeddda8c36940e48bec-006a0b15c3
             X-Amz-Request-Id:
-                - txg9f3de97c87a94f698a3b-006a0aeadb
+                - txg4eeddda8c36940e48bec-006a0b15c3
         status: 200 OK
         code: 200
-        duration: 20.5445ms
+        duration: 18.62775ms
     - id: 83
       request:
         proto: HTTP/1.1
@@ -4338,7 +4338,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4347,7 +4347,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 45354779-e687-4c9f-9d5a-7feff288df89
+                - 4f99be3c-9371-4462-a1e8-3521b4dc3407
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4355,8 +4355,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103259Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T133603Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4375,14 +4375,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:32:59 GMT
+                - Mon, 18 May 2026 13:36:03 GMT
             X-Amz-Id-2:
-                - txgcd35da98a6e34797bf3d-006a0aeadb
+                - txg5b870d2e84c2461893f4-006a0b15c3
             X-Amz-Request-Id:
-                - txgcd35da98a6e34797bf3d-006a0aeadb
+                - txg5b870d2e84c2461893f4-006a0b15c3
         status: 200 OK
         code: 200
-        duration: 22.399584ms
+        duration: 19.295084ms
     - id: 84
       request:
         proto: HTTP/1.1
@@ -4391,7 +4391,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4400,7 +4400,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 680de311-ea5c-4f22-9f00-64d9bcae5ca6
+                - eec8879c-f01b-4630-8a57-25e847dbdc01
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4408,8 +4408,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103259Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T133603Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4428,14 +4428,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:32:59 GMT
+                - Mon, 18 May 2026 13:36:03 GMT
             X-Amz-Id-2:
-                - txg5a55b9d48c254303a904-006a0aeadb
+                - txgc6c23d56c9c74712b9b5-006a0b15c3
             X-Amz-Request-Id:
-                - txg5a55b9d48c254303a904-006a0aeadb
+                - txgc6c23d56c9c74712b9b5-006a0b15c3
         status: 200 OK
         code: 200
-        duration: 33.894042ms
+        duration: 59.989041ms
     - id: 85
       request:
         proto: HTTP/1.1
@@ -4444,7 +4444,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4453,7 +4453,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 742bf7e3-ae3a-4eb0-b436-dec8b2e16e06
+                - fc39d1eb-cfa8-4bb8-8134-eedd2a2f96b4
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4461,8 +4461,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103259Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T133603Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4470,23 +4470,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 330
+        content_length: 329
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg11d056991ee64e5897e6-006a0aeadb</RequestId><HostId>txg11d056991ee64e5897e6-006a0aeadb</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg246540cd03d44d36bf62-006a0b15c3</RequestId><HostId>txg246540cd03d44d36bf62-006a0b15c3</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
         headers:
             Content-Length:
-                - "330"
+                - "329"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:32:59 GMT
+                - Mon, 18 May 2026 13:36:03 GMT
             X-Amz-Id-2:
-                - txg11d056991ee64e5897e6-006a0aeadb
+                - txg246540cd03d44d36bf62-006a0b15c3
             X-Amz-Request-Id:
-                - txg11d056991ee64e5897e6-006a0aeadb
+                - txg246540cd03d44d36bf62-006a0b15c3
         status: 404 Not Found
         code: 404
-        duration: 21.624625ms
+        duration: 19.477167ms
     - id: 86
       request:
         proto: HTTP/1.1
@@ -4495,7 +4495,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4504,7 +4504,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 272b7fc8-e221-4dc4-a42b-4989a8a76db0
+                - fe00fd94-5a22-43fa-a771-c6a3e72a838e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4512,8 +4512,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103259Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
+                - 20260518T133603Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -4521,25 +4521,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 287
+        content_length: 286
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "287"
+                - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:32:59 GMT
+                - Mon, 18 May 2026 13:36:03 GMT
             X-Amz-Id-2:
-                - txgaeb4e60d63cc4c94a2a3-006a0aeadb
+                - txgbf67fa987cdc4f0684aa-006a0b15c3
             X-Amz-Request-Id:
-                - txgaeb4e60d63cc4c94a2a3-006a0aeadb
+                - txgbf67fa987cdc4f0684aa-006a0b15c3
         status: 200 OK
         code: 200
-        duration: 21.262833ms
+        duration: 49.012041ms
     - id: 87
       request:
         proto: HTTP/1.1
@@ -4548,7 +4548,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4557,7 +4557,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e6e67699-ce75-49a2-a915-9f1e04b0b61a
+                - 810759ac-5c9c-436c-8c0e-ac9665a08f98
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4565,8 +4565,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103259Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T133603Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4574,23 +4574,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 361
+        content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg0e2805d25f894f13aee1-006a0aeadb</RequestId><HostId>txg0e2805d25f894f13aee1-006a0aeadb</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg1e9d7570da3d46d69f75-006a0b15c3</RequestId><HostId>txg1e9d7570da3d46d69f75-006a0b15c3</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</BucketName></Error>
         headers:
             Content-Length:
-                - "361"
+                - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:32:59 GMT
+                - Mon, 18 May 2026 13:36:03 GMT
             X-Amz-Id-2:
-                - txg0e2805d25f894f13aee1-006a0aeadb
+                - txg1e9d7570da3d46d69f75-006a0b15c3
             X-Amz-Request-Id:
-                - txg0e2805d25f894f13aee1-006a0aeadb
+                - txg1e9d7570da3d46d69f75-006a0b15c3
         status: 404 Not Found
         code: 404
-        duration: 19.891459ms
+        duration: 60.656709ms
     - id: 88
       request:
         proto: HTTP/1.1
@@ -4599,7 +4599,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4608,7 +4608,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - eec848fa-1d54-47f9-b33c-523cf1fa3794
+                - f7b82545-6a6f-4de5-91cd-2085abb8525a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4616,8 +4616,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103259Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T133603Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4625,23 +4625,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 298
+        content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txge98d5c84cff94b068b1f-006a0aeadb</RequestId><HostId>txge98d5c84cff94b068b1f-006a0aeadb</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg7cd0962096274628b762-006a0b15c3</RequestId><HostId>txg7cd0962096274628b762-006a0b15c3</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
         headers:
             Content-Length:
-                - "298"
+                - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:32:59 GMT
+                - Mon, 18 May 2026 13:36:03 GMT
             X-Amz-Id-2:
-                - txge98d5c84cff94b068b1f-006a0aeadb
+                - txg7cd0962096274628b762-006a0b15c3
             X-Amz-Request-Id:
-                - txge98d5c84cff94b068b1f-006a0aeadb
+                - txg7cd0962096274628b762-006a0b15c3
         status: 404 Not Found
         code: 404
-        duration: 20.964792ms
+        duration: 18.084916ms
     - id: 89
       request:
         proto: HTTP/1.1
@@ -4650,7 +4650,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4659,7 +4659,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 217c1dc4-6142-478b-acf7-61fdb80c828a
+                - 571131ea-862b-4538-a272-5ef381ea3262
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4667,8 +4667,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103259Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T133603Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4687,14 +4687,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:32:59 GMT
+                - Mon, 18 May 2026 13:36:03 GMT
             X-Amz-Id-2:
-                - txgd7d981d1709943c8b011-006a0aeadb
+                - txg532d759c6fa64c17be92-006a0b15c3
             X-Amz-Request-Id:
-                - txgd7d981d1709943c8b011-006a0aeadb
+                - txg532d759c6fa64c17be92-006a0b15c3
         status: 200 OK
         code: 200
-        duration: 20.569416ms
+        duration: 18.627291ms
     - id: 90
       request:
         proto: HTTP/1.1
@@ -4703,7 +4703,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4712,7 +4712,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 81ac707c-0d81-47a0-8c9b-50f46fc04917
+                - 7d5f1c83-dfc2-4628-bd4f-dd59395ff187
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4720,8 +4720,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103259Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T133603Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4740,14 +4740,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:32:59 GMT
+                - Mon, 18 May 2026 13:36:03 GMT
             X-Amz-Id-2:
-                - txg9230d4be316d498c893c-006a0aeadb
+                - txg3b44a5324e994920a3b4-006a0b15c3
             X-Amz-Request-Id:
-                - txg9230d4be316d498c893c-006a0aeadb
+                - txg3b44a5324e994920a3b4-006a0b15c3
         status: 200 OK
         code: 200
-        duration: 20.602625ms
+        duration: 19.56ms
     - id: 91
       request:
         proto: HTTP/1.1
@@ -4756,7 +4756,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4765,7 +4765,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c65b4fb5-02ab-42f1-bda7-401ff7bb2397
+                - 42185baf-312c-4fd5-9bec-c982e5700a7f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4773,8 +4773,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103300Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T133603Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4793,14 +4793,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:33:00 GMT
+                - Mon, 18 May 2026 13:36:03 GMT
             X-Amz-Id-2:
-                - txg9066d87ecc5640dc954b-006a0aeadc
+                - txg0c9242daf3bd49a2908d-006a0b15c3
             X-Amz-Request-Id:
-                - txg9066d87ecc5640dc954b-006a0aeadc
+                - txg0c9242daf3bd49a2908d-006a0b15c3
         status: 200 OK
         code: 200
-        duration: 20.46225ms
+        duration: 19.343166ms
     - id: 92
       request:
         proto: HTTP/1.1
@@ -4809,7 +4809,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4818,7 +4818,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e7ea82e3-e995-4b66-8a45-c10eafd8b5ff
+                - e0aaa70d-9160-4ae4-a7f3-3e9ee9dbf3e2
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4826,8 +4826,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103300Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T133603Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4835,23 +4835,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 330
+        content_length: 329
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg8be55af6c19d4394b8a6-006a0aeadc</RequestId><HostId>txg8be55af6c19d4394b8a6-006a0aeadc</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg1ec5b71219224a558b71-006a0b15c3</RequestId><HostId>txg1ec5b71219224a558b71-006a0b15c3</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
         headers:
             Content-Length:
-                - "330"
+                - "329"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:33:00 GMT
+                - Mon, 18 May 2026 13:36:03 GMT
             X-Amz-Id-2:
-                - txg8be55af6c19d4394b8a6-006a0aeadc
+                - txg1ec5b71219224a558b71-006a0b15c3
             X-Amz-Request-Id:
-                - txg8be55af6c19d4394b8a6-006a0aeadc
+                - txg1ec5b71219224a558b71-006a0b15c3
         status: 404 Not Found
         code: 404
-        duration: 20.405125ms
+        duration: 20.155416ms
     - id: 93
       request:
         proto: HTTP/1.1
@@ -4860,7 +4860,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4869,7 +4869,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0e869fa4-d3ca-4bfc-93e6-48abaff09b69
+                - 6bc4ffce-9a28-4c2e-92e4-b1b36c32419b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4877,8 +4877,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103300Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
+                - 20260518T133603Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -4886,25 +4886,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 287
+        content_length: 286
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "287"
+                - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:33:00 GMT
+                - Mon, 18 May 2026 13:36:03 GMT
             X-Amz-Id-2:
-                - txg4efa7e7ce72e43299a01-006a0aeadc
+                - txgdd622b9fa50d4fe08d17-006a0b15c3
             X-Amz-Request-Id:
-                - txg4efa7e7ce72e43299a01-006a0aeadc
+                - txgdd622b9fa50d4fe08d17-006a0b15c3
         status: 200 OK
         code: 200
-        duration: 21.130542ms
+        duration: 31.426083ms
     - id: 94
       request:
         proto: HTTP/1.1
@@ -4913,7 +4913,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4922,7 +4922,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - a5167c65-2c35-4ab9-95c5-43e3b36a1159
+                - 563dc347-3bf6-4e64-ae91-a2cba76ca0fa
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4930,8 +4930,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103300Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T133603Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4939,23 +4939,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 361
+        content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg454e7076c01242e9a4ae-006a0aeadc</RequestId><HostId>txg454e7076c01242e9a4ae-006a0aeadc</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txge4e82ad4ea85417dbe88-006a0b15c3</RequestId><HostId>txge4e82ad4ea85417dbe88-006a0b15c3</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</BucketName></Error>
         headers:
             Content-Length:
-                - "361"
+                - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:33:00 GMT
+                - Mon, 18 May 2026 13:36:03 GMT
             X-Amz-Id-2:
-                - txg454e7076c01242e9a4ae-006a0aeadc
+                - txge4e82ad4ea85417dbe88-006a0b15c3
             X-Amz-Request-Id:
-                - txg454e7076c01242e9a4ae-006a0aeadc
+                - txge4e82ad4ea85417dbe88-006a0b15c3
         status: 404 Not Found
         code: 404
-        duration: 20.54675ms
+        duration: 59.015416ms
     - id: 95
       request:
         proto: HTTP/1.1
@@ -4964,7 +4964,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4973,7 +4973,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - a3666118-51ee-47b6-906c-07602037625c
+                - b955b179-90e5-4ce7-9898-68d358d20b39
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4981,8 +4981,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103300Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T133603Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4990,23 +4990,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 298
+        content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg07338799148745f79252-006a0aeadc</RequestId><HostId>txg07338799148745f79252-006a0aeadc</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgc584a0d5be7b45cc843a-006a0b15c3</RequestId><HostId>txgc584a0d5be7b45cc843a-006a0b15c3</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
         headers:
             Content-Length:
-                - "298"
+                - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:33:00 GMT
+                - Mon, 18 May 2026 13:36:03 GMT
             X-Amz-Id-2:
-                - txg07338799148745f79252-006a0aeadc
+                - txgc584a0d5be7b45cc843a-006a0b15c3
             X-Amz-Request-Id:
-                - txg07338799148745f79252-006a0aeadc
+                - txgc584a0d5be7b45cc843a-006a0b15c3
         status: 404 Not Found
         code: 404
-        duration: 19.395167ms
+        duration: 19.094792ms
     - id: 96
       request:
         proto: HTTP/1.1
@@ -5015,7 +5015,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5024,7 +5024,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c646ac1c-c7f6-4e36-8ab4-f0fc35c8f9e5
+                - f5321642-8077-456c-bdd3-b9d69ffdda3b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5032,8 +5032,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103300Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T133603Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5052,14 +5052,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:33:00 GMT
+                - Mon, 18 May 2026 13:36:03 GMT
             X-Amz-Id-2:
-                - txg46e1e9827ca045869d4e-006a0aeadc
+                - txg4f8d2a8540bc41e8aa75-006a0b15c3
             X-Amz-Request-Id:
-                - txg46e1e9827ca045869d4e-006a0aeadc
+                - txg4f8d2a8540bc41e8aa75-006a0b15c3
         status: 200 OK
         code: 200
-        duration: 92.125834ms
+        duration: 30.262875ms
     - id: 97
       request:
         proto: HTTP/1.1
@@ -5068,7 +5068,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5077,7 +5077,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 60eefe44-517d-48a3-b64b-bcebb8878544
+                - cb8ca374-bc60-4a9a-8e80-53d5b747c897
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5085,8 +5085,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103300Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T133603Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5105,14 +5105,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:33:00 GMT
+                - Mon, 18 May 2026 13:36:03 GMT
             X-Amz-Id-2:
-                - txg0c19572d3ae94b16a5ca-006a0aeadc
+                - txg8f556bb2ebd34de9a817-006a0b15c3
             X-Amz-Request-Id:
-                - txg0c19572d3ae94b16a5ca-006a0aeadc
+                - txg8f556bb2ebd34de9a817-006a0b15c3
         status: 200 OK
         code: 200
-        duration: 159.451542ms
+        duration: 18.5705ms
     - id: 98
       request:
         proto: HTTP/1.1
@@ -5121,7 +5121,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5130,7 +5130,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e7556cd6-aac8-4d85-9341-dabaa8a96084
+                - 29b6328d-d227-4377-955a-173f623756b9
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5138,8 +5138,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103300Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
+                - 20260518T133604Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -5154,16 +5154,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:33:00 GMT
+                - Mon, 18 May 2026 13:36:04 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txg31de8f6f732544349638-006a0aeadc
+                - txgefd1174a9dd24e5e8588-006a0b15c4
             X-Amz-Request-Id:
-                - txg31de8f6f732544349638-006a0aeadc
+                - txgefd1174a9dd24e5e8588-006a0b15c4
         status: 200 OK
         code: 200
-        duration: 235.836292ms
+        duration: 678.278667ms
     - id: 99
       request:
         proto: HTTP/1.1
@@ -5172,7 +5172,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5181,7 +5181,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - cb105fd6-238c-4c2d-966c-124068cf9dcb
+                - c1d8d61c-9ca3-439b-a8f0-25001e9753f4
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5189,8 +5189,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103300Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T133604Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5209,14 +5209,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:33:00 GMT
+                - Mon, 18 May 2026 13:36:04 GMT
             X-Amz-Id-2:
-                - txg7bd2805711594d838873-006a0aeadc
+                - txgc22a386516ea47048d48-006a0b15c4
             X-Amz-Request-Id:
-                - txg7bd2805711594d838873-006a0aeadc
+                - txgc22a386516ea47048d48-006a0b15c4
         status: 200 OK
         code: 200
-        duration: 21.910833ms
+        duration: 56.451917ms
     - id: 100
       request:
         proto: HTTP/1.1
@@ -5225,7 +5225,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5234,7 +5234,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 07cde1ad-090e-4bd1-afbc-f1ee9d2ae31e
+                - 94f39d9c-da5f-4148-8837-74782d6bbaaa
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5242,8 +5242,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103301Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T133605Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5262,14 +5262,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:33:01 GMT
+                - Mon, 18 May 2026 13:36:05 GMT
             X-Amz-Id-2:
-                - txg3e2015aa67e34721a148-006a0aeadd
+                - txg2de748b3b6c0428c803f-006a0b15c5
             X-Amz-Request-Id:
-                - txg3e2015aa67e34721a148-006a0aeadd
+                - txg2de748b3b6c0428c803f-006a0b15c5
         status: 200 OK
         code: 200
-        duration: 31.39325ms
+        duration: 19.418167ms
     - id: 101
       request:
         proto: HTTP/1.1
@@ -5278,7 +5278,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5287,7 +5287,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 48d2bb57-ccca-4d1c-a0ea-f7c756d654c4
+                - e74cadd9-a2e9-491e-ab86-ad668fb186a4
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5295,8 +5295,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103301Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T133605Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5304,23 +5304,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 330
+        content_length: 329
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg1f7c9bef662a4af6a4cf-006a0aeadd</RequestId><HostId>txg1f7c9bef662a4af6a4cf-006a0aeadd</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgd752d331f67f406fad58-006a0b15c5</RequestId><HostId>txgd752d331f67f406fad58-006a0b15c5</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
         headers:
             Content-Length:
-                - "330"
+                - "329"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:33:01 GMT
+                - Mon, 18 May 2026 13:36:05 GMT
             X-Amz-Id-2:
-                - txg1f7c9bef662a4af6a4cf-006a0aeadd
+                - txgd752d331f67f406fad58-006a0b15c5
             X-Amz-Request-Id:
-                - txg1f7c9bef662a4af6a4cf-006a0aeadd
+                - txgd752d331f67f406fad58-006a0b15c5
         status: 404 Not Found
         code: 404
-        duration: 21.63775ms
+        duration: 21.582458ms
     - id: 102
       request:
         proto: HTTP/1.1
@@ -5329,7 +5329,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5338,7 +5338,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 124317a7-db1d-498c-93b0-d38f6a91c035
+                - 5607591a-d5d4-40e4-81a1-fc0ecd4968b1
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5346,8 +5346,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103301Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
+                - 20260518T133605Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -5355,25 +5355,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 287
+        content_length: 286
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "287"
+                - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:33:01 GMT
+                - Mon, 18 May 2026 13:36:05 GMT
             X-Amz-Id-2:
-                - txg03d3a97eb7874282bb91-006a0aeadd
+                - txg3268bbac9edd41a29920-006a0b15c5
             X-Amz-Request-Id:
-                - txg03d3a97eb7874282bb91-006a0aeadd
+                - txg3268bbac9edd41a29920-006a0b15c5
         status: 200 OK
         code: 200
-        duration: 239.383625ms
+        duration: 20.680875ms
     - id: 103
       request:
         proto: HTTP/1.1
@@ -5382,7 +5382,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5391,7 +5391,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b52a165d-0354-4952-9729-bed4af2bdcf7
+                - 85fd0406-775f-4134-acd3-14dd7e6404c0
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5399,8 +5399,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103301Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T133605Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5408,23 +5408,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 361
+        content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgf6a42e4433214fcc9012-006a0aeadd</RequestId><HostId>txgf6a42e4433214fcc9012-006a0aeadd</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txge3eb600e2232468399a7-006a0b15c5</RequestId><HostId>txge3eb600e2232468399a7-006a0b15c5</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</BucketName></Error>
         headers:
             Content-Length:
-                - "361"
+                - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:33:01 GMT
+                - Mon, 18 May 2026 13:36:05 GMT
             X-Amz-Id-2:
-                - txgf6a42e4433214fcc9012-006a0aeadd
+                - txge3eb600e2232468399a7-006a0b15c5
             X-Amz-Request-Id:
-                - txgf6a42e4433214fcc9012-006a0aeadd
+                - txge3eb600e2232468399a7-006a0b15c5
         status: 404 Not Found
         code: 404
-        duration: 159.813167ms
+        duration: 18.6755ms
     - id: 104
       request:
         proto: HTTP/1.1
@@ -5433,7 +5433,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5442,7 +5442,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - a0a475e1-b6c7-4c6e-87a9-2ce0399140e4
+                - 92914863-9943-4966-aaa7-7454743242ce
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5450,8 +5450,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103301Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T133605Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5459,23 +5459,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 298
+        content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg27235c37e07b4d70ad36-006a0aeadd</RequestId><HostId>txg27235c37e07b4d70ad36-006a0aeadd</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg58eccead3de74c02974d-006a0b15c5</RequestId><HostId>txg58eccead3de74c02974d-006a0b15c5</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
         headers:
             Content-Length:
-                - "298"
+                - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:33:01 GMT
+                - Mon, 18 May 2026 13:36:05 GMT
             X-Amz-Id-2:
-                - txg27235c37e07b4d70ad36-006a0aeadd
+                - txg58eccead3de74c02974d-006a0b15c5
             X-Amz-Request-Id:
-                - txg27235c37e07b4d70ad36-006a0aeadd
+                - txg58eccead3de74c02974d-006a0b15c5
         status: 404 Not Found
         code: 404
-        duration: 245.5335ms
+        duration: 20.254542ms
     - id: 105
       request:
         proto: HTTP/1.1
@@ -5484,7 +5484,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5493,7 +5493,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 6aef73de-f3a4-4e59-a704-b1994dc14ceb
+                - 33fdc835-260e-45cc-adfd-284990cdfd29
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5501,8 +5501,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103301Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T133605Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5521,14 +5521,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:33:01 GMT
+                - Mon, 18 May 2026 13:36:05 GMT
             X-Amz-Id-2:
-                - txg4ddb9fc50bc7425280ff-006a0aeadd
+                - txgdaeb24d03a74436f826d-006a0b15c5
             X-Amz-Request-Id:
-                - txg4ddb9fc50bc7425280ff-006a0aeadd
+                - txgdaeb24d03a74436f826d-006a0b15c5
         status: 200 OK
         code: 200
-        duration: 21.431041ms
+        duration: 20.798459ms
     - id: 106
       request:
         proto: HTTP/1.1
@@ -5537,7 +5537,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5546,7 +5546,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b90da4c2-c4df-4eba-83b9-02e6e55e0ca6
+                - cbe0ca0c-cf01-4723-919f-fa0fb67c60d6
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5554,8 +5554,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103301Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T133605Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5574,14 +5574,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:33:01 GMT
+                - Mon, 18 May 2026 13:36:05 GMT
             X-Amz-Id-2:
-                - txg21944da3a3b4487192d0-006a0aeadd
+                - txg1f83fe80f1464b61b129-006a0b15c5
             X-Amz-Request-Id:
-                - txg21944da3a3b4487192d0-006a0aeadd
+                - txg1f83fe80f1464b61b129-006a0b15c5
         status: 200 OK
         code: 200
-        duration: 73.99525ms
+        duration: 49.231333ms
     - id: 107
       request:
         proto: HTTP/1.1
@@ -5590,7 +5590,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5599,7 +5599,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - cf9583e4-b24a-429f-8b22-10e60fd6260e
+                - 00225984-fee9-4284-b208-552c6ec322bf
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5607,8 +5607,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103302Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T133605Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5627,14 +5627,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:33:02 GMT
+                - Mon, 18 May 2026 13:36:05 GMT
             X-Amz-Id-2:
-                - txg75e39bad7a6a43ab8ccf-006a0aeade
+                - txg608761dbce3d472e93f7-006a0b15c5
             X-Amz-Request-Id:
-                - txg75e39bad7a6a43ab8ccf-006a0aeade
+                - txg608761dbce3d472e93f7-006a0b15c5
         status: 200 OK
         code: 200
-        duration: 261.741333ms
+        duration: 20.496959ms
     - id: 108
       request:
         proto: HTTP/1.1
@@ -5643,7 +5643,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5652,7 +5652,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e560caea-2614-4167-8205-74dc067d2447
+                - 1ad8bc58-cb94-404b-8d8a-e2fc0fc85354
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5660,8 +5660,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103302Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T133605Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5669,23 +5669,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 330
+        content_length: 329
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg644be24963d84de5bd52-006a0aeade</RequestId><HostId>txg644be24963d84de5bd52-006a0aeade</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg3ce8f6caa7ec456ea3b3-006a0b15c5</RequestId><HostId>txg3ce8f6caa7ec456ea3b3-006a0b15c5</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
         headers:
             Content-Length:
-                - "330"
+                - "329"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:33:02 GMT
+                - Mon, 18 May 2026 13:36:05 GMT
             X-Amz-Id-2:
-                - txg644be24963d84de5bd52-006a0aeade
+                - txg3ce8f6caa7ec456ea3b3-006a0b15c5
             X-Amz-Request-Id:
-                - txg644be24963d84de5bd52-006a0aeade
+                - txg3ce8f6caa7ec456ea3b3-006a0b15c5
         status: 404 Not Found
         code: 404
-        duration: 21.92125ms
+        duration: 20.549917ms
     - id: 109
       request:
         proto: HTTP/1.1
@@ -5694,7 +5694,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5703,7 +5703,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9f3c206b-06d6-4610-8ebe-94aee5d48a38
+                - 59693bf9-190d-42ce-a636-6ac4bb06c01a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5711,8 +5711,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103302Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
+                - 20260518T133605Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -5720,25 +5720,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 287
+        content_length: 286
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "287"
+                - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:33:02 GMT
+                - Mon, 18 May 2026 13:36:05 GMT
             X-Amz-Id-2:
-                - txg2bef5b9dc4f645d9bd42-006a0aeade
+                - txg2804ea820a0b4d9c8fcb-006a0b15c5
             X-Amz-Request-Id:
-                - txg2bef5b9dc4f645d9bd42-006a0aeade
+                - txg2804ea820a0b4d9c8fcb-006a0b15c5
         status: 200 OK
         code: 200
-        duration: 21.114417ms
+        duration: 57.276084ms
     - id: 110
       request:
         proto: HTTP/1.1
@@ -5747,7 +5747,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5756,7 +5756,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0b8f8865-fa71-4c49-b867-0607b54008ab
+                - a44f0651-de4b-4d10-bddb-dfdbf59d6120
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5764,8 +5764,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103302Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T133605Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5773,23 +5773,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 361
+        content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgc4dd6c33ee814a849d96-006a0aeade</RequestId><HostId>txgc4dd6c33ee814a849d96-006a0aeade</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg42fccefa95d74163a1d7-006a0b15c5</RequestId><HostId>txg42fccefa95d74163a1d7-006a0b15c5</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</BucketName></Error>
         headers:
             Content-Length:
-                - "361"
+                - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:33:02 GMT
+                - Mon, 18 May 2026 13:36:05 GMT
             X-Amz-Id-2:
-                - txgc4dd6c33ee814a849d96-006a0aeade
+                - txg42fccefa95d74163a1d7-006a0b15c5
             X-Amz-Request-Id:
-                - txgc4dd6c33ee814a849d96-006a0aeade
+                - txg42fccefa95d74163a1d7-006a0b15c5
         status: 404 Not Found
         code: 404
-        duration: 21.072542ms
+        duration: 19.278792ms
     - id: 111
       request:
         proto: HTTP/1.1
@@ -5798,7 +5798,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5807,7 +5807,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 6758e217-7209-447c-9d40-5741dffcaa83
+                - ebc5b244-b70a-4cfb-ad87-883fa03aa01b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5815,8 +5815,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103302Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T133605Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5824,23 +5824,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 298
+        content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgf1931029f40a43e184d1-006a0aeade</RequestId><HostId>txgf1931029f40a43e184d1-006a0aeade</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txged7b380cd04244bca52f-006a0b15c5</RequestId><HostId>txged7b380cd04244bca52f-006a0b15c5</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
         headers:
             Content-Length:
-                - "298"
+                - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:33:02 GMT
+                - Mon, 18 May 2026 13:36:05 GMT
             X-Amz-Id-2:
-                - txgf1931029f40a43e184d1-006a0aeade
+                - txged7b380cd04244bca52f-006a0b15c5
             X-Amz-Request-Id:
-                - txgf1931029f40a43e184d1-006a0aeade
+                - txged7b380cd04244bca52f-006a0b15c5
         status: 404 Not Found
         code: 404
-        duration: 21.981541ms
+        duration: 19.9545ms
     - id: 112
       request:
         proto: HTTP/1.1
@@ -5849,7 +5849,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5858,7 +5858,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 322487c5-3fb7-4fe9-b8d9-0d815c9c9c43
+                - d380e281-b231-48db-8c3b-dfcde25b9139
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5866,8 +5866,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103302Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T133605Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5886,14 +5886,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:33:02 GMT
+                - Mon, 18 May 2026 13:36:05 GMT
             X-Amz-Id-2:
-                - txgcf9ee8429b3a4ad5b45d-006a0aeade
+                - txgdf1cd6803e3e4fd3a0fd-006a0b15c5
             X-Amz-Request-Id:
-                - txgcf9ee8429b3a4ad5b45d-006a0aeade
+                - txgdf1cd6803e3e4fd3a0fd-006a0b15c5
         status: 200 OK
         code: 200
-        duration: 166.968542ms
+        duration: 20.145958ms
     - id: 113
       request:
         proto: HTTP/1.1
@@ -5902,7 +5902,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5911,7 +5911,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 06c3a7b2-0ce7-4363-a223-cfc68409ff27
+                - 961cc332-8ea8-4089-a1fe-6443ac683c41
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5919,8 +5919,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103302Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T133605Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5939,14 +5939,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:33:02 GMT
+                - Mon, 18 May 2026 13:36:05 GMT
             X-Amz-Id-2:
-                - txg19e6d62d8b2341bbbcb7-006a0aeade
+                - txg8508f0c96ebf44e78b4a-006a0b15c5
             X-Amz-Request-Id:
-                - txg19e6d62d8b2341bbbcb7-006a0aeade
+                - txg8508f0c96ebf44e78b4a-006a0b15c5
         status: 200 OK
         code: 200
-        duration: 20.977125ms
+        duration: 19.486917ms
     - id: 114
       request:
         proto: HTTP/1.1
@@ -5955,7 +5955,7 @@ interactions:
         content_length: 344
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path1/</Prefix><Tag><Key>deleted</Key><Value>true</Value></Tag></And></Filter><ID>id1</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
@@ -5964,7 +5964,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7ea35ffc-7f01-47dd-b6a6-a9d92d7b83af
+                - a3e10bde-0b31-4c07-9b7c-c7afc323eda7
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
@@ -5976,8 +5976,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - b0de451c31309fbdd3611c566f2f38ddccf0dd237feb3e8d186422993ecf7a1f
             X-Amz-Date:
-                - 20260518T103302Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T133605Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -5992,14 +5992,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 18 May 2026 10:33:02 GMT
+                - Mon, 18 May 2026 13:36:05 GMT
             X-Amz-Id-2:
-                - txg691e2bdc786f4866a6d4-006a0aeade
+                - txg6b7e2edcf3bf423db8a8-006a0b15c5
             X-Amz-Request-Id:
-                - txg691e2bdc786f4866a6d4-006a0aeade
+                - txg6b7e2edcf3bf423db8a8-006a0b15c5
         status: 200 OK
         code: 200
-        duration: 22.800709ms
+        duration: 20.614292ms
     - id: 115
       request:
         proto: HTTP/1.1
@@ -6008,7 +6008,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6017,7 +6017,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c944bc15-c71e-44a7-9351-51cb11887d4b
+                - 01b31146-0eb7-4bd4-a8a4-d9dddbd5a33e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6025,8 +6025,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103302Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T133605Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6045,14 +6045,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:33:02 GMT
+                - Mon, 18 May 2026 13:36:05 GMT
             X-Amz-Id-2:
-                - txge2707ae093174eefa24d-006a0aeade
+                - txg61c5c3f978214818a368-006a0b15c5
             X-Amz-Request-Id:
-                - txge2707ae093174eefa24d-006a0aeade
+                - txg61c5c3f978214818a368-006a0b15c5
         status: 200 OK
         code: 200
-        duration: 20.513667ms
+        duration: 34.886542ms
     - id: 116
       request:
         proto: HTTP/1.1
@@ -6061,7 +6061,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6070,7 +6070,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 8f197b1f-2963-4192-9d1c-6482722a1c76
+                - 1749c4ea-7445-4292-88f6-c641dc5e9ad2
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6078,8 +6078,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103302Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T133605Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6087,23 +6087,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 330
+        content_length: 329
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg20375f35046746ef9b9a-006a0aeade</RequestId><HostId>txg20375f35046746ef9b9a-006a0aeade</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg579079461cd741be8636-006a0b15c5</RequestId><HostId>txg579079461cd741be8636-006a0b15c5</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
         headers:
             Content-Length:
-                - "330"
+                - "329"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:33:02 GMT
+                - Mon, 18 May 2026 13:36:05 GMT
             X-Amz-Id-2:
-                - txg20375f35046746ef9b9a-006a0aeade
+                - txg579079461cd741be8636-006a0b15c5
             X-Amz-Request-Id:
-                - txg20375f35046746ef9b9a-006a0aeade
+                - txg579079461cd741be8636-006a0b15c5
         status: 404 Not Found
         code: 404
-        duration: 100.272583ms
+        duration: 20.192291ms
     - id: 117
       request:
         proto: HTTP/1.1
@@ -6112,7 +6112,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6121,7 +6121,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 785ab30a-fc16-416b-bbac-388023f56ff5
+                - 927088f7-c11b-48f3-90f7-8eb68bcd53d4
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6129,8 +6129,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103302Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
+                - 20260518T133605Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -6138,25 +6138,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 287
+        content_length: 286
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "287"
+                - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:33:02 GMT
+                - Mon, 18 May 2026 13:36:05 GMT
             X-Amz-Id-2:
-                - txga5e912aa9a3d47fea80c-006a0aeade
+                - txgb2d4e87e9a59433795d9-006a0b15c5
             X-Amz-Request-Id:
-                - txga5e912aa9a3d47fea80c-006a0aeade
+                - txgb2d4e87e9a59433795d9-006a0b15c5
         status: 200 OK
         code: 200
-        duration: 59.242792ms
+        duration: 135.229958ms
     - id: 118
       request:
         proto: HTTP/1.1
@@ -6165,7 +6165,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6174,7 +6174,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 1d3407c5-1c9f-4b9f-9bf5-76a44a77a142
+                - 68adbcd7-c6be-4c6d-ba53-c2856009a832
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6182,8 +6182,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103302Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T133605Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6191,23 +6191,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 361
+        content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg3780e790f73d44329550-006a0aeadf</RequestId><HostId>txg3780e790f73d44329550-006a0aeadf</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgdd92c63746b240b0b2f7-006a0b15c6</RequestId><HostId>txgdd92c63746b240b0b2f7-006a0b15c6</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</BucketName></Error>
         headers:
             Content-Length:
-                - "361"
+                - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:33:03 GMT
+                - Mon, 18 May 2026 13:36:06 GMT
             X-Amz-Id-2:
-                - txg3780e790f73d44329550-006a0aeadf
+                - txgdd92c63746b240b0b2f7-006a0b15c6
             X-Amz-Request-Id:
-                - txg3780e790f73d44329550-006a0aeadf
+                - txgdd92c63746b240b0b2f7-006a0b15c6
         status: 404 Not Found
         code: 404
-        duration: 77.781208ms
+        duration: 34.880292ms
     - id: 119
       request:
         proto: HTTP/1.1
@@ -6216,7 +6216,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6225,7 +6225,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e81ab851-ba37-470e-99d5-38e5928ec44a
+                - 4bec1fa2-b835-4b44-b865-41471e00ba55
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6233,8 +6233,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103303Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T133606Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6242,23 +6242,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 298
+        content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg59f26068d7f648e3bae9-006a0aeadf</RequestId><HostId>txg59f26068d7f648e3bae9-006a0aeadf</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg9733cb7730b8464cbd60-006a0b15c6</RequestId><HostId>txg9733cb7730b8464cbd60-006a0b15c6</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
         headers:
             Content-Length:
-                - "298"
+                - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:33:03 GMT
+                - Mon, 18 May 2026 13:36:06 GMT
             X-Amz-Id-2:
-                - txg59f26068d7f648e3bae9-006a0aeadf
+                - txg9733cb7730b8464cbd60-006a0b15c6
             X-Amz-Request-Id:
-                - txg59f26068d7f648e3bae9-006a0aeadf
+                - txg9733cb7730b8464cbd60-006a0b15c6
         status: 404 Not Found
         code: 404
-        duration: 139.597625ms
+        duration: 19.534375ms
     - id: 120
       request:
         proto: HTTP/1.1
@@ -6267,7 +6267,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6276,7 +6276,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 47b4277a-f051-4eda-88f2-c867adad6d47
+                - 55cc270d-8710-4452-a1d2-1ebb629f8114
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6284,8 +6284,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103303Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T133606Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6304,14 +6304,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:33:03 GMT
+                - Mon, 18 May 2026 13:36:06 GMT
             X-Amz-Id-2:
-                - txg8793299c86854b5b948e-006a0aeadf
+                - txgcc8d061ee07e462ab467-006a0b15c6
             X-Amz-Request-Id:
-                - txg8793299c86854b5b948e-006a0aeadf
+                - txgcc8d061ee07e462ab467-006a0b15c6
         status: 200 OK
         code: 200
-        duration: 170.103334ms
+        duration: 51.285125ms
     - id: 121
       request:
         proto: HTTP/1.1
@@ -6320,7 +6320,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6329,7 +6329,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d49ccaaf-a7d8-4307-9049-fa2e4f195260
+                - 73030ee8-bf34-4ac3-8d6d-c80a175bf77c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6337,8 +6337,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103303Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T133606Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6357,14 +6357,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:33:03 GMT
+                - Mon, 18 May 2026 13:36:06 GMT
             X-Amz-Id-2:
-                - txg31730813c9204cefb350-006a0aeadf
+                - txg4a63c826cff643a6ad4d-006a0b15c6
             X-Amz-Request-Id:
-                - txg31730813c9204cefb350-006a0aeadf
+                - txg4a63c826cff643a6ad4d-006a0b15c6
         status: 200 OK
         code: 200
-        duration: 21.312209ms
+        duration: 19.366042ms
     - id: 122
       request:
         proto: HTTP/1.1
@@ -6373,7 +6373,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6382,7 +6382,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - a6e38b46-f71e-4c75-9849-357f251d47be
+                - 61c48d5f-5088-4596-8649-4200c51f7286
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6390,8 +6390,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103303Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
+                - 20260518T133606Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -6406,16 +6406,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:33:03 GMT
+                - Mon, 18 May 2026 13:36:06 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txg586527cecae84dfaa232-006a0aeadf
+                - txg38b0717f16ef4eaba188-006a0b15c6
             X-Amz-Request-Id:
-                - txg586527cecae84dfaa232-006a0aeadf
+                - txg38b0717f16ef4eaba188-006a0b15c6
         status: 200 OK
         code: 200
-        duration: 20.509416ms
+        duration: 29.100417ms
     - id: 123
       request:
         proto: HTTP/1.1
@@ -6424,7 +6424,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6433,7 +6433,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 477b7cbc-c77d-47f3-8f16-92531fa16f5f
+                - e9a32af2-0685-417f-941a-3a3488953105
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6441,8 +6441,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103303Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T133606Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6461,14 +6461,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:33:03 GMT
+                - Mon, 18 May 2026 13:36:06 GMT
             X-Amz-Id-2:
-                - txgded9bf927fd24986b30e-006a0aeadf
+                - txg0484cbb56001449eaecf-006a0b15c6
             X-Amz-Request-Id:
-                - txgded9bf927fd24986b30e-006a0aeadf
+                - txg0484cbb56001449eaecf-006a0b15c6
         status: 200 OK
         code: 200
-        duration: 21.046791ms
+        duration: 22.066792ms
     - id: 124
       request:
         proto: HTTP/1.1
@@ -6477,7 +6477,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6486,7 +6486,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d948a1dc-d39f-43ec-bc2a-8fb96bbfcdb0
+                - affe0440-10d1-4d2f-905a-7dbd3a56f698
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6494,8 +6494,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103303Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T133606Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6514,14 +6514,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:33:03 GMT
+                - Mon, 18 May 2026 13:36:06 GMT
             X-Amz-Id-2:
-                - txg394846b907d44dc6ac44-006a0aeadf
+                - txge0e1fdc14e764d998a3e-006a0b15c6
             X-Amz-Request-Id:
-                - txg394846b907d44dc6ac44-006a0aeadf
+                - txge0e1fdc14e764d998a3e-006a0b15c6
         status: 200 OK
         code: 200
-        duration: 30.000917ms
+        duration: 32.23075ms
     - id: 125
       request:
         proto: HTTP/1.1
@@ -6530,7 +6530,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6539,7 +6539,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 70b18353-32f0-42cc-b372-6bf6198e57dc
+                - 63cfda8d-7639-4da4-83c1-d1c5c330a9e0
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6547,8 +6547,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103303Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T133606Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6556,23 +6556,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 330
+        content_length: 329
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg8ee65063a43f47ad9ced-006a0aeadf</RequestId><HostId>txg8ee65063a43f47ad9ced-006a0aeadf</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg2ec4bfe5cfa44f03bed5-006a0b15c6</RequestId><HostId>txg2ec4bfe5cfa44f03bed5-006a0b15c6</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
         headers:
             Content-Length:
-                - "330"
+                - "329"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:33:03 GMT
+                - Mon, 18 May 2026 13:36:06 GMT
             X-Amz-Id-2:
-                - txg8ee65063a43f47ad9ced-006a0aeadf
+                - txg2ec4bfe5cfa44f03bed5-006a0b15c6
             X-Amz-Request-Id:
-                - txg8ee65063a43f47ad9ced-006a0aeadf
+                - txg2ec4bfe5cfa44f03bed5-006a0b15c6
         status: 404 Not Found
         code: 404
-        duration: 21.332042ms
+        duration: 19.91925ms
     - id: 126
       request:
         proto: HTTP/1.1
@@ -6581,7 +6581,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6590,7 +6590,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b57cb951-88fe-4e6c-adec-58622cb06a3a
+                - 1105aa3b-3dea-48d0-906a-c07661875c54
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6598,8 +6598,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103303Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
+                - 20260518T133606Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -6607,25 +6607,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 287
+        content_length: 286
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "287"
+                - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:33:03 GMT
+                - Mon, 18 May 2026 13:36:06 GMT
             X-Amz-Id-2:
-                - txgb41926ae5cde49959bf9-006a0aeadf
+                - txg81c1614609b1444eb0a1-006a0b15c6
             X-Amz-Request-Id:
-                - txgb41926ae5cde49959bf9-006a0aeadf
+                - txg81c1614609b1444eb0a1-006a0b15c6
         status: 200 OK
         code: 200
-        duration: 271.063292ms
+        duration: 33.842833ms
     - id: 127
       request:
         proto: HTTP/1.1
@@ -6634,7 +6634,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6643,7 +6643,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 176a1f30-9060-47fb-8d92-47b9adb2ea07
+                - ad66677d-bb5e-4f52-8bb9-b97308d6d71a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6651,8 +6651,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103303Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T133606Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6660,23 +6660,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 361
+        content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg18c56dd2e0804766816e-006a0aeae0</RequestId><HostId>txg18c56dd2e0804766816e-006a0aeae0</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgc1985b358cca4d7f87af-006a0b15c6</RequestId><HostId>txgc1985b358cca4d7f87af-006a0b15c6</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</BucketName></Error>
         headers:
             Content-Length:
-                - "361"
+                - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:33:04 GMT
+                - Mon, 18 May 2026 13:36:06 GMT
             X-Amz-Id-2:
-                - txg18c56dd2e0804766816e-006a0aeae0
+                - txgc1985b358cca4d7f87af-006a0b15c6
             X-Amz-Request-Id:
-                - txg18c56dd2e0804766816e-006a0aeae0
+                - txgc1985b358cca4d7f87af-006a0b15c6
         status: 404 Not Found
         code: 404
-        duration: 20.547458ms
+        duration: 24.712583ms
     - id: 128
       request:
         proto: HTTP/1.1
@@ -6685,7 +6685,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6694,7 +6694,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 3e767e3f-c99a-4dd7-bce6-dbf800af81d7
+                - 87f99006-8f33-462a-8579-68930998e62d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6702,8 +6702,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103304Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T133606Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6711,23 +6711,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 298
+        content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgb04286331a5f4a8db3e8-006a0aeae0</RequestId><HostId>txgb04286331a5f4a8db3e8-006a0aeae0</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg3e3ba8e564204019affd-006a0b15c6</RequestId><HostId>txg3e3ba8e564204019affd-006a0b15c6</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
         headers:
             Content-Length:
-                - "298"
+                - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:33:04 GMT
+                - Mon, 18 May 2026 13:36:06 GMT
             X-Amz-Id-2:
-                - txgb04286331a5f4a8db3e8-006a0aeae0
+                - txg3e3ba8e564204019affd-006a0b15c6
             X-Amz-Request-Id:
-                - txgb04286331a5f4a8db3e8-006a0aeae0
+                - txg3e3ba8e564204019affd-006a0b15c6
         status: 404 Not Found
         code: 404
-        duration: 21.058792ms
+        duration: 34.034458ms
     - id: 129
       request:
         proto: HTTP/1.1
@@ -6736,7 +6736,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6745,7 +6745,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 29adb2a6-518a-402e-8df5-adb019eb4bd7
+                - 68409dd3-8714-4fcc-aba0-a00139ca245f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6753,8 +6753,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103304Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T133606Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6773,14 +6773,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:33:04 GMT
+                - Mon, 18 May 2026 13:36:06 GMT
             X-Amz-Id-2:
-                - txg6a7d6223e1154e79a4e0-006a0aeae0
+                - txg277895b04c434bc7a414-006a0b15c6
             X-Amz-Request-Id:
-                - txg6a7d6223e1154e79a4e0-006a0aeae0
+                - txg277895b04c434bc7a414-006a0b15c6
         status: 200 OK
         code: 200
-        duration: 137.600125ms
+        duration: 20.435125ms
     - id: 130
       request:
         proto: HTTP/1.1
@@ -6789,7 +6789,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6798,7 +6798,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 41ed37e1-3e5f-41ff-8407-05b330506f97
+                - eeb217f9-fe74-4ef7-a7cd-2f5d6e11c937
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6806,8 +6806,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103304Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T133606Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6826,14 +6826,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:33:04 GMT
+                - Mon, 18 May 2026 13:36:06 GMT
             X-Amz-Id-2:
-                - txgba22ed3a873f4bafb52f-006a0aeae0
+                - txg5ca1a5f37a454f5982b4-006a0b15c6
             X-Amz-Request-Id:
-                - txgba22ed3a873f4bafb52f-006a0aeae0
+                - txg5ca1a5f37a454f5982b4-006a0b15c6
         status: 200 OK
         code: 200
-        duration: 24.55275ms
+        duration: 34.457708ms
     - id: 131
       request:
         proto: HTTP/1.1
@@ -6842,7 +6842,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6851,7 +6851,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 854e8a25-750b-4315-a44e-35311cb8b45b
+                - 5d9c9ff9-1033-4369-b396-28566f06109f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6859,8 +6859,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103304Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T133606Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6879,14 +6879,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:33:04 GMT
+                - Mon, 18 May 2026 13:36:06 GMT
             X-Amz-Id-2:
-                - txgbecd93e963764e569160-006a0aeae0
+                - txg588f548f05e4494198f2-006a0b15c6
             X-Amz-Request-Id:
-                - txgbecd93e963764e569160-006a0aeae0
+                - txg588f548f05e4494198f2-006a0b15c6
         status: 200 OK
         code: 200
-        duration: 20.643ms
+        duration: 21.376833ms
     - id: 132
       request:
         proto: HTTP/1.1
@@ -6895,7 +6895,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6904,7 +6904,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 308ca343-c665-44aa-b002-f34cdca5add5
+                - d0bb9c47-f8f3-4949-9d0b-a1804ba1f86f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6912,8 +6912,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103304Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T133606Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6921,23 +6921,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 330
+        content_length: 329
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgd092787c6f2d46c59d6f-006a0aeae0</RequestId><HostId>txgd092787c6f2d46c59d6f-006a0aeae0</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgbba9f64554694ccaa6bf-006a0b15c6</RequestId><HostId>txgbba9f64554694ccaa6bf-006a0b15c6</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
         headers:
             Content-Length:
-                - "330"
+                - "329"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:33:04 GMT
+                - Mon, 18 May 2026 13:36:06 GMT
             X-Amz-Id-2:
-                - txgd092787c6f2d46c59d6f-006a0aeae0
+                - txgbba9f64554694ccaa6bf-006a0b15c6
             X-Amz-Request-Id:
-                - txgd092787c6f2d46c59d6f-006a0aeae0
+                - txgbba9f64554694ccaa6bf-006a0b15c6
         status: 404 Not Found
         code: 404
-        duration: 23.778416ms
+        duration: 19.581875ms
     - id: 133
       request:
         proto: HTTP/1.1
@@ -6946,7 +6946,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6955,7 +6955,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 725ad7cc-c5f3-4301-b051-bfe310cdef8c
+                - 671f6392-00bb-48e2-b773-c1ebc17b7868
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6963,8 +6963,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103304Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
+                - 20260518T133606Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -6972,25 +6972,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 287
+        content_length: 286
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "287"
+                - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:33:04 GMT
+                - Mon, 18 May 2026 13:36:06 GMT
             X-Amz-Id-2:
-                - txg08dfe6d04830420789a2-006a0aeae0
+                - txg23cc5af37f8a42b5bd20-006a0b15c6
             X-Amz-Request-Id:
-                - txg08dfe6d04830420789a2-006a0aeae0
+                - txg23cc5af37f8a42b5bd20-006a0b15c6
         status: 200 OK
         code: 200
-        duration: 92.270167ms
+        duration: 20.355375ms
     - id: 134
       request:
         proto: HTTP/1.1
@@ -6999,7 +6999,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7008,7 +7008,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 8c4d9209-b3b9-4622-a7d4-1dfca05b1d88
+                - 178009fc-04b4-4392-b197-d69ba35b98f7
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7016,8 +7016,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103304Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T133606Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7025,23 +7025,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 361
+        content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgde9844c7ce654880ad88-006a0aeae0</RequestId><HostId>txgde9844c7ce654880ad88-006a0aeae0</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg680523882c2641d6b4fc-006a0b15c6</RequestId><HostId>txg680523882c2641d6b4fc-006a0b15c6</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</BucketName></Error>
         headers:
             Content-Length:
-                - "361"
+                - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:33:04 GMT
+                - Mon, 18 May 2026 13:36:06 GMT
             X-Amz-Id-2:
-                - txgde9844c7ce654880ad88-006a0aeae0
+                - txg680523882c2641d6b4fc-006a0b15c6
             X-Amz-Request-Id:
-                - txgde9844c7ce654880ad88-006a0aeae0
+                - txg680523882c2641d6b4fc-006a0b15c6
         status: 404 Not Found
         code: 404
-        duration: 20.825292ms
+        duration: 35.253917ms
     - id: 135
       request:
         proto: HTTP/1.1
@@ -7050,7 +7050,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7059,7 +7059,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - cae6e91d-2690-4a04-a3bd-1941cb323257
+                - f7678680-e3fb-4d97-a748-25675f4cb15b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7067,8 +7067,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103304Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T133606Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7076,23 +7076,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 298
+        content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg1318f8282ec840d59540-006a0aeae0</RequestId><HostId>txg1318f8282ec840d59540-006a0aeae0</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txga83bd6330daf4c37953a-006a0b15c7</RequestId><HostId>txga83bd6330daf4c37953a-006a0b15c7</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
         headers:
             Content-Length:
-                - "298"
+                - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:33:04 GMT
+                - Mon, 18 May 2026 13:36:07 GMT
             X-Amz-Id-2:
-                - txg1318f8282ec840d59540-006a0aeae0
+                - txga83bd6330daf4c37953a-006a0b15c7
             X-Amz-Request-Id:
-                - txg1318f8282ec840d59540-006a0aeae0
+                - txga83bd6330daf4c37953a-006a0b15c7
         status: 404 Not Found
         code: 404
-        duration: 20.631667ms
+        duration: 19.747834ms
     - id: 136
       request:
         proto: HTTP/1.1
@@ -7101,7 +7101,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7110,7 +7110,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 49055b1f-2af8-4222-bfb8-e0f76f9821a4
+                - 8c48f5b7-fad7-49aa-937e-3b1f875f36fe
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7118,8 +7118,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103304Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T133607Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7138,14 +7138,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:33:04 GMT
+                - Mon, 18 May 2026 13:36:07 GMT
             X-Amz-Id-2:
-                - txg58d0ac520ece43a48d66-006a0aeae0
+                - txg88043fddf1ea4736a06e-006a0b15c7
             X-Amz-Request-Id:
-                - txg58d0ac520ece43a48d66-006a0aeae0
+                - txg88043fddf1ea4736a06e-006a0b15c7
         status: 200 OK
         code: 200
-        duration: 20.852709ms
+        duration: 19.924292ms
     - id: 137
       request:
         proto: HTTP/1.1
@@ -7154,7 +7154,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7163,7 +7163,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 44bb72a2-432f-4fd1-84ad-c73543d5c28c
+                - da0c122d-56f9-4d1b-8a28-5aaf8b99edfa
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7171,8 +7171,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103304Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T133607Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7191,14 +7191,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:33:04 GMT
+                - Mon, 18 May 2026 13:36:07 GMT
             X-Amz-Id-2:
-                - txgc1c2ba7b56a04273ad1b-006a0aeae0
+                - txg47a562c937eb44eda718-006a0b15c7
             X-Amz-Request-Id:
-                - txgc1c2ba7b56a04273ad1b-006a0aeae0
+                - txg47a562c937eb44eda718-006a0b15c7
         status: 200 OK
         code: 200
-        duration: 20.335791ms
+        duration: 22.189541ms
     - id: 138
       request:
         proto: HTTP/1.1
@@ -7207,7 +7207,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7216,7 +7216,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0fa4e3ba-f2f3-466f-a820-0a1f0c1fe849
+                - 83373199-0722-4eee-b923-09a5596f5711
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7224,8 +7224,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103304Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
+                - 20260518T133607Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -7238,14 +7238,14 @@ interactions:
         body: ""
         headers:
             Date:
-                - Mon, 18 May 2026 10:33:04 GMT
+                - Mon, 18 May 2026 13:36:07 GMT
             X-Amz-Id-2:
-                - txgc1852804beaf4ced865b-006a0aeae0
+                - txgaa2d6132d2f64dababff-006a0b15c7
             X-Amz-Request-Id:
-                - txgc1852804beaf4ced865b-006a0aeae0
+                - txgaa2d6132d2f64dababff-006a0b15c7
         status: 204 No Content
         code: 204
-        duration: 304.217209ms
+        duration: 172.2125ms
     - id: 139
       request:
         proto: HTTP/1.1
@@ -7254,7 +7254,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7263,7 +7263,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ec105e2f-c4f0-4ff7-b609-10e56c245e56
+                - 82e754ae-22c9-44d8-babc-8a970e59463f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7273,8 +7273,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103305Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
+                - 20260518T133607Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
         method: PUT
       response:
         proto: HTTP/2.0
@@ -7289,16 +7289,16 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 18 May 2026 10:33:05 GMT
+                - Mon, 18 May 2026 13:36:07 GMT
             Location:
-                - /tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018
+                - /tf-tests-scaleway-object-bucket-lifecycle-361671012043732063
             X-Amz-Id-2:
-                - txg058e006c1b2e43b49943-006a0aeae1
+                - txg00b3096cabcb4df98b10-006a0b15c7
             X-Amz-Request-Id:
-                - txg058e006c1b2e43b49943-006a0aeae1
+                - txg00b3096cabcb4df98b10-006a0b15c7
         status: 200 OK
         code: 200
-        duration: 6.623443708s
+        duration: 4.614000417s
     - id: 140
       request:
         proto: HTTP/1.1
@@ -7307,7 +7307,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7316,7 +7316,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f3798a8e-e472-4a59-9df5-823c9d5a2521
+                - 00fb1f57-3b60-46bb-8b36-1345f7b4e835
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7328,8 +7328,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103311Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T133612Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?acl=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -7344,14 +7344,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 18 May 2026 10:33:11 GMT
+                - Mon, 18 May 2026 13:36:12 GMT
             X-Amz-Id-2:
-                - txg199edc6ef3234c47b0a7-006a0aeae7
+                - txg73455e353882410dae15-006a0b15cc
             X-Amz-Request-Id:
-                - txg199edc6ef3234c47b0a7-006a0aeae7
+                - txg73455e353882410dae15-006a0b15cc
         status: 200 OK
         code: 200
-        duration: 2.084652125s
+        duration: 1.164811459s
     - id: 141
       request:
         proto: HTTP/1.1
@@ -7360,16 +7360,16 @@ interactions:
         content_length: 532
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
-        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>2</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260518103313987200000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260518103313987300000002</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
+        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>2</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260518133613185900000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260518133613186000000002</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
         form: {}
         headers:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - cf958ac5-1511-45c6-be0b-171c58c60d50
+                - 453b8cd5-7bd8-414f-b7f6-aba97a126bc9
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
@@ -7377,12 +7377,12 @@ interactions:
             User-Agent:
                 - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,Z,e
             X-Amz-Checksum-Crc32:
-                - QCBdtA==
+                - 9y+UsA==
             X-Amz-Content-Sha256:
-                - bd197515a5bbdbfbbdcd8b19bf2b1c0b0b72b958b359436e3274692df93c1055
+                - d8c2af333845b17443ca15939e6571c2f7b75a8be7c50d49b01359dafbd939b0
             X-Amz-Date:
-                - 20260518T103311Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T133612Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -7397,14 +7397,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 18 May 2026 10:33:14 GMT
+                - Mon, 18 May 2026 13:36:13 GMT
             X-Amz-Id-2:
-                - txgbe6d30bb9d604ad3965a-006a0aeaea
+                - txg38ad9e04960f45a0b015-006a0b15cd
             X-Amz-Request-Id:
-                - txgbe6d30bb9d604ad3965a-006a0aeaea
+                - txg38ad9e04960f45a0b015-006a0b15cd
         status: 200 OK
         code: 200
-        duration: 1.227554709s
+        duration: 2.82618975s
     - id: 142
       request:
         proto: HTTP/1.1
@@ -7413,7 +7413,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7422,7 +7422,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d632be9e-f030-4336-b83b-acd8d0d32e4b
+                - 26962e3b-c559-460c-8bf8-041d7ba52548
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7430,8 +7430,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103315Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T133616Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7450,14 +7450,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:33:15 GMT
+                - Mon, 18 May 2026 13:36:16 GMT
             X-Amz-Id-2:
-                - txge6a0b89de4094422a805-006a0aeaeb
+                - txg15cfa35478ce4741a9f3-006a0b15d0
             X-Amz-Request-Id:
-                - txge6a0b89de4094422a805-006a0aeaeb
+                - txg15cfa35478ce4741a9f3-006a0b15d0
         status: 200 OK
         code: 200
-        duration: 1.106076333s
+        duration: 1.721237208s
     - id: 143
       request:
         proto: HTTP/1.1
@@ -7466,7 +7466,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7475,7 +7475,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 075240e8-96ac-4fb2-b25e-d84800019d3e
+                - 845b1933-71e1-4ca6-a82e-e96bd412c6de
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7483,8 +7483,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103315Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T133616Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7503,14 +7503,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:33:16 GMT
+                - Mon, 18 May 2026 13:36:17 GMT
             X-Amz-Id-2:
-                - txgd1d83c93c2f54851893a-006a0aeaec
+                - txge7fd2044e6804ed780cf-006a0b15d1
             X-Amz-Request-Id:
-                - txgd1d83c93c2f54851893a-006a0aeaec
+                - txge7fd2044e6804ed780cf-006a0b15d1
         status: 200 OK
         code: 200
-        duration: 1.348184459s
+        duration: 1.224746792s
     - id: 144
       request:
         proto: HTTP/1.1
@@ -7519,7 +7519,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7528,7 +7528,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d154343f-2163-4fac-9aac-5763b163b703
+                - 9c978479-b4c3-40c1-89b9-da9f83ecd3f2
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7536,8 +7536,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103316Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
+                - 20260518T133617Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -7545,25 +7545,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 287
+        content_length: 286
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "287"
+                - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:33:17 GMT
+                - Mon, 18 May 2026 13:36:19 GMT
             X-Amz-Id-2:
-                - txg776e3fdfc4a4403599ae-006a0aeaed
+                - txga84e5cabce7a4a07b19c-006a0b15d3
             X-Amz-Request-Id:
-                - txg776e3fdfc4a4403599ae-006a0aeaed
+                - txga84e5cabce7a4a07b19c-006a0b15d3
         status: 200 OK
         code: 200
-        duration: 246.652333ms
+        duration: 2.14837875s
     - id: 145
       request:
         proto: HTTP/1.1
@@ -7572,7 +7572,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7581,7 +7581,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - bcc74c7c-aab9-4cd2-863d-0e3c17ac8b39
+                - b288b763-41c3-405d-8743-5d7a24b555ea
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7589,8 +7589,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103317Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T133619Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7598,23 +7598,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 361
+        content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg5076c164504f4d8ab6e6-006a0aeaed</RequestId><HostId>txg5076c164504f4d8ab6e6-006a0aeaed</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg187fd8f4103a4adaa6c0-006a0b15d5</RequestId><HostId>txg187fd8f4103a4adaa6c0-006a0b15d5</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</BucketName></Error>
         headers:
             Content-Length:
-                - "361"
+                - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:33:17 GMT
+                - Mon, 18 May 2026 13:36:21 GMT
             X-Amz-Id-2:
-                - txg5076c164504f4d8ab6e6-006a0aeaed
+                - txg187fd8f4103a4adaa6c0-006a0b15d5
             X-Amz-Request-Id:
-                - txg5076c164504f4d8ab6e6-006a0aeaed
+                - txg187fd8f4103a4adaa6c0-006a0b15d5
         status: 404 Not Found
         code: 404
-        duration: 1.104151125s
+        duration: 1.021799709s
     - id: 146
       request:
         proto: HTTP/1.1
@@ -7623,7 +7623,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7632,7 +7632,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - cb581e93-5210-405a-9848-4073f6c9814e
+                - ec66e44d-beb0-4499-b899-1e20df3e1358
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7640,8 +7640,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103317Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T133621Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7649,23 +7649,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 298
+        content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg6cf2c3325b3346e6b2e6-006a0aeaef</RequestId><HostId>txg6cf2c3325b3346e6b2e6-006a0aeaef</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg37a6591647024ab3a4e1-006a0b15d6</RequestId><HostId>txg37a6591647024ab3a4e1-006a0b15d6</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
         headers:
             Content-Length:
-                - "298"
+                - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:33:19 GMT
+                - Mon, 18 May 2026 13:36:22 GMT
             X-Amz-Id-2:
-                - txg6cf2c3325b3346e6b2e6-006a0aeaef
+                - txg37a6591647024ab3a4e1-006a0b15d6
             X-Amz-Request-Id:
-                - txg6cf2c3325b3346e6b2e6-006a0aeaef
+                - txg37a6591647024ab3a4e1-006a0b15d6
         status: 404 Not Found
         code: 404
-        duration: 1.095099791s
+        duration: 126.612084ms
     - id: 147
       request:
         proto: HTTP/1.1
@@ -7674,7 +7674,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7683,7 +7683,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 46604555-8423-4e68-836a-cbacf2e31b60
+                - 365a515f-30ef-43de-9714-fbcbc5afddc9
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7691,8 +7691,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103319Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T133622Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7711,14 +7711,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:33:20 GMT
+                - Mon, 18 May 2026 13:36:22 GMT
             X-Amz-Id-2:
-                - txg077278964858423dadaf-006a0aeaf0
+                - txg54e30f2d7954445fb9d1-006a0b15d6
             X-Amz-Request-Id:
-                - txg077278964858423dadaf-006a0aeaf0
+                - txg54e30f2d7954445fb9d1-006a0b15d6
         status: 200 OK
         code: 200
-        duration: 190.706917ms
+        duration: 1.246878125s
     - id: 148
       request:
         proto: HTTP/1.1
@@ -7727,7 +7727,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7736,7 +7736,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 86ad0f90-d938-470f-aa59-63d75ea5ed3e
+                - 347115f4-64e8-481e-b845-f7831cd1f83c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7744,8 +7744,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103320Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T133622Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7757,21 +7757,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>2</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260518103313987200000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260518103313987300000002</ID><Status>Enabled</Status></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>2</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260518133613185900000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260518133613186000000002</ID><Status>Enabled</Status></Rule></Configuration>
         headers:
             Content-Length:
                 - "505"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:33:20 GMT
+                - Mon, 18 May 2026 13:36:23 GMT
             X-Amz-Id-2:
-                - txg3f4bffcc78a04d7a95da-006a0aeaf0
+                - txgc69e5595ea564ee0892d-006a0b15d7
             X-Amz-Request-Id:
-                - txg3f4bffcc78a04d7a95da-006a0aeaf0
+                - txgc69e5595ea564ee0892d-006a0b15d7
         status: 200 OK
         code: 200
-        duration: 309.994833ms
+        duration: 121.593833ms
     - id: 149
       request:
         proto: HTTP/1.1
@@ -7780,7 +7780,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7789,7 +7789,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b690f0c6-5cfe-4438-8306-48bc3602321e
+                - 00692af2-9e20-4ae0-a7d7-ed0b93d33b4d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7797,8 +7797,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103320Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
+                - 20260518T133623Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -7813,16 +7813,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:33:20 GMT
+                - Mon, 18 May 2026 13:36:23 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txg401ac5d11f6b49fb9824-006a0aeaf0
+                - txg2e807df5c57a4b85bfc8-006a0b15d7
             X-Amz-Request-Id:
-                - txg401ac5d11f6b49fb9824-006a0aeaf0
+                - txg2e807df5c57a4b85bfc8-006a0b15d7
         status: 200 OK
         code: 200
-        duration: 1.125599625s
+        duration: 19.981708ms
     - id: 150
       request:
         proto: HTTP/1.1
@@ -7831,7 +7831,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7840,7 +7840,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - db876194-cfa6-4859-9a24-7467baf6abd3
+                - 0d15dec2-bf99-4d84-aa0c-cb6f44a1a5ae
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7848,8 +7848,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103321Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T133623Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7861,21 +7861,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>2</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260518103313987200000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260518103313987300000002</ID><Status>Enabled</Status></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>2</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260518133613185900000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260518133613186000000002</ID><Status>Enabled</Status></Rule></Configuration>
         headers:
             Content-Length:
                 - "505"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:33:21 GMT
+                - Mon, 18 May 2026 13:36:23 GMT
             X-Amz-Id-2:
-                - txg9fbab9ebdca2416195ea-006a0aeaf1
+                - txg24b00641544f48c8a01b-006a0b15d7
             X-Amz-Request-Id:
-                - txg9fbab9ebdca2416195ea-006a0aeaf1
+                - txg24b00641544f48c8a01b-006a0b15d7
         status: 200 OK
         code: 200
-        duration: 1.105517458s
+        duration: 1.044525375s
     - id: 151
       request:
         proto: HTTP/1.1
@@ -7884,7 +7884,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7893,7 +7893,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - eb173eda-d967-437b-970e-daf22aeb0724
+                - 3b330b6b-9611-47b1-9835-9b5e16e5462e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7901,8 +7901,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103323Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T133625Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7921,14 +7921,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:33:23 GMT
+                - Mon, 18 May 2026 13:36:25 GMT
             X-Amz-Id-2:
-                - txg42c0ac59c66a4f748d84-006a0aeaf3
+                - txg3feea4b005104b649ec6-006a0b15d9
             X-Amz-Request-Id:
-                - txg42c0ac59c66a4f748d84-006a0aeaf3
+                - txg3feea4b005104b649ec6-006a0b15d9
         status: 200 OK
         code: 200
-        duration: 1.032293709s
+        duration: 2.626895875s
     - id: 152
       request:
         proto: HTTP/1.1
@@ -7937,7 +7937,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7946,7 +7946,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e2b56d77-e7ee-405e-96c6-e9e68564440e
+                - 9c5eb019-8372-4e32-b777-6ccb24aaf5ac
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7954,8 +7954,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103323Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T133625Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7974,14 +7974,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:33:24 GMT
+                - Mon, 18 May 2026 13:36:27 GMT
             X-Amz-Id-2:
-                - txg740bb4dfd3864f34a058-006a0aeaf4
+                - txgc4622629c3df46f195f7-006a0b15db
             X-Amz-Request-Id:
-                - txg740bb4dfd3864f34a058-006a0aeaf4
+                - txgc4622629c3df46f195f7-006a0b15db
         status: 200 OK
         code: 200
-        duration: 549.219375ms
+        duration: 1.026374s
     - id: 153
       request:
         proto: HTTP/1.1
@@ -7990,7 +7990,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7999,7 +7999,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 551193b2-3821-4a14-bb36-0e7d674883d3
+                - 41627670-0ed6-41ff-bbe6-6fef04b20c91
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8007,8 +8007,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103324Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
+                - 20260518T133627Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -8016,25 +8016,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 287
+        content_length: 286
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "287"
+                - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:33:24 GMT
+                - Mon, 18 May 2026 13:36:28 GMT
             X-Amz-Id-2:
-                - txg726eb2b567e04d5981d6-006a0aeaf4
+                - txg1b6e70c7b8d9412b8729-006a0b15dc
             X-Amz-Request-Id:
-                - txg726eb2b567e04d5981d6-006a0aeaf4
+                - txg1b6e70c7b8d9412b8729-006a0b15dc
         status: 200 OK
         code: 200
-        duration: 1.096914459s
+        duration: 3.898730125s
     - id: 154
       request:
         proto: HTTP/1.1
@@ -8043,7 +8043,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8052,7 +8052,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - aa9fbcc7-c236-4f66-90bd-bc65a01cade4
+                - 4191e922-8850-49c3-9880-e7010642969a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8060,8 +8060,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103324Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T133628Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8069,23 +8069,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 361
+        content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgbefe8e3b23f24e468525-006a0aeaf5</RequestId><HostId>txgbefe8e3b23f24e468525-006a0aeaf5</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgc292dbe82b7b441fb3a4-006a0b15e0</RequestId><HostId>txgc292dbe82b7b441fb3a4-006a0b15e0</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</BucketName></Error>
         headers:
             Content-Length:
-                - "361"
+                - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:33:25 GMT
+                - Mon, 18 May 2026 13:36:32 GMT
             X-Amz-Id-2:
-                - txgbefe8e3b23f24e468525-006a0aeaf5
+                - txgc292dbe82b7b441fb3a4-006a0b15e0
             X-Amz-Request-Id:
-                - txgbefe8e3b23f24e468525-006a0aeaf5
+                - txgc292dbe82b7b441fb3a4-006a0b15e0
         status: 404 Not Found
         code: 404
-        duration: 1.024578458s
+        duration: 2.074946833s
     - id: 155
       request:
         proto: HTTP/1.1
@@ -8094,7 +8094,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8103,7 +8103,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ee57e0a5-f2b4-4cb7-83ab-4eacc39ecba6
+                - 97b1b641-3dab-41f7-9170-0ee2c0736c31
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8111,8 +8111,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103325Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T133632Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8120,23 +8120,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 298
+        content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg1cce3103dcb149a99807-006a0aeaf6</RequestId><HostId>txg1cce3103dcb149a99807-006a0aeaf6</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg89c70743b3f44f59b094-006a0b15e2</RequestId><HostId>txg89c70743b3f44f59b094-006a0b15e2</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
         headers:
             Content-Length:
-                - "298"
+                - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:33:26 GMT
+                - Mon, 18 May 2026 13:36:34 GMT
             X-Amz-Id-2:
-                - txg1cce3103dcb149a99807-006a0aeaf6
+                - txg89c70743b3f44f59b094-006a0b15e2
             X-Amz-Request-Id:
-                - txg1cce3103dcb149a99807-006a0aeaf6
+                - txg89c70743b3f44f59b094-006a0b15e2
         status: 404 Not Found
         code: 404
-        duration: 71.806708ms
+        duration: 1.06716775s
     - id: 156
       request:
         proto: HTTP/1.1
@@ -8145,7 +8145,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8154,7 +8154,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 254873c3-9134-4103-a722-6a518a720ba1
+                - 7f783e30-0214-46c7-b03c-abf64f595d81
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8162,8 +8162,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103326Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T133634Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8182,14 +8182,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:33:27 GMT
+                - Mon, 18 May 2026 13:36:35 GMT
             X-Amz-Id-2:
-                - txg9c613dda64624fcd8883-006a0aeaf7
+                - txg7c5a3b70206746a18903-006a0b15e3
             X-Amz-Request-Id:
-                - txg9c613dda64624fcd8883-006a0aeaf7
+                - txg7c5a3b70206746a18903-006a0b15e3
         status: 200 OK
         code: 200
-        duration: 1.105907625s
+        duration: 1.02447225s
     - id: 157
       request:
         proto: HTTP/1.1
@@ -8198,7 +8198,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8207,7 +8207,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e040b7a8-bfcc-47f4-a2e3-ae0898530ac8
+                - 4980715e-506e-4c6e-aa63-551ac52f5a0a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8215,8 +8215,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103327Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T133635Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8228,21 +8228,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>2</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260518103313987200000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260518103313987300000002</ID><Status>Enabled</Status></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>2</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260518133613185900000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260518133613186000000002</ID><Status>Enabled</Status></Rule></Configuration>
         headers:
             Content-Length:
                 - "505"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:33:28 GMT
+                - Mon, 18 May 2026 13:36:36 GMT
             X-Amz-Id-2:
-                - txg1d34f8bb53684630b797-006a0aeaf8
+                - txge1ca7e12e742464f9df4-006a0b15e4
             X-Amz-Request-Id:
-                - txg1d34f8bb53684630b797-006a0aeaf8
+                - txge1ca7e12e742464f9df4-006a0b15e4
         status: 200 OK
         code: 200
-        duration: 1.02378325s
+        duration: 19.926833ms
     - id: 158
       request:
         proto: HTTP/1.1
@@ -8251,7 +8251,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8260,7 +8260,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7b25cb46-080c-4226-bad1-fc625b58db38
+                - 14454924-53f7-44ea-8095-211c9cc5172d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8268,8 +8268,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103329Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T133636Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8288,14 +8288,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:33:29 GMT
+                - Mon, 18 May 2026 13:36:37 GMT
             X-Amz-Id-2:
-                - txg01ebe9087157422ebc4e-006a0aeaf9
+                - txg311e2daa16d341c98757-006a0b15e5
             X-Amz-Request-Id:
-                - txg01ebe9087157422ebc4e-006a0aeaf9
+                - txg311e2daa16d341c98757-006a0b15e5
         status: 200 OK
         code: 200
-        duration: 1.143612125s
+        duration: 19.793375ms
     - id: 159
       request:
         proto: HTTP/1.1
@@ -8304,7 +8304,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8313,7 +8313,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 815e40bb-86ed-4d5a-93e9-e66c08352d6d
+                - 55be1f5d-8bae-4f45-b6f1-6618368a9f8f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8321,8 +8321,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103329Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T133637Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8341,14 +8341,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:33:30 GMT
+                - Mon, 18 May 2026 13:36:37 GMT
             X-Amz-Id-2:
-                - txg25db23bbb65a4bf88f59-006a0aeafa
+                - txgd2eb2c6102844ab39c75-006a0b15e5
             X-Amz-Request-Id:
-                - txg25db23bbb65a4bf88f59-006a0aeafa
+                - txgd2eb2c6102844ab39c75-006a0b15e5
         status: 200 OK
         code: 200
-        duration: 35.676625ms
+        duration: 51.1095ms
     - id: 160
       request:
         proto: HTTP/1.1
@@ -8357,7 +8357,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8366,7 +8366,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b3e136c5-d3df-45f9-8113-6832b5b5df22
+                - 0fb81303-b500-4e39-828a-6816f57ef147
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8374,8 +8374,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103330Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
+                - 20260518T133637Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -8383,25 +8383,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 287
+        content_length: 286
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "287"
+                - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:33:30 GMT
+                - Mon, 18 May 2026 13:36:37 GMT
             X-Amz-Id-2:
-                - txg88d877c72d544c4c8e4e-006a0aeafa
+                - txg12e1489453a845889488-006a0b15e5
             X-Amz-Request-Id:
-                - txg88d877c72d544c4c8e4e-006a0aeafa
+                - txg12e1489453a845889488-006a0b15e5
         status: 200 OK
         code: 200
-        duration: 1.148444834s
+        duration: 1.546570667s
     - id: 161
       request:
         proto: HTTP/1.1
@@ -8410,7 +8410,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8419,7 +8419,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - eedf59cb-b178-4bd2-862a-68f98f14661c
+                - b646ee0e-0a26-4a35-acbd-c5f0f9860eeb
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8427,8 +8427,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103330Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T133637Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8436,23 +8436,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 361
+        content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgd8799066a1644821b94c-006a0aeafb</RequestId><HostId>txgd8799066a1644821b94c-006a0aeafb</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgef11b52df2ea410cad15-006a0b15e6</RequestId><HostId>txgef11b52df2ea410cad15-006a0b15e6</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</BucketName></Error>
         headers:
             Content-Length:
-                - "361"
+                - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:33:31 GMT
+                - Mon, 18 May 2026 13:36:38 GMT
             X-Amz-Id-2:
-                - txgd8799066a1644821b94c-006a0aeafb
+                - txgef11b52df2ea410cad15-006a0b15e6
             X-Amz-Request-Id:
-                - txgd8799066a1644821b94c-006a0aeafb
+                - txgef11b52df2ea410cad15-006a0b15e6
         status: 404 Not Found
         code: 404
-        duration: 31.889292ms
+        duration: 20.574417ms
     - id: 162
       request:
         proto: HTTP/1.1
@@ -8461,7 +8461,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8470,7 +8470,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - eaf9ae7f-29ff-4ce8-871f-e93cf95d6fc9
+                - ecd10f29-e68c-4714-967d-d7c435114308
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8478,8 +8478,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103331Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T133638Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8487,23 +8487,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 298
+        content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgca812d1da5b44a56a739-006a0aeafb</RequestId><HostId>txgca812d1da5b44a56a739-006a0aeafb</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg40230d9e6eb440989826-006a0b15e6</RequestId><HostId>txg40230d9e6eb440989826-006a0b15e6</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
         headers:
             Content-Length:
-                - "298"
+                - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:33:31 GMT
+                - Mon, 18 May 2026 13:36:38 GMT
             X-Amz-Id-2:
-                - txgca812d1da5b44a56a739-006a0aeafb
+                - txg40230d9e6eb440989826-006a0b15e6
             X-Amz-Request-Id:
-                - txgca812d1da5b44a56a739-006a0aeafb
+                - txg40230d9e6eb440989826-006a0b15e6
         status: 404 Not Found
         code: 404
-        duration: 1.114490916s
+        duration: 18.98525ms
     - id: 163
       request:
         proto: HTTP/1.1
@@ -8512,7 +8512,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8521,7 +8521,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 503b826d-4b9c-4ad7-9fd5-667a0790569d
+                - 6ed1fc9e-96c1-4c4f-aeb6-3274bff17ef0
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8529,8 +8529,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103331Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T133638Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8549,14 +8549,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:33:32 GMT
+                - Mon, 18 May 2026 13:36:38 GMT
             X-Amz-Id-2:
-                - txgc1573d658df64c909e23-006a0aeafc
+                - txg583dd89ca4334830930c-006a0b15e6
             X-Amz-Request-Id:
-                - txgc1573d658df64c909e23-006a0aeafc
+                - txg583dd89ca4334830930c-006a0b15e6
         status: 200 OK
         code: 200
-        duration: 1.022142125s
+        duration: 19.562333ms
     - id: 164
       request:
         proto: HTTP/1.1
@@ -8565,7 +8565,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8574,7 +8574,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 2e178e56-16fa-43d2-a354-410df32c1a7f
+                - 5097609e-d0c7-40b7-b47d-4ff7d2decf59
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8582,8 +8582,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103332Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T133638Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8595,21 +8595,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>2</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260518103313987200000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260518103313987300000002</ID><Status>Enabled</Status></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>2</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260518133613185900000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260518133613186000000002</ID><Status>Enabled</Status></Rule></Configuration>
         headers:
             Content-Length:
                 - "505"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:33:33 GMT
+                - Mon, 18 May 2026 13:36:38 GMT
             X-Amz-Id-2:
-                - txg61d469be9085412ca573-006a0aeafd
+                - txg05e6fb394e9c4377b0cc-006a0b15e6
             X-Amz-Request-Id:
-                - txg61d469be9085412ca573-006a0aeafd
+                - txg05e6fb394e9c4377b0cc-006a0b15e6
         status: 200 OK
         code: 200
-        duration: 1.02136575s
+        duration: 1.803375458s
     - id: 165
       request:
         proto: HTTP/1.1
@@ -8618,7 +8618,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8627,7 +8627,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 97ee5cea-5022-43c5-b9f0-703f0e849b0c
+                - 9ce3acf4-fbe4-49b4-a0dd-383ab160744a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8635,8 +8635,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103335Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
+                - 20260518T133640Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -8649,14 +8649,14 @@ interactions:
         body: ""
         headers:
             Date:
-                - Mon, 18 May 2026 10:33:35 GMT
+                - Mon, 18 May 2026 13:36:40 GMT
             X-Amz-Id-2:
-                - txgd14ae818a8944a5f9a30-006a0aeaff
+                - txg77aedfae1b934475a48c-006a0b15e8
             X-Amz-Request-Id:
-                - txgd14ae818a8944a5f9a30-006a0aeaff
+                - txg77aedfae1b934475a48c-006a0b15e8
         status: 204 No Content
         code: 204
-        duration: 227.17975ms
+        duration: 1.571270708s
     - id: 166
       request:
         proto: HTTP/1.1
@@ -8665,7 +8665,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8674,7 +8674,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c28fb271-1510-4e20-864d-692c09379bbd
+                - 41d1b5cc-a158-4b72-9755-8d00582e65b9
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8682,8 +8682,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103335Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
+                - 20260518T133642Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
         method: PUT
       response:
         proto: HTTP/2.0
@@ -8698,16 +8698,16 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 18 May 2026 10:33:35 GMT
+                - Mon, 18 May 2026 13:36:42 GMT
             Location:
-                - /tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018
+                - /tf-tests-scaleway-object-bucket-lifecycle-361671012043732063
             X-Amz-Id-2:
-                - txgff9b2ce38b0542a2aac2-006a0aeaff
+                - txg14e2aa10e91f49e5892c-006a0b15ea
             X-Amz-Request-Id:
-                - txgff9b2ce38b0542a2aac2-006a0aeaff
+                - txg14e2aa10e91f49e5892c-006a0b15ea
         status: 200 OK
         code: 200
-        duration: 1.576820667s
+        duration: 4.811523042s
     - id: 167
       request:
         proto: HTTP/1.1
@@ -8716,7 +8716,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8725,7 +8725,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 8ff1b6cd-a68d-469a-b9e5-8be456c544f7
+                - 67c5a3a7-0f16-4bf5-bc2b-b11e709f9e4a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8737,8 +8737,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103336Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T133647Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?acl=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -8753,14 +8753,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 18 May 2026 10:33:36 GMT
+                - Mon, 18 May 2026 13:36:47 GMT
             X-Amz-Id-2:
-                - txg7be96f451e60470e879c-006a0aeb00
+                - txgf4e824ffa9f2445fa09e-006a0b15ef
             X-Amz-Request-Id:
-                - txg7be96f451e60470e879c-006a0aeb00
+                - txgf4e824ffa9f2445fa09e-006a0b15ef
         status: 200 OK
         code: 200
-        duration: 2.089136166s
+        duration: 3.131689584s
     - id: 168
       request:
         proto: HTTP/1.1
@@ -8769,7 +8769,7 @@ interactions:
         content_length: 1829
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>30</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition><Transition><Days>210</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>95</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Date>2016-01-12T00:00:00Z</Date><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Filter><Prefix>path3/</Prefix></Filter><ID>id3</ID><Status>Enabled</Status><Transition><Days>130</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Date>2016-01-12T00:00:00Z</Date><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path4/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>155</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id6</ID><Status>Enabled</Status><Transition><Days>156</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></LifecycleConfiguration>
@@ -8778,7 +8778,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 81d23610-0c8b-491b-bbd4-d522ed6f3811
+                - 31754445-af5c-4eb3-92fe-2e09a38d2fb8
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
@@ -8790,8 +8790,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - 38b14e9de843e5a2c2fe4ff0e368fdc7fa7ad53552471a7082320b8f609ab675
             X-Amz-Date:
-                - 20260518T103336Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T133647Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -8806,14 +8806,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 18 May 2026 10:33:38 GMT
+                - Mon, 18 May 2026 13:36:50 GMT
             X-Amz-Id-2:
-                - txg7f64a0003f35466ba19a-006a0aeb02
+                - txgf6b1c333217e45a088db-006a0b15f2
             X-Amz-Request-Id:
-                - txg7f64a0003f35466ba19a-006a0aeb02
+                - txgf6b1c333217e45a088db-006a0b15f2
         status: 200 OK
         code: 200
-        duration: 1.175113083s
+        duration: 2.448533917s
     - id: 169
       request:
         proto: HTTP/1.1
@@ -8822,7 +8822,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8831,7 +8831,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - abd938b2-457a-46b5-8b94-1ee707fff842
+                - 7734b22d-13aa-4037-a643-4829b7b2acc3
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8839,8 +8839,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103340Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T133652Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8859,14 +8859,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:33:40 GMT
+                - Mon, 18 May 2026 13:36:52 GMT
             X-Amz-Id-2:
-                - txgead31256ff194e88b097-006a0aeb04
+                - txgd78e7c92cebd4dfa8171-006a0b15f4
             X-Amz-Request-Id:
-                - txgead31256ff194e88b097-006a0aeb04
+                - txgd78e7c92cebd4dfa8171-006a0b15f4
         status: 200 OK
         code: 200
-        duration: 1.159439292s
+        duration: 3.192811708s
     - id: 170
       request:
         proto: HTTP/1.1
@@ -8875,7 +8875,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8884,7 +8884,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0af97e09-88ab-4609-8ac6-7237c11ee40a
+                - d24f487d-0cd9-4a62-a649-65f8ff74d4a9
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8892,8 +8892,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103340Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T133652Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8901,23 +8901,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 330
+        content_length: 329
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg157286aea37b47f9943b-006a0aeb05</RequestId><HostId>txg157286aea37b47f9943b-006a0aeb05</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txga935992339ba438fa6e9-006a0b15f7</RequestId><HostId>txga935992339ba438fa6e9-006a0b15f7</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
         headers:
             Content-Length:
-                - "330"
+                - "329"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:33:41 GMT
+                - Mon, 18 May 2026 13:36:55 GMT
             X-Amz-Id-2:
-                - txg157286aea37b47f9943b-006a0aeb05
+                - txga935992339ba438fa6e9-006a0b15f7
             X-Amz-Request-Id:
-                - txg157286aea37b47f9943b-006a0aeb05
+                - txga935992339ba438fa6e9-006a0b15f7
         status: 404 Not Found
         code: 404
-        duration: 1.038956375s
+        duration: 1.025827083s
     - id: 171
       request:
         proto: HTTP/1.1
@@ -8926,7 +8926,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8935,7 +8935,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 1b4d1774-dc54-49b4-8b14-ae2f0f8f7ad1
+                - 17ba028f-8088-4b17-b8c5-d3808c4bfedc
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8943,8 +8943,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103341Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
+                - 20260518T133655Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -8952,25 +8952,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 287
+        content_length: 286
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "287"
+                - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:33:42 GMT
+                - Mon, 18 May 2026 13:36:56 GMT
             X-Amz-Id-2:
-                - txgc054c2891ae54c9aae4a-006a0aeb06
+                - txg9dcddb49f12349e6a2be-006a0b15f8
             X-Amz-Request-Id:
-                - txgc054c2891ae54c9aae4a-006a0aeb06
+                - txg9dcddb49f12349e6a2be-006a0b15f8
         status: 200 OK
         code: 200
-        duration: 2.150766166s
+        duration: 1.061964125s
     - id: 172
       request:
         proto: HTTP/1.1
@@ -8979,7 +8979,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8988,7 +8988,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9823c15f-07db-4f20-a60e-9a5348b0e5ea
+                - 0ca9be72-6d04-4d99-9e66-aab11c5b5cfd
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8996,8 +8996,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103342Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T133656Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -9005,23 +9005,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 361
+        content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgdc1d4f4e83084268af86-006a0aeb08</RequestId><HostId>txgdc1d4f4e83084268af86-006a0aeb08</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg3f0e7093e75c410ea20f-006a0b15f9</RequestId><HostId>txg3f0e7093e75c410ea20f-006a0b15f9</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</BucketName></Error>
         headers:
             Content-Length:
-                - "361"
+                - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:33:44 GMT
+                - Mon, 18 May 2026 13:36:57 GMT
             X-Amz-Id-2:
-                - txgdc1d4f4e83084268af86-006a0aeb08
+                - txg3f0e7093e75c410ea20f-006a0b15f9
             X-Amz-Request-Id:
-                - txgdc1d4f4e83084268af86-006a0aeb08
+                - txg3f0e7093e75c410ea20f-006a0b15f9
         status: 404 Not Found
         code: 404
-        duration: 1.105654917s
+        duration: 30.869958ms
     - id: 173
       request:
         proto: HTTP/1.1
@@ -9030,7 +9030,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -9039,7 +9039,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 8253045c-14b9-4602-a92a-01ae439ae74c
+                - a75cacd1-3a96-4199-b1f4-c32acef84d2a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -9047,8 +9047,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103344Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T133657Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -9056,23 +9056,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 298
+        content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txga9fd564284df4b1f8957-006a0aeb09</RequestId><HostId>txga9fd564284df4b1f8957-006a0aeb09</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg9d3cf982ed9447ad8b4a-006a0b15f9</RequestId><HostId>txg9d3cf982ed9447ad8b4a-006a0b15f9</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
         headers:
             Content-Length:
-                - "298"
+                - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:33:45 GMT
+                - Mon, 18 May 2026 13:36:57 GMT
             X-Amz-Id-2:
-                - txga9fd564284df4b1f8957-006a0aeb09
+                - txg9d3cf982ed9447ad8b4a-006a0b15f9
             X-Amz-Request-Id:
-                - txga9fd564284df4b1f8957-006a0aeb09
+                - txg9d3cf982ed9447ad8b4a-006a0b15f9
         status: 404 Not Found
         code: 404
-        duration: 22.094667ms
+        duration: 31.321625ms
     - id: 174
       request:
         proto: HTTP/1.1
@@ -9081,7 +9081,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -9090,7 +9090,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ebb08a56-fb3b-400a-bb35-09d6962a2784
+                - 0204795d-2ab5-4a5c-80ac-cd8bdcbb8d1d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -9098,8 +9098,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103345Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T133657Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -9118,14 +9118,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:33:45 GMT
+                - Mon, 18 May 2026 13:36:58 GMT
             X-Amz-Id-2:
-                - txg0ba2afd5f4644d1a8fda-006a0aeb09
+                - txg2e8ab82588f740408b5a-006a0b15fa
             X-Amz-Request-Id:
-                - txg0ba2afd5f4644d1a8fda-006a0aeb09
+                - txg2e8ab82588f740408b5a-006a0b15fa
         status: 200 OK
         code: 200
-        duration: 113.575916ms
+        duration: 1.036417541s
     - id: 175
       request:
         proto: HTTP/1.1
@@ -9134,7 +9134,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -9143,7 +9143,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 62d1f2b9-d7c4-4a42-82b0-5a6ce7ced200
+                - 201ffaf5-5cea-473e-817b-b5a5bc746df8
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -9151,8 +9151,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103345Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T133658Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -9171,14 +9171,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:33:45 GMT
+                - Mon, 18 May 2026 13:36:59 GMT
             X-Amz-Id-2:
-                - txgf612a20d850842ef9ef7-006a0aeb09
+                - txg075a69d53aa64d87b7f6-006a0b15fb
             X-Amz-Request-Id:
-                - txgf612a20d850842ef9ef7-006a0aeb09
+                - txg075a69d53aa64d87b7f6-006a0b15fb
         status: 200 OK
         code: 200
-        duration: 1.027390541s
+        duration: 1.711657875s
     - id: 176
       request:
         proto: HTTP/1.1
@@ -9187,7 +9187,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -9196,7 +9196,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 1a272055-c60c-44bc-809e-8440ba110498
+                - c2527145-a967-4195-9de0-81891854d6d9
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -9204,8 +9204,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103346Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
+                - 20260518T133700Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -9220,16 +9220,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:33:46 GMT
+                - Mon, 18 May 2026 13:37:00 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txg1c6fcc5b1da84d83b15f-006a0aeb0a
+                - txgd6de7f7894584946ba9e-006a0b15fc
             X-Amz-Request-Id:
-                - txg1c6fcc5b1da84d83b15f-006a0aeb0a
+                - txgd6de7f7894584946ba9e-006a0b15fc
         status: 200 OK
         code: 200
-        duration: 114.358083ms
+        duration: 21.484375ms
     - id: 177
       request:
         proto: HTTP/1.1
@@ -9238,7 +9238,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -9247,7 +9247,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5bcf6340-c5e0-4fed-8c0c-9a1fe849ca44
+                - b225a73e-52bc-44ad-bc68-26dc0f7e0860
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -9255,8 +9255,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103347Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T133701Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -9275,14 +9275,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:33:47 GMT
+                - Mon, 18 May 2026 13:37:01 GMT
             X-Amz-Id-2:
-                - txg10ef656aa0f14afdaa7b-006a0aeb0b
+                - txg569ef4b9091840119b2f-006a0b15fd
             X-Amz-Request-Id:
-                - txg10ef656aa0f14afdaa7b-006a0aeb0b
+                - txg569ef4b9091840119b2f-006a0b15fd
         status: 200 OK
         code: 200
-        duration: 1.021324958s
+        duration: 19.377542ms
     - id: 178
       request:
         proto: HTTP/1.1
@@ -9291,7 +9291,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -9300,7 +9300,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9ac0c79c-4568-4398-a045-73569a4970d3
+                - d43978c5-12f1-4cbe-b98a-7830d0f27e42
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -9308,8 +9308,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103347Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T133701Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -9317,23 +9317,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 330
+        content_length: 329
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg091e093c3c084390851d-006a0aeb0c</RequestId><HostId>txg091e093c3c084390851d-006a0aeb0c</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg5e9921f6fb9f4d1eadc8-006a0b15fd</RequestId><HostId>txg5e9921f6fb9f4d1eadc8-006a0b15fd</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
         headers:
             Content-Length:
-                - "330"
+                - "329"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:33:48 GMT
+                - Mon, 18 May 2026 13:37:01 GMT
             X-Amz-Id-2:
-                - txg091e093c3c084390851d-006a0aeb0c
+                - txg5e9921f6fb9f4d1eadc8-006a0b15fd
             X-Amz-Request-Id:
-                - txg091e093c3c084390851d-006a0aeb0c
+                - txg5e9921f6fb9f4d1eadc8-006a0b15fd
         status: 404 Not Found
         code: 404
-        duration: 92.883ms
+        duration: 1.094344666s
     - id: 179
       request:
         proto: HTTP/1.1
@@ -9342,7 +9342,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -9351,7 +9351,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e6f09272-3add-4c4a-a72a-91a7a5ae6289
+                - 034f8429-eb6d-4acb-930f-3cab54315019
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -9359,8 +9359,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103348Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
+                - 20260518T133701Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -9368,25 +9368,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 287
+        content_length: 286
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "287"
+                - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:33:48 GMT
+                - Mon, 18 May 2026 13:37:02 GMT
             X-Amz-Id-2:
-                - txg8f3de702f3d94e17ab1a-006a0aeb0c
+                - txg47d88f65fbe04d1d90bf-006a0b15fe
             X-Amz-Request-Id:
-                - txg8f3de702f3d94e17ab1a-006a0aeb0c
+                - txg47d88f65fbe04d1d90bf-006a0b15fe
         status: 200 OK
         code: 200
-        duration: 2.1312345s
+        duration: 2.737119209s
     - id: 180
       request:
         proto: HTTP/1.1
@@ -9395,7 +9395,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -9404,7 +9404,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 2001b76d-fdbc-4690-8e39-57f01d77311e
+                - ece0197b-d4a4-486e-ba1f-f6490e69414c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -9412,8 +9412,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103348Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T133702Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -9421,23 +9421,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 361
+        content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txge129f6df51f64355acf7-006a0aeb0e</RequestId><HostId>txge129f6df51f64355acf7-006a0aeb0e</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgd5b7fcd7bc9f4b0998cd-006a0b1600</RequestId><HostId>txgd5b7fcd7bc9f4b0998cd-006a0b1600</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</BucketName></Error>
         headers:
             Content-Length:
-                - "361"
+                - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:33:50 GMT
+                - Mon, 18 May 2026 13:37:04 GMT
             X-Amz-Id-2:
-                - txge129f6df51f64355acf7-006a0aeb0e
+                - txgd5b7fcd7bc9f4b0998cd-006a0b1600
             X-Amz-Request-Id:
-                - txge129f6df51f64355acf7-006a0aeb0e
+                - txgd5b7fcd7bc9f4b0998cd-006a0b1600
         status: 404 Not Found
         code: 404
-        duration: 21.775041ms
+        duration: 1.208632167s
     - id: 181
       request:
         proto: HTTP/1.1
@@ -9446,7 +9446,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -9455,7 +9455,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f2f9d702-7751-404b-867f-669a67e440fd
+                - 07b9e7c2-b370-4ec4-a828-727b92a7a1c8
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -9463,8 +9463,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103350Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T133704Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -9472,23 +9472,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 298
+        content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txge38803462d574c238c2a-006a0aeb0e</RequestId><HostId>txge38803462d574c238c2a-006a0aeb0e</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg986ca7e70dba4092ae70-006a0b1602</RequestId><HostId>txg986ca7e70dba4092ae70-006a0b1602</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
         headers:
             Content-Length:
-                - "298"
+                - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 10:33:50 GMT
+                - Mon, 18 May 2026 13:37:06 GMT
             X-Amz-Id-2:
-                - txge38803462d574c238c2a-006a0aeb0e
+                - txg986ca7e70dba4092ae70-006a0b1602
             X-Amz-Request-Id:
-                - txge38803462d574c238c2a-006a0aeb0e
+                - txg986ca7e70dba4092ae70-006a0b1602
         status: 404 Not Found
         code: 404
-        duration: 78.490833ms
+        duration: 20.982166ms
     - id: 182
       request:
         proto: HTTP/1.1
@@ -9497,7 +9497,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -9506,7 +9506,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b4f40b5e-c717-48a1-850a-d9c84dc2485f
+                - d9789034-97fc-44b9-a867-a7480b8fb027
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -9514,8 +9514,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103350Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T133706Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -9534,14 +9534,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:33:50 GMT
+                - Mon, 18 May 2026 13:37:06 GMT
             X-Amz-Id-2:
-                - txg5484323753e64cea9427-006a0aeb0e
+                - txge417bb90497b474ea907-006a0b1602
             X-Amz-Request-Id:
-                - txg5484323753e64cea9427-006a0aeb0e
+                - txge417bb90497b474ea907-006a0b1602
         status: 200 OK
         code: 200
-        duration: 1.137410584s
+        duration: 21.192958ms
     - id: 183
       request:
         proto: HTTP/1.1
@@ -9550,7 +9550,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -9559,7 +9559,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 925c6438-8ec4-4984-826f-b98dd3487c99
+                - fb90a67f-d197-4d18-9d14-5f72ae7cfe4a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -9567,8 +9567,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103350Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T133706Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -9587,14 +9587,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 10:33:51 GMT
+                - Mon, 18 May 2026 13:37:06 GMT
             X-Amz-Id-2:
-                - txgd0cb68695cdc49cf9d6d-006a0aeb0f
+                - txgd18aa3ede71d4538821f-006a0b1602
             X-Amz-Request-Id:
-                - txgd0cb68695cdc49cf9d6d-006a0aeb0f
+                - txgd18aa3ede71d4538821f-006a0b1602
         status: 200 OK
         code: 200
-        duration: 1.109110458s
+        duration: 1.021161042s
     - id: 184
       request:
         proto: HTTP/1.1
@@ -9603,7 +9603,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -9612,7 +9612,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 60727178-06b4-42e3-8521-ec2094a3af94
+                - c2613daf-923e-4d9a-9c49-55c1ceac4639
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -9620,8 +9620,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T103353Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
+                - 20260518T133707Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -9634,11 +9634,11 @@ interactions:
         body: ""
         headers:
             Date:
-                - Mon, 18 May 2026 10:33:53 GMT
+                - Mon, 18 May 2026 13:37:07 GMT
             X-Amz-Id-2:
-                - txg02fffc5fec774364b86a-006a0aeb11
+                - txgeda50dc90aab4c6eb3c7-006a0b1603
             X-Amz-Request-Id:
-                - txg02fffc5fec774364b86a-006a0aeb11
+                - txgeda50dc90aab4c6eb3c7-006a0b1603
         status: 204 No Content
         code: 204
-        duration: 240.324459ms
+        duration: 180.393125ms

--- a/internal/services/object/testdata/object-bucket-lifecycle.cassette.yaml
+++ b/internal/services/object/testdata/object-bucket-lifecycle.cassette.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -18,7 +18,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 71daac1d-2cd2-43ef-89b2-d3b70cb2d143
+                - 48845399-eb26-40cf-ac55-faeb30320f39
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -26,8 +26,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154658Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
+                - 20260513T074811Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
         method: PUT
       response:
         proto: HTTP/2.0
@@ -42,16 +42,16 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 12 May 2026 15:46:58 GMT
+                - Wed, 13 May 2026 07:48:11 GMT
             Location:
-                - /tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300
+                - /tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985
             X-Amz-Id-2:
-                - txg140dcf6543c142a28774-006a034b72
+                - txg01c839c2f56c4c41ac2f-006a042cbb
             X-Amz-Request-Id:
-                - txg140dcf6543c142a28774-006a034b72
+                - txg01c839c2f56c4c41ac2f-006a042cbb
         status: 200 OK
         code: 200
-        duration: 566.649958ms
+        duration: 4.075785625s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -60,7 +60,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -69,7 +69,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f4388f4c-21f2-46b7-b97c-e5ddd82af890
+                - 3af74be3-d82f-4c41-a7b3-fdc05750a962
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -81,8 +81,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154658Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?acl=
+                - 20260513T074815Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?acl=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -97,14 +97,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 12 May 2026 15:46:58 GMT
+                - Wed, 13 May 2026 07:48:15 GMT
             X-Amz-Id-2:
-                - txgb24a5e61c4964f25a096-006a034b72
+                - txg574650c457ec48879193-006a042cbf
             X-Amz-Request-Id:
-                - txgb24a5e61c4964f25a096-006a034b72
+                - txg574650c457ec48879193-006a042cbf
         status: 200 OK
         code: 200
-        duration: 93.750542ms
+        duration: 110.911834ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -113,7 +113,7 @@ interactions:
         content_length: 303
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></LifecycleConfiguration>
@@ -122,7 +122,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 826a01eb-1813-4955-964b-a1e0b5ca1c8b
+                - ffe7c7fb-90f1-471b-98e0-db45626af438
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
@@ -134,8 +134,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - 13feec03c398f242f302d24e62c26ce8c47f46e3921d2bf7a84ca9914cd3488a
             X-Amz-Date:
-                - 20260512T154658Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260513T074815Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -150,14 +150,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 12 May 2026 15:46:58 GMT
+                - Wed, 13 May 2026 07:48:15 GMT
             X-Amz-Id-2:
-                - txgb8d96fbd2cb246038bb7-006a034b72
+                - txg6a97c8d5a4754b89a97c-006a042cbf
             X-Amz-Request-Id:
-                - txgb8d96fbd2cb246038bb7-006a034b72
+                - txg6a97c8d5a4754b89a97c-006a042cbf
         status: 200 OK
         code: 200
-        duration: 113.538375ms
+        duration: 67.742167ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -166,7 +166,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -175,7 +175,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 457dbc41-1189-4e50-a199-3e92f2b3573f
+                - 8a887b89-1e92-4bb0-91f3-2012f391d445
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -183,8 +183,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154658Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?acl=
+                - 20260513T074815Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -203,14 +203,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:46:58 GMT
+                - Wed, 13 May 2026 07:48:15 GMT
             X-Amz-Id-2:
-                - txgec1f5284f14d4d18bc02-006a034b72
+                - txg83efff3939334341a1af-006a042cbf
             X-Amz-Request-Id:
-                - txgec1f5284f14d4d18bc02-006a034b72
+                - txg83efff3939334341a1af-006a042cbf
         status: 200 OK
         code: 200
-        duration: 61.110583ms
+        duration: 31.337709ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -219,7 +219,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -228,7 +228,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 6b37f0f6-3372-41d5-a317-3d22057798aa
+                - e2df5559-27d4-4dfd-9b10-9c798383e61c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -236,8 +236,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154658Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260513T074815Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -247,21 +247,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txge681d3c051bc4b53a000-006a034b73</RequestId><HostId>txge681d3c051bc4b53a000-006a034b73</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txge5117727cda141579338-006a042cbf</RequestId><HostId>txge5117727cda141579338-006a042cbf</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:46:59 GMT
+                - Wed, 13 May 2026 07:48:15 GMT
             X-Amz-Id-2:
-                - txge681d3c051bc4b53a000-006a034b73
+                - txge5117727cda141579338-006a042cbf
             X-Amz-Request-Id:
-                - txge681d3c051bc4b53a000-006a034b73
+                - txge5117727cda141579338-006a042cbf
         status: 404 Not Found
         code: 404
-        duration: 64.390458ms
+        duration: 33.250459ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -270,7 +270,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -279,7 +279,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - bea1880c-a588-4bae-b9c7-4d182bd2e022
+                - d51059d7-f042-4cbf-a2b1-7176f9f75332
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -287,8 +287,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154659Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
+                - 20260513T074815Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -300,21 +300,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:46:59 GMT
+                - Wed, 13 May 2026 07:48:15 GMT
             X-Amz-Id-2:
-                - txgd77dc590d7af450fbf50-006a034b73
+                - txg7fafc6b4d33d40d3a53a-006a042cbf
             X-Amz-Request-Id:
-                - txgd77dc590d7af450fbf50-006a034b73
+                - txg7fafc6b4d33d40d3a53a-006a042cbf
         status: 200 OK
         code: 200
-        duration: 108.886958ms
+        duration: 60.921209ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -323,7 +323,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -332,7 +332,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e850ad1d-4874-4179-a090-eef9b4475335
+                - ad4dfce3-e1a2-4fa3-b3f8-26068b549cb2
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -340,8 +340,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154659Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?tagging=
+                - 20260513T074815Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -351,21 +351,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgb042cc487c334a55bbdb-006a034b73</RequestId><HostId>txgb042cc487c334a55bbdb-006a034b73</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg2716cf76a3fe43378f83-006a042cbf</RequestId><HostId>txg2716cf76a3fe43378f83-006a042cbf</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:46:59 GMT
+                - Wed, 13 May 2026 07:48:15 GMT
             X-Amz-Id-2:
-                - txgb042cc487c334a55bbdb-006a034b73
+                - txg2716cf76a3fe43378f83-006a042cbf
             X-Amz-Request-Id:
-                - txgb042cc487c334a55bbdb-006a034b73
+                - txg2716cf76a3fe43378f83-006a042cbf
         status: 404 Not Found
         code: 404
-        duration: 48.085209ms
+        duration: 31.091708ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -374,7 +374,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -383,7 +383,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b695c344-60bd-4ccd-9b2c-cdbc3be30940
+                - 3ee0dc91-8be9-4463-a975-99307bec0814
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -391,8 +391,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154659Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?cors=
+                - 20260513T074815Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -402,21 +402,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg55d934d5fdc44020a089-006a034b73</RequestId><HostId>txg55d934d5fdc44020a089-006a034b73</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg03efceb5b2dc48e6bf5c-006a042cbf</RequestId><HostId>txg03efceb5b2dc48e6bf5c-006a042cbf</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:46:59 GMT
+                - Wed, 13 May 2026 07:48:15 GMT
             X-Amz-Id-2:
-                - txg55d934d5fdc44020a089-006a034b73
+                - txg03efceb5b2dc48e6bf5c-006a042cbf
             X-Amz-Request-Id:
-                - txg55d934d5fdc44020a089-006a034b73
+                - txg03efceb5b2dc48e6bf5c-006a042cbf
         status: 404 Not Found
         code: 404
-        duration: 37.088917ms
+        duration: 31.801958ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -425,7 +425,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -434,7 +434,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 569df663-43cf-483c-93a4-5a14daf2cd2c
+                - d5baf1fc-a04d-4d5a-9146-a369d42ec638
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -442,8 +442,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154659Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?versioning=
+                - 20260513T074815Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -462,14 +462,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:46:59 GMT
+                - Wed, 13 May 2026 07:48:15 GMT
             X-Amz-Id-2:
-                - txg285dfc8a5d45444c90f2-006a034b73
+                - txg006caa18f3ea4741aff6-006a042cbf
             X-Amz-Request-Id:
-                - txg285dfc8a5d45444c90f2-006a034b73
+                - txg006caa18f3ea4741aff6-006a042cbf
         status: 200 OK
         code: 200
-        duration: 65.594ms
+        duration: 60.138916ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -478,7 +478,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -487,7 +487,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d26da0c8-f927-4a4a-90c0-fd5932074645
+                - 87b0ebda-857d-4cd2-944d-3ceeb5e107dc
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -495,8 +495,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154659Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260513T074815Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -515,14 +515,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:46:59 GMT
+                - Wed, 13 May 2026 07:48:15 GMT
             X-Amz-Id-2:
-                - txg252a9fa4e163405e886a-006a034b73
+                - txg94ba033dd4664a99b786-006a042cbf
             X-Amz-Request-Id:
-                - txg252a9fa4e163405e886a-006a034b73
+                - txg94ba033dd4664a99b786-006a042cbf
         status: 200 OK
         code: 200
-        duration: 58.136167ms
+        duration: 55.496459ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -531,7 +531,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -540,7 +540,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0bd473ba-bebf-4f3d-9e86-70cabf0b7087
+                - 804a1c4c-9197-4d99-b84b-de2ba15ba105
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -548,8 +548,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154659Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
+                - 20260513T074815Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -564,16 +564,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:46:59 GMT
+                - Wed, 13 May 2026 07:48:15 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txg23744b352eff4e8eadd5-006a034b73
+                - txg045be2e9ff6746b5bf3a-006a042cbf
             X-Amz-Request-Id:
-                - txg23744b352eff4e8eadd5-006a034b73
+                - txg045be2e9ff6746b5bf3a-006a042cbf
         status: 200 OK
         code: 200
-        duration: 153.095708ms
+        duration: 20.357541ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -582,7 +582,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -591,7 +591,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 48b2fbe1-ccbf-4bcc-8603-9df7a22aa28a
+                - aba52da3-86ea-4789-a13b-8bac4e92ea98
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -599,8 +599,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154659Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260513T074815Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -619,14 +619,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:46:59 GMT
+                - Wed, 13 May 2026 07:48:15 GMT
             X-Amz-Id-2:
-                - txgbca94a7e6cbc4eba9cde-006a034b73
+                - txg262bf2b57ec746cca512-006a042cbf
             X-Amz-Request-Id:
-                - txgbca94a7e6cbc4eba9cde-006a034b73
+                - txg262bf2b57ec746cca512-006a042cbf
         status: 200 OK
         code: 200
-        duration: 33.824666ms
+        duration: 60.880916ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -635,7 +635,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -644,7 +644,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - a5e63d5f-ba9b-4a87-bbef-776884db2254
+                - a9a8d00d-6a45-47f1-967f-771ffdcdf96a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -652,8 +652,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154659Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?acl=
+                - 20260513T074816Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -672,14 +672,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:00 GMT
+                - Wed, 13 May 2026 07:48:16 GMT
             X-Amz-Id-2:
-                - txg5c71fc945f254088969a-006a034b74
+                - txgbcc3fff8efc840fe88a2-006a042cc0
             X-Amz-Request-Id:
-                - txg5c71fc945f254088969a-006a034b74
+                - txgbcc3fff8efc840fe88a2-006a042cc0
         status: 200 OK
         code: 200
-        duration: 64.970084ms
+        duration: 28.624708ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -688,7 +688,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -697,7 +697,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 31858566-71c4-48da-bc33-cf6fb18bcfae
+                - ffaa74e2-fedc-4762-8a55-fbc7154782ac
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -705,8 +705,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154700Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260513T074816Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -716,21 +716,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgf3de7c28fe6f4795809a-006a034b74</RequestId><HostId>txgf3de7c28fe6f4795809a-006a034b74</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg26d3279a0d2c45aab7b0-006a042cc0</RequestId><HostId>txg26d3279a0d2c45aab7b0-006a042cc0</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:00 GMT
+                - Wed, 13 May 2026 07:48:16 GMT
             X-Amz-Id-2:
-                - txgf3de7c28fe6f4795809a-006a034b74
+                - txg26d3279a0d2c45aab7b0-006a042cc0
             X-Amz-Request-Id:
-                - txgf3de7c28fe6f4795809a-006a034b74
+                - txg26d3279a0d2c45aab7b0-006a042cc0
         status: 404 Not Found
         code: 404
-        duration: 51.524625ms
+        duration: 51.293417ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -739,7 +739,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -748,7 +748,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f58464a6-07a8-4f6c-b429-e08056f0750b
+                - 2a5b4aeb-dbfc-40d7-b21f-bff808d76c8f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -756,8 +756,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154700Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
+                - 20260513T074816Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -769,21 +769,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:00 GMT
+                - Wed, 13 May 2026 07:48:16 GMT
             X-Amz-Id-2:
-                - txgbafe55563fff4f70a0fa-006a034b74
+                - txgd60331e84be74ece95b4-006a042cc0
             X-Amz-Request-Id:
-                - txgbafe55563fff4f70a0fa-006a034b74
+                - txgd60331e84be74ece95b4-006a042cc0
         status: 200 OK
         code: 200
-        duration: 110.820625ms
+        duration: 84.631959ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -792,7 +792,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -801,7 +801,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 115501b5-e28b-454a-94ed-611455ebf875
+                - 429871dd-2f7c-4d5c-a2e7-de1a429e0195
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -809,8 +809,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154700Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?tagging=
+                - 20260513T074816Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -820,21 +820,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg93497706494b480bbab5-006a034b74</RequestId><HostId>txg93497706494b480bbab5-006a034b74</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg6b85fe55fe9b4495b60f-006a042cc0</RequestId><HostId>txg6b85fe55fe9b4495b60f-006a042cc0</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:00 GMT
+                - Wed, 13 May 2026 07:48:16 GMT
             X-Amz-Id-2:
-                - txg93497706494b480bbab5-006a034b74
+                - txg6b85fe55fe9b4495b60f-006a042cc0
             X-Amz-Request-Id:
-                - txg93497706494b480bbab5-006a034b74
+                - txg6b85fe55fe9b4495b60f-006a042cc0
         status: 404 Not Found
         code: 404
-        duration: 32.694292ms
+        duration: 51.238ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -843,7 +843,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -852,7 +852,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ce8c20c9-3e0e-4011-959b-b44ed1ed74bb
+                - 78d41808-2dc5-4954-95a0-aa3352d4633c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -860,8 +860,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154700Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?cors=
+                - 20260513T074816Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -871,21 +871,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgafa4cbd6a84b4b6cadd5-006a034b74</RequestId><HostId>txgafa4cbd6a84b4b6cadd5-006a034b74</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg85511478376d495ea01b-006a042cc0</RequestId><HostId>txg85511478376d495ea01b-006a042cc0</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:00 GMT
+                - Wed, 13 May 2026 07:48:16 GMT
             X-Amz-Id-2:
-                - txgafa4cbd6a84b4b6cadd5-006a034b74
+                - txg85511478376d495ea01b-006a042cc0
             X-Amz-Request-Id:
-                - txgafa4cbd6a84b4b6cadd5-006a034b74
+                - txg85511478376d495ea01b-006a042cc0
         status: 404 Not Found
         code: 404
-        duration: 65.175ms
+        duration: 88.529708ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -894,7 +894,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -903,7 +903,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 21b88ff3-73bb-4ea4-8878-a00b71c9b402
+                - d2c42833-71d3-4a1f-a52e-4871ac405dbf
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -911,8 +911,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154700Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?versioning=
+                - 20260513T074816Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -931,14 +931,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:00 GMT
+                - Wed, 13 May 2026 07:48:16 GMT
             X-Amz-Id-2:
-                - txgfff411e18fee4d9daf99-006a034b74
+                - txg6c3b67032d234e0ba4ae-006a042cc0
             X-Amz-Request-Id:
-                - txgfff411e18fee4d9daf99-006a034b74
+                - txg6c3b67032d234e0ba4ae-006a042cc0
         status: 200 OK
         code: 200
-        duration: 54.579708ms
+        duration: 71.567083ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -947,7 +947,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -956,7 +956,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ea0b556a-6adc-4d0f-a410-bce110e1eeeb
+                - 8cd0f86e-e559-4e9a-a48d-bc77a1de29a2
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -964,8 +964,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154700Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260513T074816Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -984,14 +984,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:00 GMT
+                - Wed, 13 May 2026 07:48:16 GMT
             X-Amz-Id-2:
-                - txgfc3fa9279deb42ac8dec-006a034b74
+                - txg5708cd472d0246d0b17f-006a042cc0
             X-Amz-Request-Id:
-                - txgfc3fa9279deb42ac8dec-006a034b74
+                - txg5708cd472d0246d0b17f-006a042cc0
         status: 200 OK
         code: 200
-        duration: 34.297667ms
+        duration: 68.75775ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -1000,7 +1000,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1009,7 +1009,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 669ab30e-fb30-4e4e-8755-82cd3a5856a9
+                - f5e7742c-ca55-4d12-a6ab-0df7b0195159
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1017,8 +1017,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154700Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?acl=
+                - 20260513T074816Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1037,14 +1037,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:00 GMT
+                - Wed, 13 May 2026 07:48:16 GMT
             X-Amz-Id-2:
-                - txg170dc3b9e44644078d73-006a034b74
+                - txg1a83eb144f4a47eea151-006a042cc0
             X-Amz-Request-Id:
-                - txg170dc3b9e44644078d73-006a034b74
+                - txg1a83eb144f4a47eea151-006a042cc0
         status: 200 OK
         code: 200
-        duration: 48.81625ms
+        duration: 48.569083ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1053,7 +1053,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1062,7 +1062,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b4b31751-7041-44bc-989b-a3b68d52af0b
+                - 31812e15-6d4c-48f2-b356-b9ae6aa580f7
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1070,8 +1070,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154700Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260513T074816Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1081,21 +1081,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txge352786b6fc648daae5a-006a034b74</RequestId><HostId>txge352786b6fc648daae5a-006a034b74</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg53f74b8a25214b32b262-006a042cc0</RequestId><HostId>txg53f74b8a25214b32b262-006a042cc0</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:00 GMT
+                - Wed, 13 May 2026 07:48:16 GMT
             X-Amz-Id-2:
-                - txge352786b6fc648daae5a-006a034b74
+                - txg53f74b8a25214b32b262-006a042cc0
             X-Amz-Request-Id:
-                - txge352786b6fc648daae5a-006a034b74
+                - txg53f74b8a25214b32b262-006a042cc0
         status: 404 Not Found
         code: 404
-        duration: 20.499ms
+        duration: 19.21175ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1104,7 +1104,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1113,7 +1113,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b18ad6b0-7975-48f1-8140-205f9b8501e6
+                - bbca1bd5-3851-496a-b2e5-8a678d8d0ec4
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1121,8 +1121,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154700Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
+                - 20260513T074816Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -1134,21 +1134,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:00 GMT
+                - Wed, 13 May 2026 07:48:16 GMT
             X-Amz-Id-2:
-                - txgbc15a3a894a245df8e96-006a034b74
+                - txg218d7b4ddd6248a68146-006a042cc0
             X-Amz-Request-Id:
-                - txgbc15a3a894a245df8e96-006a034b74
+                - txg218d7b4ddd6248a68146-006a042cc0
         status: 200 OK
         code: 200
-        duration: 87.893083ms
+        duration: 49.656416ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1157,7 +1157,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1166,7 +1166,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 1aeae2b8-8a17-48fe-8538-edebb47d6dff
+                - 40147079-50ad-4e26-a942-5e572a51ca0c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1174,8 +1174,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154700Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?tagging=
+                - 20260513T074816Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1185,21 +1185,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg942e6f427f74428391b1-006a034b74</RequestId><HostId>txg942e6f427f74428391b1-006a034b74</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg1a17098a967d4d3b8f48-006a042cc0</RequestId><HostId>txg1a17098a967d4d3b8f48-006a042cc0</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:00 GMT
+                - Wed, 13 May 2026 07:48:16 GMT
             X-Amz-Id-2:
-                - txg942e6f427f74428391b1-006a034b74
+                - txg1a17098a967d4d3b8f48-006a042cc0
             X-Amz-Request-Id:
-                - txg942e6f427f74428391b1-006a034b74
+                - txg1a17098a967d4d3b8f48-006a042cc0
         status: 404 Not Found
         code: 404
-        duration: 57.299125ms
+        duration: 59.495292ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1208,7 +1208,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1217,7 +1217,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b3e9bfef-ab84-43b7-ad82-d6d2fa2cb388
+                - 17c010a1-b819-4e14-a321-b7a879b7f692
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1225,8 +1225,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154700Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?cors=
+                - 20260513T074816Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1236,21 +1236,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg67d5607d436a412c92fe-006a034b74</RequestId><HostId>txg67d5607d436a412c92fe-006a034b74</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgbf9d0181e04646daac73-006a042cc1</RequestId><HostId>txgbf9d0181e04646daac73-006a042cc1</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:00 GMT
+                - Wed, 13 May 2026 07:48:17 GMT
             X-Amz-Id-2:
-                - txg67d5607d436a412c92fe-006a034b74
+                - txgbf9d0181e04646daac73-006a042cc1
             X-Amz-Request-Id:
-                - txg67d5607d436a412c92fe-006a034b74
+                - txgbf9d0181e04646daac73-006a042cc1
         status: 404 Not Found
         code: 404
-        duration: 49.759916ms
+        duration: 58.983042ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1259,7 +1259,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1268,7 +1268,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ca8cd3ef-54e8-4b04-a20a-2a7632c8fddc
+                - 118dc171-c8fa-4f10-9630-ec6845ea5ccd
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1276,8 +1276,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154700Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?versioning=
+                - 20260513T074817Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1296,14 +1296,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:00 GMT
+                - Wed, 13 May 2026 07:48:17 GMT
             X-Amz-Id-2:
-                - txgd5d2ab4b0c7549db8d37-006a034b74
+                - txg9d3c67cb56d743418d14-006a042cc1
             X-Amz-Request-Id:
-                - txgd5d2ab4b0c7549db8d37-006a034b74
+                - txg9d3c67cb56d743418d14-006a042cc1
         status: 200 OK
         code: 200
-        duration: 35.688125ms
+        duration: 48.517333ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1312,7 +1312,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1321,7 +1321,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5f35920f-8c03-420d-8871-ef8a27faa5e2
+                - bde78c96-182d-4202-a35b-527001733eb4
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1329,8 +1329,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154700Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260513T074817Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1349,14 +1349,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:00 GMT
+                - Wed, 13 May 2026 07:48:17 GMT
             X-Amz-Id-2:
-                - txg5e9f30e876d644a18fdb-006a034b74
+                - txgff19b5d44e844d538c99-006a042cc1
             X-Amz-Request-Id:
-                - txg5e9f30e876d644a18fdb-006a034b74
+                - txgff19b5d44e844d538c99-006a042cc1
         status: 200 OK
         code: 200
-        duration: 61.750083ms
+        duration: 60.471041ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1365,7 +1365,7 @@ interactions:
         content_length: 306
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition></Rule></LifecycleConfiguration>
@@ -1374,7 +1374,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 89734e80-3bde-49b8-b442-4354afedfade
+                - 08fcce07-67f4-458d-90a8-9500c90ba012
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
@@ -1386,8 +1386,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - de1418e62a2680330e07a11a092b47b671d4ed12fe9fe6d9780b095b8f45d69c
             X-Amz-Date:
-                - 20260512T154701Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260513T074817Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -1402,14 +1402,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 12 May 2026 15:47:01 GMT
+                - Wed, 13 May 2026 07:48:17 GMT
             X-Amz-Id-2:
-                - txgb0d6abe8eb1b4b3c96ab-006a034b75
+                - txg92dd6b08e4d340e189c5-006a042cc1
             X-Amz-Request-Id:
-                - txgb0d6abe8eb1b4b3c96ab-006a034b75
+                - txg92dd6b08e4d340e189c5-006a042cc1
         status: 200 OK
         code: 200
-        duration: 382.065709ms
+        duration: 36.007542ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1418,7 +1418,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1427,7 +1427,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b8be8623-aa34-4f6d-94c3-66626f0ffca3
+                - 17a3ac10-b47f-4d72-a51d-9540faee46a1
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1435,8 +1435,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154701Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?acl=
+                - 20260513T074817Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1455,14 +1455,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:01 GMT
+                - Wed, 13 May 2026 07:48:17 GMT
             X-Amz-Id-2:
-                - txg2e9d25d68cab4337a156-006a034b75
+                - txg3c6343421c6644c99592-006a042cc1
             X-Amz-Request-Id:
-                - txg2e9d25d68cab4337a156-006a034b75
+                - txg3c6343421c6644c99592-006a042cc1
         status: 200 OK
         code: 200
-        duration: 27.545667ms
+        duration: 36.070417ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1471,7 +1471,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1480,7 +1480,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - bf3c5868-4293-4deb-a8bd-95b79540067b
+                - 6d0d542b-916d-4fda-8a67-c79cbea8073b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1488,8 +1488,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154701Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260513T074817Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1499,21 +1499,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgfaa6ba9f8d3343d58f42-006a034b75</RequestId><HostId>txgfaa6ba9f8d3343d58f42-006a034b75</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgb8f81b272bd14fe9b89b-006a042cc1</RequestId><HostId>txgb8f81b272bd14fe9b89b-006a042cc1</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:01 GMT
+                - Wed, 13 May 2026 07:48:17 GMT
             X-Amz-Id-2:
-                - txgfaa6ba9f8d3343d58f42-006a034b75
+                - txgb8f81b272bd14fe9b89b-006a042cc1
             X-Amz-Request-Id:
-                - txgfaa6ba9f8d3343d58f42-006a034b75
+                - txgb8f81b272bd14fe9b89b-006a042cc1
         status: 404 Not Found
         code: 404
-        duration: 61.66575ms
+        duration: 102.069542ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1522,7 +1522,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1531,7 +1531,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 6c2e6b67-5165-465e-812f-3d6ac6cdd5f5
+                - 13a34a22-ccd3-497b-b80e-da66a561b884
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1539,8 +1539,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154701Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
+                - 20260513T074817Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -1552,21 +1552,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:01 GMT
+                - Wed, 13 May 2026 07:48:17 GMT
             X-Amz-Id-2:
-                - txgc15e405c39d4424994b4-006a034b75
+                - txgfc9388419fd7458f86c5-006a042cc1
             X-Amz-Request-Id:
-                - txgc15e405c39d4424994b4-006a034b75
+                - txgfc9388419fd7458f86c5-006a042cc1
         status: 200 OK
         code: 200
-        duration: 62.07775ms
+        duration: 68.033125ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1575,7 +1575,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1584,7 +1584,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b812e6b8-f8ad-4526-8e8d-5734f8aa2975
+                - 42f89609-f454-4830-bb51-cd5368168eea
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1592,8 +1592,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154701Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?tagging=
+                - 20260513T074817Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1603,21 +1603,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg2d171acd55254432a215-006a034b75</RequestId><HostId>txg2d171acd55254432a215-006a034b75</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgbe505783a54a48c89301-006a042cc1</RequestId><HostId>txgbe505783a54a48c89301-006a042cc1</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:01 GMT
+                - Wed, 13 May 2026 07:48:17 GMT
             X-Amz-Id-2:
-                - txg2d171acd55254432a215-006a034b75
+                - txgbe505783a54a48c89301-006a042cc1
             X-Amz-Request-Id:
-                - txg2d171acd55254432a215-006a034b75
+                - txgbe505783a54a48c89301-006a042cc1
         status: 404 Not Found
         code: 404
-        duration: 66.506167ms
+        duration: 49.626208ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1626,7 +1626,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1635,7 +1635,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 572f3f8b-1664-495b-8f18-19caa1d18218
+                - 09255db4-6b80-4881-a3df-69def5ffd980
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1643,8 +1643,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154701Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?cors=
+                - 20260513T074817Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1654,21 +1654,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg0544bbf471074d039631-006a034b75</RequestId><HostId>txg0544bbf471074d039631-006a034b75</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg938b3508a9a94cbdbe96-006a042cc1</RequestId><HostId>txg938b3508a9a94cbdbe96-006a042cc1</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:01 GMT
+                - Wed, 13 May 2026 07:48:17 GMT
             X-Amz-Id-2:
-                - txg0544bbf471074d039631-006a034b75
+                - txg938b3508a9a94cbdbe96-006a042cc1
             X-Amz-Request-Id:
-                - txg0544bbf471074d039631-006a034b75
+                - txg938b3508a9a94cbdbe96-006a042cc1
         status: 404 Not Found
         code: 404
-        duration: 56.68025ms
+        duration: 66.505167ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1677,7 +1677,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1686,7 +1686,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 600be7cd-8068-4c7d-87e5-3cf0d1abb0a5
+                - b22f1d29-81d7-4008-a3e5-ab9dfdfd5448
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1694,8 +1694,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154701Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?versioning=
+                - 20260513T074817Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1714,14 +1714,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:01 GMT
+                - Wed, 13 May 2026 07:48:17 GMT
             X-Amz-Id-2:
-                - txgf9e83b3ce8a14638bd8e-006a034b75
+                - txga138806f5f3f4ec480a0-006a042cc1
             X-Amz-Request-Id:
-                - txgf9e83b3ce8a14638bd8e-006a034b75
+                - txga138806f5f3f4ec480a0-006a042cc1
         status: 200 OK
         code: 200
-        duration: 32.053292ms
+        duration: 34.010791ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1730,7 +1730,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1739,7 +1739,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5ded8b2e-bb8f-4996-94c5-c77a984521d2
+                - 069a5561-82c4-48c3-8c46-33bb1a7bf760
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1747,8 +1747,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154701Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260513T074817Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1767,14 +1767,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:01 GMT
+                - Wed, 13 May 2026 07:48:17 GMT
             X-Amz-Id-2:
-                - txg88861a0042f447658d28-006a034b75
+                - txgeba51595a76e473d8105-006a042cc1
             X-Amz-Request-Id:
-                - txg88861a0042f447658d28-006a034b75
+                - txgeba51595a76e473d8105-006a042cc1
         status: 200 OK
         code: 200
-        duration: 50.38075ms
+        duration: 18.767042ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1783,7 +1783,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1792,7 +1792,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 761d062c-c9e3-4931-b38f-9326749991f2
+                - 858aafa3-767a-49ca-a58b-b1d7d6a312eb
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1800,8 +1800,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154701Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
+                - 20260513T074817Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -1816,16 +1816,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:02 GMT
+                - Wed, 13 May 2026 07:48:17 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txg0f86d6ca41604ccc8af0-006a034b76
+                - txg558b695eb59e4ac0a18c-006a042cc1
             X-Amz-Request-Id:
-                - txg0f86d6ca41604ccc8af0-006a034b76
+                - txg558b695eb59e4ac0a18c-006a042cc1
         status: 200 OK
         code: 200
-        duration: 63.14875ms
+        duration: 33.53275ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1834,7 +1834,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1843,7 +1843,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9e107acd-d0ca-4b0b-97ca-13c7a07dc385
+                - d428d3cd-3aa7-44d3-9eb5-ee2bb9a7695b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1851,8 +1851,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154702Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260513T074817Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1871,14 +1871,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:02 GMT
+                - Wed, 13 May 2026 07:48:17 GMT
             X-Amz-Id-2:
-                - txg58efc7b32caf43d99cca-006a034b76
+                - txg71fb96a834b04d3aa602-006a042cc1
             X-Amz-Request-Id:
-                - txg58efc7b32caf43d99cca-006a034b76
+                - txg71fb96a834b04d3aa602-006a042cc1
         status: 200 OK
         code: 200
-        duration: 66.225083ms
+        duration: 82.476375ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1887,7 +1887,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1896,7 +1896,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 8f9cb86a-e38e-4e11-a939-a56d2e8a1a62
+                - 9ce53966-b32d-439f-a157-9d022a0356fb
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1904,8 +1904,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154702Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?acl=
+                - 20260513T074818Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1924,14 +1924,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:02 GMT
+                - Wed, 13 May 2026 07:48:18 GMT
             X-Amz-Id-2:
-                - txg7ae719455a09481dbe19-006a034b76
+                - txgf4ea6c45b0454cff850d-006a042cc2
             X-Amz-Request-Id:
-                - txg7ae719455a09481dbe19-006a034b76
+                - txgf4ea6c45b0454cff850d-006a042cc2
         status: 200 OK
         code: 200
-        duration: 70.923666ms
+        duration: 22.024083ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1940,7 +1940,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1949,7 +1949,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c879459b-fd78-497c-bce1-aa660747315b
+                - 72b0fd53-15df-48fc-91df-5b78f9333e0a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1957,8 +1957,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154702Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260513T074818Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1968,21 +1968,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgfe1562a00ed24e7d9f16-006a034b76</RequestId><HostId>txgfe1562a00ed24e7d9f16-006a034b76</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg63c5bfe50eac42468380-006a042cc2</RequestId><HostId>txg63c5bfe50eac42468380-006a042cc2</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:02 GMT
+                - Wed, 13 May 2026 07:48:18 GMT
             X-Amz-Id-2:
-                - txgfe1562a00ed24e7d9f16-006a034b76
+                - txg63c5bfe50eac42468380-006a042cc2
             X-Amz-Request-Id:
-                - txgfe1562a00ed24e7d9f16-006a034b76
+                - txg63c5bfe50eac42468380-006a042cc2
         status: 404 Not Found
         code: 404
-        duration: 54.485375ms
+        duration: 51.018ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1991,7 +1991,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2000,7 +2000,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 954b7039-e9c8-4280-9391-35793b691cd5
+                - d8bf758c-68a0-471f-997e-7b2f763b9a02
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2008,8 +2008,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154702Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
+                - 20260513T074818Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -2021,21 +2021,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:02 GMT
+                - Wed, 13 May 2026 07:48:18 GMT
             X-Amz-Id-2:
-                - txg3f469a5cae104290a5e0-006a034b76
+                - txgc6866f9273b6450f9651-006a042cc2
             X-Amz-Request-Id:
-                - txg3f469a5cae104290a5e0-006a034b76
+                - txgc6866f9273b6450f9651-006a042cc2
         status: 200 OK
         code: 200
-        duration: 101.040625ms
+        duration: 53.117542ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -2044,7 +2044,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2053,7 +2053,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - a4baafe1-96f9-4ec1-ae61-cdfe5daa50aa
+                - c55dedb1-a198-4120-8b2e-a2a2091f3206
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2061,8 +2061,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154702Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?tagging=
+                - 20260513T074818Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2072,21 +2072,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg9060865ddd8241adaeed-006a034b76</RequestId><HostId>txg9060865ddd8241adaeed-006a034b76</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgc2c22544572a4c1d81cc-006a042cc2</RequestId><HostId>txgc2c22544572a4c1d81cc-006a042cc2</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:02 GMT
+                - Wed, 13 May 2026 07:48:18 GMT
             X-Amz-Id-2:
-                - txg9060865ddd8241adaeed-006a034b76
+                - txgc2c22544572a4c1d81cc-006a042cc2
             X-Amz-Request-Id:
-                - txg9060865ddd8241adaeed-006a034b76
+                - txgc2c22544572a4c1d81cc-006a042cc2
         status: 404 Not Found
         code: 404
-        duration: 21.989167ms
+        duration: 48.96525ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -2095,7 +2095,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2104,7 +2104,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9693e1bb-9114-4b70-bb13-03b99301fa42
+                - 9c373155-faf6-402b-8e90-8e53ee187c32
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2112,8 +2112,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154702Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?cors=
+                - 20260513T074818Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2123,21 +2123,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txga09d8ceced8a40608e91-006a034b76</RequestId><HostId>txga09d8ceced8a40608e91-006a034b76</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg2b7f75e5712a49708c2f-006a042cc2</RequestId><HostId>txg2b7f75e5712a49708c2f-006a042cc2</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:02 GMT
+                - Wed, 13 May 2026 07:48:18 GMT
             X-Amz-Id-2:
-                - txga09d8ceced8a40608e91-006a034b76
+                - txg2b7f75e5712a49708c2f-006a042cc2
             X-Amz-Request-Id:
-                - txga09d8ceced8a40608e91-006a034b76
+                - txg2b7f75e5712a49708c2f-006a042cc2
         status: 404 Not Found
         code: 404
-        duration: 52.910708ms
+        duration: 18.285833ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -2146,7 +2146,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2155,7 +2155,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f7dfff2c-1ea3-4fee-9fc3-463439248b68
+                - 174a646a-1e00-4b41-9b00-4d2d02c874c5
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2163,8 +2163,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154702Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?versioning=
+                - 20260513T074818Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2183,14 +2183,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:02 GMT
+                - Wed, 13 May 2026 07:48:18 GMT
             X-Amz-Id-2:
-                - txge64853af349f41329e96-006a034b76
+                - txg5b53effff8ea40b499d3-006a042cc2
             X-Amz-Request-Id:
-                - txge64853af349f41329e96-006a034b76
+                - txg5b53effff8ea40b499d3-006a042cc2
         status: 200 OK
         code: 200
-        duration: 18.839667ms
+        duration: 50.49275ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -2199,7 +2199,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2208,7 +2208,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d3043098-5b64-44c3-be1f-618ee91769e6
+                - a13eeb5c-0cb6-4e18-bbcd-e7466b8cb84e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2216,8 +2216,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154702Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260513T074818Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2236,14 +2236,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:02 GMT
+                - Wed, 13 May 2026 07:48:18 GMT
             X-Amz-Id-2:
-                - txg32ca6b149bc74ba380bd-006a034b76
+                - txg7b785dc2f53d4d86a5d2-006a042cc2
             X-Amz-Request-Id:
-                - txg32ca6b149bc74ba380bd-006a034b76
+                - txg7b785dc2f53d4d86a5d2-006a042cc2
         status: 200 OK
         code: 200
-        duration: 63.147834ms
+        duration: 141.6625ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -2252,7 +2252,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2261,7 +2261,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7144b770-ee95-45ce-a896-7100b2349059
+                - c31f10d1-d605-4139-b7d6-9c68c60a911f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2269,8 +2269,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154702Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?acl=
+                - 20260513T074818Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2289,14 +2289,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:02 GMT
+                - Wed, 13 May 2026 07:48:18 GMT
             X-Amz-Id-2:
-                - txg12f6a319ea49427c9e47-006a034b76
+                - txg683615d1e4444a3daa8a-006a042cc2
             X-Amz-Request-Id:
-                - txg12f6a319ea49427c9e47-006a034b76
+                - txg683615d1e4444a3daa8a-006a042cc2
         status: 200 OK
         code: 200
-        duration: 60.921416ms
+        duration: 48.680625ms
     - id: 44
       request:
         proto: HTTP/1.1
@@ -2305,7 +2305,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2314,7 +2314,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7e5ca420-bd61-4ba1-ad44-5e10b388b383
+                - e58adac6-c8a3-4e70-ae54-05625379dbb1
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2322,8 +2322,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154702Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260513T074818Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2333,21 +2333,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg271cefb832d9439a868c-006a034b77</RequestId><HostId>txg271cefb832d9439a868c-006a034b77</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgd713dc3066594208abf1-006a042cc2</RequestId><HostId>txgd713dc3066594208abf1-006a042cc2</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:03 GMT
+                - Wed, 13 May 2026 07:48:18 GMT
             X-Amz-Id-2:
-                - txg271cefb832d9439a868c-006a034b77
+                - txgd713dc3066594208abf1-006a042cc2
             X-Amz-Request-Id:
-                - txg271cefb832d9439a868c-006a034b77
+                - txgd713dc3066594208abf1-006a042cc2
         status: 404 Not Found
         code: 404
-        duration: 28.173542ms
+        duration: 70.9235ms
     - id: 45
       request:
         proto: HTTP/1.1
@@ -2356,7 +2356,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2365,7 +2365,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5b3cb681-02c1-45ea-bca3-e139376c4146
+                - 37969cd1-8936-407b-82bf-fe703ab55e22
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2373,8 +2373,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154703Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
+                - 20260513T074818Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -2386,21 +2386,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:03 GMT
+                - Wed, 13 May 2026 07:48:18 GMT
             X-Amz-Id-2:
-                - txg890b62578437467985eb-006a034b77
+                - txg9dec83662cde47c7bc29-006a042cc2
             X-Amz-Request-Id:
-                - txg890b62578437467985eb-006a034b77
+                - txg9dec83662cde47c7bc29-006a042cc2
         status: 200 OK
         code: 200
-        duration: 67.817833ms
+        duration: 33.989625ms
     - id: 46
       request:
         proto: HTTP/1.1
@@ -2409,7 +2409,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2418,7 +2418,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9f1da802-f92d-4565-8161-712039864853
+                - b6444975-c11d-4f36-b8dd-08ebdd8a4112
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2426,8 +2426,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154703Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?tagging=
+                - 20260513T074818Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2437,21 +2437,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg6fcb4dce2a5b4788bb70-006a034b77</RequestId><HostId>txg6fcb4dce2a5b4788bb70-006a034b77</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg73fc1b47b5bb49e1b784-006a042cc2</RequestId><HostId>txg73fc1b47b5bb49e1b784-006a042cc2</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:03 GMT
+                - Wed, 13 May 2026 07:48:18 GMT
             X-Amz-Id-2:
-                - txg6fcb4dce2a5b4788bb70-006a034b77
+                - txg73fc1b47b5bb49e1b784-006a042cc2
             X-Amz-Request-Id:
-                - txg6fcb4dce2a5b4788bb70-006a034b77
+                - txg73fc1b47b5bb49e1b784-006a042cc2
         status: 404 Not Found
         code: 404
-        duration: 30.213875ms
+        duration: 65.054042ms
     - id: 47
       request:
         proto: HTTP/1.1
@@ -2460,7 +2460,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2469,7 +2469,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f774e696-bb54-4d82-a59a-a04ca1fa820d
+                - ec37e775-65c1-4e9c-99ba-50cf6a4750fe
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2477,8 +2477,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154703Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?cors=
+                - 20260513T074818Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2488,21 +2488,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg650b9eca63da45a1b147-006a034b77</RequestId><HostId>txg650b9eca63da45a1b147-006a034b77</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg5adbb8508b1546008706-006a042cc3</RequestId><HostId>txg5adbb8508b1546008706-006a042cc3</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:03 GMT
+                - Wed, 13 May 2026 07:48:19 GMT
             X-Amz-Id-2:
-                - txg650b9eca63da45a1b147-006a034b77
+                - txg5adbb8508b1546008706-006a042cc3
             X-Amz-Request-Id:
-                - txg650b9eca63da45a1b147-006a034b77
+                - txg5adbb8508b1546008706-006a042cc3
         status: 404 Not Found
         code: 404
-        duration: 20.61725ms
+        duration: 72.370334ms
     - id: 48
       request:
         proto: HTTP/1.1
@@ -2511,7 +2511,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2520,7 +2520,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0596ee9e-0278-4de5-90f7-cb714fd81b9c
+                - 6ad3296e-6ed6-428b-a6dc-f016b7b85026
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2528,8 +2528,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154703Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?versioning=
+                - 20260513T074819Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2548,14 +2548,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:03 GMT
+                - Wed, 13 May 2026 07:48:19 GMT
             X-Amz-Id-2:
-                - txg2e41c71817514c65bff4-006a034b77
+                - txg3bf62556648042399730-006a042cc3
             X-Amz-Request-Id:
-                - txg2e41c71817514c65bff4-006a034b77
+                - txg3bf62556648042399730-006a042cc3
         status: 200 OK
         code: 200
-        duration: 71.657959ms
+        duration: 97.487ms
     - id: 49
       request:
         proto: HTTP/1.1
@@ -2564,7 +2564,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2573,7 +2573,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f7e973a6-1c5c-4274-8329-f8ba33b18396
+                - 95af853e-c0d6-46ba-9ee3-310c8806c281
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2581,8 +2581,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154703Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260513T074819Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2601,14 +2601,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:03 GMT
+                - Wed, 13 May 2026 07:48:19 GMT
             X-Amz-Id-2:
-                - txgf1bebb28bb634f919b80-006a034b77
+                - txgb7546c71df7e45918bd5-006a042cc3
             X-Amz-Request-Id:
-                - txgf1bebb28bb634f919b80-006a034b77
+                - txgb7546c71df7e45918bd5-006a042cc3
         status: 200 OK
         code: 200
-        duration: 19.460125ms
+        duration: 20.4865ms
     - id: 50
       request:
         proto: HTTP/1.1
@@ -2617,16 +2617,16 @@ interactions:
         content_length: 1132
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
-        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></LifecycleConfiguration>
+        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></LifecycleConfiguration>
         form: {}
         headers:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 95d851a1-e1a3-478b-aac9-8c0220762601
+                - 37fe57a2-b904-4f40-84de-41e32dfc1654
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
@@ -2634,12 +2634,12 @@ interactions:
             User-Agent:
                 - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,Z,e
             X-Amz-Checksum-Crc32:
-                - Ptm59w==
+                - Iut4Cw==
             X-Amz-Content-Sha256:
-                - 5a66f5284daa450c521e7ab251a0d5d0fd30f5aab4a326acf3665950e98d54c9
+                - abdb2689a9d25a928122283e4e5fdf5ef5744bed79f37794b44a3c66662be0c1
             X-Amz-Date:
-                - 20260512T154703Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260513T074819Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -2654,14 +2654,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 12 May 2026 15:47:03 GMT
+                - Wed, 13 May 2026 07:48:19 GMT
             X-Amz-Id-2:
-                - txgb98ed1657cb74284873b-006a034b77
+                - txg19bf561a00b24ba0bb2f-006a042cc3
             X-Amz-Request-Id:
-                - txgb98ed1657cb74284873b-006a034b77
+                - txg19bf561a00b24ba0bb2f-006a042cc3
         status: 200 OK
         code: 200
-        duration: 103.55075ms
+        duration: 62.31425ms
     - id: 51
       request:
         proto: HTTP/1.1
@@ -2670,7 +2670,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2679,7 +2679,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ba657b46-80f6-4c84-a917-fa63615638be
+                - 47c65c63-4810-4cc5-8b2a-8a94802a44f3
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2687,8 +2687,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154703Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?acl=
+                - 20260513T074819Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2707,14 +2707,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:03 GMT
+                - Wed, 13 May 2026 07:48:19 GMT
             X-Amz-Id-2:
-                - txgc4fefd46375040768ccb-006a034b77
+                - txg8ce7bdd0c5b641b2a29d-006a042cc3
             X-Amz-Request-Id:
-                - txgc4fefd46375040768ccb-006a034b77
+                - txg8ce7bdd0c5b641b2a29d-006a042cc3
         status: 200 OK
         code: 200
-        duration: 54.513042ms
+        duration: 22.82575ms
     - id: 52
       request:
         proto: HTTP/1.1
@@ -2723,7 +2723,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2732,7 +2732,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 90362c73-0afc-43ba-b38f-ac4ff59bb1b5
+                - 4020acf2-c497-4b1c-a009-956b18528a20
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2740,8 +2740,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154703Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260513T074819Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2751,21 +2751,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg081d7d86b678450ca2a6-006a034b77</RequestId><HostId>txg081d7d86b678450ca2a6-006a034b77</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg71a8d244966e4a5f82b7-006a042cc3</RequestId><HostId>txg71a8d244966e4a5f82b7-006a042cc3</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:03 GMT
+                - Wed, 13 May 2026 07:48:19 GMT
             X-Amz-Id-2:
-                - txg081d7d86b678450ca2a6-006a034b77
+                - txg71a8d244966e4a5f82b7-006a042cc3
             X-Amz-Request-Id:
-                - txg081d7d86b678450ca2a6-006a034b77
+                - txg71a8d244966e4a5f82b7-006a042cc3
         status: 404 Not Found
         code: 404
-        duration: 36.12325ms
+        duration: 54.006084ms
     - id: 53
       request:
         proto: HTTP/1.1
@@ -2774,7 +2774,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2783,7 +2783,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 8f4db4d9-0d37-42e4-8137-9d9210a499bf
+                - 7eae9336-663c-4c97-bd43-b16879c13e63
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2791,8 +2791,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154703Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
+                - 20260513T074819Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -2804,21 +2804,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:03 GMT
+                - Wed, 13 May 2026 07:48:19 GMT
             X-Amz-Id-2:
-                - txg37db4e494b704218b4a5-006a034b77
+                - txg981809cb97a14763a8d9-006a042cc3
             X-Amz-Request-Id:
-                - txg37db4e494b704218b4a5-006a034b77
+                - txg981809cb97a14763a8d9-006a042cc3
         status: 200 OK
         code: 200
-        duration: 46.524583ms
+        duration: 60.401333ms
     - id: 54
       request:
         proto: HTTP/1.1
@@ -2827,7 +2827,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2836,7 +2836,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e46ccde0-ac31-4234-9208-ff8bd37211dc
+                - e8eeb3d9-85fb-4c5d-9b3d-4618d680fb6e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2844,8 +2844,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154703Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?tagging=
+                - 20260513T074819Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2855,21 +2855,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg2b2f770f5dfe48858005-006a034b77</RequestId><HostId>txg2b2f770f5dfe48858005-006a034b77</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg72c1ae4dec0c4c9c8b1e-006a042cc3</RequestId><HostId>txg72c1ae4dec0c4c9c8b1e-006a042cc3</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:03 GMT
+                - Wed, 13 May 2026 07:48:19 GMT
             X-Amz-Id-2:
-                - txg2b2f770f5dfe48858005-006a034b77
+                - txg72c1ae4dec0c4c9c8b1e-006a042cc3
             X-Amz-Request-Id:
-                - txg2b2f770f5dfe48858005-006a034b77
+                - txg72c1ae4dec0c4c9c8b1e-006a042cc3
         status: 404 Not Found
         code: 404
-        duration: 42.157542ms
+        duration: 26.214875ms
     - id: 55
       request:
         proto: HTTP/1.1
@@ -2878,7 +2878,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2887,7 +2887,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 6a058e0d-327d-4aac-94f3-35b4cf15f193
+                - 4733cb84-29ec-4fd3-a7a3-fcd2dac77d77
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2895,8 +2895,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154703Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?cors=
+                - 20260513T074819Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2906,21 +2906,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgc99e0d518ed042699a81-006a034b77</RequestId><HostId>txgc99e0d518ed042699a81-006a034b77</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg1338f499d55c4f92b816-006a042cc3</RequestId><HostId>txg1338f499d55c4f92b816-006a042cc3</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:03 GMT
+                - Wed, 13 May 2026 07:48:19 GMT
             X-Amz-Id-2:
-                - txgc99e0d518ed042699a81-006a034b77
+                - txg1338f499d55c4f92b816-006a042cc3
             X-Amz-Request-Id:
-                - txgc99e0d518ed042699a81-006a034b77
+                - txg1338f499d55c4f92b816-006a042cc3
         status: 404 Not Found
         code: 404
-        duration: 56.858833ms
+        duration: 38.600417ms
     - id: 56
       request:
         proto: HTTP/1.1
@@ -2929,7 +2929,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2938,7 +2938,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 8b9aa2c8-256d-4e9f-986c-0ff97f82a2fa
+                - e96d9ff6-5466-4571-82ec-1b3c9240d894
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2946,8 +2946,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154703Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?versioning=
+                - 20260513T074819Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2966,14 +2966,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:03 GMT
+                - Wed, 13 May 2026 07:48:19 GMT
             X-Amz-Id-2:
-                - txgd25338b2180548c2a9d7-006a034b77
+                - txg1d3ea7ea45ad4be0b4d7-006a042cc3
             X-Amz-Request-Id:
-                - txgd25338b2180548c2a9d7-006a034b77
+                - txg1d3ea7ea45ad4be0b4d7-006a042cc3
         status: 200 OK
         code: 200
-        duration: 20.290917ms
+        duration: 18.686542ms
     - id: 57
       request:
         proto: HTTP/1.1
@@ -2982,7 +2982,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2991,7 +2991,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 09d75c91-4159-4200-b3be-78d3b3dd59c4
+                - f4e0a111-a3ef-4025-8210-fd9b8e03b035
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2999,8 +2999,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154703Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260513T074819Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3012,21 +3012,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
                 - "1105"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:03 GMT
+                - Wed, 13 May 2026 07:48:19 GMT
             X-Amz-Id-2:
-                - txgbae88f2d702247a699d0-006a034b77
+                - txgd25ad196abd0416c80bf-006a042cc3
             X-Amz-Request-Id:
-                - txgbae88f2d702247a699d0-006a034b77
+                - txgd25ad196abd0416c80bf-006a042cc3
         status: 200 OK
         code: 200
-        duration: 50.915042ms
+        duration: 18.793083ms
     - id: 58
       request:
         proto: HTTP/1.1
@@ -3035,7 +3035,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3044,7 +3044,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e2dcd1a8-1f25-4560-a08d-9ff9eaa9efcc
+                - e6f5cc1a-bb6d-4b4d-93e8-40f2dd68c1ab
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3052,8 +3052,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154703Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
+                - 20260513T074819Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -3068,16 +3068,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:04 GMT
+                - Wed, 13 May 2026 07:48:19 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txg9a476ac55d4846949ab3-006a034b78
+                - txg74a18d8175ff4611a3cb-006a042cc3
             X-Amz-Request-Id:
-                - txg9a476ac55d4846949ab3-006a034b78
+                - txg74a18d8175ff4611a3cb-006a042cc3
         status: 200 OK
         code: 200
-        duration: 56.132375ms
+        duration: 49.725208ms
     - id: 59
       request:
         proto: HTTP/1.1
@@ -3086,7 +3086,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3095,7 +3095,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d840106e-8af4-419d-adb9-5c0d6d12b239
+                - 50095aee-cada-4256-867f-8efbd855239f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3103,8 +3103,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154704Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260513T074819Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3116,21 +3116,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
                 - "1105"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:04 GMT
+                - Wed, 13 May 2026 07:48:19 GMT
             X-Amz-Id-2:
-                - txg8dfce26d8e814532a9b3-006a034b78
+                - txg599b096dde6446dbbbf5-006a042cc3
             X-Amz-Request-Id:
-                - txg8dfce26d8e814532a9b3-006a034b78
+                - txg599b096dde6446dbbbf5-006a042cc3
         status: 200 OK
         code: 200
-        duration: 66.619917ms
+        duration: 76.08275ms
     - id: 60
       request:
         proto: HTTP/1.1
@@ -3139,7 +3139,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3148,7 +3148,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5fc0dd2c-df80-4232-8e6e-20d5c2be022c
+                - e085cada-78db-487d-8e9c-a08727ae010a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3156,8 +3156,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154704Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?acl=
+                - 20260513T074820Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3176,14 +3176,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:04 GMT
+                - Wed, 13 May 2026 07:48:20 GMT
             X-Amz-Id-2:
-                - txg0ace4c6a67cb4d289210-006a034b78
+                - txg4a0d111d1296422a8f93-006a042cc4
             X-Amz-Request-Id:
-                - txg0ace4c6a67cb4d289210-006a034b78
+                - txg4a0d111d1296422a8f93-006a042cc4
         status: 200 OK
         code: 200
-        duration: 138.402709ms
+        duration: 20.4895ms
     - id: 61
       request:
         proto: HTTP/1.1
@@ -3192,7 +3192,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3201,7 +3201,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5df87850-68cb-4199-9e87-64f86d84a51a
+                - 407a632a-8a77-469e-8fe9-f679bcc0cec5
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3209,8 +3209,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154704Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260513T074820Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3220,21 +3220,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg51b27713df6e4cb2b539-006a034b78</RequestId><HostId>txg51b27713df6e4cb2b539-006a034b78</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg9c31fb0b5d90437a9690-006a042cc4</RequestId><HostId>txg9c31fb0b5d90437a9690-006a042cc4</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:04 GMT
+                - Wed, 13 May 2026 07:48:20 GMT
             X-Amz-Id-2:
-                - txg51b27713df6e4cb2b539-006a034b78
+                - txg9c31fb0b5d90437a9690-006a042cc4
             X-Amz-Request-Id:
-                - txg51b27713df6e4cb2b539-006a034b78
+                - txg9c31fb0b5d90437a9690-006a042cc4
         status: 404 Not Found
         code: 404
-        duration: 22.031958ms
+        duration: 62.161541ms
     - id: 62
       request:
         proto: HTTP/1.1
@@ -3243,7 +3243,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3252,7 +3252,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 55bbc4f5-a183-46c5-80bb-4a693b5e6ed0
+                - 97811574-7bbf-4931-9b9e-06469cfdcc92
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3260,8 +3260,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154704Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
+                - 20260513T074820Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -3273,21 +3273,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:04 GMT
+                - Wed, 13 May 2026 07:48:20 GMT
             X-Amz-Id-2:
-                - txg6767769be67f4207845f-006a034b78
+                - txgd5dcd7ec2e03448eba06-006a042cc4
             X-Amz-Request-Id:
-                - txg6767769be67f4207845f-006a034b78
+                - txgd5dcd7ec2e03448eba06-006a042cc4
         status: 200 OK
         code: 200
-        duration: 79.470125ms
+        duration: 20.919042ms
     - id: 63
       request:
         proto: HTTP/1.1
@@ -3296,7 +3296,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3305,7 +3305,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 80f50981-6116-40bc-913b-bb61259beda7
+                - 25df477a-2ee9-4eb1-becb-b7f48384d3e3
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3313,8 +3313,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154704Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?tagging=
+                - 20260513T074820Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3324,21 +3324,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg47e2bcdcbe5549289ccd-006a034b78</RequestId><HostId>txg47e2bcdcbe5549289ccd-006a034b78</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg8772b1c804c843b4adf3-006a042cc4</RequestId><HostId>txg8772b1c804c843b4adf3-006a042cc4</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:04 GMT
+                - Wed, 13 May 2026 07:48:20 GMT
             X-Amz-Id-2:
-                - txg47e2bcdcbe5549289ccd-006a034b78
+                - txg8772b1c804c843b4adf3-006a042cc4
             X-Amz-Request-Id:
-                - txg47e2bcdcbe5549289ccd-006a034b78
+                - txg8772b1c804c843b4adf3-006a042cc4
         status: 404 Not Found
         code: 404
-        duration: 25.286584ms
+        duration: 50.272875ms
     - id: 64
       request:
         proto: HTTP/1.1
@@ -3347,7 +3347,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3356,7 +3356,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f4b8013e-998c-4f96-a9cb-c33dfd908383
+                - 2bbafd2f-6879-4dee-ba53-27e21907a7c6
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3364,8 +3364,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154704Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?cors=
+                - 20260513T074820Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3375,21 +3375,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgcfd2f144c36a44d6950c-006a034b78</RequestId><HostId>txgcfd2f144c36a44d6950c-006a034b78</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg375488a0268a4256a800-006a042cc4</RequestId><HostId>txg375488a0268a4256a800-006a042cc4</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:04 GMT
+                - Wed, 13 May 2026 07:48:20 GMT
             X-Amz-Id-2:
-                - txgcfd2f144c36a44d6950c-006a034b78
+                - txg375488a0268a4256a800-006a042cc4
             X-Amz-Request-Id:
-                - txgcfd2f144c36a44d6950c-006a034b78
+                - txg375488a0268a4256a800-006a042cc4
         status: 404 Not Found
         code: 404
-        duration: 75.754041ms
+        duration: 19.4435ms
     - id: 65
       request:
         proto: HTTP/1.1
@@ -3398,7 +3398,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3407,7 +3407,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 086ac3df-159f-4b1d-b650-8f3886a3c179
+                - 0ed58415-89c6-4bd0-9459-988c0ee534bd
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3415,8 +3415,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154704Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?versioning=
+                - 20260513T074820Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3435,14 +3435,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:04 GMT
+                - Wed, 13 May 2026 07:48:20 GMT
             X-Amz-Id-2:
-                - txgda4b88d335004948a9d1-006a034b78
+                - txgce08f4ef2c6c481088d9-006a042cc4
             X-Amz-Request-Id:
-                - txgda4b88d335004948a9d1-006a034b78
+                - txgce08f4ef2c6c481088d9-006a042cc4
         status: 200 OK
         code: 200
-        duration: 21.309708ms
+        duration: 51.809125ms
     - id: 66
       request:
         proto: HTTP/1.1
@@ -3451,7 +3451,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3460,7 +3460,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 507d73f8-505d-41f8-ba38-07efc00d4d36
+                - f9a6fe18-20d2-4ff1-b3c1-6715caad3e7a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3468,8 +3468,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154704Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260513T074820Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3481,21 +3481,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
                 - "1105"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:04 GMT
+                - Wed, 13 May 2026 07:48:20 GMT
             X-Amz-Id-2:
-                - txga4365cc18c01472b9bca-006a034b78
+                - txgfab97f5f4230426ca7d3-006a042cc4
             X-Amz-Request-Id:
-                - txga4365cc18c01472b9bca-006a034b78
+                - txgfab97f5f4230426ca7d3-006a042cc4
         status: 200 OK
         code: 200
-        duration: 25.505167ms
+        duration: 50.786542ms
     - id: 67
       request:
         proto: HTTP/1.1
@@ -3504,7 +3504,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3513,7 +3513,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0cf371fe-3883-40e8-8ff3-a4a812eaedb9
+                - 6f1bc441-c994-471e-acd1-687cb2ab3294
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3521,8 +3521,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154704Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?acl=
+                - 20260513T074820Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3541,14 +3541,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:04 GMT
+                - Wed, 13 May 2026 07:48:20 GMT
             X-Amz-Id-2:
-                - txg67bee90b48174342ba57-006a034b78
+                - txgac0b816622e94a33bb0c-006a042cc4
             X-Amz-Request-Id:
-                - txg67bee90b48174342ba57-006a034b78
+                - txgac0b816622e94a33bb0c-006a042cc4
         status: 200 OK
         code: 200
-        duration: 56.178375ms
+        duration: 49.54475ms
     - id: 68
       request:
         proto: HTTP/1.1
@@ -3557,7 +3557,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3566,7 +3566,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - eaaee6b9-8adf-42cf-b79a-69be64a169ee
+                - b8be9224-6a38-44fc-9c14-9e948a53fc8c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3574,8 +3574,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154704Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260513T074820Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3585,21 +3585,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg2d148f6d9911412a995c-006a034b79</RequestId><HostId>txg2d148f6d9911412a995c-006a034b79</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg47726daf41854d6d9f43-006a042cc4</RequestId><HostId>txg47726daf41854d6d9f43-006a042cc4</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:05 GMT
+                - Wed, 13 May 2026 07:48:20 GMT
             X-Amz-Id-2:
-                - txg2d148f6d9911412a995c-006a034b79
+                - txg47726daf41854d6d9f43-006a042cc4
             X-Amz-Request-Id:
-                - txg2d148f6d9911412a995c-006a034b79
+                - txg47726daf41854d6d9f43-006a042cc4
         status: 404 Not Found
         code: 404
-        duration: 30.552709ms
+        duration: 53.079375ms
     - id: 69
       request:
         proto: HTTP/1.1
@@ -3608,7 +3608,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3617,16 +3617,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b8e27334-2bde-461d-a156-975e925c5046
+                - eb9a25d5-01d0-4b42-801c-4ba2d60714a3
             Amz-Sdk-Request:
-                - attempt=1; max=3; ttl=20260512T175704Z
+                - attempt=1; max=3
             User-Agent:
                 - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154705Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
+                - 20260513T074820Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -3638,21 +3638,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:05 GMT
+                - Wed, 13 May 2026 07:48:20 GMT
             X-Amz-Id-2:
-                - txged1618ebb12a43c7a5e3-006a034b79
+                - txg299f3b19d44749d4ab66-006a042cc4
             X-Amz-Request-Id:
-                - txged1618ebb12a43c7a5e3-006a034b79
+                - txg299f3b19d44749d4ab66-006a042cc4
         status: 200 OK
         code: 200
-        duration: 78.917209ms
+        duration: 259.691292ms
     - id: 70
       request:
         proto: HTTP/1.1
@@ -3661,7 +3661,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3670,7 +3670,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 76607146-c31b-4e9e-bb85-69d74c496999
+                - deca9702-a689-4150-8474-ccc2703f408a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3678,8 +3678,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154705Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?tagging=
+                - 20260513T074820Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3689,21 +3689,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgfbdd404fe9ed4776bc6b-006a034b79</RequestId><HostId>txgfbdd404fe9ed4776bc6b-006a034b79</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgacaa4102bc16433b82a4-006a042cc5</RequestId><HostId>txgacaa4102bc16433b82a4-006a042cc5</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:05 GMT
+                - Wed, 13 May 2026 07:48:21 GMT
             X-Amz-Id-2:
-                - txgfbdd404fe9ed4776bc6b-006a034b79
+                - txgacaa4102bc16433b82a4-006a042cc5
             X-Amz-Request-Id:
-                - txgfbdd404fe9ed4776bc6b-006a034b79
+                - txgacaa4102bc16433b82a4-006a042cc5
         status: 404 Not Found
         code: 404
-        duration: 58.461125ms
+        duration: 19.710125ms
     - id: 71
       request:
         proto: HTTP/1.1
@@ -3712,7 +3712,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3721,7 +3721,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 01954971-39cf-4287-929b-80853f2f29bc
+                - c45956c7-034c-4e47-b630-43f1820f6f0a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3729,8 +3729,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154705Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?cors=
+                - 20260513T074821Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3740,21 +3740,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgea95c71319fe44e2bf9f-006a034b79</RequestId><HostId>txgea95c71319fe44e2bf9f-006a034b79</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg7006791408da47abb6c0-006a042cc5</RequestId><HostId>txg7006791408da47abb6c0-006a042cc5</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:05 GMT
+                - Wed, 13 May 2026 07:48:21 GMT
             X-Amz-Id-2:
-                - txgea95c71319fe44e2bf9f-006a034b79
+                - txg7006791408da47abb6c0-006a042cc5
             X-Amz-Request-Id:
-                - txgea95c71319fe44e2bf9f-006a034b79
+                - txg7006791408da47abb6c0-006a042cc5
         status: 404 Not Found
         code: 404
-        duration: 19.908708ms
+        duration: 22.71175ms
     - id: 72
       request:
         proto: HTTP/1.1
@@ -3763,7 +3763,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3772,7 +3772,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b91e7d23-70ca-4502-8196-7b6eb494977a
+                - 4c596297-2857-4b98-bca6-da6f8a94cdd7
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3780,8 +3780,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154705Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?versioning=
+                - 20260513T074821Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3800,14 +3800,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:05 GMT
+                - Wed, 13 May 2026 07:48:21 GMT
             X-Amz-Id-2:
-                - txgecd3a88ed9a54eddb4a5-006a034b79
+                - txg5c71dca9c97a4e839b75-006a042cc5
             X-Amz-Request-Id:
-                - txgecd3a88ed9a54eddb4a5-006a034b79
+                - txg5c71dca9c97a4e839b75-006a042cc5
         status: 200 OK
         code: 200
-        duration: 60.798083ms
+        duration: 46.447584ms
     - id: 73
       request:
         proto: HTTP/1.1
@@ -3816,7 +3816,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3825,7 +3825,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4c4874ed-1bc9-48bb-96a1-9a44beb043e8
+                - 15f6f5e3-7d2a-4a34-bab1-325aa070bf7f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3833,8 +3833,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154705Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260513T074821Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3846,21 +3846,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
                 - "1105"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:05 GMT
+                - Wed, 13 May 2026 07:48:21 GMT
             X-Amz-Id-2:
-                - txg8b29c7fb58b94266a981-006a034b79
+                - txg507fc652967548b5b002-006a042cc5
             X-Amz-Request-Id:
-                - txg8b29c7fb58b94266a981-006a034b79
+                - txg507fc652967548b5b002-006a042cc5
         status: 200 OK
         code: 200
-        duration: 36.367959ms
+        duration: 26.534583ms
     - id: 74
       request:
         proto: HTTP/1.1
@@ -3869,7 +3869,7 @@ interactions:
         content_length: 296
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
@@ -3878,7 +3878,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 303dfbef-79c3-439d-9673-2664a622f901
+                - e3f9ad81-b470-49aa-83e0-40184026caea
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
@@ -3890,8 +3890,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - 7756d51b786b61edff20b7957d22346417f85f71d19eeca0d6d28d6df7b15bbc
             X-Amz-Date:
-                - 20260512T154705Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260513T074821Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -3906,14 +3906,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 12 May 2026 15:47:05 GMT
+                - Wed, 13 May 2026 07:48:21 GMT
             X-Amz-Id-2:
-                - txgad48c4c5ee0b4fcd8d84-006a034b79
+                - txgd329469e8db64d608849-006a042cc5
             X-Amz-Request-Id:
-                - txgad48c4c5ee0b4fcd8d84-006a034b79
+                - txgd329469e8db64d608849-006a042cc5
         status: 200 OK
         code: 200
-        duration: 100.239875ms
+        duration: 64.367292ms
     - id: 75
       request:
         proto: HTTP/1.1
@@ -3922,7 +3922,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3931,7 +3931,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 8d7c63f9-03b9-4641-8bd9-e84f6aea6242
+                - 2b626ac6-c9ec-4d89-91a4-951b7c8cba9c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3939,8 +3939,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154705Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?acl=
+                - 20260513T074821Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3959,14 +3959,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:05 GMT
+                - Wed, 13 May 2026 07:48:21 GMT
             X-Amz-Id-2:
-                - txg16593e0c781847eba055-006a034b79
+                - txg990f798e45834ec39fc5-006a042cc5
             X-Amz-Request-Id:
-                - txg16593e0c781847eba055-006a034b79
+                - txg990f798e45834ec39fc5-006a042cc5
         status: 200 OK
         code: 200
-        duration: 20.617792ms
+        duration: 34.432458ms
     - id: 76
       request:
         proto: HTTP/1.1
@@ -3975,7 +3975,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3984,7 +3984,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5d6f8c3e-3cb0-4949-a3f2-b1b86e158da4
+                - d2a6a5c8-2e43-4c80-b3be-766e8d6595ba
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3992,8 +3992,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154705Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260513T074821Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4003,21 +4003,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg0d896dfcdeaa4ad39f04-006a034b79</RequestId><HostId>txg0d896dfcdeaa4ad39f04-006a034b79</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgb90791856c8e460b912d-006a042cc5</RequestId><HostId>txgb90791856c8e460b912d-006a042cc5</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:05 GMT
+                - Wed, 13 May 2026 07:48:21 GMT
             X-Amz-Id-2:
-                - txg0d896dfcdeaa4ad39f04-006a034b79
+                - txgb90791856c8e460b912d-006a042cc5
             X-Amz-Request-Id:
-                - txg0d896dfcdeaa4ad39f04-006a034b79
+                - txgb90791856c8e460b912d-006a042cc5
         status: 404 Not Found
         code: 404
-        duration: 61.250834ms
+        duration: 61.341334ms
     - id: 77
       request:
         proto: HTTP/1.1
@@ -4026,7 +4026,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4035,7 +4035,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b055261f-a253-43e8-bcee-9dd5b860f073
+                - 417f36bf-06c0-4452-8cac-d3491222ab8e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4043,8 +4043,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154705Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
+                - 20260513T074821Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -4056,21 +4056,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:05 GMT
+                - Wed, 13 May 2026 07:48:21 GMT
             X-Amz-Id-2:
-                - txg56b2efce45464f268e32-006a034b79
+                - txg40a228eb542942b3a668-006a042cc5
             X-Amz-Request-Id:
-                - txg56b2efce45464f268e32-006a034b79
+                - txg40a228eb542942b3a668-006a042cc5
         status: 200 OK
         code: 200
-        duration: 67.498583ms
+        duration: 89.903084ms
     - id: 78
       request:
         proto: HTTP/1.1
@@ -4079,7 +4079,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4088,7 +4088,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 6473e15b-0994-4707-87b3-b25a3ddea88e
+                - 18ac0952-d34b-4d14-87a1-06ae3a60ced6
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4096,8 +4096,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154705Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?tagging=
+                - 20260513T074821Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4107,21 +4107,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg3f21a883735348dcbbac-006a034b79</RequestId><HostId>txg3f21a883735348dcbbac-006a034b79</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txga7c0a2c1c30b4419a7e4-006a042cc5</RequestId><HostId>txga7c0a2c1c30b4419a7e4-006a042cc5</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:05 GMT
+                - Wed, 13 May 2026 07:48:21 GMT
             X-Amz-Id-2:
-                - txg3f21a883735348dcbbac-006a034b79
+                - txga7c0a2c1c30b4419a7e4-006a042cc5
             X-Amz-Request-Id:
-                - txg3f21a883735348dcbbac-006a034b79
+                - txga7c0a2c1c30b4419a7e4-006a042cc5
         status: 404 Not Found
         code: 404
-        duration: 36.2405ms
+        duration: 37.44725ms
     - id: 79
       request:
         proto: HTTP/1.1
@@ -4130,7 +4130,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4139,7 +4139,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 1097086b-f793-4733-bec4-babac789e2ff
+                - 8a8d8775-202d-40dc-8cb6-345a96471b4d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4147,8 +4147,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154705Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?cors=
+                - 20260513T074821Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4158,21 +4158,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgc2969a2e212846f497ca-006a034b79</RequestId><HostId>txgc2969a2e212846f497ca-006a034b79</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg6341274c3ba9448b8cc9-006a042cc5</RequestId><HostId>txg6341274c3ba9448b8cc9-006a042cc5</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:05 GMT
+                - Wed, 13 May 2026 07:48:21 GMT
             X-Amz-Id-2:
-                - txgc2969a2e212846f497ca-006a034b79
+                - txg6341274c3ba9448b8cc9-006a042cc5
             X-Amz-Request-Id:
-                - txgc2969a2e212846f497ca-006a034b79
+                - txg6341274c3ba9448b8cc9-006a042cc5
         status: 404 Not Found
         code: 404
-        duration: 70.816375ms
+        duration: 50.196875ms
     - id: 80
       request:
         proto: HTTP/1.1
@@ -4181,7 +4181,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4190,7 +4190,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 153e49be-172e-42e8-970b-674189ac3225
+                - 247909df-9989-467d-91f0-6b08140ac095
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4198,8 +4198,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154705Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?versioning=
+                - 20260513T074821Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4218,14 +4218,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:05 GMT
+                - Wed, 13 May 2026 07:48:21 GMT
             X-Amz-Id-2:
-                - txgbc6be79045214965a1c3-006a034b79
+                - txg427204cd34a8432da1e8-006a042cc5
             X-Amz-Request-Id:
-                - txgbc6be79045214965a1c3-006a034b79
+                - txg427204cd34a8432da1e8-006a042cc5
         status: 200 OK
         code: 200
-        duration: 73.37675ms
+        duration: 51.505291ms
     - id: 81
       request:
         proto: HTTP/1.1
@@ -4234,7 +4234,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4243,7 +4243,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 900a4980-2c73-4606-9c6f-4b859253cb36
+                - c222d532-8098-401f-8778-bb31b879976a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4251,8 +4251,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154705Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260513T074821Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4271,14 +4271,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:05 GMT
+                - Wed, 13 May 2026 07:48:21 GMT
             X-Amz-Id-2:
-                - txg96adcf3e53374837a6db-006a034b79
+                - txgfa327537947448ff9976-006a042cc5
             X-Amz-Request-Id:
-                - txg96adcf3e53374837a6db-006a034b79
+                - txgfa327537947448ff9976-006a042cc5
         status: 200 OK
         code: 200
-        duration: 43.584708ms
+        duration: 50.43475ms
     - id: 82
       request:
         proto: HTTP/1.1
@@ -4287,7 +4287,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4296,7 +4296,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 1c78eb30-039d-4292-ac08-51f34eae1106
+                - 0e29c93e-74d8-4dae-9504-eb37d3fd4822
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4304,8 +4304,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154706Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
+                - 20260513T074821Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -4320,16 +4320,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:06 GMT
+                - Wed, 13 May 2026 07:48:21 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txg1b0a7d791b9c4ce28d9e-006a034b7a
+                - txgb203caa6d923422693d9-006a042cc5
             X-Amz-Request-Id:
-                - txg1b0a7d791b9c4ce28d9e-006a034b7a
+                - txgb203caa6d923422693d9-006a042cc5
         status: 200 OK
         code: 200
-        duration: 19.17275ms
+        duration: 33.996167ms
     - id: 83
       request:
         proto: HTTP/1.1
@@ -4338,7 +4338,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4347,7 +4347,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - a225c2c7-4456-4340-95c7-65d7a82f6f2c
+                - b4d47dc1-1dc3-499d-9644-504f509ab220
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4355,8 +4355,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154706Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260513T074821Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4375,14 +4375,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:06 GMT
+                - Wed, 13 May 2026 07:48:21 GMT
             X-Amz-Id-2:
-                - txgc1a2223529d640e8ac05-006a034b7a
+                - txg588929aba6a94204a073-006a042cc5
             X-Amz-Request-Id:
-                - txgc1a2223529d640e8ac05-006a034b7a
+                - txg588929aba6a94204a073-006a042cc5
         status: 200 OK
         code: 200
-        duration: 43.666208ms
+        duration: 35.7095ms
     - id: 84
       request:
         proto: HTTP/1.1
@@ -4391,7 +4391,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4400,7 +4400,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 436e94d3-ca19-49b2-aa11-90bf360811fa
+                - 237b5112-146c-41b1-af7c-fd61e24b3675
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4408,8 +4408,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154706Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?acl=
+                - 20260513T074822Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4428,14 +4428,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:06 GMT
+                - Wed, 13 May 2026 07:48:22 GMT
             X-Amz-Id-2:
-                - txgb40e59535078462fb730-006a034b7a
+                - txgc479f8070a2e43c8bab4-006a042cc6
             X-Amz-Request-Id:
-                - txgb40e59535078462fb730-006a034b7a
+                - txgc479f8070a2e43c8bab4-006a042cc6
         status: 200 OK
         code: 200
-        duration: 21.139167ms
+        duration: 22.978917ms
     - id: 85
       request:
         proto: HTTP/1.1
@@ -4444,7 +4444,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4453,7 +4453,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 8fc7736f-e1bd-4ab9-b181-f6b80c60fcf6
+                - 5485dd19-dfa8-42d6-a877-a7c213c65261
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4461,8 +4461,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154706Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260513T074822Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4472,21 +4472,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgef42905edbe4463082ae-006a034b7a</RequestId><HostId>txgef42905edbe4463082ae-006a034b7a</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgff81dea521064a44a5c1-006a042cc6</RequestId><HostId>txgff81dea521064a44a5c1-006a042cc6</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:06 GMT
+                - Wed, 13 May 2026 07:48:22 GMT
             X-Amz-Id-2:
-                - txgef42905edbe4463082ae-006a034b7a
+                - txgff81dea521064a44a5c1-006a042cc6
             X-Amz-Request-Id:
-                - txgef42905edbe4463082ae-006a034b7a
+                - txgff81dea521064a44a5c1-006a042cc6
         status: 404 Not Found
         code: 404
-        duration: 20.698209ms
+        duration: 19.397458ms
     - id: 86
       request:
         proto: HTTP/1.1
@@ -4495,7 +4495,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4504,7 +4504,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - dcc85190-988c-41d9-83a2-a7038da11f44
+                - 70f20393-c6f6-4c57-a1b2-80029d7d6fc4
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4512,8 +4512,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154706Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
+                - 20260513T074822Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -4525,21 +4525,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:06 GMT
+                - Wed, 13 May 2026 07:48:22 GMT
             X-Amz-Id-2:
-                - txg6281307e436a47e591e8-006a034b7a
+                - txg092a709f79934270ba9e-006a042cc6
             X-Amz-Request-Id:
-                - txg6281307e436a47e591e8-006a034b7a
+                - txg092a709f79934270ba9e-006a042cc6
         status: 200 OK
         code: 200
-        duration: 21.981583ms
+        duration: 37.547042ms
     - id: 87
       request:
         proto: HTTP/1.1
@@ -4548,7 +4548,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4557,7 +4557,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 53670e98-5807-45f5-955a-71f2bf1998e2
+                - e2d457b8-bb66-476f-8a88-dd091b790c2f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4565,8 +4565,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154706Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?tagging=
+                - 20260513T074822Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4576,21 +4576,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg1e1ba3773fe34e79b27b-006a034b7a</RequestId><HostId>txg1e1ba3773fe34e79b27b-006a034b7a</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txge578e4e15d834f93a785-006a042cc6</RequestId><HostId>txge578e4e15d834f93a785-006a042cc6</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:06 GMT
+                - Wed, 13 May 2026 07:48:22 GMT
             X-Amz-Id-2:
-                - txg1e1ba3773fe34e79b27b-006a034b7a
+                - txge578e4e15d834f93a785-006a042cc6
             X-Amz-Request-Id:
-                - txg1e1ba3773fe34e79b27b-006a034b7a
+                - txge578e4e15d834f93a785-006a042cc6
         status: 404 Not Found
         code: 404
-        duration: 32.208375ms
+        duration: 124.006709ms
     - id: 88
       request:
         proto: HTTP/1.1
@@ -4599,7 +4599,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4608,7 +4608,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b7835634-da8e-4a53-963d-8b45b213d9c8
+                - 5eb39bb1-7b5c-4463-91d5-d8c045242dad
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4616,8 +4616,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154706Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?cors=
+                - 20260513T074822Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4627,21 +4627,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg44ac71b4f1ab442fb5ea-006a034b7a</RequestId><HostId>txg44ac71b4f1ab442fb5ea-006a034b7a</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg405caa180364435eb404-006a042cc6</RequestId><HostId>txg405caa180364435eb404-006a042cc6</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:06 GMT
+                - Wed, 13 May 2026 07:48:22 GMT
             X-Amz-Id-2:
-                - txg44ac71b4f1ab442fb5ea-006a034b7a
+                - txg405caa180364435eb404-006a042cc6
             X-Amz-Request-Id:
-                - txg44ac71b4f1ab442fb5ea-006a034b7a
+                - txg405caa180364435eb404-006a042cc6
         status: 404 Not Found
         code: 404
-        duration: 50.846208ms
+        duration: 47.394458ms
     - id: 89
       request:
         proto: HTTP/1.1
@@ -4650,7 +4650,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4659,7 +4659,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 06cf3152-61ce-4912-a73b-0d3d1c255b55
+                - e63e2381-f2d8-4f4d-ab12-7cc2d6a9e460
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4667,8 +4667,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154706Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?versioning=
+                - 20260513T074822Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4687,14 +4687,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:06 GMT
+                - Wed, 13 May 2026 07:48:22 GMT
             X-Amz-Id-2:
-                - txg8db6485121844948a40a-006a034b7a
+                - txg2404869d6420487ead38-006a042cc6
             X-Amz-Request-Id:
-                - txg8db6485121844948a40a-006a034b7a
+                - txg2404869d6420487ead38-006a042cc6
         status: 200 OK
         code: 200
-        duration: 45.465958ms
+        duration: 59.127125ms
     - id: 90
       request:
         proto: HTTP/1.1
@@ -4703,7 +4703,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4712,7 +4712,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 19509278-e706-42e9-88dd-66f4e4bf020c
+                - 35cfd616-8f43-4e4f-bdf7-33322cfea378
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4720,8 +4720,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154706Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260513T074822Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4740,14 +4740,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:06 GMT
+                - Wed, 13 May 2026 07:48:22 GMT
             X-Amz-Id-2:
-                - txgf32b8584deec4a5ca83d-006a034b7a
+                - txg6ea98a740d9b49f6a6e1-006a042cc6
             X-Amz-Request-Id:
-                - txgf32b8584deec4a5ca83d-006a034b7a
+                - txg6ea98a740d9b49f6a6e1-006a042cc6
         status: 200 OK
         code: 200
-        duration: 21.93ms
+        duration: 59.483458ms
     - id: 91
       request:
         proto: HTTP/1.1
@@ -4756,7 +4756,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4765,7 +4765,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 14289a7b-5d39-4c01-a193-25eaf78721a3
+                - 60e7e851-bf67-4a9b-90b3-fd0deed9dbd2
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4773,8 +4773,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154706Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?acl=
+                - 20260513T074822Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4793,14 +4793,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:06 GMT
+                - Wed, 13 May 2026 07:48:22 GMT
             X-Amz-Id-2:
-                - txg255da69fb4ec45bda4ac-006a034b7a
+                - txg804ccec48e454eaa8625-006a042cc6
             X-Amz-Request-Id:
-                - txg255da69fb4ec45bda4ac-006a034b7a
+                - txg804ccec48e454eaa8625-006a042cc6
         status: 200 OK
         code: 200
-        duration: 19.666583ms
+        duration: 21.535958ms
     - id: 92
       request:
         proto: HTTP/1.1
@@ -4809,7 +4809,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4818,7 +4818,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 87db652b-620e-4b43-ad70-06191bb2570d
+                - ad891575-0e4e-4aa5-aaed-dcb579c77bc2
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4826,8 +4826,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154706Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260513T074822Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4837,21 +4837,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg075fa1072cda4a08b8c4-006a034b7a</RequestId><HostId>txg075fa1072cda4a08b8c4-006a034b7a</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg5a28f6ffcb44434fb7eb-006a042cc6</RequestId><HostId>txg5a28f6ffcb44434fb7eb-006a042cc6</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:06 GMT
+                - Wed, 13 May 2026 07:48:22 GMT
             X-Amz-Id-2:
-                - txg075fa1072cda4a08b8c4-006a034b7a
+                - txg5a28f6ffcb44434fb7eb-006a042cc6
             X-Amz-Request-Id:
-                - txg075fa1072cda4a08b8c4-006a034b7a
+                - txg5a28f6ffcb44434fb7eb-006a042cc6
         status: 404 Not Found
         code: 404
-        duration: 20.143542ms
+        duration: 19.862625ms
     - id: 93
       request:
         proto: HTTP/1.1
@@ -4860,7 +4860,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4869,7 +4869,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c143f784-af0b-4afe-9aae-77af3ebbe587
+                - 244ed135-2a47-4f9e-b624-eb3d47a8c363
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4877,8 +4877,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154706Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
+                - 20260513T074822Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -4890,21 +4890,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:06 GMT
+                - Wed, 13 May 2026 07:48:22 GMT
             X-Amz-Id-2:
-                - txg71902707b7ee4a9196ed-006a034b7a
+                - txg63e31bbd6ae543459be4-006a042cc6
             X-Amz-Request-Id:
-                - txg71902707b7ee4a9196ed-006a034b7a
+                - txg63e31bbd6ae543459be4-006a042cc6
         status: 200 OK
         code: 200
-        duration: 20.245791ms
+        duration: 51.639625ms
     - id: 94
       request:
         proto: HTTP/1.1
@@ -4913,7 +4913,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4922,7 +4922,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 890268b7-e67b-40cc-8c14-89e7fbc21d61
+                - 0d53ff14-096c-4e2c-a9d0-5d647970667a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4930,8 +4930,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154706Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?tagging=
+                - 20260513T074822Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4941,21 +4941,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg50e7ce250e99457eb6e2-006a034b7a</RequestId><HostId>txg50e7ce250e99457eb6e2-006a034b7a</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg1a47f2e86c914d14b7ca-006a042cc6</RequestId><HostId>txg1a47f2e86c914d14b7ca-006a042cc6</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:06 GMT
+                - Wed, 13 May 2026 07:48:22 GMT
             X-Amz-Id-2:
-                - txg50e7ce250e99457eb6e2-006a034b7a
+                - txg1a47f2e86c914d14b7ca-006a042cc6
             X-Amz-Request-Id:
-                - txg50e7ce250e99457eb6e2-006a034b7a
+                - txg1a47f2e86c914d14b7ca-006a042cc6
         status: 404 Not Found
         code: 404
-        duration: 25.601917ms
+        duration: 34.929791ms
     - id: 95
       request:
         proto: HTTP/1.1
@@ -4964,7 +4964,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4973,7 +4973,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 6da42284-d111-472a-929a-d8e89749079f
+                - 499fb7c7-68df-4d25-b0b3-7ddd15643953
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4981,8 +4981,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154706Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?cors=
+                - 20260513T074822Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4992,21 +4992,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg0b94b3217db1489e925d-006a034b7a</RequestId><HostId>txg0b94b3217db1489e925d-006a034b7a</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg88986618cb2b44de9318-006a042cc6</RequestId><HostId>txg88986618cb2b44de9318-006a042cc6</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:06 GMT
+                - Wed, 13 May 2026 07:48:22 GMT
             X-Amz-Id-2:
-                - txg0b94b3217db1489e925d-006a034b7a
+                - txg88986618cb2b44de9318-006a042cc6
             X-Amz-Request-Id:
-                - txg0b94b3217db1489e925d-006a034b7a
+                - txg88986618cb2b44de9318-006a042cc6
         status: 404 Not Found
         code: 404
-        duration: 19.295166ms
+        duration: 18.928667ms
     - id: 96
       request:
         proto: HTTP/1.1
@@ -5015,7 +5015,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5024,7 +5024,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 99fb80f7-2363-4041-8bd2-a9456ab312a1
+                - 6090b13b-efce-43d8-ab58-f8e8f3d0a9c0
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5032,8 +5032,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154706Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?versioning=
+                - 20260513T074822Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5052,14 +5052,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:06 GMT
+                - Wed, 13 May 2026 07:48:22 GMT
             X-Amz-Id-2:
-                - txg8b7597495f1448bcbf02-006a034b7a
+                - txga706be90af5e492a971e-006a042cc6
             X-Amz-Request-Id:
-                - txg8b7597495f1448bcbf02-006a034b7a
+                - txga706be90af5e492a971e-006a042cc6
         status: 200 OK
         code: 200
-        duration: 20.293958ms
+        duration: 50.972125ms
     - id: 97
       request:
         proto: HTTP/1.1
@@ -5068,7 +5068,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5077,7 +5077,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0ab3f3c2-b40c-408d-aecc-bd6c717ea12e
+                - 167b3bf0-39f7-4ca7-a815-5378a9d75825
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5085,8 +5085,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154706Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260513T074822Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5105,14 +5105,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:06 GMT
+                - Wed, 13 May 2026 07:48:22 GMT
             X-Amz-Id-2:
-                - txga5162fe7c2fc4d24b376-006a034b7a
+                - txgc3217b0616ae469dabe7-006a042cc6
             X-Amz-Request-Id:
-                - txga5162fe7c2fc4d24b376-006a034b7a
+                - txgc3217b0616ae469dabe7-006a042cc6
         status: 200 OK
         code: 200
-        duration: 27.648083ms
+        duration: 26.402916ms
     - id: 98
       request:
         proto: HTTP/1.1
@@ -5121,7 +5121,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5130,7 +5130,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - bb1e97c2-4a21-47f9-bceb-cd53792c4de2
+                - 4d792364-a129-434c-b76c-c07ba5166e42
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5138,8 +5138,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154707Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
+                - 20260513T074823Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -5154,16 +5154,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:07 GMT
+                - Wed, 13 May 2026 07:48:23 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txg4378dd509650419d8af4-006a034b7b
+                - txg299f201b5bb546c4a3f0-006a042cc7
             X-Amz-Request-Id:
-                - txg4378dd509650419d8af4-006a034b7b
+                - txg299f201b5bb546c4a3f0-006a042cc7
         status: 200 OK
         code: 200
-        duration: 87.27375ms
+        duration: 73.25675ms
     - id: 99
       request:
         proto: HTTP/1.1
@@ -5172,7 +5172,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5181,7 +5181,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e77c7dec-c083-41cd-be00-cf2c35d10c62
+                - 99c63966-ff11-482b-ac1b-83bc4cb0c101
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5189,8 +5189,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154707Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260513T074823Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5209,14 +5209,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:07 GMT
+                - Wed, 13 May 2026 07:48:23 GMT
             X-Amz-Id-2:
-                - txgceed02aa0ce14033ae2c-006a034b7b
+                - txg1c819f3ba809428cb14f-006a042cc7
             X-Amz-Request-Id:
-                - txgceed02aa0ce14033ae2c-006a034b7b
+                - txg1c819f3ba809428cb14f-006a042cc7
         status: 200 OK
         code: 200
-        duration: 61.121833ms
+        duration: 53.568709ms
     - id: 100
       request:
         proto: HTTP/1.1
@@ -5225,7 +5225,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5234,7 +5234,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d2ee8bf5-dc00-4564-8b10-bd930571d5bb
+                - 9c9ddf69-712f-4086-aafd-2609601277aa
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5242,8 +5242,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154707Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?acl=
+                - 20260513T074823Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5262,14 +5262,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:07 GMT
+                - Wed, 13 May 2026 07:48:23 GMT
             X-Amz-Id-2:
-                - txg504b0302b1c84ee6bd2e-006a034b7b
+                - txga56cf04b7a4046ae927c-006a042cc7
             X-Amz-Request-Id:
-                - txg504b0302b1c84ee6bd2e-006a034b7b
+                - txga56cf04b7a4046ae927c-006a042cc7
         status: 200 OK
         code: 200
-        duration: 30.681167ms
+        duration: 60.942125ms
     - id: 101
       request:
         proto: HTTP/1.1
@@ -5278,7 +5278,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5287,7 +5287,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7f8f3c4a-221c-4acd-b570-ca8ad2d41a47
+                - 894cb037-01ce-4619-9e27-735db1d306a9
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5295,8 +5295,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154707Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260513T074823Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5306,21 +5306,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg5efa41181bfd4822b4e8-006a034b7b</RequestId><HostId>txg5efa41181bfd4822b4e8-006a034b7b</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg0423504459ea48a88fb0-006a042cc7</RequestId><HostId>txg0423504459ea48a88fb0-006a042cc7</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:07 GMT
+                - Wed, 13 May 2026 07:48:23 GMT
             X-Amz-Id-2:
-                - txg5efa41181bfd4822b4e8-006a034b7b
+                - txg0423504459ea48a88fb0-006a042cc7
             X-Amz-Request-Id:
-                - txg5efa41181bfd4822b4e8-006a034b7b
+                - txg0423504459ea48a88fb0-006a042cc7
         status: 404 Not Found
         code: 404
-        duration: 45.480417ms
+        duration: 19.586125ms
     - id: 102
       request:
         proto: HTTP/1.1
@@ -5329,7 +5329,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5338,7 +5338,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 3f00f552-8c09-4c79-a25e-f9b541dad67b
+                - 25b8a87b-c0a1-47ad-a0a0-fe86535e5de3
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5346,8 +5346,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154707Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
+                - 20260513T074823Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -5359,21 +5359,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:07 GMT
+                - Wed, 13 May 2026 07:48:23 GMT
             X-Amz-Id-2:
-                - txg465b652409584831aed5-006a034b7b
+                - txga69061d8c50243e78c29-006a042cc7
             X-Amz-Request-Id:
-                - txg465b652409584831aed5-006a034b7b
+                - txga69061d8c50243e78c29-006a042cc7
         status: 200 OK
         code: 200
-        duration: 28.929584ms
+        duration: 20.13575ms
     - id: 103
       request:
         proto: HTTP/1.1
@@ -5382,7 +5382,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5391,7 +5391,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 46afc62b-9287-47b7-9a2a-a0fae29a6786
+                - 90bb1ada-e14a-4c8b-b2c2-2abd88d773d9
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5399,8 +5399,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154707Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?tagging=
+                - 20260513T074823Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5410,21 +5410,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgba1ed0e2c5b04e54a800-006a034b7b</RequestId><HostId>txgba1ed0e2c5b04e54a800-006a034b7b</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg2698a7efcb184188bd60-006a042cc7</RequestId><HostId>txg2698a7efcb184188bd60-006a042cc7</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:07 GMT
+                - Wed, 13 May 2026 07:48:23 GMT
             X-Amz-Id-2:
-                - txgba1ed0e2c5b04e54a800-006a034b7b
+                - txg2698a7efcb184188bd60-006a042cc7
             X-Amz-Request-Id:
-                - txgba1ed0e2c5b04e54a800-006a034b7b
+                - txg2698a7efcb184188bd60-006a042cc7
         status: 404 Not Found
         code: 404
-        duration: 102.796667ms
+        duration: 21.500708ms
     - id: 104
       request:
         proto: HTTP/1.1
@@ -5433,7 +5433,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5442,7 +5442,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 537c5840-5e57-438c-ab5f-babe03504a3e
+                - 15dd2fdc-da42-42c9-9796-9897b840786d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5450,8 +5450,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154707Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?cors=
+                - 20260513T074823Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5461,21 +5461,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg1dfa80e8241041afb09e-006a034b7b</RequestId><HostId>txg1dfa80e8241041afb09e-006a034b7b</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg2c96aa05715144e8996f-006a042cc7</RequestId><HostId>txg2c96aa05715144e8996f-006a042cc7</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:07 GMT
+                - Wed, 13 May 2026 07:48:23 GMT
             X-Amz-Id-2:
-                - txg1dfa80e8241041afb09e-006a034b7b
+                - txg2c96aa05715144e8996f-006a042cc7
             X-Amz-Request-Id:
-                - txg1dfa80e8241041afb09e-006a034b7b
+                - txg2c96aa05715144e8996f-006a042cc7
         status: 404 Not Found
         code: 404
-        duration: 33.605166ms
+        duration: 31.157ms
     - id: 105
       request:
         proto: HTTP/1.1
@@ -5484,7 +5484,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5493,7 +5493,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 441de41e-ce76-4e00-85d6-3af556afd337
+                - 1a4975c1-73e1-4136-9974-2f2bd5bfe702
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5501,8 +5501,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154707Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?versioning=
+                - 20260513T074823Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5521,14 +5521,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:07 GMT
+                - Wed, 13 May 2026 07:48:23 GMT
             X-Amz-Id-2:
-                - txg30d37dc31aff44eb8b7e-006a034b7b
+                - txg633f6de82eef4b029bfd-006a042cc7
             X-Amz-Request-Id:
-                - txg30d37dc31aff44eb8b7e-006a034b7b
+                - txg633f6de82eef4b029bfd-006a042cc7
         status: 200 OK
         code: 200
-        duration: 27.858833ms
+        duration: 19.315625ms
     - id: 106
       request:
         proto: HTTP/1.1
@@ -5537,7 +5537,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5546,7 +5546,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 1dcd66b6-7abb-4fbc-862c-aebc32e74a09
+                - 89f0f673-a048-4989-9ffa-35e4e337be2c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5554,8 +5554,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154707Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260513T074823Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5574,14 +5574,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:07 GMT
+                - Wed, 13 May 2026 07:48:23 GMT
             X-Amz-Id-2:
-                - txgdefc28f8eddc44c6a3ef-006a034b7b
+                - txg59df72539b1f49f0986d-006a042cc7
             X-Amz-Request-Id:
-                - txgdefc28f8eddc44c6a3ef-006a034b7b
+                - txg59df72539b1f49f0986d-006a042cc7
         status: 200 OK
         code: 200
-        duration: 19.268083ms
+        duration: 57.857875ms
     - id: 107
       request:
         proto: HTTP/1.1
@@ -5590,7 +5590,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5599,7 +5599,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7bd4d0e4-0849-44cb-8826-ea63fca075ef
+                - 344040f2-4c91-48f5-9818-d2ec400b03fb
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5607,8 +5607,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154707Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?acl=
+                - 20260513T074823Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5627,14 +5627,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:08 GMT
+                - Wed, 13 May 2026 07:48:23 GMT
             X-Amz-Id-2:
-                - txg7952e843903a42c4b706-006a034b7c
+                - txg8100d4940ab740f6a68f-006a042cc7
             X-Amz-Request-Id:
-                - txg7952e843903a42c4b706-006a034b7c
+                - txg8100d4940ab740f6a68f-006a042cc7
         status: 200 OK
         code: 200
-        duration: 39.52025ms
+        duration: 19.225291ms
     - id: 108
       request:
         proto: HTTP/1.1
@@ -5643,7 +5643,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5652,16 +5652,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 942dc497-c54e-439f-b799-cd15ec6c8a87
+                - bb8e492b-ce0c-4b1e-9c33-4239b13949ca
             Amz-Sdk-Request:
-                - attempt=1; max=3; ttl=20260512T175707Z
+                - attempt=1; max=3
             User-Agent:
                 - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154708Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260513T074823Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5671,21 +5671,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgd08fdad9d3294671a61f-006a034b7c</RequestId><HostId>txgd08fdad9d3294671a61f-006a034b7c</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgef06b583e9e648bf9471-006a042cc7</RequestId><HostId>txgef06b583e9e648bf9471-006a042cc7</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:08 GMT
+                - Wed, 13 May 2026 07:48:23 GMT
             X-Amz-Id-2:
-                - txgd08fdad9d3294671a61f-006a034b7c
+                - txgef06b583e9e648bf9471-006a042cc7
             X-Amz-Request-Id:
-                - txgd08fdad9d3294671a61f-006a034b7c
+                - txgef06b583e9e648bf9471-006a042cc7
         status: 404 Not Found
         code: 404
-        duration: 52.261333ms
+        duration: 19.522292ms
     - id: 109
       request:
         proto: HTTP/1.1
@@ -5694,7 +5694,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5703,7 +5703,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 407cdb2c-1f34-4d62-bcb0-aa16db41bf38
+                - 4b02966e-61d4-45de-b08a-5d5dc3dcac42
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5711,8 +5711,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154708Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
+                - 20260513T074823Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -5724,21 +5724,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:08 GMT
+                - Wed, 13 May 2026 07:48:23 GMT
             X-Amz-Id-2:
-                - txg225812eaff0d400ca77f-006a034b7c
+                - txg83fcd0d44524421bb271-006a042cc7
             X-Amz-Request-Id:
-                - txg225812eaff0d400ca77f-006a034b7c
+                - txg83fcd0d44524421bb271-006a042cc7
         status: 200 OK
         code: 200
-        duration: 53.272708ms
+        duration: 49.002333ms
     - id: 110
       request:
         proto: HTTP/1.1
@@ -5747,7 +5747,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5756,7 +5756,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ae16543a-6a9f-4e11-aebd-81276a25f924
+                - 2dcce056-7558-465c-85eb-11824a92c26a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5764,8 +5764,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154708Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?tagging=
+                - 20260513T074823Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5775,21 +5775,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg4c068131a57d4ba79f4b-006a034b7c</RequestId><HostId>txg4c068131a57d4ba79f4b-006a034b7c</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg1bf50ea11c8a416b8f5c-006a042cc8</RequestId><HostId>txg1bf50ea11c8a416b8f5c-006a042cc8</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:08 GMT
+                - Wed, 13 May 2026 07:48:24 GMT
             X-Amz-Id-2:
-                - txg4c068131a57d4ba79f4b-006a034b7c
+                - txg1bf50ea11c8a416b8f5c-006a042cc8
             X-Amz-Request-Id:
-                - txg4c068131a57d4ba79f4b-006a034b7c
+                - txg1bf50ea11c8a416b8f5c-006a042cc8
         status: 404 Not Found
         code: 404
-        duration: 74.462917ms
+        duration: 19.678375ms
     - id: 111
       request:
         proto: HTTP/1.1
@@ -5798,7 +5798,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5807,7 +5807,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b83efc32-11b5-4e6f-a35c-428e2ae35f0d
+                - 0dd8e7fb-8596-493d-bd17-4f29d010c232
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5815,8 +5815,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154708Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?cors=
+                - 20260513T074824Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5826,21 +5826,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgea3843e34e424b3ba93d-006a034b7c</RequestId><HostId>txgea3843e34e424b3ba93d-006a034b7c</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgc36cf2f72c444913864b-006a042cc8</RequestId><HostId>txgc36cf2f72c444913864b-006a042cc8</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:08 GMT
+                - Wed, 13 May 2026 07:48:24 GMT
             X-Amz-Id-2:
-                - txgea3843e34e424b3ba93d-006a034b7c
+                - txgc36cf2f72c444913864b-006a042cc8
             X-Amz-Request-Id:
-                - txgea3843e34e424b3ba93d-006a034b7c
+                - txgc36cf2f72c444913864b-006a042cc8
         status: 404 Not Found
         code: 404
-        duration: 27.949583ms
+        duration: 19.733959ms
     - id: 112
       request:
         proto: HTTP/1.1
@@ -5849,7 +5849,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5858,7 +5858,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ef0c9f0d-a047-41bc-b166-6c240ee7c627
+                - 3c2263ce-589a-4e13-b943-a33ddad2cb89
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5866,8 +5866,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154708Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?versioning=
+                - 20260513T074824Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5886,14 +5886,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:08 GMT
+                - Wed, 13 May 2026 07:48:24 GMT
             X-Amz-Id-2:
-                - txgcbfc145e52cb4d19a3f5-006a034b7c
+                - txg3a675e17768b4d28b58f-006a042cc8
             X-Amz-Request-Id:
-                - txgcbfc145e52cb4d19a3f5-006a034b7c
+                - txg3a675e17768b4d28b58f-006a042cc8
         status: 200 OK
         code: 200
-        duration: 53.589416ms
+        duration: 19.672375ms
     - id: 113
       request:
         proto: HTTP/1.1
@@ -5902,7 +5902,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5911,7 +5911,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b333ab08-fe87-4897-b9ac-4c75b689affc
+                - c25c60d2-3b02-4ec8-9aa5-dab9d556df10
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5919,8 +5919,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154708Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260513T074824Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5939,14 +5939,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:08 GMT
+                - Wed, 13 May 2026 07:48:24 GMT
             X-Amz-Id-2:
-                - txgbf2f5e0f9f1646e39030-006a034b7c
+                - txgc9ee7b7318ed47f587c7-006a042cc8
             X-Amz-Request-Id:
-                - txgbf2f5e0f9f1646e39030-006a034b7c
+                - txgc9ee7b7318ed47f587c7-006a042cc8
         status: 200 OK
         code: 200
-        duration: 22.842709ms
+        duration: 50.865208ms
     - id: 114
       request:
         proto: HTTP/1.1
@@ -5955,7 +5955,7 @@ interactions:
         content_length: 284
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path1/</Prefix><Tag><Key>deleted</Key><Value>true</Value></Tag></And></Filter><ID>id1</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
@@ -5964,7 +5964,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 81f6f284-1fb3-428f-8b8c-fa940171c588
+                - 3b841a2d-0533-4ee9-863e-ed363a859656
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
@@ -5976,8 +5976,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - c66696878cc52fbe5f1b5468d871024fe4d94447494e4b1797bc44a183ccc313
             X-Amz-Date:
-                - 20260512T154708Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260513T074824Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -5992,14 +5992,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 12 May 2026 15:47:08 GMT
+                - Wed, 13 May 2026 07:48:24 GMT
             X-Amz-Id-2:
-                - txgc6abca8d5ff4409891f7-006a034b7c
+                - txg4b2eb4ffb15f485cb40f-006a042cc8
             X-Amz-Request-Id:
-                - txgc6abca8d5ff4409891f7-006a034b7c
+                - txg4b2eb4ffb15f485cb40f-006a042cc8
         status: 200 OK
         code: 200
-        duration: 138.811584ms
+        duration: 54.551125ms
     - id: 115
       request:
         proto: HTTP/1.1
@@ -6008,7 +6008,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6017,7 +6017,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - cf9c4743-1eca-4b1b-a655-5c69a4b02a7f
+                - ae568be5-ad8b-4b1b-9bbb-63a032ba28ad
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6025,8 +6025,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154708Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?acl=
+                - 20260513T074824Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6045,14 +6045,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:08 GMT
+                - Wed, 13 May 2026 07:48:24 GMT
             X-Amz-Id-2:
-                - txgb70b76429f394e8880fa-006a034b7c
+                - txgd2e7862d39c6488880b0-006a042cc8
             X-Amz-Request-Id:
-                - txgb70b76429f394e8880fa-006a034b7c
+                - txgd2e7862d39c6488880b0-006a042cc8
         status: 200 OK
         code: 200
-        duration: 22.111542ms
+        duration: 19.81875ms
     - id: 116
       request:
         proto: HTTP/1.1
@@ -6061,7 +6061,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6070,7 +6070,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 811a77ad-1824-4ad3-a370-975bf482c1a6
+                - 3de7e8a1-b7ab-45a8-b938-fb26b3bb80d1
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6078,8 +6078,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154708Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260513T074824Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6089,21 +6089,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg254cbaa29d7c495ba9f6-006a034b7c</RequestId><HostId>txg254cbaa29d7c495ba9f6-006a034b7c</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgb35d024a0e85448daa6b-006a042cc8</RequestId><HostId>txgb35d024a0e85448daa6b-006a042cc8</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:08 GMT
+                - Wed, 13 May 2026 07:48:24 GMT
             X-Amz-Id-2:
-                - txg254cbaa29d7c495ba9f6-006a034b7c
+                - txgb35d024a0e85448daa6b-006a042cc8
             X-Amz-Request-Id:
-                - txg254cbaa29d7c495ba9f6-006a034b7c
+                - txgb35d024a0e85448daa6b-006a042cc8
         status: 404 Not Found
         code: 404
-        duration: 21.297125ms
+        duration: 19.401417ms
     - id: 117
       request:
         proto: HTTP/1.1
@@ -6112,7 +6112,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6121,7 +6121,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - db1af36e-dccf-429e-a358-2f09943a806d
+                - 95ca7caf-9e95-4233-9b2e-659f03477aed
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6129,8 +6129,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154708Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
+                - 20260513T074824Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -6142,21 +6142,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:08 GMT
+                - Wed, 13 May 2026 07:48:24 GMT
             X-Amz-Id-2:
-                - txg6b84dacc0ac946fb89b9-006a034b7c
+                - txgdcff7c146a5c4f958510-006a042cc8
             X-Amz-Request-Id:
-                - txg6b84dacc0ac946fb89b9-006a034b7c
+                - txgdcff7c146a5c4f958510-006a042cc8
         status: 200 OK
         code: 200
-        duration: 41.770375ms
+        duration: 21.319917ms
     - id: 118
       request:
         proto: HTTP/1.1
@@ -6165,7 +6165,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6174,7 +6174,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0bbed266-5122-42ce-8c8e-3eb035e89115
+                - 43829665-8f48-4e43-baf0-13bf781b3acb
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6182,8 +6182,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154708Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?tagging=
+                - 20260513T074824Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6193,21 +6193,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg9a0c56f8703141afa552-006a034b7c</RequestId><HostId>txg9a0c56f8703141afa552-006a034b7c</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgeb6172da2b8a4353a841-006a042cc8</RequestId><HostId>txgeb6172da2b8a4353a841-006a042cc8</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:08 GMT
+                - Wed, 13 May 2026 07:48:24 GMT
             X-Amz-Id-2:
-                - txg9a0c56f8703141afa552-006a034b7c
+                - txgeb6172da2b8a4353a841-006a042cc8
             X-Amz-Request-Id:
-                - txg9a0c56f8703141afa552-006a034b7c
+                - txgeb6172da2b8a4353a841-006a042cc8
         status: 404 Not Found
         code: 404
-        duration: 55.146875ms
+        duration: 28.31075ms
     - id: 119
       request:
         proto: HTTP/1.1
@@ -6216,7 +6216,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6225,7 +6225,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 277d793a-ca61-412c-b070-d4a6e5ffac0a
+                - 0f6ca624-ef46-4bd4-b028-63d5e7ae6053
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6233,8 +6233,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154708Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?cors=
+                - 20260513T074824Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6244,21 +6244,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg8b98666b38de47879c82-006a034b7c</RequestId><HostId>txg8b98666b38de47879c82-006a034b7c</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txge8d3cceff37a41b78c47-006a042cc8</RequestId><HostId>txge8d3cceff37a41b78c47-006a042cc8</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:08 GMT
+                - Wed, 13 May 2026 07:48:24 GMT
             X-Amz-Id-2:
-                - txg8b98666b38de47879c82-006a034b7c
+                - txge8d3cceff37a41b78c47-006a042cc8
             X-Amz-Request-Id:
-                - txg8b98666b38de47879c82-006a034b7c
+                - txge8d3cceff37a41b78c47-006a042cc8
         status: 404 Not Found
         code: 404
-        duration: 38.834584ms
+        duration: 18.648625ms
     - id: 120
       request:
         proto: HTTP/1.1
@@ -6267,7 +6267,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6276,7 +6276,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 207f90dd-7609-4000-b0e3-a7b3cb870947
+                - efb978ec-bb42-4f76-adcb-81028ef43cbe
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6284,8 +6284,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154708Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?versioning=
+                - 20260513T074824Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6304,14 +6304,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:08 GMT
+                - Wed, 13 May 2026 07:48:24 GMT
             X-Amz-Id-2:
-                - txg99a339649aa34c2288b9-006a034b7c
+                - txge6e8d5fbcee54bb7bece-006a042cc8
             X-Amz-Request-Id:
-                - txg99a339649aa34c2288b9-006a034b7c
+                - txge6e8d5fbcee54bb7bece-006a042cc8
         status: 200 OK
         code: 200
-        duration: 21.658083ms
+        duration: 51.5015ms
     - id: 121
       request:
         proto: HTTP/1.1
@@ -6320,7 +6320,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6329,7 +6329,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0e221867-dd4c-4c29-81e0-a09cb0dcb331
+                - 2bf12149-3a69-4ff5-97bc-90d56b2aef74
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6337,8 +6337,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154708Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260513T074824Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6357,14 +6357,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:08 GMT
+                - Wed, 13 May 2026 07:48:24 GMT
             X-Amz-Id-2:
-                - txg067179c6914346c48002-006a034b7c
+                - txg15dd93800d0a4f0cbf91-006a042cc8
             X-Amz-Request-Id:
-                - txg067179c6914346c48002-006a034b7c
+                - txg15dd93800d0a4f0cbf91-006a042cc8
         status: 200 OK
         code: 200
-        duration: 63.83325ms
+        duration: 18.789208ms
     - id: 122
       request:
         proto: HTTP/1.1
@@ -6373,7 +6373,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6382,7 +6382,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e2ba9555-ceee-4a7b-80cd-c6612472911e
+                - 1fabfbd3-3cfa-4e07-9e34-8031d546cfb4
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6390,8 +6390,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154708Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
+                - 20260513T074824Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -6406,16 +6406,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:09 GMT
+                - Wed, 13 May 2026 07:48:24 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txgf77638c5b0e145648538-006a034b7d
+                - txgc9edf3f96fa948d1a3bb-006a042cc8
             X-Amz-Request-Id:
-                - txgf77638c5b0e145648538-006a034b7d
+                - txgc9edf3f96fa948d1a3bb-006a042cc8
         status: 200 OK
         code: 200
-        duration: 24.378792ms
+        duration: 36.026375ms
     - id: 123
       request:
         proto: HTTP/1.1
@@ -6424,7 +6424,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6433,7 +6433,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9d869781-7383-4244-962b-6395a43a0195
+                - 9bdc4548-d445-4ca4-9ca4-50826e7add9a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6441,8 +6441,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154708Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260513T074824Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6461,14 +6461,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:09 GMT
+                - Wed, 13 May 2026 07:48:24 GMT
             X-Amz-Id-2:
-                - txg43b75a6a144649618401-006a034b7d
+                - txg4d47909f228a4b9a8041-006a042cc8
             X-Amz-Request-Id:
-                - txg43b75a6a144649618401-006a034b7d
+                - txg4d47909f228a4b9a8041-006a042cc8
         status: 200 OK
         code: 200
-        duration: 71.79925ms
+        duration: 177.874625ms
     - id: 124
       request:
         proto: HTTP/1.1
@@ -6477,7 +6477,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6486,7 +6486,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 759e3c17-d3b1-401d-90c3-1fe3f11966bb
+                - 9b4375d2-6e96-45c9-83f7-3c2d24dd6423
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6494,8 +6494,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154709Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?acl=
+                - 20260513T074825Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6514,14 +6514,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:09 GMT
+                - Wed, 13 May 2026 07:48:25 GMT
             X-Amz-Id-2:
-                - txg51b1c339b8124e4aabf6-006a034b7d
+                - txg418f8e4d66a24692be94-006a042cc9
             X-Amz-Request-Id:
-                - txg51b1c339b8124e4aabf6-006a034b7d
+                - txg418f8e4d66a24692be94-006a042cc9
         status: 200 OK
         code: 200
-        duration: 19.411209ms
+        duration: 30.025709ms
     - id: 125
       request:
         proto: HTTP/1.1
@@ -6530,7 +6530,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6539,7 +6539,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5df630be-726b-4f28-8fc1-b6954f6c556f
+                - f8146d75-c220-489e-84f6-4d7282319229
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6547,8 +6547,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154709Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260513T074825Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6558,21 +6558,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg15b5e7a20a2f41fd8cf5-006a034b7d</RequestId><HostId>txg15b5e7a20a2f41fd8cf5-006a034b7d</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg2bc03a257fd84fd595e8-006a042cc9</RequestId><HostId>txg2bc03a257fd84fd595e8-006a042cc9</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:09 GMT
+                - Wed, 13 May 2026 07:48:25 GMT
             X-Amz-Id-2:
-                - txg15b5e7a20a2f41fd8cf5-006a034b7d
+                - txg2bc03a257fd84fd595e8-006a042cc9
             X-Amz-Request-Id:
-                - txg15b5e7a20a2f41fd8cf5-006a034b7d
+                - txg2bc03a257fd84fd595e8-006a042cc9
         status: 404 Not Found
         code: 404
-        duration: 19.411292ms
+        duration: 19.301542ms
     - id: 126
       request:
         proto: HTTP/1.1
@@ -6581,7 +6581,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6590,7 +6590,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d0114d20-afb9-4a8e-93dc-a32a36b42b53
+                - 2959f165-55fc-4e3e-b38e-79294cbbd21e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6598,8 +6598,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154709Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
+                - 20260513T074825Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -6611,21 +6611,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:09 GMT
+                - Wed, 13 May 2026 07:48:25 GMT
             X-Amz-Id-2:
-                - txg3f9c2885e54e44b39de8-006a034b7d
+                - txgc7706447d78b49b9876b-006a042cc9
             X-Amz-Request-Id:
-                - txg3f9c2885e54e44b39de8-006a034b7d
+                - txgc7706447d78b49b9876b-006a042cc9
         status: 200 OK
         code: 200
-        duration: 29.065959ms
+        duration: 19.309708ms
     - id: 127
       request:
         proto: HTTP/1.1
@@ -6634,7 +6634,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6643,7 +6643,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - accfea91-aa13-445c-bf4b-3893627c4497
+                - 2e731150-bdaa-485a-8260-6030c46a3835
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6651,8 +6651,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154709Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?tagging=
+                - 20260513T074825Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6662,21 +6662,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txga83bf052523042c49b5c-006a034b7d</RequestId><HostId>txga83bf052523042c49b5c-006a034b7d</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg78daf4a435874c5bba87-006a042cc9</RequestId><HostId>txg78daf4a435874c5bba87-006a042cc9</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:09 GMT
+                - Wed, 13 May 2026 07:48:25 GMT
             X-Amz-Id-2:
-                - txga83bf052523042c49b5c-006a034b7d
+                - txg78daf4a435874c5bba87-006a042cc9
             X-Amz-Request-Id:
-                - txga83bf052523042c49b5c-006a034b7d
+                - txg78daf4a435874c5bba87-006a042cc9
         status: 404 Not Found
         code: 404
-        duration: 53.378ms
+        duration: 19.004791ms
     - id: 128
       request:
         proto: HTTP/1.1
@@ -6685,7 +6685,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6694,7 +6694,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 98c5bc8e-556c-47ea-880d-2f457ab3f9a0
+                - 3fa9530a-8849-4707-97c6-99ea86869a27
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6702,8 +6702,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154709Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?cors=
+                - 20260513T074825Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6713,21 +6713,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg7b4930feb1394480b47a-006a034b7d</RequestId><HostId>txg7b4930feb1394480b47a-006a034b7d</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg1385e3b72a2b45c398b8-006a042cc9</RequestId><HostId>txg1385e3b72a2b45c398b8-006a042cc9</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:09 GMT
+                - Wed, 13 May 2026 07:48:25 GMT
             X-Amz-Id-2:
-                - txg7b4930feb1394480b47a-006a034b7d
+                - txg1385e3b72a2b45c398b8-006a042cc9
             X-Amz-Request-Id:
-                - txg7b4930feb1394480b47a-006a034b7d
+                - txg1385e3b72a2b45c398b8-006a042cc9
         status: 404 Not Found
         code: 404
-        duration: 19.289125ms
+        duration: 19.099167ms
     - id: 129
       request:
         proto: HTTP/1.1
@@ -6736,7 +6736,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6745,7 +6745,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 390ec1f3-94a0-44ae-8d86-41c66141cd60
+                - 761b4148-0888-4baa-83b5-8b2f117528ec
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6753,8 +6753,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154709Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?versioning=
+                - 20260513T074825Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6773,14 +6773,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:09 GMT
+                - Wed, 13 May 2026 07:48:25 GMT
             X-Amz-Id-2:
-                - txgba8a3f59b9744c0abf39-006a034b7d
+                - txg80c6f0be51a84fd4aa0e-006a042cc9
             X-Amz-Request-Id:
-                - txgba8a3f59b9744c0abf39-006a034b7d
+                - txg80c6f0be51a84fd4aa0e-006a042cc9
         status: 200 OK
         code: 200
-        duration: 28.78175ms
+        duration: 32.590875ms
     - id: 130
       request:
         proto: HTTP/1.1
@@ -6789,7 +6789,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6798,7 +6798,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0ce7798e-8d60-481c-89f2-5d7f550c73c7
+                - c06877ed-cd13-48d1-a8fe-9fe1c8abbb1d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6806,8 +6806,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154709Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260513T074825Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6826,14 +6826,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:09 GMT
+                - Wed, 13 May 2026 07:48:25 GMT
             X-Amz-Id-2:
-                - txg9f0f62b59c5e4abe88d1-006a034b7d
+                - txgaa6eba2a92ef46b4a7b4-006a042cc9
             X-Amz-Request-Id:
-                - txg9f0f62b59c5e4abe88d1-006a034b7d
+                - txgaa6eba2a92ef46b4a7b4-006a042cc9
         status: 200 OK
         code: 200
-        duration: 19.720583ms
+        duration: 68.198584ms
     - id: 131
       request:
         proto: HTTP/1.1
@@ -6842,7 +6842,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6851,7 +6851,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0cd03ce9-abd9-496a-8fa2-f3880cbb3658
+                - eecf3fb5-5b38-442a-8d74-f2b14d43dd53
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6859,8 +6859,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154709Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?acl=
+                - 20260513T074825Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6879,14 +6879,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:09 GMT
+                - Wed, 13 May 2026 07:48:25 GMT
             X-Amz-Id-2:
-                - txgae0a43d52cba4e58b95d-006a034b7d
+                - txg77d91ad23c8d482b8cf7-006a042cc9
             X-Amz-Request-Id:
-                - txgae0a43d52cba4e58b95d-006a034b7d
+                - txg77d91ad23c8d482b8cf7-006a042cc9
         status: 200 OK
         code: 200
-        duration: 48.528ms
+        duration: 22.86925ms
     - id: 132
       request:
         proto: HTTP/1.1
@@ -6895,7 +6895,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6904,7 +6904,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - a6c5896b-2594-4ed1-9a69-72745d749d8c
+                - 0237d208-5d92-4833-a638-0d12a1189806
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6912,8 +6912,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154709Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260513T074825Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6923,21 +6923,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgd396b58785aa42dd9536-006a034b7d</RequestId><HostId>txgd396b58785aa42dd9536-006a034b7d</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg3c2e4b6df6244eb49295-006a042cc9</RequestId><HostId>txg3c2e4b6df6244eb49295-006a042cc9</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:09 GMT
+                - Wed, 13 May 2026 07:48:25 GMT
             X-Amz-Id-2:
-                - txgd396b58785aa42dd9536-006a034b7d
+                - txg3c2e4b6df6244eb49295-006a042cc9
             X-Amz-Request-Id:
-                - txgd396b58785aa42dd9536-006a034b7d
+                - txg3c2e4b6df6244eb49295-006a042cc9
         status: 404 Not Found
         code: 404
-        duration: 76.955667ms
+        duration: 35.521416ms
     - id: 133
       request:
         proto: HTTP/1.1
@@ -6946,7 +6946,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6955,7 +6955,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b69fb0ed-0378-4dac-923f-ebdc59a2494d
+                - 71e23b62-f8fc-42df-850f-f6e882e42792
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6963,8 +6963,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154709Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
+                - 20260513T074825Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -6976,21 +6976,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:09 GMT
+                - Wed, 13 May 2026 07:48:25 GMT
             X-Amz-Id-2:
-                - txg5bc4b5ad5ac94f34b20c-006a034b7d
+                - txg988dfeb3bb1444bebefe-006a042cc9
             X-Amz-Request-Id:
-                - txg5bc4b5ad5ac94f34b20c-006a034b7d
+                - txg988dfeb3bb1444bebefe-006a042cc9
         status: 200 OK
         code: 200
-        duration: 25.886417ms
+        duration: 61.178042ms
     - id: 134
       request:
         proto: HTTP/1.1
@@ -6999,7 +6999,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7008,7 +7008,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e724e6e8-2e19-4460-9393-20786a341a27
+                - 199504f6-b8e9-4081-8858-6d33abed12b7
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7016,8 +7016,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154709Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?tagging=
+                - 20260513T074825Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7027,21 +7027,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg78b3a3fe5f4f469a9715-006a034b7d</RequestId><HostId>txg78b3a3fe5f4f469a9715-006a034b7d</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg392d1527ae764374bb79-006a042cc9</RequestId><HostId>txg392d1527ae764374bb79-006a042cc9</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:09 GMT
+                - Wed, 13 May 2026 07:48:25 GMT
             X-Amz-Id-2:
-                - txg78b3a3fe5f4f469a9715-006a034b7d
+                - txg392d1527ae764374bb79-006a042cc9
             X-Amz-Request-Id:
-                - txg78b3a3fe5f4f469a9715-006a034b7d
+                - txg392d1527ae764374bb79-006a042cc9
         status: 404 Not Found
         code: 404
-        duration: 61.539125ms
+        duration: 34.526833ms
     - id: 135
       request:
         proto: HTTP/1.1
@@ -7050,7 +7050,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7059,7 +7059,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 8b5825ad-3cce-4621-adad-eeea7dd14f2c
+                - 8ebb3132-e139-45e9-94fd-28c593b60b5a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7067,8 +7067,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154709Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?cors=
+                - 20260513T074825Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7078,21 +7078,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgc8df5770fd3e43ce849c-006a034b7d</RequestId><HostId>txgc8df5770fd3e43ce849c-006a034b7d</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg71e4462a04274761b297-006a042cc9</RequestId><HostId>txg71e4462a04274761b297-006a042cc9</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:09 GMT
+                - Wed, 13 May 2026 07:48:25 GMT
             X-Amz-Id-2:
-                - txgc8df5770fd3e43ce849c-006a034b7d
+                - txg71e4462a04274761b297-006a042cc9
             X-Amz-Request-Id:
-                - txgc8df5770fd3e43ce849c-006a034b7d
+                - txg71e4462a04274761b297-006a042cc9
         status: 404 Not Found
         code: 404
-        duration: 23.441666ms
+        duration: 34.645917ms
     - id: 136
       request:
         proto: HTTP/1.1
@@ -7101,7 +7101,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7110,7 +7110,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 861d90cc-4750-44a0-bdf9-87e509555a0e
+                - 77d18382-523c-4b94-9b44-3c6df219d025
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7118,8 +7118,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154709Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?versioning=
+                - 20260513T074825Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7138,14 +7138,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:09 GMT
+                - Wed, 13 May 2026 07:48:25 GMT
             X-Amz-Id-2:
-                - txgc37abceb1ca5450aa71c-006a034b7d
+                - txga2e5145b66174b25a099-006a042cc9
             X-Amz-Request-Id:
-                - txgc37abceb1ca5450aa71c-006a034b7d
+                - txga2e5145b66174b25a099-006a042cc9
         status: 200 OK
         code: 200
-        duration: 19.211708ms
+        duration: 19.494791ms
     - id: 137
       request:
         proto: HTTP/1.1
@@ -7154,7 +7154,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7163,7 +7163,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0bdf992d-806d-4bbd-85d9-188b2d5a6585
+                - 7c553a90-6a75-468f-9805-02054d79b3a5
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7171,8 +7171,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154709Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260513T074825Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7191,14 +7191,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:10 GMT
+                - Wed, 13 May 2026 07:48:25 GMT
             X-Amz-Id-2:
-                - txg422cb4c398e0451d9229-006a034b7e
+                - txgec1c15268d3a430da8b5-006a042cc9
             X-Amz-Request-Id:
-                - txg422cb4c398e0451d9229-006a034b7e
+                - txgec1c15268d3a430da8b5-006a042cc9
         status: 200 OK
         code: 200
-        duration: 55.671416ms
+        duration: 18.617791ms
     - id: 138
       request:
         proto: HTTP/1.1
@@ -7207,7 +7207,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7216,7 +7216,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7eae9a44-7e54-4120-a914-56011d9baec2
+                - e2989ed0-3bf7-4e2b-b6e3-c41671a8cb57
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7224,8 +7224,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154710Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
+                - 20260513T074825Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -7238,14 +7238,14 @@ interactions:
         body: ""
         headers:
             Date:
-                - Tue, 12 May 2026 15:47:10 GMT
+                - Wed, 13 May 2026 07:48:25 GMT
             X-Amz-Id-2:
-                - txgf55433ac474e44aa9628-006a034b7e
+                - txg31456f1a35824277bac0-006a042cc9
             X-Amz-Request-Id:
-                - txgf55433ac474e44aa9628-006a034b7e
+                - txg31456f1a35824277bac0-006a042cc9
         status: 204 No Content
         code: 204
-        duration: 173.265292ms
+        duration: 165.90975ms
     - id: 139
       request:
         proto: HTTP/1.1
@@ -7254,7 +7254,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7263,7 +7263,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7c237977-0084-4c90-8760-684f2306f4b7
+                - be792806-d17d-4d53-9082-6548ef1d9959
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7273,8 +7273,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154710Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
+                - 20260513T074826Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
         method: PUT
       response:
         proto: HTTP/2.0
@@ -7289,16 +7289,16 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 12 May 2026 15:47:10 GMT
+                - Wed, 13 May 2026 07:48:26 GMT
             Location:
-                - /tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300
+                - /tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985
             X-Amz-Id-2:
-                - txgf4f800564d8248ddbb02-006a034b7e
+                - txg317cc22dee7a4d4194b4-006a042cca
             X-Amz-Request-Id:
-                - txgf4f800564d8248ddbb02-006a034b7e
+                - txg317cc22dee7a4d4194b4-006a042cca
         status: 200 OK
         code: 200
-        duration: 1.587916375s
+        duration: 5.472016625s
     - id: 140
       request:
         proto: HTTP/1.1
@@ -7307,7 +7307,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7316,7 +7316,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 6395bbc0-cdaf-4fb6-804a-5131d708c3d1
+                - ff62e25f-bb49-4cbc-ba0f-34fa49e12326
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7328,8 +7328,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154711Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?acl=
+                - 20260513T074831Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?acl=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -7344,14 +7344,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 12 May 2026 15:47:12 GMT
+                - Wed, 13 May 2026 07:48:31 GMT
             X-Amz-Id-2:
-                - txgb2150dc520bb4389b631-006a034b80
+                - txg43cd9ef2bae04d25b676-006a042ccf
             X-Amz-Request-Id:
-                - txgb2150dc520bb4389b631-006a034b80
+                - txg43cd9ef2bae04d25b676-006a042ccf
         status: 200 OK
         code: 200
-        duration: 1.057404292s
+        duration: 71.118708ms
     - id: 141
       request:
         proto: HTTP/1.1
@@ -7360,16 +7360,16 @@ interactions:
         content_length: 472
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
-        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>2</Days></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260512154713008100000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260512154713008200000002</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
+        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>2</Days></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260513074831661600000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260513074831661600000002</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
         form: {}
         headers:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - de7a11c6-0562-489f-9bf7-56c6d9790e00
+                - 36fae49e-8a98-4890-b518-d6e4d34c4146
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
@@ -7377,12 +7377,12 @@ interactions:
             User-Agent:
                 - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,Z,e
             X-Amz-Checksum-Crc32:
-                - pMwilA==
+                - h/0tLg==
             X-Amz-Content-Sha256:
-                - 5a9cd047e1f756ff619042639ebc8013696645cd2f01214289a1bf3bff27d28f
+                - 5d45c7b68c03071c79b583a8f2f892b3fad5be399dd8622107f2068e425fd6c8
             X-Amz-Date:
-                - 20260512T154712Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260513T074831Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -7397,14 +7397,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 12 May 2026 15:47:13 GMT
+                - Wed, 13 May 2026 07:48:31 GMT
             X-Amz-Id-2:
-                - txg3b40247154ce4087972b-006a034b81
+                - txg4ef7941df8a940889189-006a042ccf
             X-Amz-Request-Id:
-                - txg3b40247154ce4087972b-006a034b81
+                - txg4ef7941df8a940889189-006a042ccf
         status: 200 OK
         code: 200
-        duration: 1.0489855s
+        duration: 72.734416ms
     - id: 142
       request:
         proto: HTTP/1.1
@@ -7413,7 +7413,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7422,7 +7422,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 986d08c4-e7a2-4d47-9788-217257cd5c21
+                - 41e72d8e-14ad-4925-88e9-685c7ddb6262
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7430,8 +7430,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154714Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?acl=
+                - 20260513T074831Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7450,14 +7450,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:14 GMT
+                - Wed, 13 May 2026 07:48:31 GMT
             X-Amz-Id-2:
-                - txgae1228b676bd43c8a90a-006a034b82
+                - txg2cf8fdc8646d4022bcd9-006a042ccf
             X-Amz-Request-Id:
-                - txgae1228b676bd43c8a90a-006a034b82
+                - txg2cf8fdc8646d4022bcd9-006a042ccf
         status: 200 OK
         code: 200
-        duration: 1.157620792s
+        duration: 18.726666ms
     - id: 143
       request:
         proto: HTTP/1.1
@@ -7466,7 +7466,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7475,7 +7475,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 97eb5a3f-cd40-4dc6-8862-348b71059916
+                - 3b2d5667-ed2c-4fe4-a2e0-09bb3c53164a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7483,8 +7483,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154714Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260513T074831Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7503,14 +7503,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:15 GMT
+                - Wed, 13 May 2026 07:48:31 GMT
             X-Amz-Id-2:
-                - txge02284d62b9e49bba057-006a034b83
+                - txg43d1369f21e34686a647-006a042ccf
             X-Amz-Request-Id:
-                - txge02284d62b9e49bba057-006a034b83
+                - txg43d1369f21e34686a647-006a042ccf
         status: 200 OK
         code: 200
-        duration: 1.156693584s
+        duration: 24.61925ms
     - id: 144
       request:
         proto: HTTP/1.1
@@ -7519,7 +7519,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7528,7 +7528,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 440f3e38-049b-4795-9a69-e6f4f537f349
+                - 968ab00e-862f-4eaf-9869-14a948d0befd
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7536,8 +7536,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154715Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
+                - 20260513T074831Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -7549,21 +7549,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:16 GMT
+                - Wed, 13 May 2026 07:48:31 GMT
             X-Amz-Id-2:
-                - txgc52c9a2c721543b29e7b-006a034b84
+                - txge6a4018801db4d139d0a-006a042ccf
             X-Amz-Request-Id:
-                - txgc52c9a2c721543b29e7b-006a034b84
+                - txge6a4018801db4d139d0a-006a042ccf
         status: 200 OK
         code: 200
-        duration: 2.028652042s
+        duration: 19.305833ms
     - id: 145
       request:
         proto: HTTP/1.1
@@ -7572,7 +7572,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7581,7 +7581,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 2a7131e6-e9e9-4b51-8bd2-4c81e0b8b9bf
+                - 0af4c56b-4b48-4269-8698-9ac2d9490389
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7589,8 +7589,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154716Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?tagging=
+                - 20260513T074831Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7600,21 +7600,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg9e130e0a97dc418ab9e0-006a034b86</RequestId><HostId>txg9e130e0a97dc418ab9e0-006a034b86</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg20fd2b1b087142928dcb-006a042ccf</RequestId><HostId>txg20fd2b1b087142928dcb-006a042ccf</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:18 GMT
+                - Wed, 13 May 2026 07:48:31 GMT
             X-Amz-Id-2:
-                - txg9e130e0a97dc418ab9e0-006a034b86
+                - txg20fd2b1b087142928dcb-006a042ccf
             X-Amz-Request-Id:
-                - txg9e130e0a97dc418ab9e0-006a034b86
+                - txg20fd2b1b087142928dcb-006a042ccf
         status: 404 Not Found
         code: 404
-        duration: 1.023716459s
+        duration: 19.589375ms
     - id: 146
       request:
         proto: HTTP/1.1
@@ -7623,7 +7623,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7632,7 +7632,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c40b9a47-54e5-4ce2-84c8-850649a01621
+                - 57461287-de26-49ca-8161-240308962ffb
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7640,8 +7640,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154718Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?cors=
+                - 20260513T074831Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7651,21 +7651,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg8d8ac94905034445af0a-006a034b87</RequestId><HostId>txg8d8ac94905034445af0a-006a034b87</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg6a8003a19ee449cd8fc7-006a042ccf</RequestId><HostId>txg6a8003a19ee449cd8fc7-006a042ccf</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:19 GMT
+                - Wed, 13 May 2026 07:48:31 GMT
             X-Amz-Id-2:
-                - txg8d8ac94905034445af0a-006a034b87
+                - txg6a8003a19ee449cd8fc7-006a042ccf
             X-Amz-Request-Id:
-                - txg8d8ac94905034445af0a-006a034b87
+                - txg6a8003a19ee449cd8fc7-006a042ccf
         status: 404 Not Found
         code: 404
-        duration: 1.022689167s
+        duration: 19.423792ms
     - id: 147
       request:
         proto: HTTP/1.1
@@ -7674,7 +7674,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7683,7 +7683,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ce6caa0c-dbb8-448c-b30a-dd593fc0718c
+                - 0839a32a-bc8d-4e33-9c0d-652fd4304a9a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7691,8 +7691,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154719Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?versioning=
+                - 20260513T074831Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7711,14 +7711,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:20 GMT
+                - Wed, 13 May 2026 07:48:31 GMT
             X-Amz-Id-2:
-                - txg30f004ebf3764d788491-006a034b88
+                - txg207b42963c924e63af14-006a042ccf
             X-Amz-Request-Id:
-                - txg30f004ebf3764d788491-006a034b88
+                - txg207b42963c924e63af14-006a042ccf
         status: 200 OK
         code: 200
-        duration: 21.104792ms
+        duration: 18.49975ms
     - id: 148
       request:
         proto: HTTP/1.1
@@ -7727,7 +7727,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7736,7 +7736,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9d41c79b-6619-403c-935c-58b4be2899ad
+                - 4fbf3a14-bd4b-469c-aeb4-30608432743d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7744,8 +7744,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154720Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260513T074831Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7757,21 +7757,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>2</Days></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260512154713008100000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260512154713008200000002</ID><Status>Enabled</Status></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>2</Days></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260513074831661600000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260513074831661600000002</ID><Status>Enabled</Status></Rule></Configuration>
         headers:
             Content-Length:
                 - "445"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:20 GMT
+                - Wed, 13 May 2026 07:48:31 GMT
             X-Amz-Id-2:
-                - txgbed71a91a3a84e00ba72-006a034b88
+                - txg24e69d1b46a0458da039-006a042ccf
             X-Amz-Request-Id:
-                - txgbed71a91a3a84e00ba72-006a034b88
+                - txg24e69d1b46a0458da039-006a042ccf
         status: 200 OK
         code: 200
-        duration: 1.023712042s
+        duration: 19.435875ms
     - id: 149
       request:
         proto: HTTP/1.1
@@ -7780,7 +7780,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7789,7 +7789,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - dc12f3f1-7cb2-41d7-85b9-63ee4add49c6
+                - aed40fcb-f78d-4edd-9b41-780be118e4f3
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7797,8 +7797,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154721Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
+                - 20260513T074831Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -7813,16 +7813,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:21 GMT
+                - Wed, 13 May 2026 07:48:32 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txg46362c1fce2b446b8a94-006a034b89
+                - txgd50d2c2c8f274f3ca762-006a042cd0
             X-Amz-Request-Id:
-                - txg46362c1fce2b446b8a94-006a034b89
+                - txgd50d2c2c8f274f3ca762-006a042cd0
         status: 200 OK
         code: 200
-        duration: 54.470875ms
+        duration: 20.530834ms
     - id: 150
       request:
         proto: HTTP/1.1
@@ -7831,7 +7831,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7840,7 +7840,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 678abd63-4a7a-4d7c-a76d-4990e6a6c6f6
+                - 3551f5cf-8383-474b-8a45-b030d699d0f1
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7848,8 +7848,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154721Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260513T074832Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7861,21 +7861,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>2</Days></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260512154713008100000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260512154713008200000002</ID><Status>Enabled</Status></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>2</Days></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260513074831661600000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260513074831661600000002</ID><Status>Enabled</Status></Rule></Configuration>
         headers:
             Content-Length:
                 - "445"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:21 GMT
+                - Wed, 13 May 2026 07:48:32 GMT
             X-Amz-Id-2:
-                - txg8bd5fde581e842229616-006a034b89
+                - txga9bef97df96445f48d30-006a042cd0
             X-Amz-Request-Id:
-                - txg8bd5fde581e842229616-006a034b89
+                - txga9bef97df96445f48d30-006a042cd0
         status: 200 OK
         code: 200
-        duration: 1.043814583s
+        duration: 49.327792ms
     - id: 151
       request:
         proto: HTTP/1.1
@@ -7884,7 +7884,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7893,7 +7893,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ae38f149-50ef-4360-980d-d0000aba3c74
+                - ebae6d64-7a72-4ad0-adc9-f9236c9387d9
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7901,8 +7901,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154722Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?acl=
+                - 20260513T074832Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7921,14 +7921,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:23 GMT
+                - Wed, 13 May 2026 07:48:32 GMT
             X-Amz-Id-2:
-                - txga4162cbe4b984e848e7e-006a034b8b
+                - txg4419f596885f4e2d9c10-006a042cd0
             X-Amz-Request-Id:
-                - txga4162cbe4b984e848e7e-006a034b8b
+                - txg4419f596885f4e2d9c10-006a042cd0
         status: 200 OK
         code: 200
-        duration: 1.074885166s
+        duration: 27.974291ms
     - id: 152
       request:
         proto: HTTP/1.1
@@ -7937,7 +7937,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7946,7 +7946,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ae9a49f9-0051-4571-a5bc-dba9887b705b
+                - 9d511b48-b521-400e-aa90-f47e27e1d110
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7954,8 +7954,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154723Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260513T074832Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7974,14 +7974,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:24 GMT
+                - Wed, 13 May 2026 07:48:32 GMT
             X-Amz-Id-2:
-                - txgb5a83a4cc59d402c9c64-006a034b8c
+                - txg145280bae6f346ff9978-006a042cd0
             X-Amz-Request-Id:
-                - txgb5a83a4cc59d402c9c64-006a034b8c
+                - txg145280bae6f346ff9978-006a042cd0
         status: 200 OK
         code: 200
-        duration: 1.029331584s
+        duration: 50.441708ms
     - id: 153
       request:
         proto: HTTP/1.1
@@ -7990,7 +7990,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7999,7 +7999,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 113102e2-b687-426f-b639-19c29f8cf6ad
+                - efcf78b4-0b9f-4e60-ab32-af3bda6ad0ac
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8007,8 +8007,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154724Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
+                - 20260513T074832Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -8020,21 +8020,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:25 GMT
+                - Wed, 13 May 2026 07:48:32 GMT
             X-Amz-Id-2:
-                - txg31d58961b1cc4bb69e3d-006a034b8d
+                - txg8bf7ab862e7d4e279c69-006a042cd0
             X-Amz-Request-Id:
-                - txg31d58961b1cc4bb69e3d-006a034b8d
+                - txg8bf7ab862e7d4e279c69-006a042cd0
         status: 200 OK
         code: 200
-        duration: 106.796583ms
+        duration: 19.554917ms
     - id: 154
       request:
         proto: HTTP/1.1
@@ -8043,7 +8043,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8052,7 +8052,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d15ef3b2-caca-45fa-9032-bdfeedaa9fe3
+                - 794d4f69-7dee-41d9-8cb2-c700c7169df2
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8060,8 +8060,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154725Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?tagging=
+                - 20260513T074832Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8071,21 +8071,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg78e30de675ef41b09820-006a034b8d</RequestId><HostId>txg78e30de675ef41b09820-006a034b8d</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg57ed42402eac4c7fa755-006a042cd0</RequestId><HostId>txg57ed42402eac4c7fa755-006a042cd0</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:25 GMT
+                - Wed, 13 May 2026 07:48:32 GMT
             X-Amz-Id-2:
-                - txg78e30de675ef41b09820-006a034b8d
+                - txg57ed42402eac4c7fa755-006a042cd0
             X-Amz-Request-Id:
-                - txg78e30de675ef41b09820-006a034b8d
+                - txg57ed42402eac4c7fa755-006a042cd0
         status: 404 Not Found
         code: 404
-        duration: 1.02451325s
+        duration: 21.441083ms
     - id: 155
       request:
         proto: HTTP/1.1
@@ -8094,7 +8094,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8103,7 +8103,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 38840ccb-eb5c-4259-aa7c-2467f5d03327
+                - 260ae06f-87ba-4eeb-9cd9-436aec4c715e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8111,8 +8111,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154725Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?cors=
+                - 20260513T074832Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8122,21 +8122,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg4233a4f9fc064e83ae8d-006a034b8e</RequestId><HostId>txg4233a4f9fc064e83ae8d-006a034b8e</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg7b6281db7f8a4effb283-006a042cd0</RequestId><HostId>txg7b6281db7f8a4effb283-006a042cd0</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:26 GMT
+                - Wed, 13 May 2026 07:48:32 GMT
             X-Amz-Id-2:
-                - txg4233a4f9fc064e83ae8d-006a034b8e
+                - txg7b6281db7f8a4effb283-006a042cd0
             X-Amz-Request-Id:
-                - txg4233a4f9fc064e83ae8d-006a034b8e
+                - txg7b6281db7f8a4effb283-006a042cd0
         status: 404 Not Found
         code: 404
-        duration: 1.113807625s
+        duration: 19.1605ms
     - id: 156
       request:
         proto: HTTP/1.1
@@ -8145,7 +8145,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8154,7 +8154,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - edb43d51-9012-4738-9777-36a447018517
+                - 26c97ba6-2c19-40ab-86d4-636eb722ba69
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8162,8 +8162,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154726Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?versioning=
+                - 20260513T074832Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8182,14 +8182,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:27 GMT
+                - Wed, 13 May 2026 07:48:32 GMT
             X-Amz-Id-2:
-                - txg522824a28b594b5e96f9-006a034b8f
+                - txgfb1d0f0d3c804565a179-006a042cd0
             X-Amz-Request-Id:
-                - txg522824a28b594b5e96f9-006a034b8f
+                - txgfb1d0f0d3c804565a179-006a042cd0
         status: 200 OK
         code: 200
-        duration: 1.020893333s
+        duration: 30.52075ms
     - id: 157
       request:
         proto: HTTP/1.1
@@ -8198,7 +8198,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8207,7 +8207,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b3f2f08a-8c67-4bb2-811e-be1e1334269c
+                - a4a9a660-6915-4e6e-99e9-4abd961b8e23
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8215,8 +8215,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154727Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260513T074832Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8228,21 +8228,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>2</Days></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260512154713008100000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260512154713008200000002</ID><Status>Enabled</Status></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>2</Days></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260513074831661600000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260513074831661600000002</ID><Status>Enabled</Status></Rule></Configuration>
         headers:
             Content-Length:
                 - "445"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:28 GMT
+                - Wed, 13 May 2026 07:48:32 GMT
             X-Amz-Id-2:
-                - txg47fbe9283d8a4f0e856d-006a034b90
+                - txg0717a09c43cc4079aa6a-006a042cd0
             X-Amz-Request-Id:
-                - txg47fbe9283d8a4f0e856d-006a034b90
+                - txg0717a09c43cc4079aa6a-006a042cd0
         status: 200 OK
         code: 200
-        duration: 1.034349875s
+        duration: 19.018459ms
     - id: 158
       request:
         proto: HTTP/1.1
@@ -8251,7 +8251,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8260,7 +8260,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 61471797-1443-44ba-a856-9f5f24349549
+                - 856d027c-89ad-42c2-8d16-2bd9f0ac0b81
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8268,8 +8268,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154729Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?acl=
+                - 20260513T074832Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8288,14 +8288,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:29 GMT
+                - Wed, 13 May 2026 07:48:32 GMT
             X-Amz-Id-2:
-                - txgbeb1f06dcd13487b9a9e-006a034b91
+                - txg850e10e7ccf24f2ba436-006a042cd0
             X-Amz-Request-Id:
-                - txgbeb1f06dcd13487b9a9e-006a034b91
+                - txg850e10e7ccf24f2ba436-006a042cd0
         status: 200 OK
         code: 200
-        duration: 1.027123583s
+        duration: 19.831083ms
     - id: 159
       request:
         proto: HTTP/1.1
@@ -8304,7 +8304,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8313,7 +8313,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 76eb25fa-b3b7-43ca-95a6-993ad970ddbd
+                - ed45596b-fb4e-4f5c-98c2-2c7801b94da1
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8321,8 +8321,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154729Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260513T074832Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8341,14 +8341,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:30 GMT
+                - Wed, 13 May 2026 07:48:32 GMT
             X-Amz-Id-2:
-                - txge47dedec54884d16b4a2-006a034b92
+                - txg54fda9b34e234a2c8ef7-006a042cd0
             X-Amz-Request-Id:
-                - txge47dedec54884d16b4a2-006a034b92
+                - txg54fda9b34e234a2c8ef7-006a042cd0
         status: 200 OK
         code: 200
-        duration: 1.255808917s
+        duration: 18.827083ms
     - id: 160
       request:
         proto: HTTP/1.1
@@ -8357,7 +8357,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8366,7 +8366,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 845fc027-dc3b-4bc5-b24d-2893c1c1beaa
+                - e4af4b41-2ad7-4d24-95ba-aeec7396ba21
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8374,8 +8374,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154730Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
+                - 20260513T074832Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -8387,21 +8387,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:31 GMT
+                - Wed, 13 May 2026 07:48:32 GMT
             X-Amz-Id-2:
-                - txg92d4b028a6b1440d8918-006a034b93
+                - txg2670243e82344cd69f51-006a042cd0
             X-Amz-Request-Id:
-                - txg92d4b028a6b1440d8918-006a034b93
+                - txg2670243e82344cd69f51-006a042cd0
         status: 200 OK
         code: 200
-        duration: 2.039431959s
+        duration: 32.053125ms
     - id: 161
       request:
         proto: HTTP/1.1
@@ -8410,7 +8410,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8419,7 +8419,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5be1c9e9-dabe-4c23-bf51-ff820db661ca
+                - 1b19a040-ec70-4d26-865e-9a1debf04a36
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8427,8 +8427,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154731Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?tagging=
+                - 20260513T074832Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8438,21 +8438,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg7d3ee624edbd4d6683ea-006a034b95</RequestId><HostId>txg7d3ee624edbd4d6683ea-006a034b95</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg1fbe7a0011904df98b2c-006a042cd0</RequestId><HostId>txg1fbe7a0011904df98b2c-006a042cd0</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:33 GMT
+                - Wed, 13 May 2026 07:48:32 GMT
             X-Amz-Id-2:
-                - txg7d3ee624edbd4d6683ea-006a034b95
+                - txg1fbe7a0011904df98b2c-006a042cd0
             X-Amz-Request-Id:
-                - txg7d3ee624edbd4d6683ea-006a034b95
+                - txg1fbe7a0011904df98b2c-006a042cd0
         status: 404 Not Found
         code: 404
-        duration: 1.047866541s
+        duration: 18.763791ms
     - id: 162
       request:
         proto: HTTP/1.1
@@ -8461,7 +8461,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8470,7 +8470,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c75d70a6-e0c8-4005-8469-4290400f856c
+                - 8552eee5-700e-4d13-80ef-580707f1f70b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8478,8 +8478,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154733Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?cors=
+                - 20260513T074832Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8489,21 +8489,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg921e57ddbb4045ae8958-006a034b96</RequestId><HostId>txg921e57ddbb4045ae8958-006a034b96</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg3e53fd3c41cd479f888b-006a042cd0</RequestId><HostId>txg3e53fd3c41cd479f888b-006a042cd0</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 15:47:34 GMT
+                - Wed, 13 May 2026 07:48:32 GMT
             X-Amz-Id-2:
-                - txg921e57ddbb4045ae8958-006a034b96
+                - txg3e53fd3c41cd479f888b-006a042cd0
             X-Amz-Request-Id:
-                - txg921e57ddbb4045ae8958-006a034b96
+                - txg3e53fd3c41cd479f888b-006a042cd0
         status: 404 Not Found
         code: 404
-        duration: 1.024543209s
+        duration: 20.293208ms
     - id: 163
       request:
         proto: HTTP/1.1
@@ -8512,7 +8512,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8521,7 +8521,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9ab06347-90d4-48e4-b211-560dfd45fd4b
+                - 24d92875-0b68-4ca2-94df-f3bd09926643
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8529,8 +8529,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154734Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?versioning=
+                - 20260513T074832Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8549,14 +8549,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:36 GMT
+                - Wed, 13 May 2026 07:48:32 GMT
             X-Amz-Id-2:
-                - txgff7c5af7b48d4224a425-006a034b98
+                - txg774837db87dc448ca7dd-006a042cd0
             X-Amz-Request-Id:
-                - txgff7c5af7b48d4224a425-006a034b98
+                - txg774837db87dc448ca7dd-006a042cd0
         status: 200 OK
         code: 200
-        duration: 21.319459ms
+        duration: 31.608542ms
     - id: 164
       request:
         proto: HTTP/1.1
@@ -8565,7 +8565,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8574,16 +8574,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e05ec8c9-4907-46bd-81cd-63a5d562b181
+                - 72c903d4-4092-4a5a-8786-073c61bb81df
             Amz-Sdk-Request:
-                - attempt=1; max=3; ttl=20260512T175729Z
+                - attempt=1; max=3
             User-Agent:
                 - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154736Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260513T074832Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8595,21 +8595,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>2</Days></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260512154713008100000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260512154713008200000002</ID><Status>Enabled</Status></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>2</Days></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260513074831661600000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260513074831661600000002</ID><Status>Enabled</Status></Rule></Configuration>
         headers:
             Content-Length:
                 - "445"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 15:47:36 GMT
+                - Wed, 13 May 2026 07:48:32 GMT
             X-Amz-Id-2:
-                - txg1bdba12e1e8b492194cf-006a034b98
+                - txga69846b61a4b45fd8928-006a042cd0
             X-Amz-Request-Id:
-                - txg1bdba12e1e8b492194cf-006a034b98
+                - txga69846b61a4b45fd8928-006a042cd0
         status: 200 OK
         code: 200
-        duration: 20.197958ms
+        duration: 154.836166ms
     - id: 165
       request:
         proto: HTTP/1.1
@@ -8618,7 +8618,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8627,7 +8627,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 2200040a-f412-4cc3-ae31-e04a6a63bcf5
+                - 031ee7ce-be6a-47aa-a5a2-f75d6abb3b8d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8635,8 +8635,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154736Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
+                - 20260513T074833Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -8649,14 +8649,14 @@ interactions:
         body: ""
         headers:
             Date:
-                - Tue, 12 May 2026 15:47:36 GMT
+                - Wed, 13 May 2026 07:48:33 GMT
             X-Amz-Id-2:
-                - txgb8f2539e99214076a742-006a034b98
+                - txgd3e4e0eafbed494fbe32-006a042cd1
             X-Amz-Request-Id:
-                - txgb8f2539e99214076a742-006a034b98
+                - txgd3e4e0eafbed494fbe32-006a042cd1
         status: 204 No Content
         code: 204
-        duration: 1.187202292s
+        duration: 233.905792ms
     - id: 166
       request:
         proto: HTTP/1.1
@@ -8665,7 +8665,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8674,7 +8674,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 3174c759-344a-4127-bcd5-b6e93168935d
+                - 1adffb0d-823e-4192-bbcf-c35d1b4837da
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8682,8 +8682,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154737Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
+                - 20260513T074833Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
         method: PUT
       response:
         proto: HTTP/2.0
@@ -8698,16 +8698,16 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 12 May 2026 15:47:37 GMT
+                - Wed, 13 May 2026 07:48:33 GMT
             Location:
-                - /tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300
+                - /tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985
             X-Amz-Id-2:
-                - txga163903f6c7e4954a67f-006a034b99
+                - txgc2f935613f7e4666baea-006a042cd1
             X-Amz-Request-Id:
-                - txga163903f6c7e4954a67f-006a034b99
+                - txgc2f935613f7e4666baea-006a042cd1
         status: 200 OK
         code: 200
-        duration: 4.577121958s
+        duration: 5.077956375s
     - id: 167
       request:
         proto: HTTP/1.1
@@ -8716,7 +8716,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8725,7 +8725,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d977b0ca-24e9-43b9-9d55-423af7d4ca6d
+                - c751efcd-512b-4db8-8e30-9dbb74cf2bf6
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8737,8 +8737,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154741Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?acl=
+                - 20260513T074838Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?acl=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -8753,32 +8753,32 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 12 May 2026 15:47:42 GMT
+                - Wed, 13 May 2026 07:48:38 GMT
             X-Amz-Id-2:
-                - txg11671e2f517841b28a15-006a034b9e
+                - txg9d858e1a2f2547158e5e-006a042cd6
             X-Amz-Request-Id:
-                - txg11671e2f517841b28a15-006a034b9e
+                - txg9d858e1a2f2547158e5e-006a042cd6
         status: 200 OK
         code: 200
-        duration: 1.07484975s
+        duration: 2.023114333s
     - id: 168
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 1581
+        content_length: 1649
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
-        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>30</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition><Transition><Days>210</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>95</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Filter><Prefix>path3/</Prefix></Filter><ID>id3</ID><Status>Enabled</Status><Transition><Days>0</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration></Expiration><Filter><And><Prefix>path4/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>155</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id6</ID><Status>Enabled</Status><Transition><Days>156</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></LifecycleConfiguration>
+        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>30</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition><Transition><Days>210</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>95</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Date>2016-01-12T00:00:00Z</Date></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Filter><Prefix>path3/</Prefix></Filter><ID>id3</ID><Status>Enabled</Status><Transition><Days>130</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Date>2016-01-12T00:00:00Z</Date></Expiration><Filter><And><Prefix>path4/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>155</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id6</ID><Status>Enabled</Status><Transition><Days>156</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></LifecycleConfiguration>
         form: {}
         headers:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 8f6a5453-fe3b-4777-873b-690ad4e591f7
+                - b594eeff-a1ad-4bfa-a60a-34877cf0bce4
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
@@ -8786,12 +8786,12 @@ interactions:
             User-Agent:
                 - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,Z,e
             X-Amz-Checksum-Crc32:
-                - 9sglGA==
+                - kHT1mg==
             X-Amz-Content-Sha256:
-                - 845a98ee2cf7d3d15e376c73ed8abf538e0ad8ad78ce47dcb3cb6368a7687629
+                - 711742cac597b38760bd43e3c9819ae8c0a1ef8e752194e24b79795e8d155f3b
             X-Amz-Date:
-                - 20260512T154742Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260513T074838Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -8799,23 +8799,21 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 283
+        content_length: 0
         uncompressed: false
-        body: <Error><Code>MalformedXML</Code><Message>Expiration action cannot be empty</Message><RequestId>txgbc476c77de194c159e83-006a034b9f</RequestId><HostId>txgbc476c77de194c159e83-006a034b9f</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
+        body: ""
         headers:
             Content-Length:
-                - "283"
-            Content-Type:
-                - application/xml
+                - "0"
             Date:
-                - Tue, 12 May 2026 15:47:43 GMT
+                - Wed, 13 May 2026 07:48:40 GMT
             X-Amz-Id-2:
-                - txgbc476c77de194c159e83-006a034b9f
+                - txgba7075bc37f94d909725-006a042cd8
             X-Amz-Request-Id:
-                - txgbc476c77de194c159e83-006a034b9f
-        status: 400 Bad Request
-        code: 400
-        duration: 25.881833ms
+                - txgba7075bc37f94d909725-006a042cd8
+        status: 200 OK
+        code: 200
+        duration: 1.070276459s
     - id: 169
       request:
         proto: HTTP/1.1
@@ -8824,7 +8822,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8833,7 +8831,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 05c2b88e-1822-4d9b-b881-6ea32b622ebe
+                - b34f8bab-f507-4236-bc8a-1c011ba5bbe1
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8841,8 +8839,789 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T154743Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
+                - 20260513T074841Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?acl=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 698
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+        headers:
+            Content-Length:
+                - "698"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Wed, 13 May 2026 07:48:41 GMT
+            X-Amz-Id-2:
+                - txgb4b8f3c924d84cb0b181-006a042cd9
+            X-Amz-Request-Id:
+                - txgb4b8f3c924d84cb0b181-006a042cd9
+        status: 200 OK
+        code: 200
+        duration: 1.075334917s
+    - id: 170
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 71812e02-9201-48a5-8fdc-e015872937bb
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260513T074841Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?object-lock=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 330
+        uncompressed: false
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg725c04291f6642efb5a2-006a042cda</RequestId><HostId>txg725c04291f6642efb5a2-006a042cda</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
+        headers:
+            Content-Length:
+                - "330"
+            Content-Type:
+                - application/xml
+            Date:
+                - Wed, 13 May 2026 07:48:42 GMT
+            X-Amz-Id-2:
+                - txg725c04291f6642efb5a2-006a042cda
+            X-Amz-Request-Id:
+                - txg725c04291f6642efb5a2-006a042cda
+        status: 404 Not Found
+        code: 404
+        duration: 1.10287475s
+    - id: 171
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 874637af-8311-4b2f-a26e-b9b29f9ad013
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260513T074842Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 287
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+        headers:
+            Content-Length:
+                - "287"
+            Content-Type:
+                - application/xml
+            Date:
+                - Wed, 13 May 2026 07:48:43 GMT
+            X-Amz-Id-2:
+                - txg302b12a2b5264979969b-006a042cdb
+            X-Amz-Request-Id:
+                - txg302b12a2b5264979969b-006a042cdb
+        status: 200 OK
+        code: 200
+        duration: 2.088223417s
+    - id: 172
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 857877c4-15b9-4ff1-999a-c7aa1344e2c5
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260513T074843Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?tagging=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 361
+        uncompressed: false
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg368a73e8d827468a866c-006a042cdd</RequestId><HostId>txg368a73e8d827468a866c-006a042cdd</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</BucketName></Error>
+        headers:
+            Content-Length:
+                - "361"
+            Content-Type:
+                - application/xml
+            Date:
+                - Wed, 13 May 2026 07:48:45 GMT
+            X-Amz-Id-2:
+                - txg368a73e8d827468a866c-006a042cdd
+            X-Amz-Request-Id:
+                - txg368a73e8d827468a866c-006a042cdd
+        status: 404 Not Found
+        code: 404
+        duration: 1.1051855s
+    - id: 173
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - edad08f0-0d21-4a02-8be1-e241825329ae
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260513T074845Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?cors=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 298
+        uncompressed: false
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg7e6bd239ee384e0f8a3d-006a042cdf</RequestId><HostId>txg7e6bd239ee384e0f8a3d-006a042cdf</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
+        headers:
+            Content-Length:
+                - "298"
+            Content-Type:
+                - application/xml
+            Date:
+                - Wed, 13 May 2026 07:48:47 GMT
+            X-Amz-Id-2:
+                - txg7e6bd239ee384e0f8a3d-006a042cdf
+            X-Amz-Request-Id:
+                - txg7e6bd239ee384e0f8a3d-006a042cdf
+        status: 404 Not Found
+        code: 404
+        duration: 1.058982709s
+    - id: 174
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - afd4d76f-310f-457f-bddb-26a808bf2b0d
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260513T074847Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?versioning=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 107
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <VersioningConfiguration><Status></Status></VersioningConfiguration>
+        headers:
+            Content-Length:
+                - "107"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Wed, 13 May 2026 07:48:48 GMT
+            X-Amz-Id-2:
+                - txg58c92c6ceb0e44798334-006a042ce0
+            X-Amz-Request-Id:
+                - txg58c92c6ceb0e44798334-006a042ce0
+        status: 200 OK
+        code: 200
+        duration: 1.15020825s
+    - id: 175
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - e9a8d40a-c843-43ed-8dd7-457086e3c77c
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260513T074848Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1622
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>30</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition><Transition><Days>210</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>95</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Date>2016-01-12T00:00:00Z</Date></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Filter><Prefix>path3/</Prefix></Filter><ID>id3</ID><Status>Enabled</Status><Transition><Days>130</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Date>2016-01-12T00:00:00Z</Date></Expiration><Filter><And><Prefix>path4/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>155</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id6</ID><Status>Enabled</Status><Transition><Days>156</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
+        headers:
+            Content-Length:
+                - "1622"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Wed, 13 May 2026 07:48:49 GMT
+            X-Amz-Id-2:
+                - txgfdf4bd846b8d4c19a3f2-006a042ce1
+            X-Amz-Request-Id:
+                - txgfdf4bd846b8d4c19a3f2-006a042ce1
+        status: 200 OK
+        code: 200
+        duration: 1.108319916s
+    - id: 176
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 6cfa5003-0ee0-41ac-89c0-9e316caadbc4
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260513T074850Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
+        method: HEAD
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Type:
+                - application/xml
+            Date:
+                - Wed, 13 May 2026 07:48:50 GMT
+            X-Amz-Bucket-Region:
+                - nl-ams
+            X-Amz-Id-2:
+                - txgf96eba6365224831a1e4-006a042ce2
+            X-Amz-Request-Id:
+                - txgf96eba6365224831a1e4-006a042ce2
+        status: 200 OK
+        code: 200
+        duration: 1.022027708s
+    - id: 177
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 1b1f5ff5-87df-41dd-9cc0-5d2be204f36e
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260513T074851Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?acl=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 698
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+        headers:
+            Content-Length:
+                - "698"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Wed, 13 May 2026 07:48:51 GMT
+            X-Amz-Id-2:
+                - txg38138d9b84fd432d9306-006a042ce3
+            X-Amz-Request-Id:
+                - txg38138d9b84fd432d9306-006a042ce3
+        status: 200 OK
+        code: 200
+        duration: 57.543792ms
+    - id: 178
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - f4c5e0a9-2d7c-402d-b343-b49efcfe5785
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260513T074851Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?object-lock=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 330
+        uncompressed: false
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg55b4fdf88388495f9ee8-006a042ce3</RequestId><HostId>txg55b4fdf88388495f9ee8-006a042ce3</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
+        headers:
+            Content-Length:
+                - "330"
+            Content-Type:
+                - application/xml
+            Date:
+                - Wed, 13 May 2026 07:48:51 GMT
+            X-Amz-Id-2:
+                - txg55b4fdf88388495f9ee8-006a042ce3
+            X-Amz-Request-Id:
+                - txg55b4fdf88388495f9ee8-006a042ce3
+        status: 404 Not Found
+        code: 404
+        duration: 1.052115834s
+    - id: 179
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 3bd56216-cfd2-468a-90e4-53390e4d4271
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260513T074851Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 287
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+        headers:
+            Content-Length:
+                - "287"
+            Content-Type:
+                - application/xml
+            Date:
+                - Wed, 13 May 2026 07:48:52 GMT
+            X-Amz-Id-2:
+                - txgbce8a19871b04fffad38-006a042ce4
+            X-Amz-Request-Id:
+                - txgbce8a19871b04fffad38-006a042ce4
+        status: 200 OK
+        code: 200
+        duration: 1.051386083s
+    - id: 180
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - a2a4c7cc-8412-454e-80b6-df8b9dfcacf1
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260513T074852Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?tagging=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 361
+        uncompressed: false
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg275c1a1c1d8d44888d8b-006a042ce5</RequestId><HostId>txg275c1a1c1d8d44888d8b-006a042ce5</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</BucketName></Error>
+        headers:
+            Content-Length:
+                - "361"
+            Content-Type:
+                - application/xml
+            Date:
+                - Wed, 13 May 2026 07:48:53 GMT
+            X-Amz-Id-2:
+                - txg275c1a1c1d8d44888d8b-006a042ce5
+            X-Amz-Request-Id:
+                - txg275c1a1c1d8d44888d8b-006a042ce5
+        status: 404 Not Found
+        code: 404
+        duration: 32.3685ms
+    - id: 181
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 7a1234aa-4ad8-42c6-9ad1-f64856c594f6
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260513T074853Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?cors=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 298
+        uncompressed: false
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgae39a14e048641cca121-006a042ce5</RequestId><HostId>txgae39a14e048641cca121-006a042ce5</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
+        headers:
+            Content-Length:
+                - "298"
+            Content-Type:
+                - application/xml
+            Date:
+                - Wed, 13 May 2026 07:48:53 GMT
+            X-Amz-Id-2:
+                - txgae39a14e048641cca121-006a042ce5
+            X-Amz-Request-Id:
+                - txgae39a14e048641cca121-006a042ce5
+        status: 404 Not Found
+        code: 404
+        duration: 59.573625ms
+    - id: 182
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - f1398667-fc7e-4c17-af72-898246de8e27
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260513T074853Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?versioning=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 107
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <VersioningConfiguration><Status></Status></VersioningConfiguration>
+        headers:
+            Content-Length:
+                - "107"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Wed, 13 May 2026 07:48:53 GMT
+            X-Amz-Id-2:
+                - txg0a97284ec2064d959f9a-006a042ce5
+            X-Amz-Request-Id:
+                - txg0a97284ec2064d959f9a-006a042ce5
+        status: 200 OK
+        code: 200
+        duration: 1.0959155s
+    - id: 183
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - b81e5362-0325-4779-93ac-e6010f00cf31
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260513T074853Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1622
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>30</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition><Transition><Days>210</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>95</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Date>2016-01-12T00:00:00Z</Date></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Filter><Prefix>path3/</Prefix></Filter><ID>id3</ID><Status>Enabled</Status><Transition><Days>130</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Date>2016-01-12T00:00:00Z</Date></Expiration><Filter><And><Prefix>path4/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>155</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id6</ID><Status>Enabled</Status><Transition><Days>156</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
+        headers:
+            Content-Length:
+                - "1622"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Wed, 13 May 2026 07:48:55 GMT
+            X-Amz-Id-2:
+                - txg1390029917ff45968078-006a042ce7
+            X-Amz-Request-Id:
+                - txg1390029917ff45968078-006a042ce7
+        status: 200 OK
+        code: 200
+        duration: 98.716209ms
+    - id: 184
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 5069afe0-3742-40e7-b6c4-8eb857e15730
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260513T074855Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -8855,11 +9634,11 @@ interactions:
         body: ""
         headers:
             Date:
-                - Tue, 12 May 2026 15:47:43 GMT
+                - Wed, 13 May 2026 07:48:55 GMT
             X-Amz-Id-2:
-                - txg21cec90721b9462c9851-006a034b9f
+                - txgf0bbf3e93bb84475b35c-006a042ce7
             X-Amz-Request-Id:
-                - txg21cec90721b9462c9851-006a034b9f
+                - txgf0bbf3e93bb84475b35c-006a042ce7
         status: 204 No Content
         code: 204
-        duration: 1.190011667s
+        duration: 196.99975ms

--- a/internal/services/object/testdata/object-bucket-lifecycle.cassette.yaml
+++ b/internal/services/object/testdata/object-bucket-lifecycle.cassette.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -18,7 +18,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 10ff8802-1044-4c4d-9e55-8336e781dc3f
+                - 71daac1d-2cd2-43ef-89b2-d3b70cb2d143
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -26,8 +26,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135508Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
+                - 20260512T154658Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
         method: PUT
       response:
         proto: HTTP/2.0
@@ -42,16 +42,16 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 12 May 2026 13:55:08 GMT
+                - Tue, 12 May 2026 15:46:58 GMT
             Location:
-                - /tf-tests-scaleway-object-bucket-lifecycle-152264452529566496
+                - /tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300
             X-Amz-Id-2:
-                - txge6e4b9e67903436eaa48-006a03313c
+                - txg140dcf6543c142a28774-006a034b72
             X-Amz-Request-Id:
-                - txge6e4b9e67903436eaa48-006a03313c
+                - txg140dcf6543c142a28774-006a034b72
         status: 200 OK
         code: 200
-        duration: 4.07021725s
+        duration: 566.649958ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -60,7 +60,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -69,7 +69,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b98a3b25-9aca-4228-9569-cf6ec43a96cf
+                - f4388f4c-21f2-46b7-b97c-e5ddd82af890
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -81,8 +81,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135512Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?acl=
+                - 20260512T154658Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?acl=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -97,14 +97,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 12 May 2026 13:55:12 GMT
+                - Tue, 12 May 2026 15:46:58 GMT
             X-Amz-Id-2:
-                - txg9ec651c97d73445e9c5a-006a033140
+                - txgb24a5e61c4964f25a096-006a034b72
             X-Amz-Request-Id:
-                - txg9ec651c97d73445e9c5a-006a033140
+                - txgb24a5e61c4964f25a096-006a034b72
         status: 200 OK
         code: 200
-        duration: 152.673833ms
+        duration: 93.750542ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -113,7 +113,7 @@ interactions:
         content_length: 303
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></LifecycleConfiguration>
@@ -122,7 +122,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 427d9555-725b-4476-86da-e09ce53f99cd
+                - 826a01eb-1813-4955-964b-a1e0b5ca1c8b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
@@ -134,8 +134,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - 13feec03c398f242f302d24e62c26ce8c47f46e3921d2bf7a84ca9914cd3488a
             X-Amz-Date:
-                - 20260512T135512Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T154658Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -150,14 +150,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 12 May 2026 13:55:12 GMT
+                - Tue, 12 May 2026 15:46:58 GMT
             X-Amz-Id-2:
-                - txg89ad8558f3924d6cb58a-006a033140
+                - txgb8d96fbd2cb246038bb7-006a034b72
             X-Amz-Request-Id:
-                - txg89ad8558f3924d6cb58a-006a033140
+                - txgb8d96fbd2cb246038bb7-006a034b72
         status: 200 OK
         code: 200
-        duration: 157.34225ms
+        duration: 113.538375ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -166,7 +166,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -175,7 +175,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d49ec74d-e2ba-4c4b-9f64-4e703ecdedac
+                - 457dbc41-1189-4e50-a199-3e92f2b3573f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -183,8 +183,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135512Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?acl=
+                - 20260512T154658Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -203,14 +203,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:12 GMT
+                - Tue, 12 May 2026 15:46:58 GMT
             X-Amz-Id-2:
-                - txgb0d15435ffef45b9841a-006a033140
+                - txgec1f5284f14d4d18bc02-006a034b72
             X-Amz-Request-Id:
-                - txgb0d15435ffef45b9841a-006a033140
+                - txgec1f5284f14d4d18bc02-006a034b72
         status: 200 OK
         code: 200
-        duration: 62.504084ms
+        duration: 61.110583ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -219,7 +219,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -228,7 +228,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5a4f97cb-edbd-423e-b835-8af1c3489f10
+                - 6b37f0f6-3372-41d5-a317-3d22057798aa
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -236,8 +236,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135512Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260512T154658Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -245,23 +245,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 329
+        content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txga9daa465b4b34c4eac9e-006a033140</RequestId><HostId>txga9daa465b4b34c4eac9e-006a033140</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txge681d3c051bc4b53a000-006a034b73</RequestId><HostId>txge681d3c051bc4b53a000-006a034b73</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
         headers:
             Content-Length:
-                - "329"
+                - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:12 GMT
+                - Tue, 12 May 2026 15:46:59 GMT
             X-Amz-Id-2:
-                - txga9daa465b4b34c4eac9e-006a033140
+                - txge681d3c051bc4b53a000-006a034b73
             X-Amz-Request-Id:
-                - txga9daa465b4b34c4eac9e-006a033140
+                - txge681d3c051bc4b53a000-006a034b73
         status: 404 Not Found
         code: 404
-        duration: 57.964334ms
+        duration: 64.390458ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -270,7 +270,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -279,7 +279,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d33eff1f-b090-43f2-a480-a22faa06b429
+                - bea1880c-a588-4bae-b9c7-4d182bd2e022
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -287,8 +287,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135512Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
+                - 20260512T154659Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -296,25 +296,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 286
+        content_length: 287
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "286"
+                - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:12 GMT
+                - Tue, 12 May 2026 15:46:59 GMT
             X-Amz-Id-2:
-                - txgaf9e0935b373468d937f-006a033140
+                - txgd77dc590d7af450fbf50-006a034b73
             X-Amz-Request-Id:
-                - txgaf9e0935b373468d937f-006a033140
+                - txgd77dc590d7af450fbf50-006a034b73
         status: 200 OK
         code: 200
-        duration: 94.300833ms
+        duration: 108.886958ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -323,7 +323,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -332,7 +332,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 2b104eac-ae72-411c-9588-748006adf98f
+                - e850ad1d-4874-4179-a090-eef9b4475335
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -340,8 +340,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135512Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?tagging=
+                - 20260512T154659Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -349,23 +349,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 359
+        content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg097a7a68391542ffb57a-006a033140</RequestId><HostId>txg097a7a68391542ffb57a-006a033140</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgb042cc487c334a55bbdb-006a034b73</RequestId><HostId>txgb042cc487c334a55bbdb-006a034b73</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</BucketName></Error>
         headers:
             Content-Length:
-                - "359"
+                - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:12 GMT
+                - Tue, 12 May 2026 15:46:59 GMT
             X-Amz-Id-2:
-                - txg097a7a68391542ffb57a-006a033140
+                - txgb042cc487c334a55bbdb-006a034b73
             X-Amz-Request-Id:
-                - txg097a7a68391542ffb57a-006a033140
+                - txgb042cc487c334a55bbdb-006a034b73
         status: 404 Not Found
         code: 404
-        duration: 19.149ms
+        duration: 48.085209ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -374,7 +374,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -383,7 +383,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 38789bdb-6152-447f-9cb8-306a9346f394
+                - b695c344-60bd-4ccd-9b2c-cdbc3be30940
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -391,8 +391,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135512Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?cors=
+                - 20260512T154659Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -400,23 +400,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 297
+        content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg113b0d67350b42b7aa56-006a033140</RequestId><HostId>txg113b0d67350b42b7aa56-006a033140</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg55d934d5fdc44020a089-006a034b73</RequestId><HostId>txg55d934d5fdc44020a089-006a034b73</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
         headers:
             Content-Length:
-                - "297"
+                - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:12 GMT
+                - Tue, 12 May 2026 15:46:59 GMT
             X-Amz-Id-2:
-                - txg113b0d67350b42b7aa56-006a033140
+                - txg55d934d5fdc44020a089-006a034b73
             X-Amz-Request-Id:
-                - txg113b0d67350b42b7aa56-006a033140
+                - txg55d934d5fdc44020a089-006a034b73
         status: 404 Not Found
         code: 404
-        duration: 28.97875ms
+        duration: 37.088917ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -425,7 +425,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -434,7 +434,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9bd6b0c5-616b-4aa1-a15c-caba6baefd1d
+                - 569df663-43cf-483c-93a4-5a14daf2cd2c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -442,8 +442,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135512Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?versioning=
+                - 20260512T154659Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -462,14 +462,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:12 GMT
+                - Tue, 12 May 2026 15:46:59 GMT
             X-Amz-Id-2:
-                - txg35efc3fbeaea4e988f16-006a033140
+                - txg285dfc8a5d45444c90f2-006a034b73
             X-Amz-Request-Id:
-                - txg35efc3fbeaea4e988f16-006a033140
+                - txg285dfc8a5d45444c90f2-006a034b73
         status: 200 OK
         code: 200
-        duration: 47.364666ms
+        duration: 65.594ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -478,7 +478,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -487,7 +487,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5846af6b-a218-478a-9cfd-0d9667c2e258
+                - d26da0c8-f927-4a4a-90c0-fd5932074645
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -495,8 +495,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135512Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T154659Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -515,14 +515,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:12 GMT
+                - Tue, 12 May 2026 15:46:59 GMT
             X-Amz-Id-2:
-                - txga4b0af80336c47b0a6ad-006a033140
+                - txg252a9fa4e163405e886a-006a034b73
             X-Amz-Request-Id:
-                - txga4b0af80336c47b0a6ad-006a033140
+                - txg252a9fa4e163405e886a-006a034b73
         status: 200 OK
         code: 200
-        duration: 29.28225ms
+        duration: 58.136167ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -531,7 +531,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -540,7 +540,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0de75463-9683-4d54-9b0c-c0ebb2f57cc6
+                - 0bd473ba-bebf-4f3d-9e86-70cabf0b7087
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -548,8 +548,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135513Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
+                - 20260512T154659Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -564,16 +564,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:13 GMT
+                - Tue, 12 May 2026 15:46:59 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txg997c4ed92f7c4645bc78-006a033141
+                - txg23744b352eff4e8eadd5-006a034b73
             X-Amz-Request-Id:
-                - txg997c4ed92f7c4645bc78-006a033141
+                - txg23744b352eff4e8eadd5-006a034b73
         status: 200 OK
         code: 200
-        duration: 61.348041ms
+        duration: 153.095708ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -582,7 +582,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -591,7 +591,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9d68c02d-259d-40cf-84df-94857398e4d8
+                - 48b2fbe1-ccbf-4bcc-8603-9df7a22aa28a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -599,8 +599,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135513Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T154659Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -619,14 +619,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:13 GMT
+                - Tue, 12 May 2026 15:46:59 GMT
             X-Amz-Id-2:
-                - txgcc4464392dc24039b046-006a033141
+                - txgbca94a7e6cbc4eba9cde-006a034b73
             X-Amz-Request-Id:
-                - txgcc4464392dc24039b046-006a033141
+                - txgbca94a7e6cbc4eba9cde-006a034b73
         status: 200 OK
         code: 200
-        duration: 70.12975ms
+        duration: 33.824666ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -635,7 +635,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -644,7 +644,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - dcc1e2d8-4b6e-4a01-8ab5-3cafff3682e3
+                - a5e63d5f-ba9b-4a87-bbef-776884db2254
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -652,8 +652,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135513Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?acl=
+                - 20260512T154659Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -672,14 +672,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:13 GMT
+                - Tue, 12 May 2026 15:47:00 GMT
             X-Amz-Id-2:
-                - txg787781c502f94b769369-006a033141
+                - txg5c71fc945f254088969a-006a034b74
             X-Amz-Request-Id:
-                - txg787781c502f94b769369-006a033141
+                - txg5c71fc945f254088969a-006a034b74
         status: 200 OK
         code: 200
-        duration: 144.294291ms
+        duration: 64.970084ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -688,7 +688,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -697,7 +697,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7e03b120-a8b3-46d8-b2d8-a364fbb38195
+                - 31858566-71c4-48da-bc33-cf6fb18bcfae
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -705,8 +705,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135513Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260512T154700Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -714,23 +714,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 329
+        content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg5a09d89fb80b4dbd9bc2-006a033141</RequestId><HostId>txg5a09d89fb80b4dbd9bc2-006a033141</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgf3de7c28fe6f4795809a-006a034b74</RequestId><HostId>txgf3de7c28fe6f4795809a-006a034b74</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
         headers:
             Content-Length:
-                - "329"
+                - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:13 GMT
+                - Tue, 12 May 2026 15:47:00 GMT
             X-Amz-Id-2:
-                - txg5a09d89fb80b4dbd9bc2-006a033141
+                - txgf3de7c28fe6f4795809a-006a034b74
             X-Amz-Request-Id:
-                - txg5a09d89fb80b4dbd9bc2-006a033141
+                - txgf3de7c28fe6f4795809a-006a034b74
         status: 404 Not Found
         code: 404
-        duration: 37.304917ms
+        duration: 51.524625ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -739,7 +739,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -748,7 +748,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e678dc6d-3e6b-4206-9f74-70210c8a09b9
+                - f58464a6-07a8-4f6c-b429-e08056f0750b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -756,8 +756,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135513Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
+                - 20260512T154700Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -765,25 +765,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 286
+        content_length: 287
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "286"
+                - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:13 GMT
+                - Tue, 12 May 2026 15:47:00 GMT
             X-Amz-Id-2:
-                - txg2e64fc761bc14c4c8e42-006a033141
+                - txgbafe55563fff4f70a0fa-006a034b74
             X-Amz-Request-Id:
-                - txg2e64fc761bc14c4c8e42-006a033141
+                - txgbafe55563fff4f70a0fa-006a034b74
         status: 200 OK
         code: 200
-        duration: 101.267125ms
+        duration: 110.820625ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -792,7 +792,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -801,7 +801,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 8663ad2c-9885-409e-9dc8-c97c5a6c7c26
+                - 115501b5-e28b-454a-94ed-611455ebf875
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -809,8 +809,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135513Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?tagging=
+                - 20260512T154700Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -818,23 +818,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 359
+        content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg5ea3b2f30f4e410d9a8e-006a033141</RequestId><HostId>txg5ea3b2f30f4e410d9a8e-006a033141</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg93497706494b480bbab5-006a034b74</RequestId><HostId>txg93497706494b480bbab5-006a034b74</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</BucketName></Error>
         headers:
             Content-Length:
-                - "359"
+                - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:13 GMT
+                - Tue, 12 May 2026 15:47:00 GMT
             X-Amz-Id-2:
-                - txg5ea3b2f30f4e410d9a8e-006a033141
+                - txg93497706494b480bbab5-006a034b74
             X-Amz-Request-Id:
-                - txg5ea3b2f30f4e410d9a8e-006a033141
+                - txg93497706494b480bbab5-006a034b74
         status: 404 Not Found
         code: 404
-        duration: 46.388ms
+        duration: 32.694292ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -843,7 +843,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -852,7 +852,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9e66ec0e-5ba1-44a3-9ff9-5e2cd6511936
+                - ce8c20c9-3e0e-4011-959b-b44ed1ed74bb
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -860,8 +860,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135513Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?cors=
+                - 20260512T154700Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -869,23 +869,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 297
+        content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgcbc074546ad541ce98c3-006a033141</RequestId><HostId>txgcbc074546ad541ce98c3-006a033141</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgafa4cbd6a84b4b6cadd5-006a034b74</RequestId><HostId>txgafa4cbd6a84b4b6cadd5-006a034b74</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
         headers:
             Content-Length:
-                - "297"
+                - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:13 GMT
+                - Tue, 12 May 2026 15:47:00 GMT
             X-Amz-Id-2:
-                - txgcbc074546ad541ce98c3-006a033141
+                - txgafa4cbd6a84b4b6cadd5-006a034b74
             X-Amz-Request-Id:
-                - txgcbc074546ad541ce98c3-006a033141
+                - txgafa4cbd6a84b4b6cadd5-006a034b74
         status: 404 Not Found
         code: 404
-        duration: 32.945292ms
+        duration: 65.175ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -894,7 +894,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -903,7 +903,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 901a1d99-0711-4155-b562-bf44083666de
+                - 21b88ff3-73bb-4ea4-8878-a00b71c9b402
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -911,8 +911,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135513Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?versioning=
+                - 20260512T154700Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -931,14 +931,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:13 GMT
+                - Tue, 12 May 2026 15:47:00 GMT
             X-Amz-Id-2:
-                - txgd8d5215728924fae8428-006a033141
+                - txgfff411e18fee4d9daf99-006a034b74
             X-Amz-Request-Id:
-                - txgd8d5215728924fae8428-006a033141
+                - txgfff411e18fee4d9daf99-006a034b74
         status: 200 OK
         code: 200
-        duration: 103.211375ms
+        duration: 54.579708ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -947,7 +947,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -956,7 +956,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 33a1d5b9-7e2e-480a-ab87-19aff2ff1231
+                - ea0b556a-6adc-4d0f-a410-bce110e1eeeb
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -964,8 +964,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135513Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T154700Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -984,14 +984,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:13 GMT
+                - Tue, 12 May 2026 15:47:00 GMT
             X-Amz-Id-2:
-                - txg3c859ef92db341a89b2d-006a033141
+                - txgfc3fa9279deb42ac8dec-006a034b74
             X-Amz-Request-Id:
-                - txg3c859ef92db341a89b2d-006a033141
+                - txgfc3fa9279deb42ac8dec-006a034b74
         status: 200 OK
         code: 200
-        duration: 20.011167ms
+        duration: 34.297667ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -1000,7 +1000,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1009,7 +1009,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c3a533d4-41e4-4640-9e57-3a3135bc5aed
+                - 669ab30e-fb30-4e4e-8755-82cd3a5856a9
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1017,8 +1017,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135514Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?acl=
+                - 20260512T154700Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1037,14 +1037,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:14 GMT
+                - Tue, 12 May 2026 15:47:00 GMT
             X-Amz-Id-2:
-                - txg285bbd23b6d54dab9527-006a033142
+                - txg170dc3b9e44644078d73-006a034b74
             X-Amz-Request-Id:
-                - txg285bbd23b6d54dab9527-006a033142
+                - txg170dc3b9e44644078d73-006a034b74
         status: 200 OK
         code: 200
-        duration: 139.159541ms
+        duration: 48.81625ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1053,7 +1053,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1062,7 +1062,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9f433b90-f51b-4336-b0de-4b80652e4e0a
+                - b4b31751-7041-44bc-989b-a3b68d52af0b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1070,8 +1070,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135514Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260512T154700Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1079,23 +1079,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 329
+        content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgb632e051c9ac4609bf64-006a033142</RequestId><HostId>txgb632e051c9ac4609bf64-006a033142</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txge352786b6fc648daae5a-006a034b74</RequestId><HostId>txge352786b6fc648daae5a-006a034b74</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
         headers:
             Content-Length:
-                - "329"
+                - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:14 GMT
+                - Tue, 12 May 2026 15:47:00 GMT
             X-Amz-Id-2:
-                - txgb632e051c9ac4609bf64-006a033142
+                - txge352786b6fc648daae5a-006a034b74
             X-Amz-Request-Id:
-                - txgb632e051c9ac4609bf64-006a033142
+                - txge352786b6fc648daae5a-006a034b74
         status: 404 Not Found
         code: 404
-        duration: 21.310209ms
+        duration: 20.499ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1104,7 +1104,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1113,7 +1113,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - af624c3d-b6b1-40d7-9e3b-210b349108af
+                - b18ad6b0-7975-48f1-8140-205f9b8501e6
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1121,8 +1121,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135514Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
+                - 20260512T154700Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -1130,25 +1130,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 286
+        content_length: 287
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "286"
+                - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:14 GMT
+                - Tue, 12 May 2026 15:47:00 GMT
             X-Amz-Id-2:
-                - txg82b68b73df604901ba84-006a033142
+                - txgbc15a3a894a245df8e96-006a034b74
             X-Amz-Request-Id:
-                - txg82b68b73df604901ba84-006a033142
+                - txgbc15a3a894a245df8e96-006a034b74
         status: 200 OK
         code: 200
-        duration: 145.293875ms
+        duration: 87.893083ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1157,7 +1157,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1166,7 +1166,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - df01f45f-3546-466c-9211-6d68da0dc475
+                - 1aeae2b8-8a17-48fe-8538-edebb47d6dff
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1174,8 +1174,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135514Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?tagging=
+                - 20260512T154700Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1183,23 +1183,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 359
+        content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg79b33180c8aa4207a05c-006a033142</RequestId><HostId>txg79b33180c8aa4207a05c-006a033142</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg942e6f427f74428391b1-006a034b74</RequestId><HostId>txg942e6f427f74428391b1-006a034b74</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</BucketName></Error>
         headers:
             Content-Length:
-                - "359"
+                - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:14 GMT
+                - Tue, 12 May 2026 15:47:00 GMT
             X-Amz-Id-2:
-                - txg79b33180c8aa4207a05c-006a033142
+                - txg942e6f427f74428391b1-006a034b74
             X-Amz-Request-Id:
-                - txg79b33180c8aa4207a05c-006a033142
+                - txg942e6f427f74428391b1-006a034b74
         status: 404 Not Found
         code: 404
-        duration: 163.555916ms
+        duration: 57.299125ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1208,7 +1208,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1217,7 +1217,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5a402656-d208-4ba7-b238-d25515c452d3
+                - b3e9bfef-ab84-43b7-ad82-d6d2fa2cb388
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1225,8 +1225,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135514Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?cors=
+                - 20260512T154700Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1234,23 +1234,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 297
+        content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg0617794471f14083a707-006a033142</RequestId><HostId>txg0617794471f14083a707-006a033142</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg67d5607d436a412c92fe-006a034b74</RequestId><HostId>txg67d5607d436a412c92fe-006a034b74</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
         headers:
             Content-Length:
-                - "297"
+                - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:14 GMT
+                - Tue, 12 May 2026 15:47:00 GMT
             X-Amz-Id-2:
-                - txg0617794471f14083a707-006a033142
+                - txg67d5607d436a412c92fe-006a034b74
             X-Amz-Request-Id:
-                - txg0617794471f14083a707-006a033142
+                - txg67d5607d436a412c92fe-006a034b74
         status: 404 Not Found
         code: 404
-        duration: 50.645375ms
+        duration: 49.759916ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1259,7 +1259,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1268,7 +1268,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 32746616-e06d-4de3-9c3d-030f1dba4682
+                - ca8cd3ef-54e8-4b04-a20a-2a7632c8fddc
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1276,8 +1276,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135514Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?versioning=
+                - 20260512T154700Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1296,14 +1296,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:14 GMT
+                - Tue, 12 May 2026 15:47:00 GMT
             X-Amz-Id-2:
-                - txg3ace0365ba1a4e55b2ae-006a033142
+                - txgd5d2ab4b0c7549db8d37-006a034b74
             X-Amz-Request-Id:
-                - txg3ace0365ba1a4e55b2ae-006a033142
+                - txgd5d2ab4b0c7549db8d37-006a034b74
         status: 200 OK
         code: 200
-        duration: 19.085166ms
+        duration: 35.688125ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1312,7 +1312,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1321,7 +1321,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9b62c1fc-bb63-4e15-b22d-4e8f112cadd6
+                - 5f35920f-8c03-420d-8871-ef8a27faa5e2
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1329,8 +1329,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135514Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T154700Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1349,14 +1349,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:14 GMT
+                - Tue, 12 May 2026 15:47:00 GMT
             X-Amz-Id-2:
-                - txg0ba38a08a5e44023af8e-006a033142
+                - txg5e9f30e876d644a18fdb-006a034b74
             X-Amz-Request-Id:
-                - txg0ba38a08a5e44023af8e-006a033142
+                - txg5e9f30e876d644a18fdb-006a034b74
         status: 200 OK
         code: 200
-        duration: 56.135458ms
+        duration: 61.750083ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1365,7 +1365,7 @@ interactions:
         content_length: 306
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition></Rule></LifecycleConfiguration>
@@ -1374,7 +1374,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - fb9dad23-b875-47d0-9b6c-f93cd613f896
+                - 89734e80-3bde-49b8-b442-4354afedfade
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
@@ -1386,8 +1386,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - de1418e62a2680330e07a11a092b47b671d4ed12fe9fe6d9780b095b8f45d69c
             X-Amz-Date:
-                - 20260512T135514Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T154701Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -1402,14 +1402,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 12 May 2026 13:55:14 GMT
+                - Tue, 12 May 2026 15:47:01 GMT
             X-Amz-Id-2:
-                - txg20c64d4721cd486a8d25-006a033142
+                - txgb0d6abe8eb1b4b3c96ab-006a034b75
             X-Amz-Request-Id:
-                - txg20c64d4721cd486a8d25-006a033142
+                - txgb0d6abe8eb1b4b3c96ab-006a034b75
         status: 200 OK
         code: 200
-        duration: 69.094583ms
+        duration: 382.065709ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1418,7 +1418,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1427,7 +1427,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 2621bfb9-cc7d-4acb-95d5-fea896353869
+                - b8be8623-aa34-4f6d-94c3-66626f0ffca3
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1435,8 +1435,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135514Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?acl=
+                - 20260512T154701Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1455,14 +1455,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:14 GMT
+                - Tue, 12 May 2026 15:47:01 GMT
             X-Amz-Id-2:
-                - txg57b1e482a8f545549e29-006a033142
+                - txg2e9d25d68cab4337a156-006a034b75
             X-Amz-Request-Id:
-                - txg57b1e482a8f545549e29-006a033142
+                - txg2e9d25d68cab4337a156-006a034b75
         status: 200 OK
         code: 200
-        duration: 73.743833ms
+        duration: 27.545667ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1471,7 +1471,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1480,7 +1480,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 871573cf-6762-40f6-9914-2a618e9aace9
+                - bf3c5868-4293-4deb-a8bd-95b79540067b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1488,8 +1488,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135514Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260512T154701Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1497,23 +1497,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 329
+        content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgdc57b7410ebb45e3ad5d-006a033143</RequestId><HostId>txgdc57b7410ebb45e3ad5d-006a033143</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgfaa6ba9f8d3343d58f42-006a034b75</RequestId><HostId>txgfaa6ba9f8d3343d58f42-006a034b75</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
         headers:
             Content-Length:
-                - "329"
+                - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:15 GMT
+                - Tue, 12 May 2026 15:47:01 GMT
             X-Amz-Id-2:
-                - txgdc57b7410ebb45e3ad5d-006a033143
+                - txgfaa6ba9f8d3343d58f42-006a034b75
             X-Amz-Request-Id:
-                - txgdc57b7410ebb45e3ad5d-006a033143
+                - txgfaa6ba9f8d3343d58f42-006a034b75
         status: 404 Not Found
         code: 404
-        duration: 64.884292ms
+        duration: 61.66575ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1522,7 +1522,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1531,7 +1531,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 6668d67d-6465-4426-957f-635026f0e66c
+                - 6c2e6b67-5165-465e-812f-3d6ac6cdd5f5
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1539,8 +1539,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135515Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
+                - 20260512T154701Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -1548,25 +1548,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 286
+        content_length: 287
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "286"
+                - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:15 GMT
+                - Tue, 12 May 2026 15:47:01 GMT
             X-Amz-Id-2:
-                - txg2d14f0394d9f4e78926b-006a033143
+                - txgc15e405c39d4424994b4-006a034b75
             X-Amz-Request-Id:
-                - txg2d14f0394d9f4e78926b-006a033143
+                - txgc15e405c39d4424994b4-006a034b75
         status: 200 OK
         code: 200
-        duration: 64.7735ms
+        duration: 62.07775ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1575,7 +1575,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1584,7 +1584,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4c505056-53d4-4ef8-a68d-ef53091d1b5a
+                - b812e6b8-f8ad-4526-8e8d-5734f8aa2975
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1592,8 +1592,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135515Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?tagging=
+                - 20260512T154701Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1601,23 +1601,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 359
+        content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg2a5642d5be884aa89af9-006a033143</RequestId><HostId>txg2a5642d5be884aa89af9-006a033143</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg2d171acd55254432a215-006a034b75</RequestId><HostId>txg2d171acd55254432a215-006a034b75</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</BucketName></Error>
         headers:
             Content-Length:
-                - "359"
+                - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:15 GMT
+                - Tue, 12 May 2026 15:47:01 GMT
             X-Amz-Id-2:
-                - txg2a5642d5be884aa89af9-006a033143
+                - txg2d171acd55254432a215-006a034b75
             X-Amz-Request-Id:
-                - txg2a5642d5be884aa89af9-006a033143
+                - txg2d171acd55254432a215-006a034b75
         status: 404 Not Found
         code: 404
-        duration: 33.246209ms
+        duration: 66.506167ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1626,7 +1626,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1635,7 +1635,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0756056a-4dc2-499b-9d34-21afb8ad8697
+                - 572f3f8b-1664-495b-8f18-19caa1d18218
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1643,8 +1643,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135515Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?cors=
+                - 20260512T154701Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1652,23 +1652,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 297
+        content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg779c84fdf302412cb62d-006a033143</RequestId><HostId>txg779c84fdf302412cb62d-006a033143</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg0544bbf471074d039631-006a034b75</RequestId><HostId>txg0544bbf471074d039631-006a034b75</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
         headers:
             Content-Length:
-                - "297"
+                - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:15 GMT
+                - Tue, 12 May 2026 15:47:01 GMT
             X-Amz-Id-2:
-                - txg779c84fdf302412cb62d-006a033143
+                - txg0544bbf471074d039631-006a034b75
             X-Amz-Request-Id:
-                - txg779c84fdf302412cb62d-006a033143
+                - txg0544bbf471074d039631-006a034b75
         status: 404 Not Found
         code: 404
-        duration: 24.133292ms
+        duration: 56.68025ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1677,7 +1677,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1686,7 +1686,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0edf3725-00c2-45c3-a4a7-42d46b5b6ad0
+                - 600be7cd-8068-4c7d-87e5-3cf0d1abb0a5
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1694,8 +1694,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135515Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?versioning=
+                - 20260512T154701Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1714,14 +1714,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:15 GMT
+                - Tue, 12 May 2026 15:47:01 GMT
             X-Amz-Id-2:
-                - txg4724c5ab0874440e8916-006a033143
+                - txgf9e83b3ce8a14638bd8e-006a034b75
             X-Amz-Request-Id:
-                - txg4724c5ab0874440e8916-006a033143
+                - txgf9e83b3ce8a14638bd8e-006a034b75
         status: 200 OK
         code: 200
-        duration: 31.6515ms
+        duration: 32.053292ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1730,7 +1730,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1739,7 +1739,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7a392648-696f-447c-b5d3-e08ad6a1d2eb
+                - 5ded8b2e-bb8f-4996-94c5-c77a984521d2
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1747,8 +1747,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135515Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T154701Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1767,14 +1767,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:15 GMT
+                - Tue, 12 May 2026 15:47:01 GMT
             X-Amz-Id-2:
-                - txgbe9725ca19504289809c-006a033143
+                - txg88861a0042f447658d28-006a034b75
             X-Amz-Request-Id:
-                - txgbe9725ca19504289809c-006a033143
+                - txg88861a0042f447658d28-006a034b75
         status: 200 OK
         code: 200
-        duration: 39.535125ms
+        duration: 50.38075ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1783,7 +1783,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1792,7 +1792,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 003cde31-3830-42a9-bd3a-791b1a4068e8
+                - 761d062c-c9e3-4931-b38f-9326749991f2
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1800,8 +1800,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135515Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
+                - 20260512T154701Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -1816,16 +1816,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:15 GMT
+                - Tue, 12 May 2026 15:47:02 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txgb0bfd0e3eb6c4ee88285-006a033143
+                - txg0f86d6ca41604ccc8af0-006a034b76
             X-Amz-Request-Id:
-                - txgb0bfd0e3eb6c4ee88285-006a033143
+                - txg0f86d6ca41604ccc8af0-006a034b76
         status: 200 OK
         code: 200
-        duration: 57.452833ms
+        duration: 63.14875ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1834,7 +1834,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1843,7 +1843,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 68873e01-3529-42c8-989e-f6b8c4886442
+                - 9e107acd-d0ca-4b0b-97ca-13c7a07dc385
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1851,8 +1851,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135515Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T154702Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1871,14 +1871,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:15 GMT
+                - Tue, 12 May 2026 15:47:02 GMT
             X-Amz-Id-2:
-                - txg50addbad5e3d4d98a9d5-006a033143
+                - txg58efc7b32caf43d99cca-006a034b76
             X-Amz-Request-Id:
-                - txg50addbad5e3d4d98a9d5-006a033143
+                - txg58efc7b32caf43d99cca-006a034b76
         status: 200 OK
         code: 200
-        duration: 26.169916ms
+        duration: 66.225083ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1887,7 +1887,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1896,7 +1896,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 98bce07a-5c5d-4cce-9ec7-b82c70ea7eba
+                - 8f9cb86a-e38e-4e11-a939-a56d2e8a1a62
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1904,8 +1904,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135515Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?acl=
+                - 20260512T154702Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1924,14 +1924,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:15 GMT
+                - Tue, 12 May 2026 15:47:02 GMT
             X-Amz-Id-2:
-                - txg8043c1c1aab7441cb201-006a033143
+                - txg7ae719455a09481dbe19-006a034b76
             X-Amz-Request-Id:
-                - txg8043c1c1aab7441cb201-006a033143
+                - txg7ae719455a09481dbe19-006a034b76
         status: 200 OK
         code: 200
-        duration: 48.389709ms
+        duration: 70.923666ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1940,7 +1940,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1949,7 +1949,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d7632aab-4c47-4444-9904-a8aae2696ba7
+                - c879459b-fd78-497c-bce1-aa660747315b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1957,8 +1957,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135515Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260512T154702Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1966,23 +1966,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 329
+        content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgfeda056c03ce4f23b569-006a033143</RequestId><HostId>txgfeda056c03ce4f23b569-006a033143</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgfe1562a00ed24e7d9f16-006a034b76</RequestId><HostId>txgfe1562a00ed24e7d9f16-006a034b76</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
         headers:
             Content-Length:
-                - "329"
+                - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:15 GMT
+                - Tue, 12 May 2026 15:47:02 GMT
             X-Amz-Id-2:
-                - txgfeda056c03ce4f23b569-006a033143
+                - txgfe1562a00ed24e7d9f16-006a034b76
             X-Amz-Request-Id:
-                - txgfeda056c03ce4f23b569-006a033143
+                - txgfe1562a00ed24e7d9f16-006a034b76
         status: 404 Not Found
         code: 404
-        duration: 55.827333ms
+        duration: 54.485375ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1991,7 +1991,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2000,7 +2000,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 886d074e-58b4-4125-94aa-21d0e49082c4
+                - 954b7039-e9c8-4280-9391-35793b691cd5
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2008,8 +2008,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135515Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
+                - 20260512T154702Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -2017,25 +2017,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 286
+        content_length: 287
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "286"
+                - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:15 GMT
+                - Tue, 12 May 2026 15:47:02 GMT
             X-Amz-Id-2:
-                - txg81125a9b605f42209f5c-006a033143
+                - txg3f469a5cae104290a5e0-006a034b76
             X-Amz-Request-Id:
-                - txg81125a9b605f42209f5c-006a033143
+                - txg3f469a5cae104290a5e0-006a034b76
         status: 200 OK
         code: 200
-        duration: 34.095833ms
+        duration: 101.040625ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -2044,7 +2044,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2053,7 +2053,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0dfd9786-e8bd-4171-92f7-66e70e1238a8
+                - a4baafe1-96f9-4ec1-ae61-cdfe5daa50aa
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2061,8 +2061,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135515Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?tagging=
+                - 20260512T154702Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2070,23 +2070,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 359
+        content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg6da07cdf9aae445a98a3-006a033143</RequestId><HostId>txg6da07cdf9aae445a98a3-006a033143</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg9060865ddd8241adaeed-006a034b76</RequestId><HostId>txg9060865ddd8241adaeed-006a034b76</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</BucketName></Error>
         headers:
             Content-Length:
-                - "359"
+                - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:15 GMT
+                - Tue, 12 May 2026 15:47:02 GMT
             X-Amz-Id-2:
-                - txg6da07cdf9aae445a98a3-006a033143
+                - txg9060865ddd8241adaeed-006a034b76
             X-Amz-Request-Id:
-                - txg6da07cdf9aae445a98a3-006a033143
+                - txg9060865ddd8241adaeed-006a034b76
         status: 404 Not Found
         code: 404
-        duration: 29.990625ms
+        duration: 21.989167ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -2095,7 +2095,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2104,7 +2104,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 754156fc-55f9-4485-8030-a4fa42f94eda
+                - 9693e1bb-9114-4b70-bb13-03b99301fa42
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2112,8 +2112,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135515Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?cors=
+                - 20260512T154702Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2121,23 +2121,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 297
+        content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg916e5a63b03247d3bafe-006a033143</RequestId><HostId>txg916e5a63b03247d3bafe-006a033143</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txga09d8ceced8a40608e91-006a034b76</RequestId><HostId>txga09d8ceced8a40608e91-006a034b76</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
         headers:
             Content-Length:
-                - "297"
+                - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:15 GMT
+                - Tue, 12 May 2026 15:47:02 GMT
             X-Amz-Id-2:
-                - txg916e5a63b03247d3bafe-006a033143
+                - txga09d8ceced8a40608e91-006a034b76
             X-Amz-Request-Id:
-                - txg916e5a63b03247d3bafe-006a033143
+                - txga09d8ceced8a40608e91-006a034b76
         status: 404 Not Found
         code: 404
-        duration: 22.27375ms
+        duration: 52.910708ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -2146,7 +2146,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2155,7 +2155,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 59ce8466-0681-422e-8531-8a4da3f71617
+                - f7dfff2c-1ea3-4fee-9fc3-463439248b68
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2163,8 +2163,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135515Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?versioning=
+                - 20260512T154702Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2183,14 +2183,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:15 GMT
+                - Tue, 12 May 2026 15:47:02 GMT
             X-Amz-Id-2:
-                - txgfce8d4c3639d49d1b842-006a033143
+                - txge64853af349f41329e96-006a034b76
             X-Amz-Request-Id:
-                - txgfce8d4c3639d49d1b842-006a033143
+                - txge64853af349f41329e96-006a034b76
         status: 200 OK
         code: 200
-        duration: 60.574792ms
+        duration: 18.839667ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -2199,7 +2199,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2208,7 +2208,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 1f18b9d1-c741-4c54-af8b-0e3b5d42f8aa
+                - d3043098-5b64-44c3-be1f-618ee91769e6
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2216,8 +2216,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135515Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T154702Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2236,14 +2236,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:16 GMT
+                - Tue, 12 May 2026 15:47:02 GMT
             X-Amz-Id-2:
-                - txgabda9d76ba4c46f488a4-006a033144
+                - txg32ca6b149bc74ba380bd-006a034b76
             X-Amz-Request-Id:
-                - txgabda9d76ba4c46f488a4-006a033144
+                - txg32ca6b149bc74ba380bd-006a034b76
         status: 200 OK
         code: 200
-        duration: 58.660625ms
+        duration: 63.147834ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -2252,7 +2252,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2261,7 +2261,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9222afac-ba9a-4c32-b519-4bdd5dbed1dc
+                - 7144b770-ee95-45ce-a896-7100b2349059
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2269,8 +2269,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135516Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?acl=
+                - 20260512T154702Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2289,14 +2289,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:16 GMT
+                - Tue, 12 May 2026 15:47:02 GMT
             X-Amz-Id-2:
-                - txg86e76ad194024421b8b2-006a033144
+                - txg12f6a319ea49427c9e47-006a034b76
             X-Amz-Request-Id:
-                - txg86e76ad194024421b8b2-006a033144
+                - txg12f6a319ea49427c9e47-006a034b76
         status: 200 OK
         code: 200
-        duration: 80.913291ms
+        duration: 60.921416ms
     - id: 44
       request:
         proto: HTTP/1.1
@@ -2305,7 +2305,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2314,7 +2314,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - bb19eb51-63c9-4064-b8f4-1fbea293dcd3
+                - 7e5ca420-bd61-4ba1-ad44-5e10b388b383
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2322,8 +2322,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135516Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260512T154702Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2331,23 +2331,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 329
+        content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg0edd3ab24f5a404db98d-006a033144</RequestId><HostId>txg0edd3ab24f5a404db98d-006a033144</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg271cefb832d9439a868c-006a034b77</RequestId><HostId>txg271cefb832d9439a868c-006a034b77</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
         headers:
             Content-Length:
-                - "329"
+                - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:16 GMT
+                - Tue, 12 May 2026 15:47:03 GMT
             X-Amz-Id-2:
-                - txg0edd3ab24f5a404db98d-006a033144
+                - txg271cefb832d9439a868c-006a034b77
             X-Amz-Request-Id:
-                - txg0edd3ab24f5a404db98d-006a033144
+                - txg271cefb832d9439a868c-006a034b77
         status: 404 Not Found
         code: 404
-        duration: 96.670042ms
+        duration: 28.173542ms
     - id: 45
       request:
         proto: HTTP/1.1
@@ -2356,7 +2356,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2365,7 +2365,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4b383b44-f236-4e54-8855-62519a2d5f0f
+                - 5b3cb681-02c1-45ea-bca3-e139376c4146
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2373,8 +2373,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135516Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
+                - 20260512T154703Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -2382,25 +2382,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 286
+        content_length: 287
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "286"
+                - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:16 GMT
+                - Tue, 12 May 2026 15:47:03 GMT
             X-Amz-Id-2:
-                - txgb3eb63f6065b425b9c33-006a033144
+                - txg890b62578437467985eb-006a034b77
             X-Amz-Request-Id:
-                - txgb3eb63f6065b425b9c33-006a033144
+                - txg890b62578437467985eb-006a034b77
         status: 200 OK
         code: 200
-        duration: 47.771ms
+        duration: 67.817833ms
     - id: 46
       request:
         proto: HTTP/1.1
@@ -2409,7 +2409,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2418,7 +2418,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9c166ecd-5e81-42f3-b2aa-90ebdba9def7
+                - 9f1da802-f92d-4565-8161-712039864853
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2426,8 +2426,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135516Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?tagging=
+                - 20260512T154703Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2435,23 +2435,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 359
+        content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgf27359f53ba84103a9af-006a033144</RequestId><HostId>txgf27359f53ba84103a9af-006a033144</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg6fcb4dce2a5b4788bb70-006a034b77</RequestId><HostId>txg6fcb4dce2a5b4788bb70-006a034b77</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</BucketName></Error>
         headers:
             Content-Length:
-                - "359"
+                - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:16 GMT
+                - Tue, 12 May 2026 15:47:03 GMT
             X-Amz-Id-2:
-                - txgf27359f53ba84103a9af-006a033144
+                - txg6fcb4dce2a5b4788bb70-006a034b77
             X-Amz-Request-Id:
-                - txgf27359f53ba84103a9af-006a033144
+                - txg6fcb4dce2a5b4788bb70-006a034b77
         status: 404 Not Found
         code: 404
-        duration: 20.249625ms
+        duration: 30.213875ms
     - id: 47
       request:
         proto: HTTP/1.1
@@ -2460,7 +2460,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2469,7 +2469,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e667c8e5-a063-4d2b-85a5-4ec50ffc6047
+                - f774e696-bb54-4d82-a59a-a04ca1fa820d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2477,8 +2477,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135516Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?cors=
+                - 20260512T154703Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2486,23 +2486,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 297
+        content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg228f69e5217846279860-006a033144</RequestId><HostId>txg228f69e5217846279860-006a033144</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg650b9eca63da45a1b147-006a034b77</RequestId><HostId>txg650b9eca63da45a1b147-006a034b77</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
         headers:
             Content-Length:
-                - "297"
+                - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:16 GMT
+                - Tue, 12 May 2026 15:47:03 GMT
             X-Amz-Id-2:
-                - txg228f69e5217846279860-006a033144
+                - txg650b9eca63da45a1b147-006a034b77
             X-Amz-Request-Id:
-                - txg228f69e5217846279860-006a033144
+                - txg650b9eca63da45a1b147-006a034b77
         status: 404 Not Found
         code: 404
-        duration: 24.762166ms
+        duration: 20.61725ms
     - id: 48
       request:
         proto: HTTP/1.1
@@ -2511,7 +2511,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2520,7 +2520,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - a079cbab-bac9-4214-b000-2cdfeede01f2
+                - 0596ee9e-0278-4de5-90f7-cb714fd81b9c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2528,8 +2528,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135516Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?versioning=
+                - 20260512T154703Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2548,14 +2548,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:16 GMT
+                - Tue, 12 May 2026 15:47:03 GMT
             X-Amz-Id-2:
-                - txg8d8d9da541b74cb1ac65-006a033144
+                - txg2e41c71817514c65bff4-006a034b77
             X-Amz-Request-Id:
-                - txg8d8d9da541b74cb1ac65-006a033144
+                - txg2e41c71817514c65bff4-006a034b77
         status: 200 OK
         code: 200
-        duration: 22.489208ms
+        duration: 71.657959ms
     - id: 49
       request:
         proto: HTTP/1.1
@@ -2564,7 +2564,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2573,7 +2573,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 2feaea92-fdb5-4213-83ec-2714003212d0
+                - f7e973a6-1c5c-4274-8329-f8ba33b18396
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2581,8 +2581,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135516Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T154703Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2601,14 +2601,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:16 GMT
+                - Tue, 12 May 2026 15:47:03 GMT
             X-Amz-Id-2:
-                - txgb96efba23cb54285a0e1-006a033144
+                - txgf1bebb28bb634f919b80-006a034b77
             X-Amz-Request-Id:
-                - txgb96efba23cb54285a0e1-006a033144
+                - txgf1bebb28bb634f919b80-006a034b77
         status: 200 OK
         code: 200
-        duration: 74.399916ms
+        duration: 19.460125ms
     - id: 50
       request:
         proto: HTTP/1.1
@@ -2617,16 +2617,16 @@ interactions:
         content_length: 1132
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
-        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></LifecycleConfiguration>
+        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></LifecycleConfiguration>
         form: {}
         headers:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - a6fe50e4-d449-447f-8566-6c0b5f870ebc
+                - 95d851a1-e1a3-478b-aac9-8c0220762601
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
@@ -2634,12 +2634,12 @@ interactions:
             User-Agent:
                 - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,Z,e
             X-Amz-Checksum-Crc32:
-                - Zsh9Ug==
+                - Ptm59w==
             X-Amz-Content-Sha256:
-                - 5f9243f4f931bea9c2119f4e79c617a5c5220b643a54f2c4e442edaf30ca867a
+                - 5a66f5284daa450c521e7ab251a0d5d0fd30f5aab4a326acf3665950e98d54c9
             X-Amz-Date:
-                - 20260512T135516Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T154703Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -2654,14 +2654,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 12 May 2026 13:55:16 GMT
+                - Tue, 12 May 2026 15:47:03 GMT
             X-Amz-Id-2:
-                - txgb34b4c1e7bb64e8782c0-006a033144
+                - txgb98ed1657cb74284873b-006a034b77
             X-Amz-Request-Id:
-                - txgb34b4c1e7bb64e8782c0-006a033144
+                - txgb98ed1657cb74284873b-006a034b77
         status: 200 OK
         code: 200
-        duration: 196.586ms
+        duration: 103.55075ms
     - id: 51
       request:
         proto: HTTP/1.1
@@ -2670,7 +2670,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2679,7 +2679,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b5452d9a-35f9-4e45-81f4-172b238aac1f
+                - ba657b46-80f6-4c84-a917-fa63615638be
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2687,8 +2687,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135516Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?acl=
+                - 20260512T154703Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2707,14 +2707,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:17 GMT
+                - Tue, 12 May 2026 15:47:03 GMT
             X-Amz-Id-2:
-                - txg566a3cc597724223a5f4-006a033145
+                - txgc4fefd46375040768ccb-006a034b77
             X-Amz-Request-Id:
-                - txg566a3cc597724223a5f4-006a033145
+                - txgc4fefd46375040768ccb-006a034b77
         status: 200 OK
         code: 200
-        duration: 157.720291ms
+        duration: 54.513042ms
     - id: 52
       request:
         proto: HTTP/1.1
@@ -2723,7 +2723,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2732,7 +2732,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 40b22a6f-b1ec-474a-8570-fe074a041f61
+                - 90362c73-0afc-43ba-b38f-ac4ff59bb1b5
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2740,8 +2740,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135517Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260512T154703Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2749,23 +2749,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 329
+        content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgbd6ce5853cca4d179a38-006a033145</RequestId><HostId>txgbd6ce5853cca4d179a38-006a033145</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg081d7d86b678450ca2a6-006a034b77</RequestId><HostId>txg081d7d86b678450ca2a6-006a034b77</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
         headers:
             Content-Length:
-                - "329"
+                - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:17 GMT
+                - Tue, 12 May 2026 15:47:03 GMT
             X-Amz-Id-2:
-                - txgbd6ce5853cca4d179a38-006a033145
+                - txg081d7d86b678450ca2a6-006a034b77
             X-Amz-Request-Id:
-                - txgbd6ce5853cca4d179a38-006a033145
+                - txg081d7d86b678450ca2a6-006a034b77
         status: 404 Not Found
         code: 404
-        duration: 34.130542ms
+        duration: 36.12325ms
     - id: 53
       request:
         proto: HTTP/1.1
@@ -2774,7 +2774,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2783,7 +2783,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 30839bba-f56c-4237-a493-37873f7271a3
+                - 8f4db4d9-0d37-42e4-8137-9d9210a499bf
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2791,8 +2791,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135517Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
+                - 20260512T154703Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -2800,25 +2800,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 286
+        content_length: 287
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "286"
+                - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:17 GMT
+                - Tue, 12 May 2026 15:47:03 GMT
             X-Amz-Id-2:
-                - txgc2a1ee687edd40779c84-006a033145
+                - txg37db4e494b704218b4a5-006a034b77
             X-Amz-Request-Id:
-                - txgc2a1ee687edd40779c84-006a033145
+                - txg37db4e494b704218b4a5-006a034b77
         status: 200 OK
         code: 200
-        duration: 106.002833ms
+        duration: 46.524583ms
     - id: 54
       request:
         proto: HTTP/1.1
@@ -2827,7 +2827,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2836,7 +2836,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9d980ad0-02a5-402a-badf-654891022e4c
+                - e46ccde0-ac31-4234-9208-ff8bd37211dc
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2844,8 +2844,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135517Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?tagging=
+                - 20260512T154703Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2853,23 +2853,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 359
+        content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgd51cac43f22e48feb999-006a033145</RequestId><HostId>txgd51cac43f22e48feb999-006a033145</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg2b2f770f5dfe48858005-006a034b77</RequestId><HostId>txg2b2f770f5dfe48858005-006a034b77</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</BucketName></Error>
         headers:
             Content-Length:
-                - "359"
+                - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:17 GMT
+                - Tue, 12 May 2026 15:47:03 GMT
             X-Amz-Id-2:
-                - txgd51cac43f22e48feb999-006a033145
+                - txg2b2f770f5dfe48858005-006a034b77
             X-Amz-Request-Id:
-                - txgd51cac43f22e48feb999-006a033145
+                - txg2b2f770f5dfe48858005-006a034b77
         status: 404 Not Found
         code: 404
-        duration: 96.430042ms
+        duration: 42.157542ms
     - id: 55
       request:
         proto: HTTP/1.1
@@ -2878,7 +2878,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2887,7 +2887,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 87a23b8f-a183-4c3d-8b86-2c33f5d6a37e
+                - 6a058e0d-327d-4aac-94f3-35b4cf15f193
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2895,8 +2895,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135517Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?cors=
+                - 20260512T154703Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2904,23 +2904,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 297
+        content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg50ad68d14e054ad5a9c5-006a033145</RequestId><HostId>txg50ad68d14e054ad5a9c5-006a033145</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgc99e0d518ed042699a81-006a034b77</RequestId><HostId>txgc99e0d518ed042699a81-006a034b77</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
         headers:
             Content-Length:
-                - "297"
+                - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:17 GMT
+                - Tue, 12 May 2026 15:47:03 GMT
             X-Amz-Id-2:
-                - txg50ad68d14e054ad5a9c5-006a033145
+                - txgc99e0d518ed042699a81-006a034b77
             X-Amz-Request-Id:
-                - txg50ad68d14e054ad5a9c5-006a033145
+                - txgc99e0d518ed042699a81-006a034b77
         status: 404 Not Found
         code: 404
-        duration: 53.2495ms
+        duration: 56.858833ms
     - id: 56
       request:
         proto: HTTP/1.1
@@ -2929,7 +2929,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2938,7 +2938,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - cf33ac62-450a-4553-b45a-be5a2cf17508
+                - 8b9aa2c8-256d-4e9f-986c-0ff97f82a2fa
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2946,8 +2946,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135517Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?versioning=
+                - 20260512T154703Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2966,14 +2966,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:17 GMT
+                - Tue, 12 May 2026 15:47:03 GMT
             X-Amz-Id-2:
-                - txg1b69a51ca7164ef39bbe-006a033145
+                - txgd25338b2180548c2a9d7-006a034b77
             X-Amz-Request-Id:
-                - txg1b69a51ca7164ef39bbe-006a033145
+                - txgd25338b2180548c2a9d7-006a034b77
         status: 200 OK
         code: 200
-        duration: 63.094958ms
+        duration: 20.290917ms
     - id: 57
       request:
         proto: HTTP/1.1
@@ -2982,7 +2982,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2991,7 +2991,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 487452bf-b766-4537-ad78-c2253cf755e6
+                - 09d75c91-4159-4200-b3be-78d3b3dd59c4
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2999,8 +2999,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135517Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T154703Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3012,21 +3012,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
                 - "1105"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:17 GMT
+                - Tue, 12 May 2026 15:47:03 GMT
             X-Amz-Id-2:
-                - txg23266f7d9729481db36f-006a033145
+                - txgbae88f2d702247a699d0-006a034b77
             X-Amz-Request-Id:
-                - txg23266f7d9729481db36f-006a033145
+                - txgbae88f2d702247a699d0-006a034b77
         status: 200 OK
         code: 200
-        duration: 47.405542ms
+        duration: 50.915042ms
     - id: 58
       request:
         proto: HTTP/1.1
@@ -3035,7 +3035,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3044,7 +3044,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 272a5ec8-7448-485e-8367-5a0b5d75a036
+                - e2dcd1a8-1f25-4560-a08d-9ff9eaa9efcc
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3052,8 +3052,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135517Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
+                - 20260512T154703Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -3068,16 +3068,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:17 GMT
+                - Tue, 12 May 2026 15:47:04 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txg1aea7b3c182a4f8e82f7-006a033145
+                - txg9a476ac55d4846949ab3-006a034b78
             X-Amz-Request-Id:
-                - txg1aea7b3c182a4f8e82f7-006a033145
+                - txg9a476ac55d4846949ab3-006a034b78
         status: 200 OK
         code: 200
-        duration: 19.99825ms
+        duration: 56.132375ms
     - id: 59
       request:
         proto: HTTP/1.1
@@ -3086,7 +3086,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3095,7 +3095,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f1b52670-1541-4897-b42a-ad3dee706717
+                - d840106e-8af4-419d-adb9-5c0d6d12b239
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3103,8 +3103,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135517Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T154704Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3116,21 +3116,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
                 - "1105"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:17 GMT
+                - Tue, 12 May 2026 15:47:04 GMT
             X-Amz-Id-2:
-                - txgc8404fb3407e460dbe11-006a033145
+                - txg8dfce26d8e814532a9b3-006a034b78
             X-Amz-Request-Id:
-                - txgc8404fb3407e460dbe11-006a033145
+                - txg8dfce26d8e814532a9b3-006a034b78
         status: 200 OK
         code: 200
-        duration: 56.21525ms
+        duration: 66.619917ms
     - id: 60
       request:
         proto: HTTP/1.1
@@ -3139,7 +3139,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3148,7 +3148,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - fbdb792a-d90d-4b38-9cf0-03295bd4870b
+                - 5fc0dd2c-df80-4232-8e6e-20d5c2be022c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3156,8 +3156,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135517Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?acl=
+                - 20260512T154704Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3176,14 +3176,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:18 GMT
+                - Tue, 12 May 2026 15:47:04 GMT
             X-Amz-Id-2:
-                - txgd712bdd2ba5148ab8148-006a033146
+                - txg0ace4c6a67cb4d289210-006a034b78
             X-Amz-Request-Id:
-                - txgd712bdd2ba5148ab8148-006a033146
+                - txg0ace4c6a67cb4d289210-006a034b78
         status: 200 OK
         code: 200
-        duration: 72.101042ms
+        duration: 138.402709ms
     - id: 61
       request:
         proto: HTTP/1.1
@@ -3192,7 +3192,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3201,7 +3201,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5ff8bc03-bb1c-4bfb-97c4-1fa56e7d4ba9
+                - 5df87850-68cb-4199-9e87-64f86d84a51a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3209,8 +3209,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135518Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260512T154704Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3218,23 +3218,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 329
+        content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg14ce471be0094e93b7e1-006a033146</RequestId><HostId>txg14ce471be0094e93b7e1-006a033146</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg51b27713df6e4cb2b539-006a034b78</RequestId><HostId>txg51b27713df6e4cb2b539-006a034b78</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
         headers:
             Content-Length:
-                - "329"
+                - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:18 GMT
+                - Tue, 12 May 2026 15:47:04 GMT
             X-Amz-Id-2:
-                - txg14ce471be0094e93b7e1-006a033146
+                - txg51b27713df6e4cb2b539-006a034b78
             X-Amz-Request-Id:
-                - txg14ce471be0094e93b7e1-006a033146
+                - txg51b27713df6e4cb2b539-006a034b78
         status: 404 Not Found
         code: 404
-        duration: 104.584875ms
+        duration: 22.031958ms
     - id: 62
       request:
         proto: HTTP/1.1
@@ -3243,7 +3243,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3252,7 +3252,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 1d78632d-ea37-414f-8614-eb03d2c765a0
+                - 55bbc4f5-a183-46c5-80bb-4a693b5e6ed0
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3260,8 +3260,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135518Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
+                - 20260512T154704Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -3269,25 +3269,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 286
+        content_length: 287
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "286"
+                - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:18 GMT
+                - Tue, 12 May 2026 15:47:04 GMT
             X-Amz-Id-2:
-                - txg3ae0feb5131e411783a4-006a033146
+                - txg6767769be67f4207845f-006a034b78
             X-Amz-Request-Id:
-                - txg3ae0feb5131e411783a4-006a033146
+                - txg6767769be67f4207845f-006a034b78
         status: 200 OK
         code: 200
-        duration: 34.824416ms
+        duration: 79.470125ms
     - id: 63
       request:
         proto: HTTP/1.1
@@ -3296,7 +3296,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3305,7 +3305,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 505993bc-2a8c-46c2-a345-37b8d31bcc26
+                - 80f50981-6116-40bc-913b-bb61259beda7
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3313,8 +3313,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135518Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?tagging=
+                - 20260512T154704Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3322,23 +3322,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 359
+        content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgdd6ada5a19c34f09a253-006a033146</RequestId><HostId>txgdd6ada5a19c34f09a253-006a033146</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg47e2bcdcbe5549289ccd-006a034b78</RequestId><HostId>txg47e2bcdcbe5549289ccd-006a034b78</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</BucketName></Error>
         headers:
             Content-Length:
-                - "359"
+                - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:18 GMT
+                - Tue, 12 May 2026 15:47:04 GMT
             X-Amz-Id-2:
-                - txgdd6ada5a19c34f09a253-006a033146
+                - txg47e2bcdcbe5549289ccd-006a034b78
             X-Amz-Request-Id:
-                - txgdd6ada5a19c34f09a253-006a033146
+                - txg47e2bcdcbe5549289ccd-006a034b78
         status: 404 Not Found
         code: 404
-        duration: 35.96575ms
+        duration: 25.286584ms
     - id: 64
       request:
         proto: HTTP/1.1
@@ -3347,7 +3347,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3356,7 +3356,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f8003b54-152d-4b2a-9c03-38027e7162e9
+                - f4b8013e-998c-4f96-a9cb-c33dfd908383
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3364,8 +3364,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135518Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?cors=
+                - 20260512T154704Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3373,23 +3373,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 297
+        content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txga61cb20c37ab448ab0cc-006a033146</RequestId><HostId>txga61cb20c37ab448ab0cc-006a033146</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgcfd2f144c36a44d6950c-006a034b78</RequestId><HostId>txgcfd2f144c36a44d6950c-006a034b78</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
         headers:
             Content-Length:
-                - "297"
+                - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:18 GMT
+                - Tue, 12 May 2026 15:47:04 GMT
             X-Amz-Id-2:
-                - txga61cb20c37ab448ab0cc-006a033146
+                - txgcfd2f144c36a44d6950c-006a034b78
             X-Amz-Request-Id:
-                - txga61cb20c37ab448ab0cc-006a033146
+                - txgcfd2f144c36a44d6950c-006a034b78
         status: 404 Not Found
         code: 404
-        duration: 26.490458ms
+        duration: 75.754041ms
     - id: 65
       request:
         proto: HTTP/1.1
@@ -3398,7 +3398,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3407,7 +3407,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c59224a2-f54b-4dbe-a098-a56217cc5996
+                - 086ac3df-159f-4b1d-b650-8f3886a3c179
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3415,8 +3415,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135518Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?versioning=
+                - 20260512T154704Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3435,14 +3435,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:18 GMT
+                - Tue, 12 May 2026 15:47:04 GMT
             X-Amz-Id-2:
-                - txgd07006175c234edba755-006a033146
+                - txgda4b88d335004948a9d1-006a034b78
             X-Amz-Request-Id:
-                - txgd07006175c234edba755-006a033146
+                - txgda4b88d335004948a9d1-006a034b78
         status: 200 OK
         code: 200
-        duration: 19.544375ms
+        duration: 21.309708ms
     - id: 66
       request:
         proto: HTTP/1.1
@@ -3451,7 +3451,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3460,7 +3460,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - bf81a3ff-1ba8-4870-889c-648ad06337fd
+                - 507d73f8-505d-41f8-ba38-07efc00d4d36
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3468,8 +3468,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135518Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T154704Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3481,21 +3481,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
                 - "1105"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:18 GMT
+                - Tue, 12 May 2026 15:47:04 GMT
             X-Amz-Id-2:
-                - txg15596aa7cada4dada905-006a033146
+                - txga4365cc18c01472b9bca-006a034b78
             X-Amz-Request-Id:
-                - txg15596aa7cada4dada905-006a033146
+                - txga4365cc18c01472b9bca-006a034b78
         status: 200 OK
         code: 200
-        duration: 22.281875ms
+        duration: 25.505167ms
     - id: 67
       request:
         proto: HTTP/1.1
@@ -3504,7 +3504,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3513,7 +3513,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - a7377838-2518-4924-a6c2-f5d06955500b
+                - 0cf371fe-3883-40e8-8ff3-a4a812eaedb9
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3521,8 +3521,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135518Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?acl=
+                - 20260512T154704Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3541,14 +3541,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:18 GMT
+                - Tue, 12 May 2026 15:47:04 GMT
             X-Amz-Id-2:
-                - txg203ac848f15f4f788127-006a033146
+                - txg67bee90b48174342ba57-006a034b78
             X-Amz-Request-Id:
-                - txg203ac848f15f4f788127-006a033146
+                - txg67bee90b48174342ba57-006a034b78
         status: 200 OK
         code: 200
-        duration: 31.438458ms
+        duration: 56.178375ms
     - id: 68
       request:
         proto: HTTP/1.1
@@ -3557,7 +3557,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3566,7 +3566,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 100e3e1a-af68-43f8-b92a-1b6785e8d8da
+                - eaaee6b9-8adf-42cf-b79a-69be64a169ee
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3574,8 +3574,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135518Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260512T154704Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3583,23 +3583,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 329
+        content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgf8d1ef21f67842228fa6-006a033146</RequestId><HostId>txgf8d1ef21f67842228fa6-006a033146</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg2d148f6d9911412a995c-006a034b79</RequestId><HostId>txg2d148f6d9911412a995c-006a034b79</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
         headers:
             Content-Length:
-                - "329"
+                - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:18 GMT
+                - Tue, 12 May 2026 15:47:05 GMT
             X-Amz-Id-2:
-                - txgf8d1ef21f67842228fa6-006a033146
+                - txg2d148f6d9911412a995c-006a034b79
             X-Amz-Request-Id:
-                - txgf8d1ef21f67842228fa6-006a033146
+                - txg2d148f6d9911412a995c-006a034b79
         status: 404 Not Found
         code: 404
-        duration: 20.420292ms
+        duration: 30.552709ms
     - id: 69
       request:
         proto: HTTP/1.1
@@ -3608,7 +3608,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3617,16 +3617,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 1fc5c2a8-ad6d-4c0a-b8e0-cfb04aadd7a1
+                - b8e27334-2bde-461d-a156-975e925c5046
             Amz-Sdk-Request:
-                - attempt=1; max=3
+                - attempt=1; max=3; ttl=20260512T175704Z
             User-Agent:
                 - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135518Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
+                - 20260512T154705Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -3634,25 +3634,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 286
+        content_length: 287
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "286"
+                - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:18 GMT
+                - Tue, 12 May 2026 15:47:05 GMT
             X-Amz-Id-2:
-                - txge8baac581acf4ebeb4a0-006a033146
+                - txged1618ebb12a43c7a5e3-006a034b79
             X-Amz-Request-Id:
-                - txge8baac581acf4ebeb4a0-006a033146
+                - txged1618ebb12a43c7a5e3-006a034b79
         status: 200 OK
         code: 200
-        duration: 49.411542ms
+        duration: 78.917209ms
     - id: 70
       request:
         proto: HTTP/1.1
@@ -3661,7 +3661,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3670,7 +3670,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7c4ba859-d434-4c1a-b2f2-fc5144e27f2a
+                - 76607146-c31b-4e9e-bb85-69d74c496999
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3678,8 +3678,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135518Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?tagging=
+                - 20260512T154705Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3687,23 +3687,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 359
+        content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgc67d9dce0f534cd3bc11-006a033146</RequestId><HostId>txgc67d9dce0f534cd3bc11-006a033146</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgfbdd404fe9ed4776bc6b-006a034b79</RequestId><HostId>txgfbdd404fe9ed4776bc6b-006a034b79</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</BucketName></Error>
         headers:
             Content-Length:
-                - "359"
+                - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:18 GMT
+                - Tue, 12 May 2026 15:47:05 GMT
             X-Amz-Id-2:
-                - txgc67d9dce0f534cd3bc11-006a033146
+                - txgfbdd404fe9ed4776bc6b-006a034b79
             X-Amz-Request-Id:
-                - txgc67d9dce0f534cd3bc11-006a033146
+                - txgfbdd404fe9ed4776bc6b-006a034b79
         status: 404 Not Found
         code: 404
-        duration: 49.502583ms
+        duration: 58.461125ms
     - id: 71
       request:
         proto: HTTP/1.1
@@ -3712,7 +3712,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3721,7 +3721,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 3880bc22-6c9a-48c1-a3c9-789603657f73
+                - 01954971-39cf-4287-929b-80853f2f29bc
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3729,8 +3729,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135518Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?cors=
+                - 20260512T154705Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3738,23 +3738,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 297
+        content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg3769078401ea44e38bf2-006a033146</RequestId><HostId>txg3769078401ea44e38bf2-006a033146</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgea95c71319fe44e2bf9f-006a034b79</RequestId><HostId>txgea95c71319fe44e2bf9f-006a034b79</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
         headers:
             Content-Length:
-                - "297"
+                - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:18 GMT
+                - Tue, 12 May 2026 15:47:05 GMT
             X-Amz-Id-2:
-                - txg3769078401ea44e38bf2-006a033146
+                - txgea95c71319fe44e2bf9f-006a034b79
             X-Amz-Request-Id:
-                - txg3769078401ea44e38bf2-006a033146
+                - txgea95c71319fe44e2bf9f-006a034b79
         status: 404 Not Found
         code: 404
-        duration: 112.965334ms
+        duration: 19.908708ms
     - id: 72
       request:
         proto: HTTP/1.1
@@ -3763,7 +3763,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3772,7 +3772,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 1887a5f7-dfc9-4120-8e72-ca7f5487dc48
+                - b91e7d23-70ca-4502-8196-7b6eb494977a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3780,8 +3780,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135518Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?versioning=
+                - 20260512T154705Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3800,14 +3800,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:18 GMT
+                - Tue, 12 May 2026 15:47:05 GMT
             X-Amz-Id-2:
-                - txgc4e99f061bd640cfba81-006a033146
+                - txgecd3a88ed9a54eddb4a5-006a034b79
             X-Amz-Request-Id:
-                - txgc4e99f061bd640cfba81-006a033146
+                - txgecd3a88ed9a54eddb4a5-006a034b79
         status: 200 OK
         code: 200
-        duration: 19.993958ms
+        duration: 60.798083ms
     - id: 73
       request:
         proto: HTTP/1.1
@@ -3816,7 +3816,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3825,7 +3825,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 64c701ce-2831-4710-964e-30859d7b9cd1
+                - 4c4874ed-1bc9-48bb-96a1-9a44beb043e8
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3833,8 +3833,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135518Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T154705Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3846,21 +3846,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
                 - "1105"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:18 GMT
+                - Tue, 12 May 2026 15:47:05 GMT
             X-Amz-Id-2:
-                - txg71377e59f53244448fff-006a033146
+                - txg8b29c7fb58b94266a981-006a034b79
             X-Amz-Request-Id:
-                - txg71377e59f53244448fff-006a033146
+                - txg8b29c7fb58b94266a981-006a034b79
         status: 200 OK
         code: 200
-        duration: 30.984167ms
+        duration: 36.367959ms
     - id: 74
       request:
         proto: HTTP/1.1
@@ -3869,7 +3869,7 @@ interactions:
         content_length: 296
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
@@ -3878,7 +3878,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 3269ba5d-5c2e-4dc3-b87b-817afcbfe8e7
+                - 303dfbef-79c3-439d-9673-2664a622f901
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
@@ -3890,8 +3890,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - 7756d51b786b61edff20b7957d22346417f85f71d19eeca0d6d28d6df7b15bbc
             X-Amz-Date:
-                - 20260512T135518Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T154705Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -3906,14 +3906,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 12 May 2026 13:55:19 GMT
+                - Tue, 12 May 2026 15:47:05 GMT
             X-Amz-Id-2:
-                - txg3d02ef7990b34aa5844c-006a033147
+                - txgad48c4c5ee0b4fcd8d84-006a034b79
             X-Amz-Request-Id:
-                - txg3d02ef7990b34aa5844c-006a033147
+                - txgad48c4c5ee0b4fcd8d84-006a034b79
         status: 200 OK
         code: 200
-        duration: 20.701917ms
+        duration: 100.239875ms
     - id: 75
       request:
         proto: HTTP/1.1
@@ -3922,7 +3922,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3931,7 +3931,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 6df9afaf-c81b-4532-bdc8-b105e1418129
+                - 8d7c63f9-03b9-4641-8bd9-e84f6aea6242
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3939,8 +3939,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135519Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?acl=
+                - 20260512T154705Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3959,14 +3959,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:19 GMT
+                - Tue, 12 May 2026 15:47:05 GMT
             X-Amz-Id-2:
-                - txg8aaa8a54860441b3bacc-006a033147
+                - txg16593e0c781847eba055-006a034b79
             X-Amz-Request-Id:
-                - txg8aaa8a54860441b3bacc-006a033147
+                - txg16593e0c781847eba055-006a034b79
         status: 200 OK
         code: 200
-        duration: 19.091708ms
+        duration: 20.617792ms
     - id: 76
       request:
         proto: HTTP/1.1
@@ -3975,7 +3975,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3984,7 +3984,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 35c7405f-d9ae-486d-8363-2ca2167de4f7
+                - 5d6f8c3e-3cb0-4949-a3f2-b1b86e158da4
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3992,8 +3992,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135519Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260512T154705Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4001,23 +4001,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 329
+        content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg6b3e4a5d78b54f9b8ef8-006a033147</RequestId><HostId>txg6b3e4a5d78b54f9b8ef8-006a033147</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg0d896dfcdeaa4ad39f04-006a034b79</RequestId><HostId>txg0d896dfcdeaa4ad39f04-006a034b79</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
         headers:
             Content-Length:
-                - "329"
+                - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:19 GMT
+                - Tue, 12 May 2026 15:47:05 GMT
             X-Amz-Id-2:
-                - txg6b3e4a5d78b54f9b8ef8-006a033147
+                - txg0d896dfcdeaa4ad39f04-006a034b79
             X-Amz-Request-Id:
-                - txg6b3e4a5d78b54f9b8ef8-006a033147
+                - txg0d896dfcdeaa4ad39f04-006a034b79
         status: 404 Not Found
         code: 404
-        duration: 23.076875ms
+        duration: 61.250834ms
     - id: 77
       request:
         proto: HTTP/1.1
@@ -4026,7 +4026,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4035,7 +4035,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b8102b72-3ffb-46c5-b252-0908c3b5f7cd
+                - b055261f-a253-43e8-bcee-9dd5b860f073
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4043,8 +4043,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135519Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
+                - 20260512T154705Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -4052,25 +4052,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 286
+        content_length: 287
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "286"
+                - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:19 GMT
+                - Tue, 12 May 2026 15:47:05 GMT
             X-Amz-Id-2:
-                - txg13c74295130042738510-006a033147
+                - txg56b2efce45464f268e32-006a034b79
             X-Amz-Request-Id:
-                - txg13c74295130042738510-006a033147
+                - txg56b2efce45464f268e32-006a034b79
         status: 200 OK
         code: 200
-        duration: 116.101542ms
+        duration: 67.498583ms
     - id: 78
       request:
         proto: HTTP/1.1
@@ -4079,7 +4079,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4088,7 +4088,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e001b1fe-ffb8-4590-a1b0-9d283cfd5e8d
+                - 6473e15b-0994-4707-87b3-b25a3ddea88e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4096,8 +4096,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135519Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?tagging=
+                - 20260512T154705Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4105,23 +4105,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 359
+        content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg85b85817892c42f08642-006a033147</RequestId><HostId>txg85b85817892c42f08642-006a033147</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg3f21a883735348dcbbac-006a034b79</RequestId><HostId>txg3f21a883735348dcbbac-006a034b79</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</BucketName></Error>
         headers:
             Content-Length:
-                - "359"
+                - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:19 GMT
+                - Tue, 12 May 2026 15:47:05 GMT
             X-Amz-Id-2:
-                - txg85b85817892c42f08642-006a033147
+                - txg3f21a883735348dcbbac-006a034b79
             X-Amz-Request-Id:
-                - txg85b85817892c42f08642-006a033147
+                - txg3f21a883735348dcbbac-006a034b79
         status: 404 Not Found
         code: 404
-        duration: 19.174875ms
+        duration: 36.2405ms
     - id: 79
       request:
         proto: HTTP/1.1
@@ -4130,7 +4130,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4139,7 +4139,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4569210f-3dce-45b0-94df-b60a8e554d6e
+                - 1097086b-f793-4733-bec4-babac789e2ff
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4147,8 +4147,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135519Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?cors=
+                - 20260512T154705Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4156,23 +4156,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 297
+        content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgf27ed968893e4621961a-006a033147</RequestId><HostId>txgf27ed968893e4621961a-006a033147</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgc2969a2e212846f497ca-006a034b79</RequestId><HostId>txgc2969a2e212846f497ca-006a034b79</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
         headers:
             Content-Length:
-                - "297"
+                - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:19 GMT
+                - Tue, 12 May 2026 15:47:05 GMT
             X-Amz-Id-2:
-                - txgf27ed968893e4621961a-006a033147
+                - txgc2969a2e212846f497ca-006a034b79
             X-Amz-Request-Id:
-                - txgf27ed968893e4621961a-006a033147
+                - txgc2969a2e212846f497ca-006a034b79
         status: 404 Not Found
         code: 404
-        duration: 19.487917ms
+        duration: 70.816375ms
     - id: 80
       request:
         proto: HTTP/1.1
@@ -4181,7 +4181,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4190,7 +4190,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 09852399-31ab-41ba-8355-931f836ff45d
+                - 153e49be-172e-42e8-970b-674189ac3225
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4198,8 +4198,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135519Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?versioning=
+                - 20260512T154705Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4218,14 +4218,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:19 GMT
+                - Tue, 12 May 2026 15:47:05 GMT
             X-Amz-Id-2:
-                - txg93019c29501c47649a2f-006a033147
+                - txgbc6be79045214965a1c3-006a034b79
             X-Amz-Request-Id:
-                - txg93019c29501c47649a2f-006a033147
+                - txgbc6be79045214965a1c3-006a034b79
         status: 200 OK
         code: 200
-        duration: 18.384583ms
+        duration: 73.37675ms
     - id: 81
       request:
         proto: HTTP/1.1
@@ -4234,7 +4234,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4243,7 +4243,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - faba06b7-3289-432c-a950-db70b140026b
+                - 900a4980-2c73-4606-9c6f-4b859253cb36
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4251,8 +4251,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135519Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T154705Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4271,14 +4271,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:19 GMT
+                - Tue, 12 May 2026 15:47:05 GMT
             X-Amz-Id-2:
-                - txga37b3c0a049b43bfa94b-006a033147
+                - txg96adcf3e53374837a6db-006a034b79
             X-Amz-Request-Id:
-                - txga37b3c0a049b43bfa94b-006a033147
+                - txg96adcf3e53374837a6db-006a034b79
         status: 200 OK
         code: 200
-        duration: 47.521333ms
+        duration: 43.584708ms
     - id: 82
       request:
         proto: HTTP/1.1
@@ -4287,7 +4287,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4296,7 +4296,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 04f95681-c664-4abc-b58e-8c5b188b7b88
+                - 1c78eb30-039d-4292-ac08-51f34eae1106
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4304,8 +4304,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135519Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
+                - 20260512T154706Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -4320,16 +4320,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:19 GMT
+                - Tue, 12 May 2026 15:47:06 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txg4c13f3c8929347e196f3-006a033147
+                - txg1b0a7d791b9c4ce28d9e-006a034b7a
             X-Amz-Request-Id:
-                - txg4c13f3c8929347e196f3-006a033147
+                - txg1b0a7d791b9c4ce28d9e-006a034b7a
         status: 200 OK
         code: 200
-        duration: 53.389292ms
+        duration: 19.17275ms
     - id: 83
       request:
         proto: HTTP/1.1
@@ -4338,7 +4338,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4347,7 +4347,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d7c07c0d-d261-4405-a09b-f917f942e391
+                - a225c2c7-4456-4340-95c7-65d7a82f6f2c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4355,8 +4355,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135519Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T154706Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4375,14 +4375,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:19 GMT
+                - Tue, 12 May 2026 15:47:06 GMT
             X-Amz-Id-2:
-                - txg1f0a1cb81cd24c16a92a-006a033147
+                - txgc1a2223529d640e8ac05-006a034b7a
             X-Amz-Request-Id:
-                - txg1f0a1cb81cd24c16a92a-006a033147
+                - txgc1a2223529d640e8ac05-006a034b7a
         status: 200 OK
         code: 200
-        duration: 50.287125ms
+        duration: 43.666208ms
     - id: 84
       request:
         proto: HTTP/1.1
@@ -4391,7 +4391,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4400,7 +4400,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ba695672-50a6-445e-91e6-1c2d77f73ba8
+                - 436e94d3-ca19-49b2-aa11-90bf360811fa
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4408,8 +4408,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135519Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?acl=
+                - 20260512T154706Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4428,14 +4428,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:19 GMT
+                - Tue, 12 May 2026 15:47:06 GMT
             X-Amz-Id-2:
-                - txg8762209f772e44128f0b-006a033147
+                - txgb40e59535078462fb730-006a034b7a
             X-Amz-Request-Id:
-                - txg8762209f772e44128f0b-006a033147
+                - txgb40e59535078462fb730-006a034b7a
         status: 200 OK
         code: 200
-        duration: 37.150042ms
+        duration: 21.139167ms
     - id: 85
       request:
         proto: HTTP/1.1
@@ -4444,7 +4444,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4453,7 +4453,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b3ce8f20-da42-492d-a371-6f188d15b778
+                - 8fc7736f-e1bd-4ab9-b181-f6b80c60fcf6
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4461,8 +4461,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135519Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260512T154706Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4470,23 +4470,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 329
+        content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgffd998eb882b4976a344-006a033147</RequestId><HostId>txgffd998eb882b4976a344-006a033147</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgef42905edbe4463082ae-006a034b7a</RequestId><HostId>txgef42905edbe4463082ae-006a034b7a</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
         headers:
             Content-Length:
-                - "329"
+                - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:19 GMT
+                - Tue, 12 May 2026 15:47:06 GMT
             X-Amz-Id-2:
-                - txgffd998eb882b4976a344-006a033147
+                - txgef42905edbe4463082ae-006a034b7a
             X-Amz-Request-Id:
-                - txgffd998eb882b4976a344-006a033147
+                - txgef42905edbe4463082ae-006a034b7a
         status: 404 Not Found
         code: 404
-        duration: 21.636291ms
+        duration: 20.698209ms
     - id: 86
       request:
         proto: HTTP/1.1
@@ -4495,7 +4495,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4504,7 +4504,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9d65eca6-2920-4c41-ad92-b2bda097635f
+                - dcc85190-988c-41d9-83a2-a7038da11f44
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4512,8 +4512,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135519Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
+                - 20260512T154706Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -4521,25 +4521,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 286
+        content_length: 287
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "286"
+                - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:19 GMT
+                - Tue, 12 May 2026 15:47:06 GMT
             X-Amz-Id-2:
-                - txgb61dd29925c94230bd97-006a033147
+                - txg6281307e436a47e591e8-006a034b7a
             X-Amz-Request-Id:
-                - txgb61dd29925c94230bd97-006a033147
+                - txg6281307e436a47e591e8-006a034b7a
         status: 200 OK
         code: 200
-        duration: 53.486417ms
+        duration: 21.981583ms
     - id: 87
       request:
         proto: HTTP/1.1
@@ -4548,7 +4548,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4557,7 +4557,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9f620409-3e5f-4d63-bee6-294d7451fef0
+                - 53670e98-5807-45f5-955a-71f2bf1998e2
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4565,8 +4565,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135519Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?tagging=
+                - 20260512T154706Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4574,23 +4574,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 359
+        content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg3ca2f0bbf1e74ba79422-006a033147</RequestId><HostId>txg3ca2f0bbf1e74ba79422-006a033147</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg1e1ba3773fe34e79b27b-006a034b7a</RequestId><HostId>txg1e1ba3773fe34e79b27b-006a034b7a</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</BucketName></Error>
         headers:
             Content-Length:
-                - "359"
+                - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:19 GMT
+                - Tue, 12 May 2026 15:47:06 GMT
             X-Amz-Id-2:
-                - txg3ca2f0bbf1e74ba79422-006a033147
+                - txg1e1ba3773fe34e79b27b-006a034b7a
             X-Amz-Request-Id:
-                - txg3ca2f0bbf1e74ba79422-006a033147
+                - txg1e1ba3773fe34e79b27b-006a034b7a
         status: 404 Not Found
         code: 404
-        duration: 34.094541ms
+        duration: 32.208375ms
     - id: 88
       request:
         proto: HTTP/1.1
@@ -4599,7 +4599,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4608,7 +4608,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - bea33d29-0ccd-4f94-8d59-6d1e37abcddf
+                - b7835634-da8e-4a53-963d-8b45b213d9c8
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4616,8 +4616,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135519Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?cors=
+                - 20260512T154706Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4625,23 +4625,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 297
+        content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg19616aa2a22844c59e9e-006a033147</RequestId><HostId>txg19616aa2a22844c59e9e-006a033147</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg44ac71b4f1ab442fb5ea-006a034b7a</RequestId><HostId>txg44ac71b4f1ab442fb5ea-006a034b7a</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
         headers:
             Content-Length:
-                - "297"
+                - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:19 GMT
+                - Tue, 12 May 2026 15:47:06 GMT
             X-Amz-Id-2:
-                - txg19616aa2a22844c59e9e-006a033147
+                - txg44ac71b4f1ab442fb5ea-006a034b7a
             X-Amz-Request-Id:
-                - txg19616aa2a22844c59e9e-006a033147
+                - txg44ac71b4f1ab442fb5ea-006a034b7a
         status: 404 Not Found
         code: 404
-        duration: 90.53025ms
+        duration: 50.846208ms
     - id: 89
       request:
         proto: HTTP/1.1
@@ -4650,7 +4650,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4659,7 +4659,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 807c83b0-b354-4e7f-a3e3-b07bf1dff5c3
+                - 06cf3152-61ce-4912-a73b-0d3d1c255b55
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4667,8 +4667,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135519Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?versioning=
+                - 20260512T154706Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4687,14 +4687,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:20 GMT
+                - Tue, 12 May 2026 15:47:06 GMT
             X-Amz-Id-2:
-                - txgd99ffc7099c9446dbf45-006a033148
+                - txg8db6485121844948a40a-006a034b7a
             X-Amz-Request-Id:
-                - txgd99ffc7099c9446dbf45-006a033148
+                - txg8db6485121844948a40a-006a034b7a
         status: 200 OK
         code: 200
-        duration: 57.579542ms
+        duration: 45.465958ms
     - id: 90
       request:
         proto: HTTP/1.1
@@ -4703,7 +4703,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4712,7 +4712,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c2d3ed70-db0e-4502-b29e-e5b4a6f477bc
+                - 19509278-e706-42e9-88dd-66f4e4bf020c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4720,8 +4720,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135520Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T154706Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4740,14 +4740,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:20 GMT
+                - Tue, 12 May 2026 15:47:06 GMT
             X-Amz-Id-2:
-                - txg506806035d8243a7adf9-006a033148
+                - txgf32b8584deec4a5ca83d-006a034b7a
             X-Amz-Request-Id:
-                - txg506806035d8243a7adf9-006a033148
+                - txgf32b8584deec4a5ca83d-006a034b7a
         status: 200 OK
         code: 200
-        duration: 50.597375ms
+        duration: 21.93ms
     - id: 91
       request:
         proto: HTTP/1.1
@@ -4756,7 +4756,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4765,7 +4765,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7ef21bdf-f69d-40df-b410-ea39a6c0b82d
+                - 14289a7b-5d39-4c01-a193-25eaf78721a3
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4773,8 +4773,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135520Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?acl=
+                - 20260512T154706Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4793,14 +4793,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:20 GMT
+                - Tue, 12 May 2026 15:47:06 GMT
             X-Amz-Id-2:
-                - txg427c28e519904129bd5f-006a033148
+                - txg255da69fb4ec45bda4ac-006a034b7a
             X-Amz-Request-Id:
-                - txg427c28e519904129bd5f-006a033148
+                - txg255da69fb4ec45bda4ac-006a034b7a
         status: 200 OK
         code: 200
-        duration: 42.407333ms
+        duration: 19.666583ms
     - id: 92
       request:
         proto: HTTP/1.1
@@ -4809,7 +4809,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4818,7 +4818,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c2a2792f-65c4-4d58-8b24-4c5b41663b12
+                - 87db652b-620e-4b43-ad70-06191bb2570d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4826,8 +4826,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135520Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260512T154706Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4835,23 +4835,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 329
+        content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txga28555b7af4241b897c1-006a033148</RequestId><HostId>txga28555b7af4241b897c1-006a033148</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg075fa1072cda4a08b8c4-006a034b7a</RequestId><HostId>txg075fa1072cda4a08b8c4-006a034b7a</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
         headers:
             Content-Length:
-                - "329"
+                - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:20 GMT
+                - Tue, 12 May 2026 15:47:06 GMT
             X-Amz-Id-2:
-                - txga28555b7af4241b897c1-006a033148
+                - txg075fa1072cda4a08b8c4-006a034b7a
             X-Amz-Request-Id:
-                - txga28555b7af4241b897c1-006a033148
+                - txg075fa1072cda4a08b8c4-006a034b7a
         status: 404 Not Found
         code: 404
-        duration: 20.022041ms
+        duration: 20.143542ms
     - id: 93
       request:
         proto: HTTP/1.1
@@ -4860,7 +4860,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4869,7 +4869,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7187a77b-3fc0-49e0-bf28-07465716df88
+                - c143f784-af0b-4afe-9aae-77af3ebbe587
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4877,8 +4877,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135520Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
+                - 20260512T154706Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -4886,25 +4886,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 286
+        content_length: 287
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "286"
+                - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:20 GMT
+                - Tue, 12 May 2026 15:47:06 GMT
             X-Amz-Id-2:
-                - txg65c519a823be4395b367-006a033148
+                - txg71902707b7ee4a9196ed-006a034b7a
             X-Amz-Request-Id:
-                - txg65c519a823be4395b367-006a033148
+                - txg71902707b7ee4a9196ed-006a034b7a
         status: 200 OK
         code: 200
-        duration: 27.352542ms
+        duration: 20.245791ms
     - id: 94
       request:
         proto: HTTP/1.1
@@ -4913,7 +4913,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4922,7 +4922,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e370b700-9753-4999-8de6-4c821be55276
+                - 890268b7-e67b-40cc-8c14-89e7fbc21d61
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4930,8 +4930,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135520Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?tagging=
+                - 20260512T154706Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4939,23 +4939,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 359
+        content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgb5f189f21e9746cfb647-006a033148</RequestId><HostId>txgb5f189f21e9746cfb647-006a033148</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg50e7ce250e99457eb6e2-006a034b7a</RequestId><HostId>txg50e7ce250e99457eb6e2-006a034b7a</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</BucketName></Error>
         headers:
             Content-Length:
-                - "359"
+                - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:20 GMT
+                - Tue, 12 May 2026 15:47:06 GMT
             X-Amz-Id-2:
-                - txgb5f189f21e9746cfb647-006a033148
+                - txg50e7ce250e99457eb6e2-006a034b7a
             X-Amz-Request-Id:
-                - txgb5f189f21e9746cfb647-006a033148
+                - txg50e7ce250e99457eb6e2-006a034b7a
         status: 404 Not Found
         code: 404
-        duration: 35.000542ms
+        duration: 25.601917ms
     - id: 95
       request:
         proto: HTTP/1.1
@@ -4964,7 +4964,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4973,7 +4973,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 2d9e56c6-9c20-42c0-bc40-31d9b35504ea
+                - 6da42284-d111-472a-929a-d8e89749079f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4981,8 +4981,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135520Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?cors=
+                - 20260512T154706Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4990,23 +4990,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 297
+        content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgf3600ecf465843bca10e-006a033148</RequestId><HostId>txgf3600ecf465843bca10e-006a033148</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg0b94b3217db1489e925d-006a034b7a</RequestId><HostId>txg0b94b3217db1489e925d-006a034b7a</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
         headers:
             Content-Length:
-                - "297"
+                - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:20 GMT
+                - Tue, 12 May 2026 15:47:06 GMT
             X-Amz-Id-2:
-                - txgf3600ecf465843bca10e-006a033148
+                - txg0b94b3217db1489e925d-006a034b7a
             X-Amz-Request-Id:
-                - txgf3600ecf465843bca10e-006a033148
+                - txg0b94b3217db1489e925d-006a034b7a
         status: 404 Not Found
         code: 404
-        duration: 70.657375ms
+        duration: 19.295166ms
     - id: 96
       request:
         proto: HTTP/1.1
@@ -5015,7 +5015,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5024,7 +5024,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c5fe15ea-8dd8-4573-8835-0aa68f0b9160
+                - 99fb80f7-2363-4041-8bd2-a9456ab312a1
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5032,8 +5032,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135520Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?versioning=
+                - 20260512T154706Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5052,14 +5052,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:20 GMT
+                - Tue, 12 May 2026 15:47:06 GMT
             X-Amz-Id-2:
-                - txg01f9e7254aa5405fa534-006a033148
+                - txg8b7597495f1448bcbf02-006a034b7a
             X-Amz-Request-Id:
-                - txg01f9e7254aa5405fa534-006a033148
+                - txg8b7597495f1448bcbf02-006a034b7a
         status: 200 OK
         code: 200
-        duration: 47.946416ms
+        duration: 20.293958ms
     - id: 97
       request:
         proto: HTTP/1.1
@@ -5068,7 +5068,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5077,7 +5077,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 51abe473-2119-4b14-8cf2-41352a033f46
+                - 0ab3f3c2-b40c-408d-aecc-bd6c717ea12e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5085,8 +5085,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135520Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T154706Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5105,14 +5105,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:20 GMT
+                - Tue, 12 May 2026 15:47:06 GMT
             X-Amz-Id-2:
-                - txg214e1be10b294ac188dd-006a033148
+                - txga5162fe7c2fc4d24b376-006a034b7a
             X-Amz-Request-Id:
-                - txg214e1be10b294ac188dd-006a033148
+                - txga5162fe7c2fc4d24b376-006a034b7a
         status: 200 OK
         code: 200
-        duration: 235.878875ms
+        duration: 27.648083ms
     - id: 98
       request:
         proto: HTTP/1.1
@@ -5121,7 +5121,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5130,7 +5130,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0af3d453-3fdf-4c5f-b975-1cc188be63fc
+                - bb1e97c2-4a21-47f9-bceb-cd53792c4de2
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5138,8 +5138,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135520Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
+                - 20260512T154707Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -5154,16 +5154,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:20 GMT
+                - Tue, 12 May 2026 15:47:07 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txg5c8e3a76759d4801af90-006a033148
+                - txg4378dd509650419d8af4-006a034b7b
             X-Amz-Request-Id:
-                - txg5c8e3a76759d4801af90-006a033148
+                - txg4378dd509650419d8af4-006a034b7b
         status: 200 OK
         code: 200
-        duration: 91.038792ms
+        duration: 87.27375ms
     - id: 99
       request:
         proto: HTTP/1.1
@@ -5172,7 +5172,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5181,7 +5181,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f6fdbcfa-e6c5-4406-b8ba-b2f11d899d90
+                - e77c7dec-c083-41cd-be00-cf2c35d10c62
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5189,8 +5189,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135521Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T154707Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5209,14 +5209,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:21 GMT
+                - Tue, 12 May 2026 15:47:07 GMT
             X-Amz-Id-2:
-                - txgdabf07d797e342e7b014-006a033149
+                - txgceed02aa0ce14033ae2c-006a034b7b
             X-Amz-Request-Id:
-                - txgdabf07d797e342e7b014-006a033149
+                - txgceed02aa0ce14033ae2c-006a034b7b
         status: 200 OK
         code: 200
-        duration: 89.298ms
+        duration: 61.121833ms
     - id: 100
       request:
         proto: HTTP/1.1
@@ -5225,7 +5225,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5234,7 +5234,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - bfcf364c-248b-442b-bc10-8de8f02b1071
+                - d2ee8bf5-dc00-4564-8b10-bd930571d5bb
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5242,8 +5242,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135521Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?acl=
+                - 20260512T154707Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5262,14 +5262,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:21 GMT
+                - Tue, 12 May 2026 15:47:07 GMT
             X-Amz-Id-2:
-                - txg97956c39d36b41dba205-006a033149
+                - txg504b0302b1c84ee6bd2e-006a034b7b
             X-Amz-Request-Id:
-                - txg97956c39d36b41dba205-006a033149
+                - txg504b0302b1c84ee6bd2e-006a034b7b
         status: 200 OK
         code: 200
-        duration: 19.203ms
+        duration: 30.681167ms
     - id: 101
       request:
         proto: HTTP/1.1
@@ -5278,7 +5278,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5287,7 +5287,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9485812a-32e9-4a1c-919c-ef132bd651ce
+                - 7f8f3c4a-221c-4acd-b570-ca8ad2d41a47
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5295,8 +5295,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135521Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260512T154707Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5304,23 +5304,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 329
+        content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg64a31e8219e34f7b91c5-006a033149</RequestId><HostId>txg64a31e8219e34f7b91c5-006a033149</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg5efa41181bfd4822b4e8-006a034b7b</RequestId><HostId>txg5efa41181bfd4822b4e8-006a034b7b</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
         headers:
             Content-Length:
-                - "329"
+                - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:21 GMT
+                - Tue, 12 May 2026 15:47:07 GMT
             X-Amz-Id-2:
-                - txg64a31e8219e34f7b91c5-006a033149
+                - txg5efa41181bfd4822b4e8-006a034b7b
             X-Amz-Request-Id:
-                - txg64a31e8219e34f7b91c5-006a033149
+                - txg5efa41181bfd4822b4e8-006a034b7b
         status: 404 Not Found
         code: 404
-        duration: 19.184833ms
+        duration: 45.480417ms
     - id: 102
       request:
         proto: HTTP/1.1
@@ -5329,7 +5329,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5338,7 +5338,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0543d415-e316-4d9e-b3fb-3a63c62dd2d8
+                - 3f00f552-8c09-4c79-a25e-f9b541dad67b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5346,8 +5346,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135521Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
+                - 20260512T154707Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -5355,25 +5355,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 286
+        content_length: 287
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "286"
+                - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:21 GMT
+                - Tue, 12 May 2026 15:47:07 GMT
             X-Amz-Id-2:
-                - txg2c1ea0b59506439e9128-006a033149
+                - txg465b652409584831aed5-006a034b7b
             X-Amz-Request-Id:
-                - txg2c1ea0b59506439e9128-006a033149
+                - txg465b652409584831aed5-006a034b7b
         status: 200 OK
         code: 200
-        duration: 72.947083ms
+        duration: 28.929584ms
     - id: 103
       request:
         proto: HTTP/1.1
@@ -5382,7 +5382,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5391,7 +5391,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d21d0883-32a0-4336-ba2d-92123de41a7b
+                - 46afc62b-9287-47b7-9a2a-a0fae29a6786
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5399,8 +5399,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135521Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?tagging=
+                - 20260512T154707Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5408,23 +5408,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 359
+        content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgc7df6a5912f748fbab39-006a033149</RequestId><HostId>txgc7df6a5912f748fbab39-006a033149</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgba1ed0e2c5b04e54a800-006a034b7b</RequestId><HostId>txgba1ed0e2c5b04e54a800-006a034b7b</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</BucketName></Error>
         headers:
             Content-Length:
-                - "359"
+                - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:21 GMT
+                - Tue, 12 May 2026 15:47:07 GMT
             X-Amz-Id-2:
-                - txgc7df6a5912f748fbab39-006a033149
+                - txgba1ed0e2c5b04e54a800-006a034b7b
             X-Amz-Request-Id:
-                - txgc7df6a5912f748fbab39-006a033149
+                - txgba1ed0e2c5b04e54a800-006a034b7b
         status: 404 Not Found
         code: 404
-        duration: 20.821792ms
+        duration: 102.796667ms
     - id: 104
       request:
         proto: HTTP/1.1
@@ -5433,7 +5433,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5442,7 +5442,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 69c5ac33-d3a3-4def-9e30-f43f7adf523a
+                - 537c5840-5e57-438c-ab5f-babe03504a3e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5450,8 +5450,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135521Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?cors=
+                - 20260512T154707Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5459,23 +5459,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 297
+        content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgd0014a9227d541369b65-006a033149</RequestId><HostId>txgd0014a9227d541369b65-006a033149</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg1dfa80e8241041afb09e-006a034b7b</RequestId><HostId>txg1dfa80e8241041afb09e-006a034b7b</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
         headers:
             Content-Length:
-                - "297"
+                - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:21 GMT
+                - Tue, 12 May 2026 15:47:07 GMT
             X-Amz-Id-2:
-                - txgd0014a9227d541369b65-006a033149
+                - txg1dfa80e8241041afb09e-006a034b7b
             X-Amz-Request-Id:
-                - txgd0014a9227d541369b65-006a033149
+                - txg1dfa80e8241041afb09e-006a034b7b
         status: 404 Not Found
         code: 404
-        duration: 19.522875ms
+        duration: 33.605166ms
     - id: 105
       request:
         proto: HTTP/1.1
@@ -5484,7 +5484,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5493,7 +5493,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4200646e-c846-4f29-b5bc-30f1e6c4030a
+                - 441de41e-ce76-4e00-85d6-3af556afd337
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5501,8 +5501,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135521Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?versioning=
+                - 20260512T154707Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5521,14 +5521,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:21 GMT
+                - Tue, 12 May 2026 15:47:07 GMT
             X-Amz-Id-2:
-                - txgb083e9ef4e2e42eca09e-006a033149
+                - txg30d37dc31aff44eb8b7e-006a034b7b
             X-Amz-Request-Id:
-                - txgb083e9ef4e2e42eca09e-006a033149
+                - txg30d37dc31aff44eb8b7e-006a034b7b
         status: 200 OK
         code: 200
-        duration: 32.930334ms
+        duration: 27.858833ms
     - id: 106
       request:
         proto: HTTP/1.1
@@ -5537,7 +5537,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5546,7 +5546,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 1924be38-b0d4-45f2-8ce6-f9a4689149d8
+                - 1dcd66b6-7abb-4fbc-862c-aebc32e74a09
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5554,8 +5554,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135521Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T154707Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5574,14 +5574,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:21 GMT
+                - Tue, 12 May 2026 15:47:07 GMT
             X-Amz-Id-2:
-                - txgb4dbcac6c6424f7ca931-006a033149
+                - txgdefc28f8eddc44c6a3ef-006a034b7b
             X-Amz-Request-Id:
-                - txgb4dbcac6c6424f7ca931-006a033149
+                - txgdefc28f8eddc44c6a3ef-006a034b7b
         status: 200 OK
         code: 200
-        duration: 25.740208ms
+        duration: 19.268083ms
     - id: 107
       request:
         proto: HTTP/1.1
@@ -5590,7 +5590,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5599,7 +5599,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 797b2580-3c31-405d-8e3d-7d202e070b0a
+                - 7bd4d0e4-0849-44cb-8826-ea63fca075ef
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5607,8 +5607,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135521Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?acl=
+                - 20260512T154707Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5627,14 +5627,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:21 GMT
+                - Tue, 12 May 2026 15:47:08 GMT
             X-Amz-Id-2:
-                - txg1aacc04a279244c3b038-006a033149
+                - txg7952e843903a42c4b706-006a034b7c
             X-Amz-Request-Id:
-                - txg1aacc04a279244c3b038-006a033149
+                - txg7952e843903a42c4b706-006a034b7c
         status: 200 OK
         code: 200
-        duration: 47.894375ms
+        duration: 39.52025ms
     - id: 108
       request:
         proto: HTTP/1.1
@@ -5643,7 +5643,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5652,16 +5652,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b8b8374b-8847-4a3a-a07f-aef7d6907698
+                - 942dc497-c54e-439f-b799-cd15ec6c8a87
             Amz-Sdk-Request:
-                - attempt=1; max=3
+                - attempt=1; max=3; ttl=20260512T175707Z
             User-Agent:
                 - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135521Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260512T154708Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5669,23 +5669,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 329
+        content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgee8672df9e904543b98c-006a033149</RequestId><HostId>txgee8672df9e904543b98c-006a033149</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgd08fdad9d3294671a61f-006a034b7c</RequestId><HostId>txgd08fdad9d3294671a61f-006a034b7c</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
         headers:
             Content-Length:
-                - "329"
+                - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:21 GMT
+                - Tue, 12 May 2026 15:47:08 GMT
             X-Amz-Id-2:
-                - txgee8672df9e904543b98c-006a033149
+                - txgd08fdad9d3294671a61f-006a034b7c
             X-Amz-Request-Id:
-                - txgee8672df9e904543b98c-006a033149
+                - txgd08fdad9d3294671a61f-006a034b7c
         status: 404 Not Found
         code: 404
-        duration: 24.569875ms
+        duration: 52.261333ms
     - id: 109
       request:
         proto: HTTP/1.1
@@ -5694,7 +5694,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5703,7 +5703,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9522d5b3-96bf-4a91-ad8d-c16307499a45
+                - 407cdb2c-1f34-4d62-bcb0-aa16db41bf38
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5711,8 +5711,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135521Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
+                - 20260512T154708Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -5720,25 +5720,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 286
+        content_length: 287
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "286"
+                - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:21 GMT
+                - Tue, 12 May 2026 15:47:08 GMT
             X-Amz-Id-2:
-                - txga711b5ec56fb4e42b62f-006a033149
+                - txg225812eaff0d400ca77f-006a034b7c
             X-Amz-Request-Id:
-                - txga711b5ec56fb4e42b62f-006a033149
+                - txg225812eaff0d400ca77f-006a034b7c
         status: 200 OK
         code: 200
-        duration: 65.307083ms
+        duration: 53.272708ms
     - id: 110
       request:
         proto: HTTP/1.1
@@ -5747,7 +5747,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5756,7 +5756,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 96e32741-3c37-41fd-b953-9cdab2102b19
+                - ae16543a-6a9f-4e11-aebd-81276a25f924
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5764,8 +5764,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135521Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?tagging=
+                - 20260512T154708Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5773,23 +5773,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 359
+        content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgbc494b71c26f49e6931e-006a033149</RequestId><HostId>txgbc494b71c26f49e6931e-006a033149</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg4c068131a57d4ba79f4b-006a034b7c</RequestId><HostId>txg4c068131a57d4ba79f4b-006a034b7c</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</BucketName></Error>
         headers:
             Content-Length:
-                - "359"
+                - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:21 GMT
+                - Tue, 12 May 2026 15:47:08 GMT
             X-Amz-Id-2:
-                - txgbc494b71c26f49e6931e-006a033149
+                - txg4c068131a57d4ba79f4b-006a034b7c
             X-Amz-Request-Id:
-                - txgbc494b71c26f49e6931e-006a033149
+                - txg4c068131a57d4ba79f4b-006a034b7c
         status: 404 Not Found
         code: 404
-        duration: 18.642166ms
+        duration: 74.462917ms
     - id: 111
       request:
         proto: HTTP/1.1
@@ -5798,7 +5798,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5807,7 +5807,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7f76b794-b1a6-4d41-aadf-b06ea2444e87
+                - b83efc32-11b5-4e6f-a35c-428e2ae35f0d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5815,8 +5815,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135521Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?cors=
+                - 20260512T154708Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5824,23 +5824,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 297
+        content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg258a0b51f34445cfbb5b-006a033149</RequestId><HostId>txg258a0b51f34445cfbb5b-006a033149</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgea3843e34e424b3ba93d-006a034b7c</RequestId><HostId>txgea3843e34e424b3ba93d-006a034b7c</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
         headers:
             Content-Length:
-                - "297"
+                - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:21 GMT
+                - Tue, 12 May 2026 15:47:08 GMT
             X-Amz-Id-2:
-                - txg258a0b51f34445cfbb5b-006a033149
+                - txgea3843e34e424b3ba93d-006a034b7c
             X-Amz-Request-Id:
-                - txg258a0b51f34445cfbb5b-006a033149
+                - txgea3843e34e424b3ba93d-006a034b7c
         status: 404 Not Found
         code: 404
-        duration: 42.730167ms
+        duration: 27.949583ms
     - id: 112
       request:
         proto: HTTP/1.1
@@ -5849,7 +5849,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5858,7 +5858,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 1a03a15f-05ec-4ff2-b744-2cf6dcaf4998
+                - ef0c9f0d-a047-41bc-b166-6c240ee7c627
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5866,8 +5866,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135521Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?versioning=
+                - 20260512T154708Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5886,14 +5886,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:21 GMT
+                - Tue, 12 May 2026 15:47:08 GMT
             X-Amz-Id-2:
-                - txga8fb4998817047a1af8a-006a033149
+                - txgcbfc145e52cb4d19a3f5-006a034b7c
             X-Amz-Request-Id:
-                - txga8fb4998817047a1af8a-006a033149
+                - txgcbfc145e52cb4d19a3f5-006a034b7c
         status: 200 OK
         code: 200
-        duration: 19.405583ms
+        duration: 53.589416ms
     - id: 113
       request:
         proto: HTTP/1.1
@@ -5902,7 +5902,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5911,7 +5911,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - dfdd75d5-cafc-4aa7-823f-d447a23ba2c2
+                - b333ab08-fe87-4897-b9ac-4c75b689affc
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5919,8 +5919,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135521Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T154708Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5939,14 +5939,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:22 GMT
+                - Tue, 12 May 2026 15:47:08 GMT
             X-Amz-Id-2:
-                - txge5cbb8e0b5914e76908b-006a03314a
+                - txgbf2f5e0f9f1646e39030-006a034b7c
             X-Amz-Request-Id:
-                - txge5cbb8e0b5914e76908b-006a03314a
+                - txgbf2f5e0f9f1646e39030-006a034b7c
         status: 200 OK
         code: 200
-        duration: 20.901583ms
+        duration: 22.842709ms
     - id: 114
       request:
         proto: HTTP/1.1
@@ -5955,7 +5955,7 @@ interactions:
         content_length: 284
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path1/</Prefix><Tag><Key>deleted</Key><Value>true</Value></Tag></And></Filter><ID>id1</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
@@ -5964,7 +5964,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - a69d15f2-ef47-4cd1-949d-6a868e4f6ab8
+                - 81f6f284-1fb3-428f-8b8c-fa940171c588
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
@@ -5976,8 +5976,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - c66696878cc52fbe5f1b5468d871024fe4d94447494e4b1797bc44a183ccc313
             X-Amz-Date:
-                - 20260512T135522Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T154708Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -5992,14 +5992,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 12 May 2026 13:55:22 GMT
+                - Tue, 12 May 2026 15:47:08 GMT
             X-Amz-Id-2:
-                - txg04509622a7694b1cac6e-006a03314a
+                - txgc6abca8d5ff4409891f7-006a034b7c
             X-Amz-Request-Id:
-                - txg04509622a7694b1cac6e-006a03314a
+                - txgc6abca8d5ff4409891f7-006a034b7c
         status: 200 OK
         code: 200
-        duration: 23.121084ms
+        duration: 138.811584ms
     - id: 115
       request:
         proto: HTTP/1.1
@@ -6008,7 +6008,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6017,7 +6017,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 3759e80a-6145-4768-aeea-91ec5db1b0d3
+                - cf9c4743-1eca-4b1b-a655-5c69a4b02a7f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6025,8 +6025,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135522Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?acl=
+                - 20260512T154708Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6045,14 +6045,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:22 GMT
+                - Tue, 12 May 2026 15:47:08 GMT
             X-Amz-Id-2:
-                - txg9c51959ebfc54ce48497-006a03314a
+                - txgb70b76429f394e8880fa-006a034b7c
             X-Amz-Request-Id:
-                - txg9c51959ebfc54ce48497-006a03314a
+                - txgb70b76429f394e8880fa-006a034b7c
         status: 200 OK
         code: 200
-        duration: 19.872459ms
+        duration: 22.111542ms
     - id: 116
       request:
         proto: HTTP/1.1
@@ -6061,7 +6061,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6070,7 +6070,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4511da53-330a-4e68-b281-7599bee158c7
+                - 811a77ad-1824-4ad3-a370-975bf482c1a6
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6078,8 +6078,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135522Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260512T154708Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6087,23 +6087,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 329
+        content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg00d4a0870b89473dadd6-006a03314a</RequestId><HostId>txg00d4a0870b89473dadd6-006a03314a</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg254cbaa29d7c495ba9f6-006a034b7c</RequestId><HostId>txg254cbaa29d7c495ba9f6-006a034b7c</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
         headers:
             Content-Length:
-                - "329"
+                - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:22 GMT
+                - Tue, 12 May 2026 15:47:08 GMT
             X-Amz-Id-2:
-                - txg00d4a0870b89473dadd6-006a03314a
+                - txg254cbaa29d7c495ba9f6-006a034b7c
             X-Amz-Request-Id:
-                - txg00d4a0870b89473dadd6-006a03314a
+                - txg254cbaa29d7c495ba9f6-006a034b7c
         status: 404 Not Found
         code: 404
-        duration: 46.869041ms
+        duration: 21.297125ms
     - id: 117
       request:
         proto: HTTP/1.1
@@ -6112,7 +6112,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6121,7 +6121,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - cddb18e2-7c79-4a6f-9a91-8fc1389dfd21
+                - db1af36e-dccf-429e-a358-2f09943a806d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6129,8 +6129,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135522Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
+                - 20260512T154708Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -6138,25 +6138,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 286
+        content_length: 287
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "286"
+                - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:22 GMT
+                - Tue, 12 May 2026 15:47:08 GMT
             X-Amz-Id-2:
-                - txgd746a0c0967149e9a54c-006a03314a
+                - txg6b84dacc0ac946fb89b9-006a034b7c
             X-Amz-Request-Id:
-                - txgd746a0c0967149e9a54c-006a03314a
+                - txg6b84dacc0ac946fb89b9-006a034b7c
         status: 200 OK
         code: 200
-        duration: 23.430833ms
+        duration: 41.770375ms
     - id: 118
       request:
         proto: HTTP/1.1
@@ -6165,7 +6165,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6174,7 +6174,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 19d37562-a292-4db9-beb7-27b2541cabd5
+                - 0bbed266-5122-42ce-8c8e-3eb035e89115
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6182,8 +6182,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135522Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?tagging=
+                - 20260512T154708Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6191,23 +6191,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 359
+        content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgc61ae3e4951d4b98b673-006a03314a</RequestId><HostId>txgc61ae3e4951d4b98b673-006a03314a</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg9a0c56f8703141afa552-006a034b7c</RequestId><HostId>txg9a0c56f8703141afa552-006a034b7c</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</BucketName></Error>
         headers:
             Content-Length:
-                - "359"
+                - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:22 GMT
+                - Tue, 12 May 2026 15:47:08 GMT
             X-Amz-Id-2:
-                - txgc61ae3e4951d4b98b673-006a03314a
+                - txg9a0c56f8703141afa552-006a034b7c
             X-Amz-Request-Id:
-                - txgc61ae3e4951d4b98b673-006a03314a
+                - txg9a0c56f8703141afa552-006a034b7c
         status: 404 Not Found
         code: 404
-        duration: 21.116792ms
+        duration: 55.146875ms
     - id: 119
       request:
         proto: HTTP/1.1
@@ -6216,7 +6216,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6225,7 +6225,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0d51bf37-90b4-4b2b-a9fb-e9bdfda7955c
+                - 277d793a-ca61-412c-b070-d4a6e5ffac0a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6233,8 +6233,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135522Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?cors=
+                - 20260512T154708Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6242,23 +6242,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 297
+        content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txga2e3401f86314ae9aabf-006a03314a</RequestId><HostId>txga2e3401f86314ae9aabf-006a03314a</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg8b98666b38de47879c82-006a034b7c</RequestId><HostId>txg8b98666b38de47879c82-006a034b7c</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
         headers:
             Content-Length:
-                - "297"
+                - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:22 GMT
+                - Tue, 12 May 2026 15:47:08 GMT
             X-Amz-Id-2:
-                - txga2e3401f86314ae9aabf-006a03314a
+                - txg8b98666b38de47879c82-006a034b7c
             X-Amz-Request-Id:
-                - txga2e3401f86314ae9aabf-006a03314a
+                - txg8b98666b38de47879c82-006a034b7c
         status: 404 Not Found
         code: 404
-        duration: 19.798791ms
+        duration: 38.834584ms
     - id: 120
       request:
         proto: HTTP/1.1
@@ -6267,7 +6267,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6276,7 +6276,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 23b897ce-7aba-4c6e-be3f-4b08df6ec168
+                - 207f90dd-7609-4000-b0e3-a7b3cb870947
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6284,8 +6284,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135522Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?versioning=
+                - 20260512T154708Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6304,14 +6304,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:22 GMT
+                - Tue, 12 May 2026 15:47:08 GMT
             X-Amz-Id-2:
-                - txg871c15b8c8f14180954e-006a03314a
+                - txg99a339649aa34c2288b9-006a034b7c
             X-Amz-Request-Id:
-                - txg871c15b8c8f14180954e-006a03314a
+                - txg99a339649aa34c2288b9-006a034b7c
         status: 200 OK
         code: 200
-        duration: 22.648292ms
+        duration: 21.658083ms
     - id: 121
       request:
         proto: HTTP/1.1
@@ -6320,7 +6320,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6329,7 +6329,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c59c9091-94f0-4dd5-91b0-76af84c8a619
+                - 0e221867-dd4c-4c29-81e0-a09cb0dcb331
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6337,8 +6337,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135522Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T154708Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6357,14 +6357,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:22 GMT
+                - Tue, 12 May 2026 15:47:08 GMT
             X-Amz-Id-2:
-                - txg4e62f26c94c64338b188-006a03314a
+                - txg067179c6914346c48002-006a034b7c
             X-Amz-Request-Id:
-                - txg4e62f26c94c64338b188-006a03314a
+                - txg067179c6914346c48002-006a034b7c
         status: 200 OK
         code: 200
-        duration: 25.441458ms
+        duration: 63.83325ms
     - id: 122
       request:
         proto: HTTP/1.1
@@ -6373,7 +6373,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6382,7 +6382,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7de9a271-70cd-4ade-ac69-658e50d15451
+                - e2ba9555-ceee-4a7b-80cd-c6612472911e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6390,8 +6390,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135522Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
+                - 20260512T154708Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -6406,16 +6406,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:22 GMT
+                - Tue, 12 May 2026 15:47:09 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txg693dc6d8198e4cffb307-006a03314a
+                - txgf77638c5b0e145648538-006a034b7d
             X-Amz-Request-Id:
-                - txg693dc6d8198e4cffb307-006a03314a
+                - txgf77638c5b0e145648538-006a034b7d
         status: 200 OK
         code: 200
-        duration: 19.140292ms
+        duration: 24.378792ms
     - id: 123
       request:
         proto: HTTP/1.1
@@ -6424,7 +6424,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6433,7 +6433,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 2789e92a-0d17-461f-bd32-3b584cbf187b
+                - 9d869781-7383-4244-962b-6395a43a0195
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6441,8 +6441,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135522Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T154708Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6461,14 +6461,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:22 GMT
+                - Tue, 12 May 2026 15:47:09 GMT
             X-Amz-Id-2:
-                - txg8556638fd4204762943e-006a03314a
+                - txg43b75a6a144649618401-006a034b7d
             X-Amz-Request-Id:
-                - txg8556638fd4204762943e-006a03314a
+                - txg43b75a6a144649618401-006a034b7d
         status: 200 OK
         code: 200
-        duration: 21.51225ms
+        duration: 71.79925ms
     - id: 124
       request:
         proto: HTTP/1.1
@@ -6477,7 +6477,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6486,7 +6486,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - bfa069ee-00c1-4784-8947-4fd80696b8e3
+                - 759e3c17-d3b1-401d-90c3-1fe3f11966bb
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6494,8 +6494,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135522Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?acl=
+                - 20260512T154709Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6514,14 +6514,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:22 GMT
+                - Tue, 12 May 2026 15:47:09 GMT
             X-Amz-Id-2:
-                - txg5a71bdd1a8334af694a9-006a03314a
+                - txg51b1c339b8124e4aabf6-006a034b7d
             X-Amz-Request-Id:
-                - txg5a71bdd1a8334af694a9-006a03314a
+                - txg51b1c339b8124e4aabf6-006a034b7d
         status: 200 OK
         code: 200
-        duration: 29.207708ms
+        duration: 19.411209ms
     - id: 125
       request:
         proto: HTTP/1.1
@@ -6530,7 +6530,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6539,7 +6539,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 72b6d799-4295-4d63-b532-0fb4637369a5
+                - 5df630be-726b-4f28-8fc1-b6954f6c556f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6547,8 +6547,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135522Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260512T154709Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6556,23 +6556,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 329
+        content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg505e5f766fc44d44a331-006a03314a</RequestId><HostId>txg505e5f766fc44d44a331-006a03314a</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg15b5e7a20a2f41fd8cf5-006a034b7d</RequestId><HostId>txg15b5e7a20a2f41fd8cf5-006a034b7d</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
         headers:
             Content-Length:
-                - "329"
+                - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:22 GMT
+                - Tue, 12 May 2026 15:47:09 GMT
             X-Amz-Id-2:
-                - txg505e5f766fc44d44a331-006a03314a
+                - txg15b5e7a20a2f41fd8cf5-006a034b7d
             X-Amz-Request-Id:
-                - txg505e5f766fc44d44a331-006a03314a
+                - txg15b5e7a20a2f41fd8cf5-006a034b7d
         status: 404 Not Found
         code: 404
-        duration: 20.107125ms
+        duration: 19.411292ms
     - id: 126
       request:
         proto: HTTP/1.1
@@ -6581,7 +6581,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6590,7 +6590,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - a81bbbb8-2ffb-4244-a492-89df7ac7231c
+                - d0114d20-afb9-4a8e-93dc-a32a36b42b53
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6598,8 +6598,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135522Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
+                - 20260512T154709Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -6607,25 +6607,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 286
+        content_length: 287
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "286"
+                - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:22 GMT
+                - Tue, 12 May 2026 15:47:09 GMT
             X-Amz-Id-2:
-                - txgd4da645a416e4d209c38-006a03314a
+                - txg3f9c2885e54e44b39de8-006a034b7d
             X-Amz-Request-Id:
-                - txgd4da645a416e4d209c38-006a03314a
+                - txg3f9c2885e54e44b39de8-006a034b7d
         status: 200 OK
         code: 200
-        duration: 348.77375ms
+        duration: 29.065959ms
     - id: 127
       request:
         proto: HTTP/1.1
@@ -6634,7 +6634,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6643,7 +6643,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 67769d02-f605-4b07-b9d3-f262dd68d556
+                - accfea91-aa13-445c-bf4b-3893627c4497
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6651,8 +6651,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135522Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?tagging=
+                - 20260512T154709Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6660,23 +6660,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 359
+        content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txge68c19ba9a8f4d40b5af-006a03314b</RequestId><HostId>txge68c19ba9a8f4d40b5af-006a03314b</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txga83bf052523042c49b5c-006a034b7d</RequestId><HostId>txga83bf052523042c49b5c-006a034b7d</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</BucketName></Error>
         headers:
             Content-Length:
-                - "359"
+                - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:23 GMT
+                - Tue, 12 May 2026 15:47:09 GMT
             X-Amz-Id-2:
-                - txge68c19ba9a8f4d40b5af-006a03314b
+                - txga83bf052523042c49b5c-006a034b7d
             X-Amz-Request-Id:
-                - txge68c19ba9a8f4d40b5af-006a03314b
+                - txga83bf052523042c49b5c-006a034b7d
         status: 404 Not Found
         code: 404
-        duration: 130.055667ms
+        duration: 53.378ms
     - id: 128
       request:
         proto: HTTP/1.1
@@ -6685,7 +6685,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6694,7 +6694,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 2b846205-2588-4f68-a694-7fcf56e6ec3c
+                - 98c5bc8e-556c-47ea-880d-2f457ab3f9a0
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6702,8 +6702,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135523Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?cors=
+                - 20260512T154709Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6711,23 +6711,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 297
+        content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txga6d3716993c0451a9763-006a03314b</RequestId><HostId>txga6d3716993c0451a9763-006a03314b</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg7b4930feb1394480b47a-006a034b7d</RequestId><HostId>txg7b4930feb1394480b47a-006a034b7d</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
         headers:
             Content-Length:
-                - "297"
+                - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:23 GMT
+                - Tue, 12 May 2026 15:47:09 GMT
             X-Amz-Id-2:
-                - txga6d3716993c0451a9763-006a03314b
+                - txg7b4930feb1394480b47a-006a034b7d
             X-Amz-Request-Id:
-                - txga6d3716993c0451a9763-006a03314b
+                - txg7b4930feb1394480b47a-006a034b7d
         status: 404 Not Found
         code: 404
-        duration: 19.738791ms
+        duration: 19.289125ms
     - id: 129
       request:
         proto: HTTP/1.1
@@ -6736,7 +6736,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6745,7 +6745,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - cb19048f-c39b-4c5f-993c-031e6e82adf3
+                - 390ec1f3-94a0-44ae-8d86-41c66141cd60
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6753,8 +6753,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135523Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?versioning=
+                - 20260512T154709Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6773,14 +6773,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:23 GMT
+                - Tue, 12 May 2026 15:47:09 GMT
             X-Amz-Id-2:
-                - txgbc37bf33073643b08901-006a03314b
+                - txgba8a3f59b9744c0abf39-006a034b7d
             X-Amz-Request-Id:
-                - txgbc37bf33073643b08901-006a03314b
+                - txgba8a3f59b9744c0abf39-006a034b7d
         status: 200 OK
         code: 200
-        duration: 21.871417ms
+        duration: 28.78175ms
     - id: 130
       request:
         proto: HTTP/1.1
@@ -6789,7 +6789,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6798,7 +6798,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 1a273235-6736-4c86-997b-5c066d4b3c33
+                - 0ce7798e-8d60-481c-89f2-5d7f550c73c7
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6806,8 +6806,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135523Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T154709Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6826,14 +6826,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:23 GMT
+                - Tue, 12 May 2026 15:47:09 GMT
             X-Amz-Id-2:
-                - txg0c32630b6b104c6d808c-006a03314b
+                - txg9f0f62b59c5e4abe88d1-006a034b7d
             X-Amz-Request-Id:
-                - txg0c32630b6b104c6d808c-006a03314b
+                - txg9f0f62b59c5e4abe88d1-006a034b7d
         status: 200 OK
         code: 200
-        duration: 158.039416ms
+        duration: 19.720583ms
     - id: 131
       request:
         proto: HTTP/1.1
@@ -6842,7 +6842,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6851,7 +6851,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 2ef97178-9fd7-4512-847d-a1036e8c1396
+                - 0cd03ce9-abd9-496a-8fa2-f3880cbb3658
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6859,8 +6859,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135523Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?acl=
+                - 20260512T154709Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6879,14 +6879,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:23 GMT
+                - Tue, 12 May 2026 15:47:09 GMT
             X-Amz-Id-2:
-                - txg6d021f0c19ae4d3a9a0a-006a03314b
+                - txgae0a43d52cba4e58b95d-006a034b7d
             X-Amz-Request-Id:
-                - txg6d021f0c19ae4d3a9a0a-006a03314b
+                - txgae0a43d52cba4e58b95d-006a034b7d
         status: 200 OK
         code: 200
-        duration: 21.207166ms
+        duration: 48.528ms
     - id: 132
       request:
         proto: HTTP/1.1
@@ -6895,7 +6895,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6904,7 +6904,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 972c23bf-4c6b-47bf-be36-130e404486c9
+                - a6c5896b-2594-4ed1-9a69-72745d749d8c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6912,8 +6912,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135523Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260512T154709Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6921,23 +6921,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 329
+        content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgfb880ec4f0224ab795f0-006a03314b</RequestId><HostId>txgfb880ec4f0224ab795f0-006a03314b</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgd396b58785aa42dd9536-006a034b7d</RequestId><HostId>txgd396b58785aa42dd9536-006a034b7d</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
         headers:
             Content-Length:
-                - "329"
+                - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:23 GMT
+                - Tue, 12 May 2026 15:47:09 GMT
             X-Amz-Id-2:
-                - txgfb880ec4f0224ab795f0-006a03314b
+                - txgd396b58785aa42dd9536-006a034b7d
             X-Amz-Request-Id:
-                - txgfb880ec4f0224ab795f0-006a03314b
+                - txgd396b58785aa42dd9536-006a034b7d
         status: 404 Not Found
         code: 404
-        duration: 19.281458ms
+        duration: 76.955667ms
     - id: 133
       request:
         proto: HTTP/1.1
@@ -6946,7 +6946,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6955,7 +6955,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 14f83221-4f25-4435-9ab7-1982e1f9c7a6
+                - b69fb0ed-0378-4dac-923f-ebdc59a2494d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6963,8 +6963,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135523Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
+                - 20260512T154709Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -6972,25 +6972,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 286
+        content_length: 287
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "286"
+                - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:23 GMT
+                - Tue, 12 May 2026 15:47:09 GMT
             X-Amz-Id-2:
-                - txg7ee9b64e1aca4e1fb549-006a03314b
+                - txg5bc4b5ad5ac94f34b20c-006a034b7d
             X-Amz-Request-Id:
-                - txg7ee9b64e1aca4e1fb549-006a03314b
+                - txg5bc4b5ad5ac94f34b20c-006a034b7d
         status: 200 OK
         code: 200
-        duration: 34.765625ms
+        duration: 25.886417ms
     - id: 134
       request:
         proto: HTTP/1.1
@@ -6999,7 +6999,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7008,7 +7008,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0c5ed3eb-9f8a-4fee-9226-9bfca8108253
+                - e724e6e8-2e19-4460-9393-20786a341a27
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7016,8 +7016,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135523Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?tagging=
+                - 20260512T154709Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7025,23 +7025,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 359
+        content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg6cc74f233bf9420a8fef-006a03314b</RequestId><HostId>txg6cc74f233bf9420a8fef-006a03314b</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg78b3a3fe5f4f469a9715-006a034b7d</RequestId><HostId>txg78b3a3fe5f4f469a9715-006a034b7d</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</BucketName></Error>
         headers:
             Content-Length:
-                - "359"
+                - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:23 GMT
+                - Tue, 12 May 2026 15:47:09 GMT
             X-Amz-Id-2:
-                - txg6cc74f233bf9420a8fef-006a03314b
+                - txg78b3a3fe5f4f469a9715-006a034b7d
             X-Amz-Request-Id:
-                - txg6cc74f233bf9420a8fef-006a03314b
+                - txg78b3a3fe5f4f469a9715-006a034b7d
         status: 404 Not Found
         code: 404
-        duration: 19.917167ms
+        duration: 61.539125ms
     - id: 135
       request:
         proto: HTTP/1.1
@@ -7050,7 +7050,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7059,7 +7059,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7e21f6eb-3103-4293-9099-34ac3c06ceb1
+                - 8b5825ad-3cce-4621-adad-eeea7dd14f2c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7067,8 +7067,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135523Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?cors=
+                - 20260512T154709Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7076,23 +7076,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 297
+        content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgf9ac533bc2db4b5bb89b-006a03314b</RequestId><HostId>txgf9ac533bc2db4b5bb89b-006a03314b</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgc8df5770fd3e43ce849c-006a034b7d</RequestId><HostId>txgc8df5770fd3e43ce849c-006a034b7d</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
         headers:
             Content-Length:
-                - "297"
+                - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:23 GMT
+                - Tue, 12 May 2026 15:47:09 GMT
             X-Amz-Id-2:
-                - txgf9ac533bc2db4b5bb89b-006a03314b
+                - txgc8df5770fd3e43ce849c-006a034b7d
             X-Amz-Request-Id:
-                - txgf9ac533bc2db4b5bb89b-006a03314b
+                - txgc8df5770fd3e43ce849c-006a034b7d
         status: 404 Not Found
         code: 404
-        duration: 27.376542ms
+        duration: 23.441666ms
     - id: 136
       request:
         proto: HTTP/1.1
@@ -7101,7 +7101,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7110,7 +7110,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 3bdae863-2c7e-4295-bd08-3283a90541fb
+                - 861d90cc-4750-44a0-bdf9-87e509555a0e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7118,8 +7118,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135523Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?versioning=
+                - 20260512T154709Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7138,14 +7138,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:23 GMT
+                - Tue, 12 May 2026 15:47:09 GMT
             X-Amz-Id-2:
-                - txg2caf62660b514aa184e6-006a03314b
+                - txgc37abceb1ca5450aa71c-006a034b7d
             X-Amz-Request-Id:
-                - txg2caf62660b514aa184e6-006a03314b
+                - txgc37abceb1ca5450aa71c-006a034b7d
         status: 200 OK
         code: 200
-        duration: 19.205209ms
+        duration: 19.211708ms
     - id: 137
       request:
         proto: HTTP/1.1
@@ -7154,7 +7154,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7163,7 +7163,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 559aaa7f-f8e2-40cd-928f-b86d2195d7d3
+                - 0bdf992d-806d-4bbd-85d9-188b2d5a6585
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7171,8 +7171,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135523Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T154709Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7191,14 +7191,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:23 GMT
+                - Tue, 12 May 2026 15:47:10 GMT
             X-Amz-Id-2:
-                - txg6b538630be8f411bb016-006a03314b
+                - txg422cb4c398e0451d9229-006a034b7e
             X-Amz-Request-Id:
-                - txg6b538630be8f411bb016-006a03314b
+                - txg422cb4c398e0451d9229-006a034b7e
         status: 200 OK
         code: 200
-        duration: 22.836ms
+        duration: 55.671416ms
     - id: 138
       request:
         proto: HTTP/1.1
@@ -7207,7 +7207,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7216,7 +7216,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f5db8359-05e3-42ec-be9f-6e3deecff899
+                - 7eae9a44-7e54-4120-a914-56011d9baec2
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7224,8 +7224,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135523Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
+                - 20260512T154710Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -7238,14 +7238,14 @@ interactions:
         body: ""
         headers:
             Date:
-                - Tue, 12 May 2026 13:55:24 GMT
+                - Tue, 12 May 2026 15:47:10 GMT
             X-Amz-Id-2:
-                - txg4ac589dd770c45158960-006a03314c
+                - txgf55433ac474e44aa9628-006a034b7e
             X-Amz-Request-Id:
-                - txg4ac589dd770c45158960-006a03314c
+                - txgf55433ac474e44aa9628-006a034b7e
         status: 204 No Content
         code: 204
-        duration: 182.535459ms
+        duration: 173.265292ms
     - id: 139
       request:
         proto: HTTP/1.1
@@ -7254,7 +7254,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7263,7 +7263,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - fbef7c38-da2d-441f-b87f-830854979f10
+                - 7c237977-0084-4c90-8760-684f2306f4b7
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7273,8 +7273,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135524Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
+                - 20260512T154710Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
         method: PUT
       response:
         proto: HTTP/2.0
@@ -7289,16 +7289,16 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 12 May 2026 13:55:24 GMT
+                - Tue, 12 May 2026 15:47:10 GMT
             Location:
-                - /tf-tests-scaleway-object-bucket-lifecycle-152264452529566496
+                - /tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300
             X-Amz-Id-2:
-                - txg3ec45e7ac47f4a70be69-006a03314c
+                - txgf4f800564d8248ddbb02-006a034b7e
             X-Amz-Request-Id:
-                - txg3ec45e7ac47f4a70be69-006a03314c
+                - txgf4f800564d8248ddbb02-006a034b7e
         status: 200 OK
         code: 200
-        duration: 6.051154875s
+        duration: 1.587916375s
     - id: 140
       request:
         proto: HTTP/1.1
@@ -7307,7 +7307,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7316,7 +7316,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - bc948de2-e0f0-4603-903f-7bdea4c3faa0
+                - 6395bbc0-cdaf-4fb6-804a-5131d708c3d1
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7328,8 +7328,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135530Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?acl=
+                - 20260512T154711Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?acl=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -7344,14 +7344,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 12 May 2026 13:55:30 GMT
+                - Tue, 12 May 2026 15:47:12 GMT
             X-Amz-Id-2:
-                - txg31ae4d6e90de430099cd-006a033152
+                - txgb2150dc520bb4389b631-006a034b80
             X-Amz-Request-Id:
-                - txg31ae4d6e90de430099cd-006a033152
+                - txgb2150dc520bb4389b631-006a034b80
         status: 200 OK
         code: 200
-        duration: 2.047572167s
+        duration: 1.057404292s
     - id: 141
       request:
         proto: HTTP/1.1
@@ -7360,16 +7360,16 @@ interactions:
         content_length: 472
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
-        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>2</Days></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260512135532269800000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260512135532269900000002</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
+        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>2</Days></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260512154713008100000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260512154713008200000002</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
         form: {}
         headers:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 021efdf1-e841-4ca7-b4bf-75cf4ad7df21
+                - de7a11c6-0562-489f-9bf7-56c6d9790e00
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
@@ -7377,12 +7377,12 @@ interactions:
             User-Agent:
                 - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,Z,e
             X-Amz-Checksum-Crc32:
-                - rHzblg==
+                - pMwilA==
             X-Amz-Content-Sha256:
-                - 2ce33e4e71ad18530a2b7d88880ea22baa53d973b2eac2a7bbaad68b36687b95
+                - 5a9cd047e1f756ff619042639ebc8013696645cd2f01214289a1bf3bff27d28f
             X-Amz-Date:
-                - 20260512T135530Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T154712Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -7397,14 +7397,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 12 May 2026 13:55:32 GMT
+                - Tue, 12 May 2026 15:47:13 GMT
             X-Amz-Id-2:
-                - txge2d1c0ce543046608725-006a033154
+                - txg3b40247154ce4087972b-006a034b81
             X-Amz-Request-Id:
-                - txge2d1c0ce543046608725-006a033154
+                - txg3b40247154ce4087972b-006a034b81
         status: 200 OK
         code: 200
-        duration: 1.085308542s
+        duration: 1.0489855s
     - id: 142
       request:
         proto: HTTP/1.1
@@ -7413,7 +7413,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7422,7 +7422,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - cffc5d80-625a-478c-ad01-70cc8176b2b0
+                - 986d08c4-e7a2-4d47-9788-217257cd5c21
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7430,8 +7430,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135533Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?acl=
+                - 20260512T154714Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7450,14 +7450,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:33 GMT
+                - Tue, 12 May 2026 15:47:14 GMT
             X-Amz-Id-2:
-                - txg2d68c15ba4ae4fd6affe-006a033155
+                - txgae1228b676bd43c8a90a-006a034b82
             X-Amz-Request-Id:
-                - txg2d68c15ba4ae4fd6affe-006a033155
+                - txgae1228b676bd43c8a90a-006a034b82
         status: 200 OK
         code: 200
-        duration: 1.061887542s
+        duration: 1.157620792s
     - id: 143
       request:
         proto: HTTP/1.1
@@ -7466,7 +7466,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7475,7 +7475,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b8082991-a35e-43e9-b72c-42f984d23330
+                - 97eb5a3f-cd40-4dc6-8862-348b71059916
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7483,8 +7483,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135533Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260512T154714Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7503,14 +7503,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:34 GMT
+                - Tue, 12 May 2026 15:47:15 GMT
             X-Amz-Id-2:
-                - txgb9e546f710744ea3807a-006a033156
+                - txge02284d62b9e49bba057-006a034b83
             X-Amz-Request-Id:
-                - txgb9e546f710744ea3807a-006a033156
+                - txge02284d62b9e49bba057-006a034b83
         status: 200 OK
         code: 200
-        duration: 1.026534541s
+        duration: 1.156693584s
     - id: 144
       request:
         proto: HTTP/1.1
@@ -7519,7 +7519,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7528,7 +7528,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - fe13cc4e-2d46-4722-abc1-04f7ee4a504f
+                - 440f3e38-049b-4795-9a69-e6f4f537f349
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7536,8 +7536,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135534Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
+                - 20260512T154715Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -7545,25 +7545,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 286
+        content_length: 287
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "286"
+                - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:35 GMT
+                - Tue, 12 May 2026 15:47:16 GMT
             X-Amz-Id-2:
-                - txge008b004e47948c4ae2f-006a033157
+                - txgc52c9a2c721543b29e7b-006a034b84
             X-Amz-Request-Id:
-                - txge008b004e47948c4ae2f-006a033157
+                - txgc52c9a2c721543b29e7b-006a034b84
         status: 200 OK
         code: 200
-        duration: 1.077693042s
+        duration: 2.028652042s
     - id: 145
       request:
         proto: HTTP/1.1
@@ -7572,7 +7572,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7581,7 +7581,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 12653d58-b5a8-465b-bc93-fb1cfab1c658
+                - 2a7131e6-e9e9-4b51-8bd2-4c81e0b8b9bf
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7589,8 +7589,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135535Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?tagging=
+                - 20260512T154716Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7598,23 +7598,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 359
+        content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgf8b918f2da7242e1a258-006a033158</RequestId><HostId>txgf8b918f2da7242e1a258-006a033158</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg9e130e0a97dc418ab9e0-006a034b86</RequestId><HostId>txg9e130e0a97dc418ab9e0-006a034b86</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</BucketName></Error>
         headers:
             Content-Length:
-                - "359"
+                - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:36 GMT
+                - Tue, 12 May 2026 15:47:18 GMT
             X-Amz-Id-2:
-                - txgf8b918f2da7242e1a258-006a033158
+                - txg9e130e0a97dc418ab9e0-006a034b86
             X-Amz-Request-Id:
-                - txgf8b918f2da7242e1a258-006a033158
+                - txg9e130e0a97dc418ab9e0-006a034b86
         status: 404 Not Found
         code: 404
-        duration: 1.022651375s
+        duration: 1.023716459s
     - id: 146
       request:
         proto: HTTP/1.1
@@ -7623,7 +7623,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7632,7 +7632,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 6b2f2c80-b101-41d7-9ff4-cd7dbcbe4ca3
+                - c40b9a47-54e5-4ce2-84c8-850649a01621
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7640,8 +7640,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135536Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?cors=
+                - 20260512T154718Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7649,23 +7649,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 297
+        content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgbbae0d1899ee4c159f69-006a033159</RequestId><HostId>txgbbae0d1899ee4c159f69-006a033159</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg8d8ac94905034445af0a-006a034b87</RequestId><HostId>txg8d8ac94905034445af0a-006a034b87</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
         headers:
             Content-Length:
-                - "297"
+                - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:37 GMT
+                - Tue, 12 May 2026 15:47:19 GMT
             X-Amz-Id-2:
-                - txgbbae0d1899ee4c159f69-006a033159
+                - txg8d8ac94905034445af0a-006a034b87
             X-Amz-Request-Id:
-                - txgbbae0d1899ee4c159f69-006a033159
+                - txg8d8ac94905034445af0a-006a034b87
         status: 404 Not Found
         code: 404
-        duration: 1.022517333s
+        duration: 1.022689167s
     - id: 147
       request:
         proto: HTTP/1.1
@@ -7674,7 +7674,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7683,7 +7683,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - a76098c5-fb3b-4da1-8c43-af1447f833eb
+                - ce6caa0c-dbb8-448c-b30a-dd593fc0718c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7691,8 +7691,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135537Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?versioning=
+                - 20260512T154719Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7711,14 +7711,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:38 GMT
+                - Tue, 12 May 2026 15:47:20 GMT
             X-Amz-Id-2:
-                - txgbd78201816664824855a-006a03315a
+                - txg30f004ebf3764d788491-006a034b88
             X-Amz-Request-Id:
-                - txgbd78201816664824855a-006a03315a
+                - txg30f004ebf3764d788491-006a034b88
         status: 200 OK
         code: 200
-        duration: 33.5855ms
+        duration: 21.104792ms
     - id: 148
       request:
         proto: HTTP/1.1
@@ -7727,7 +7727,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7736,7 +7736,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 692d63fe-96a7-4bcb-81f0-426b51f2a4ad
+                - 9d41c79b-6619-403c-935c-58b4be2899ad
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7744,8 +7744,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135538Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T154720Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7757,21 +7757,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>2</Days></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260512135532269800000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260512135532269900000002</ID><Status>Enabled</Status></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>2</Days></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260512154713008100000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260512154713008200000002</ID><Status>Enabled</Status></Rule></Configuration>
         headers:
             Content-Length:
                 - "445"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:38 GMT
+                - Tue, 12 May 2026 15:47:20 GMT
             X-Amz-Id-2:
-                - txg1f069bd24b0c42049385-006a03315a
+                - txgbed71a91a3a84e00ba72-006a034b88
             X-Amz-Request-Id:
-                - txg1f069bd24b0c42049385-006a03315a
+                - txgbed71a91a3a84e00ba72-006a034b88
         status: 200 OK
         code: 200
-        duration: 90.561084ms
+        duration: 1.023712042s
     - id: 149
       request:
         proto: HTTP/1.1
@@ -7780,7 +7780,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7789,7 +7789,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 3edb1b58-d5e1-48f6-a8d3-fe9a9ae8cc04
+                - dc12f3f1-7cb2-41d7-85b9-63ee4add49c6
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7797,8 +7797,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135538Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
+                - 20260512T154721Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -7813,16 +7813,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:38 GMT
+                - Tue, 12 May 2026 15:47:21 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txg5d616bed98fa4f85b5fb-006a03315a
+                - txg46362c1fce2b446b8a94-006a034b89
             X-Amz-Request-Id:
-                - txg5d616bed98fa4f85b5fb-006a03315a
+                - txg46362c1fce2b446b8a94-006a034b89
         status: 200 OK
         code: 200
-        duration: 1.122937125s
+        duration: 54.470875ms
     - id: 150
       request:
         proto: HTTP/1.1
@@ -7831,7 +7831,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7840,7 +7840,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ebcf44c8-b88d-4766-b263-2d395c51ed8d
+                - 678abd63-4a7a-4d7c-a76d-4990e6a6c6f6
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7848,8 +7848,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135539Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T154721Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7861,21 +7861,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>2</Days></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260512135532269800000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260512135532269900000002</ID><Status>Enabled</Status></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>2</Days></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260512154713008100000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260512154713008200000002</ID><Status>Enabled</Status></Rule></Configuration>
         headers:
             Content-Length:
                 - "445"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:39 GMT
+                - Tue, 12 May 2026 15:47:21 GMT
             X-Amz-Id-2:
-                - txgac29c82027534b3384a4-006a03315b
+                - txg8bd5fde581e842229616-006a034b89
             X-Amz-Request-Id:
-                - txgac29c82027534b3384a4-006a03315b
+                - txg8bd5fde581e842229616-006a034b89
         status: 200 OK
         code: 200
-        duration: 1.022562542s
+        duration: 1.043814583s
     - id: 151
       request:
         proto: HTTP/1.1
@@ -7884,7 +7884,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7893,7 +7893,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 35c5b209-35fc-481b-8c1c-1ba7f58d0b47
+                - ae38f149-50ef-4360-980d-d0000aba3c74
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7901,8 +7901,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135541Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?acl=
+                - 20260512T154722Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7921,14 +7921,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:41 GMT
+                - Tue, 12 May 2026 15:47:23 GMT
             X-Amz-Id-2:
-                - txgc21ec160a7e444c88ccd-006a03315d
+                - txga4162cbe4b984e848e7e-006a034b8b
             X-Amz-Request-Id:
-                - txgc21ec160a7e444c88ccd-006a03315d
+                - txga4162cbe4b984e848e7e-006a034b8b
         status: 200 OK
         code: 200
-        duration: 144.855209ms
+        duration: 1.074885166s
     - id: 152
       request:
         proto: HTTP/1.1
@@ -7937,7 +7937,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7946,7 +7946,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 38d33596-8b0b-4d82-8200-a534b981225f
+                - ae9a49f9-0051-4571-a5bc-dba9887b705b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7954,8 +7954,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135541Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260512T154723Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7974,14 +7974,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:41 GMT
+                - Tue, 12 May 2026 15:47:24 GMT
             X-Amz-Id-2:
-                - txg9b6dd698f3ff4e069338-006a03315d
+                - txgb5a83a4cc59d402c9c64-006a034b8c
             X-Amz-Request-Id:
-                - txg9b6dd698f3ff4e069338-006a03315d
+                - txgb5a83a4cc59d402c9c64-006a034b8c
         status: 200 OK
         code: 200
-        duration: 1.026396208s
+        duration: 1.029331584s
     - id: 153
       request:
         proto: HTTP/1.1
@@ -7990,7 +7990,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7999,7 +7999,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e95b148f-be67-4425-b1e6-d76fc4923bdb
+                - 113102e2-b687-426f-b639-19c29f8cf6ad
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8007,8 +8007,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135541Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
+                - 20260512T154724Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -8016,25 +8016,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 286
+        content_length: 287
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "286"
+                - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:42 GMT
+                - Tue, 12 May 2026 15:47:25 GMT
             X-Amz-Id-2:
-                - txg6923b43840d34e0a993e-006a03315e
+                - txg31d58961b1cc4bb69e3d-006a034b8d
             X-Amz-Request-Id:
-                - txg6923b43840d34e0a993e-006a03315e
+                - txg31d58961b1cc4bb69e3d-006a034b8d
         status: 200 OK
         code: 200
-        duration: 2.045383125s
+        duration: 106.796583ms
     - id: 154
       request:
         proto: HTTP/1.1
@@ -8043,7 +8043,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8052,7 +8052,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d833bebc-7248-48b3-9679-e3d23dd02432
+                - d15ef3b2-caca-45fa-9032-bdfeedaa9fe3
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8060,8 +8060,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135542Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?tagging=
+                - 20260512T154725Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8069,23 +8069,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 359
+        content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgdff646dacd2f4084b9a4-006a033160</RequestId><HostId>txgdff646dacd2f4084b9a4-006a033160</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg78e30de675ef41b09820-006a034b8d</RequestId><HostId>txg78e30de675ef41b09820-006a034b8d</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</BucketName></Error>
         headers:
             Content-Length:
-                - "359"
+                - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:44 GMT
+                - Tue, 12 May 2026 15:47:25 GMT
             X-Amz-Id-2:
-                - txgdff646dacd2f4084b9a4-006a033160
+                - txg78e30de675ef41b09820-006a034b8d
             X-Amz-Request-Id:
-                - txgdff646dacd2f4084b9a4-006a033160
+                - txg78e30de675ef41b09820-006a034b8d
         status: 404 Not Found
         code: 404
-        duration: 1.126117708s
+        duration: 1.02451325s
     - id: 155
       request:
         proto: HTTP/1.1
@@ -8094,7 +8094,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8103,7 +8103,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 138a0a79-6f18-4f0d-9896-710cbcac009e
+                - 38840ccb-eb5c-4259-aa7c-2467f5d03327
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8111,8 +8111,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135544Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?cors=
+                - 20260512T154725Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8120,23 +8120,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 297
+        content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgd98fc014a13e4369ae00-006a033161</RequestId><HostId>txgd98fc014a13e4369ae00-006a033161</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg4233a4f9fc064e83ae8d-006a034b8e</RequestId><HostId>txg4233a4f9fc064e83ae8d-006a034b8e</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
         headers:
             Content-Length:
-                - "297"
+                - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:45 GMT
+                - Tue, 12 May 2026 15:47:26 GMT
             X-Amz-Id-2:
-                - txgd98fc014a13e4369ae00-006a033161
+                - txg4233a4f9fc064e83ae8d-006a034b8e
             X-Amz-Request-Id:
-                - txgd98fc014a13e4369ae00-006a033161
+                - txg4233a4f9fc064e83ae8d-006a034b8e
         status: 404 Not Found
         code: 404
-        duration: 29.80925ms
+        duration: 1.113807625s
     - id: 156
       request:
         proto: HTTP/1.1
@@ -8145,7 +8145,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8154,7 +8154,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 13407326-0134-47ba-9fba-d27d6c816c42
+                - edb43d51-9012-4738-9777-36a447018517
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8162,8 +8162,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135545Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?versioning=
+                - 20260512T154726Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8182,14 +8182,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:45 GMT
+                - Tue, 12 May 2026 15:47:27 GMT
             X-Amz-Id-2:
-                - txg6681620baceb458ab094-006a033161
+                - txg522824a28b594b5e96f9-006a034b8f
             X-Amz-Request-Id:
-                - txg6681620baceb458ab094-006a033161
+                - txg522824a28b594b5e96f9-006a034b8f
         status: 200 OK
         code: 200
-        duration: 29.023334ms
+        duration: 1.020893333s
     - id: 157
       request:
         proto: HTTP/1.1
@@ -8198,7 +8198,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8207,7 +8207,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - dd1603a6-a997-4259-885e-e21f26f2c5f8
+                - b3f2f08a-8c67-4bb2-811e-be1e1334269c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8215,8 +8215,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135545Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T154727Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8228,21 +8228,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>2</Days></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260512135532269800000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260512135532269900000002</ID><Status>Enabled</Status></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>2</Days></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260512154713008100000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260512154713008200000002</ID><Status>Enabled</Status></Rule></Configuration>
         headers:
             Content-Length:
                 - "445"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:45 GMT
+                - Tue, 12 May 2026 15:47:28 GMT
             X-Amz-Id-2:
-                - txgdeb45ef2854f4277bf1a-006a033161
+                - txg47fbe9283d8a4f0e856d-006a034b90
             X-Amz-Request-Id:
-                - txgdeb45ef2854f4277bf1a-006a033161
+                - txg47fbe9283d8a4f0e856d-006a034b90
         status: 200 OK
         code: 200
-        duration: 49.106417ms
+        duration: 1.034349875s
     - id: 158
       request:
         proto: HTTP/1.1
@@ -8251,7 +8251,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8260,7 +8260,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - de415bd8-7f19-43d8-a9d2-5c00beb31ee3
+                - 61471797-1443-44ba-a856-9f5f24349549
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8268,8 +8268,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135545Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?acl=
+                - 20260512T154729Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8288,14 +8288,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:45 GMT
+                - Tue, 12 May 2026 15:47:29 GMT
             X-Amz-Id-2:
-                - txg4227fab4f74543cc90e4-006a033161
+                - txgbeb1f06dcd13487b9a9e-006a034b91
             X-Amz-Request-Id:
-                - txg4227fab4f74543cc90e4-006a033161
+                - txgbeb1f06dcd13487b9a9e-006a034b91
         status: 200 OK
         code: 200
-        duration: 1.021198416s
+        duration: 1.027123583s
     - id: 159
       request:
         proto: HTTP/1.1
@@ -8304,7 +8304,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8313,7 +8313,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - a8973f43-fec9-493c-b97d-922500aa3f3d
+                - 76eb25fa-b3b7-43ca-95a6-993ad970ddbd
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8321,8 +8321,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135545Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260512T154729Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8341,14 +8341,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:46 GMT
+                - Tue, 12 May 2026 15:47:30 GMT
             X-Amz-Id-2:
-                - txg0892d39aac174708b6bf-006a033162
+                - txge47dedec54884d16b4a2-006a034b92
             X-Amz-Request-Id:
-                - txg0892d39aac174708b6bf-006a033162
+                - txge47dedec54884d16b4a2-006a034b92
         status: 200 OK
         code: 200
-        duration: 1.139039708s
+        duration: 1.255808917s
     - id: 160
       request:
         proto: HTTP/1.1
@@ -8357,7 +8357,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8366,7 +8366,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9bbd9af4-3eac-45d1-854f-e32a4efb9371
+                - 845fc027-dc3b-4bc5-b24d-2893c1c1beaa
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8374,8 +8374,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135546Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
+                - 20260512T154730Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -8383,25 +8383,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 286
+        content_length: 287
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "286"
+                - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:48 GMT
+                - Tue, 12 May 2026 15:47:31 GMT
             X-Amz-Id-2:
-                - txgc495ceb9d7074b299695-006a033164
+                - txg92d4b028a6b1440d8918-006a034b93
             X-Amz-Request-Id:
-                - txgc495ceb9d7074b299695-006a033164
+                - txg92d4b028a6b1440d8918-006a034b93
         status: 200 OK
         code: 200
-        duration: 2.042776917s
+        duration: 2.039431959s
     - id: 161
       request:
         proto: HTTP/1.1
@@ -8410,7 +8410,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8419,7 +8419,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d32a1648-d78c-474e-8e29-fcff322408ea
+                - 5be1c9e9-dabe-4c23-bf51-ff820db661ca
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8427,8 +8427,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135548Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?tagging=
+                - 20260512T154731Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8436,23 +8436,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 359
+        content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg12815c0879894ec1af84-006a033166</RequestId><HostId>txg12815c0879894ec1af84-006a033166</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg7d3ee624edbd4d6683ea-006a034b95</RequestId><HostId>txg7d3ee624edbd4d6683ea-006a034b95</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</BucketName></Error>
         headers:
             Content-Length:
-                - "359"
+                - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:50 GMT
+                - Tue, 12 May 2026 15:47:33 GMT
             X-Amz-Id-2:
-                - txg12815c0879894ec1af84-006a033166
+                - txg7d3ee624edbd4d6683ea-006a034b95
             X-Amz-Request-Id:
-                - txg12815c0879894ec1af84-006a033166
+                - txg7d3ee624edbd4d6683ea-006a034b95
         status: 404 Not Found
         code: 404
-        duration: 26.096583ms
+        duration: 1.047866541s
     - id: 162
       request:
         proto: HTTP/1.1
@@ -8461,7 +8461,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8470,7 +8470,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7c66beae-e19c-4c11-a267-33381a225aec
+                - c75d70a6-e0c8-4005-8469-4290400f856c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8478,8 +8478,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135550Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?cors=
+                - 20260512T154733Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8487,23 +8487,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 297
+        content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgeae4301a681145488c48-006a033166</RequestId><HostId>txgeae4301a681145488c48-006a033166</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg921e57ddbb4045ae8958-006a034b96</RequestId><HostId>txg921e57ddbb4045ae8958-006a034b96</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
         headers:
             Content-Length:
-                - "297"
+                - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 12 May 2026 13:55:50 GMT
+                - Tue, 12 May 2026 15:47:34 GMT
             X-Amz-Id-2:
-                - txgeae4301a681145488c48-006a033166
+                - txg921e57ddbb4045ae8958-006a034b96
             X-Amz-Request-Id:
-                - txgeae4301a681145488c48-006a033166
+                - txg921e57ddbb4045ae8958-006a034b96
         status: 404 Not Found
         code: 404
-        duration: 1.028613458s
+        duration: 1.024543209s
     - id: 163
       request:
         proto: HTTP/1.1
@@ -8512,7 +8512,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8521,7 +8521,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 8eea8972-f14e-456b-8a31-81956b83b6c3
+                - 9ab06347-90d4-48e4-b211-560dfd45fd4b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8529,8 +8529,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135550Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?versioning=
+                - 20260512T154734Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8549,14 +8549,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:51 GMT
+                - Tue, 12 May 2026 15:47:36 GMT
             X-Amz-Id-2:
-                - txg57622198f3e24074907c-006a033167
+                - txgff7c5af7b48d4224a425-006a034b98
             X-Amz-Request-Id:
-                - txg57622198f3e24074907c-006a033167
+                - txgff7c5af7b48d4224a425-006a034b98
         status: 200 OK
         code: 200
-        duration: 1.09513725s
+        duration: 21.319459ms
     - id: 164
       request:
         proto: HTTP/1.1
@@ -8565,7 +8565,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8574,16 +8574,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 3353e076-12d9-4f77-9a26-8b10cac34e33
+                - e05ec8c9-4907-46bd-81cd-63a5d562b181
             Amz-Sdk-Request:
-                - attempt=1; max=3
+                - attempt=1; max=3; ttl=20260512T175729Z
             User-Agent:
                 - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135551Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T154736Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8595,21 +8595,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>2</Days></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260512135532269800000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260512135532269900000002</ID><Status>Enabled</Status></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>2</Days></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260512154713008100000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260512154713008200000002</ID><Status>Enabled</Status></Rule></Configuration>
         headers:
             Content-Length:
                 - "445"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 12 May 2026 13:55:52 GMT
+                - Tue, 12 May 2026 15:47:36 GMT
             X-Amz-Id-2:
-                - txg2cc907681ac04d01aee6-006a033168
+                - txg1bdba12e1e8b492194cf-006a034b98
             X-Amz-Request-Id:
-                - txg2cc907681ac04d01aee6-006a033168
+                - txg1bdba12e1e8b492194cf-006a034b98
         status: 200 OK
         code: 200
-        duration: 19.459958ms
+        duration: 20.197958ms
     - id: 165
       request:
         proto: HTTP/1.1
@@ -8618,7 +8618,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8627,7 +8627,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 24787126-c9e2-4492-8f7f-2f50adf2af40
+                - 2200040a-f412-4cc3-ae31-e04a6a63bcf5
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8635,8 +8635,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260512T135552Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
+                - 20260512T154736Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -8649,11 +8649,217 @@ interactions:
         body: ""
         headers:
             Date:
-                - Tue, 12 May 2026 13:55:52 GMT
+                - Tue, 12 May 2026 15:47:36 GMT
             X-Amz-Id-2:
-                - txge663af13b07047f98684-006a033168
+                - txgb8f2539e99214076a742-006a034b98
             X-Amz-Request-Id:
-                - txge663af13b07047f98684-006a033168
+                - txgb8f2539e99214076a742-006a034b98
         status: 204 No Content
         code: 204
-        duration: 221.734291ms
+        duration: 1.187202292s
+    - id: 166
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 3174c759-344a-4127-bcd5-b6e93168935d
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260512T154737Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Length:
+                - "0"
+            Date:
+                - Tue, 12 May 2026 15:47:37 GMT
+            Location:
+                - /tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300
+            X-Amz-Id-2:
+                - txga163903f6c7e4954a67f-006a034b99
+            X-Amz-Request-Id:
+                - txga163903f6c7e4954a67f-006a034b99
+        status: 200 OK
+        code: 200
+        duration: 4.577121958s
+    - id: 167
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - d977b0ca-24e9-43b9-9d55-423af7d4ca6d
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,Z,e
+            X-Amz-Acl:
+                - private
+            X-Amz-Checksum-Crc32:
+                - AAAAAA==
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260512T154741Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?acl=
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Length:
+                - "0"
+            Date:
+                - Tue, 12 May 2026 15:47:42 GMT
+            X-Amz-Id-2:
+                - txg11671e2f517841b28a15-006a034b9e
+            X-Amz-Request-Id:
+                - txg11671e2f517841b28a15-006a034b9e
+        status: 200 OK
+        code: 200
+        duration: 1.07484975s
+    - id: 168
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 1581
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>30</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition><Transition><Days>210</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>95</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Filter><Prefix>path3/</Prefix></Filter><ID>id3</ID><Status>Enabled</Status><Transition><Days>0</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration></Expiration><Filter><And><Prefix>path4/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>155</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id6</ID><Status>Enabled</Status><Transition><Days>156</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></LifecycleConfiguration>
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 8f6a5453-fe3b-4777-873b-690ad4e591f7
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            Content-Type:
+                - application/xml
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,Z,e
+            X-Amz-Checksum-Crc32:
+                - 9sglGA==
+            X-Amz-Content-Sha256:
+                - 845a98ee2cf7d3d15e376c73ed8abf538e0ad8ad78ce47dcb3cb6368a7687629
+            X-Amz-Date:
+                - 20260512T154742Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/?lifecycle=
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 283
+        uncompressed: false
+        body: <Error><Code>MalformedXML</Code><Message>Expiration action cannot be empty</Message><RequestId>txgbc476c77de194c159e83-006a034b9f</RequestId><HostId>txgbc476c77de194c159e83-006a034b9f</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300</Resource></Error>
+        headers:
+            Content-Length:
+                - "283"
+            Content-Type:
+                - application/xml
+            Date:
+                - Tue, 12 May 2026 15:47:43 GMT
+            X-Amz-Id-2:
+                - txgbc476c77de194c159e83-006a034b9f
+            X-Amz-Request-Id:
+                - txgbc476c77de194c159e83-006a034b9f
+        status: 400 Bad Request
+        code: 400
+        duration: 25.881833ms
+    - id: 169
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 05c2b88e-1822-4d9b-b881-6ea32b622ebe
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260512T154743Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-5865495542186622300.s3.nl-ams.scw.cloud/
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Date:
+                - Tue, 12 May 2026 15:47:43 GMT
+            X-Amz-Id-2:
+                - txg21cec90721b9462c9851-006a034b9f
+            X-Amz-Request-Id:
+                - txg21cec90721b9462c9851-006a034b9f
+        status: 204 No Content
+        code: 204
+        duration: 1.190011667s

--- a/internal/services/object/testdata/object-bucket-lifecycle.cassette.yaml
+++ b/internal/services/object/testdata/object-bucket-lifecycle.cassette.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -18,7 +18,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 48845399-eb26-40cf-ac55-faeb30320f39
+                - 82b72117-7c13-45c6-bf5c-3c5f6b0e1952
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -26,8 +26,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074811Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
+                - 20260518T103241Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
         method: PUT
       response:
         proto: HTTP/2.0
@@ -42,16 +42,16 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Wed, 13 May 2026 07:48:11 GMT
+                - Mon, 18 May 2026 10:32:41 GMT
             Location:
-                - /tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985
+                - /tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018
             X-Amz-Id-2:
-                - txg01c839c2f56c4c41ac2f-006a042cbb
+                - txg0c6784e7608247f5b2d1-006a0aeac9
             X-Amz-Request-Id:
-                - txg01c839c2f56c4c41ac2f-006a042cbb
+                - txg0c6784e7608247f5b2d1-006a0aeac9
         status: 200 OK
         code: 200
-        duration: 4.075785625s
+        duration: 4.429925417s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -60,7 +60,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -69,7 +69,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 3af74be3-d82f-4c41-a7b3-fdc05750a962
+                - dd2b87c9-77fd-42b8-8a09-c9aecf4cc87d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -81,8 +81,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074815Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T103246Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?acl=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -97,32 +97,32 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Wed, 13 May 2026 07:48:15 GMT
+                - Mon, 18 May 2026 10:32:46 GMT
             X-Amz-Id-2:
-                - txg574650c457ec48879193-006a042cbf
+                - txgb21d590faf814d408be9-006a0aeace
             X-Amz-Request-Id:
-                - txg574650c457ec48879193-006a042cbf
+                - txgb21d590faf814d408be9-006a0aeace
         status: 200 OK
         code: 200
-        duration: 110.911834ms
+        duration: 244.391667ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 303
+        content_length: 363
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
-        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></LifecycleConfiguration>
+        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></LifecycleConfiguration>
         form: {}
         headers:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ffe7c7fb-90f1-471b-98e0-db45626af438
+                - 4d4590c6-beda-4851-9a58-b4c044084c09
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
@@ -130,12 +130,12 @@ interactions:
             User-Agent:
                 - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,Z,e
             X-Amz-Checksum-Crc32:
-                - PjCcoA==
+                - oUpeiA==
             X-Amz-Content-Sha256:
-                - 13feec03c398f242f302d24e62c26ce8c47f46e3921d2bf7a84ca9914cd3488a
+                - 512733381e697ad60e3f974cfb76a92f1c9d2b97cb251bdf165a2579d5e88cd5
             X-Amz-Date:
-                - 20260513T074815Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T103246Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -150,14 +150,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Wed, 13 May 2026 07:48:15 GMT
+                - Mon, 18 May 2026 10:32:46 GMT
             X-Amz-Id-2:
-                - txg6a97c8d5a4754b89a97c-006a042cbf
+                - txgb1265fa5b66146c4aba0-006a0aeace
             X-Amz-Request-Id:
-                - txg6a97c8d5a4754b89a97c-006a042cbf
+                - txgb1265fa5b66146c4aba0-006a0aeace
         status: 200 OK
         code: 200
-        duration: 67.742167ms
+        duration: 366.095625ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -166,7 +166,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -175,7 +175,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 8a887b89-1e92-4bb0-91f3-2012f391d445
+                - 572f6a27-339c-4b50-b2b2-52e0bab9cd62
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -183,8 +183,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074815Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T103246Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -203,14 +203,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:15 GMT
+                - Mon, 18 May 2026 10:32:46 GMT
             X-Amz-Id-2:
-                - txg83efff3939334341a1af-006a042cbf
+                - txg27237383edc0475daa48-006a0aeace
             X-Amz-Request-Id:
-                - txg83efff3939334341a1af-006a042cbf
+                - txg27237383edc0475daa48-006a0aeace
         status: 200 OK
         code: 200
-        duration: 31.337709ms
+        duration: 72.83875ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -219,7 +219,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -228,7 +228,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e2df5559-27d4-4dfd-9b10-9c798383e61c
+                - a20bc075-86e7-4f5f-9663-ae9d57f93070
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -236,8 +236,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074815Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T103246Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -247,21 +247,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txge5117727cda141579338-006a042cbf</RequestId><HostId>txge5117727cda141579338-006a042cbf</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg866d9aebda1e46fba840-006a0aeace</RequestId><HostId>txg866d9aebda1e46fba840-006a0aeace</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:15 GMT
+                - Mon, 18 May 2026 10:32:46 GMT
             X-Amz-Id-2:
-                - txge5117727cda141579338-006a042cbf
+                - txg866d9aebda1e46fba840-006a0aeace
             X-Amz-Request-Id:
-                - txge5117727cda141579338-006a042cbf
+                - txg866d9aebda1e46fba840-006a0aeace
         status: 404 Not Found
         code: 404
-        duration: 33.250459ms
+        duration: 292.820625ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -270,7 +270,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -279,7 +279,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d51059d7-f042-4cbf-a2b1-7176f9f75332
+                - c47d9d41-c84b-40cf-8ba1-18f0f1791c85
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -287,8 +287,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074815Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
+                - 20260518T103246Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -300,21 +300,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:15 GMT
+                - Mon, 18 May 2026 10:32:47 GMT
             X-Amz-Id-2:
-                - txg7fafc6b4d33d40d3a53a-006a042cbf
+                - txgbe057b70305746758658-006a0aeacf
             X-Amz-Request-Id:
-                - txg7fafc6b4d33d40d3a53a-006a042cbf
+                - txgbe057b70305746758658-006a0aeacf
         status: 200 OK
         code: 200
-        duration: 60.921209ms
+        duration: 245.360291ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -323,7 +323,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -332,7 +332,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ad4dfce3-e1a2-4fa3-b3f8-26068b549cb2
+                - df570571-4fa2-4e19-9d88-85ea40fc4429
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -340,8 +340,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074815Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T103247Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -351,21 +351,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg2716cf76a3fe43378f83-006a042cbf</RequestId><HostId>txg2716cf76a3fe43378f83-006a042cbf</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg26f07190c14d44cb9661-006a0aeacf</RequestId><HostId>txg26f07190c14d44cb9661-006a0aeacf</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:15 GMT
+                - Mon, 18 May 2026 10:32:47 GMT
             X-Amz-Id-2:
-                - txg2716cf76a3fe43378f83-006a042cbf
+                - txg26f07190c14d44cb9661-006a0aeacf
             X-Amz-Request-Id:
-                - txg2716cf76a3fe43378f83-006a042cbf
+                - txg26f07190c14d44cb9661-006a0aeacf
         status: 404 Not Found
         code: 404
-        duration: 31.091708ms
+        duration: 245.323458ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -374,7 +374,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -383,7 +383,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 3ee0dc91-8be9-4463-a975-99307bec0814
+                - 53036375-199d-4d06-932d-8aeb2c8eeb4c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -391,8 +391,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074815Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T103247Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -402,21 +402,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg03efceb5b2dc48e6bf5c-006a042cbf</RequestId><HostId>txg03efceb5b2dc48e6bf5c-006a042cbf</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg1b636d1afca24110a7b3-006a0aeacf</RequestId><HostId>txg1b636d1afca24110a7b3-006a0aeacf</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:15 GMT
+                - Mon, 18 May 2026 10:32:47 GMT
             X-Amz-Id-2:
-                - txg03efceb5b2dc48e6bf5c-006a042cbf
+                - txg1b636d1afca24110a7b3-006a0aeacf
             X-Amz-Request-Id:
-                - txg03efceb5b2dc48e6bf5c-006a042cbf
+                - txg1b636d1afca24110a7b3-006a0aeacf
         status: 404 Not Found
         code: 404
-        duration: 31.801958ms
+        duration: 20.636209ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -425,7 +425,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -434,7 +434,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d5baf1fc-a04d-4d5a-9146-a369d42ec638
+                - b28f9e5f-83bc-4be3-8695-4e02afb8193b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -442,8 +442,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074815Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T103247Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -462,14 +462,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:15 GMT
+                - Mon, 18 May 2026 10:32:47 GMT
             X-Amz-Id-2:
-                - txg006caa18f3ea4741aff6-006a042cbf
+                - txgbf962414710d40c09cf3-006a0aeacf
             X-Amz-Request-Id:
-                - txg006caa18f3ea4741aff6-006a042cbf
+                - txgbf962414710d40c09cf3-006a0aeacf
         status: 200 OK
         code: 200
-        duration: 60.138916ms
+        duration: 151.986375ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -478,7 +478,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -487,7 +487,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 87b0ebda-857d-4cd2-944d-3ceeb5e107dc
+                - 0ad4e03b-666e-480b-b141-a5cf4035a295
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -495,8 +495,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074815Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T103247Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -504,25 +504,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 276
+        content_length: 336
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
-                - "276"
+                - "336"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:15 GMT
+                - Mon, 18 May 2026 10:32:47 GMT
             X-Amz-Id-2:
-                - txg94ba033dd4664a99b786-006a042cbf
+                - txgbcd70dba7bd54cc49cde-006a0aeacf
             X-Amz-Request-Id:
-                - txg94ba033dd4664a99b786-006a042cbf
+                - txgbcd70dba7bd54cc49cde-006a0aeacf
         status: 200 OK
         code: 200
-        duration: 55.496459ms
+        duration: 33.783ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -531,7 +531,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -540,7 +540,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 804a1c4c-9197-4d99-b84b-de2ba15ba105
+                - db2e474e-2a49-4b1f-8f07-9345f3a6c9dd
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -548,8 +548,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074815Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
+                - 20260518T103248Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -564,16 +564,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:15 GMT
+                - Mon, 18 May 2026 10:32:48 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txg045be2e9ff6746b5bf3a-006a042cbf
+                - txg29d1d519413f48818501-006a0aead0
             X-Amz-Request-Id:
-                - txg045be2e9ff6746b5bf3a-006a042cbf
+                - txg29d1d519413f48818501-006a0aead0
         status: 200 OK
         code: 200
-        duration: 20.357541ms
+        duration: 44.730583ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -582,7 +582,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -591,7 +591,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - aba52da3-86ea-4789-a13b-8bac4e92ea98
+                - a7195225-330d-4efa-a06e-b6a99feb8b03
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -599,8 +599,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074815Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T103248Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -608,25 +608,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 276
+        content_length: 336
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
-                - "276"
+                - "336"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:15 GMT
+                - Mon, 18 May 2026 10:32:48 GMT
             X-Amz-Id-2:
-                - txg262bf2b57ec746cca512-006a042cbf
+                - txg3238d8e0fcc547b58b0b-006a0aead0
             X-Amz-Request-Id:
-                - txg262bf2b57ec746cca512-006a042cbf
+                - txg3238d8e0fcc547b58b0b-006a0aead0
         status: 200 OK
         code: 200
-        duration: 60.880916ms
+        duration: 127.678959ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -635,7 +635,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -644,7 +644,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - a9a8d00d-6a45-47f1-967f-771ffdcdf96a
+                - 03e94647-1724-41c5-88ca-e8bb796db3fc
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -652,8 +652,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074816Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T103248Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -672,14 +672,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:16 GMT
+                - Mon, 18 May 2026 10:32:48 GMT
             X-Amz-Id-2:
-                - txgbcc3fff8efc840fe88a2-006a042cc0
+                - txg6b8d31365c0f4c5496e3-006a0aead0
             X-Amz-Request-Id:
-                - txgbcc3fff8efc840fe88a2-006a042cc0
+                - txg6b8d31365c0f4c5496e3-006a0aead0
         status: 200 OK
         code: 200
-        duration: 28.624708ms
+        duration: 33.367167ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -688,7 +688,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -697,7 +697,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ffaa74e2-fedc-4762-8a55-fbc7154782ac
+                - 13ad3fe4-5707-4883-b335-0a3dccb23dcd
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -705,8 +705,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074816Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T103248Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -716,21 +716,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg26d3279a0d2c45aab7b0-006a042cc0</RequestId><HostId>txg26d3279a0d2c45aab7b0-006a042cc0</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgbda0eb8be8684c7c93b4-006a0aead0</RequestId><HostId>txgbda0eb8be8684c7c93b4-006a0aead0</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:16 GMT
+                - Mon, 18 May 2026 10:32:48 GMT
             X-Amz-Id-2:
-                - txg26d3279a0d2c45aab7b0-006a042cc0
+                - txgbda0eb8be8684c7c93b4-006a0aead0
             X-Amz-Request-Id:
-                - txg26d3279a0d2c45aab7b0-006a042cc0
+                - txgbda0eb8be8684c7c93b4-006a0aead0
         status: 404 Not Found
         code: 404
-        duration: 51.293417ms
+        duration: 55.058958ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -739,7 +739,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -748,7 +748,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 2a5b4aeb-dbfc-40d7-b21f-bff808d76c8f
+                - 62ca2241-ce59-4f33-b4dd-356129d02f59
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -756,8 +756,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074816Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
+                - 20260518T103248Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -769,21 +769,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:16 GMT
+                - Mon, 18 May 2026 10:32:48 GMT
             X-Amz-Id-2:
-                - txgd60331e84be74ece95b4-006a042cc0
+                - txgab28bcdf47f94ba688d6-006a0aead0
             X-Amz-Request-Id:
-                - txgd60331e84be74ece95b4-006a042cc0
+                - txgab28bcdf47f94ba688d6-006a0aead0
         status: 200 OK
         code: 200
-        duration: 84.631959ms
+        duration: 234.491042ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -792,7 +792,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -801,7 +801,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 429871dd-2f7c-4d5c-a2e7-de1a429e0195
+                - 00c19340-7cc7-4b00-a39c-3b1b3787ebaf
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -809,8 +809,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074816Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T103248Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -820,21 +820,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg6b85fe55fe9b4495b60f-006a042cc0</RequestId><HostId>txg6b85fe55fe9b4495b60f-006a042cc0</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg0239a20eb15d47bdb5fe-006a0aead0</RequestId><HostId>txg0239a20eb15d47bdb5fe-006a0aead0</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:16 GMT
+                - Mon, 18 May 2026 10:32:48 GMT
             X-Amz-Id-2:
-                - txg6b85fe55fe9b4495b60f-006a042cc0
+                - txg0239a20eb15d47bdb5fe-006a0aead0
             X-Amz-Request-Id:
-                - txg6b85fe55fe9b4495b60f-006a042cc0
+                - txg0239a20eb15d47bdb5fe-006a0aead0
         status: 404 Not Found
         code: 404
-        duration: 51.238ms
+        duration: 367.03425ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -843,7 +843,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -852,7 +852,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 78d41808-2dc5-4954-95a0-aa3352d4633c
+                - 98fa3c6f-fc63-4cf9-8a2e-76619fa097bf
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -860,8 +860,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074816Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T103248Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -871,21 +871,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg85511478376d495ea01b-006a042cc0</RequestId><HostId>txg85511478376d495ea01b-006a042cc0</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txge6279517fe8b452bb75e-006a0aead1</RequestId><HostId>txge6279517fe8b452bb75e-006a0aead1</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:16 GMT
+                - Mon, 18 May 2026 10:32:49 GMT
             X-Amz-Id-2:
-                - txg85511478376d495ea01b-006a042cc0
+                - txge6279517fe8b452bb75e-006a0aead1
             X-Amz-Request-Id:
-                - txg85511478376d495ea01b-006a042cc0
+                - txge6279517fe8b452bb75e-006a0aead1
         status: 404 Not Found
         code: 404
-        duration: 88.529708ms
+        duration: 61.131375ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -894,7 +894,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -903,7 +903,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d2c42833-71d3-4a1f-a52e-4871ac405dbf
+                - 04e1012b-2839-4c11-bf4c-2473095e8711
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -911,8 +911,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074816Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T103249Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -931,14 +931,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:16 GMT
+                - Mon, 18 May 2026 10:32:49 GMT
             X-Amz-Id-2:
-                - txg6c3b67032d234e0ba4ae-006a042cc0
+                - txg5bcaaee1e09d44218928-006a0aead1
             X-Amz-Request-Id:
-                - txg6c3b67032d234e0ba4ae-006a042cc0
+                - txg5bcaaee1e09d44218928-006a0aead1
         status: 200 OK
         code: 200
-        duration: 71.567083ms
+        duration: 34.146ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -947,7 +947,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -956,7 +956,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 8cd0f86e-e559-4e9a-a48d-bc77a1de29a2
+                - aa2675b0-f6db-4249-966a-4e9c150e9f93
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -964,8 +964,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074816Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T103249Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -973,25 +973,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 276
+        content_length: 336
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
-                - "276"
+                - "336"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:16 GMT
+                - Mon, 18 May 2026 10:32:49 GMT
             X-Amz-Id-2:
-                - txg5708cd472d0246d0b17f-006a042cc0
+                - txg6efa458e7be043e8a726-006a0aead1
             X-Amz-Request-Id:
-                - txg5708cd472d0246d0b17f-006a042cc0
+                - txg6efa458e7be043e8a726-006a0aead1
         status: 200 OK
         code: 200
-        duration: 68.75775ms
+        duration: 71.9115ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -1000,7 +1000,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1009,7 +1009,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f5e7742c-ca55-4d12-a6ab-0df7b0195159
+                - 626aaab6-46f3-40bf-b961-fcfc48b76896
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1017,8 +1017,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074816Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T103249Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1037,14 +1037,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:16 GMT
+                - Mon, 18 May 2026 10:32:49 GMT
             X-Amz-Id-2:
-                - txg1a83eb144f4a47eea151-006a042cc0
+                - txgade9dc219b98448982d3-006a0aead1
             X-Amz-Request-Id:
-                - txg1a83eb144f4a47eea151-006a042cc0
+                - txgade9dc219b98448982d3-006a0aead1
         status: 200 OK
         code: 200
-        duration: 48.569083ms
+        duration: 277.251ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1053,7 +1053,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1062,7 +1062,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 31812e15-6d4c-48f2-b356-b9ae6aa580f7
+                - f2c586b9-1cbb-4e7a-b065-c4eadb61027d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1070,8 +1070,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074816Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T103249Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1081,21 +1081,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg53f74b8a25214b32b262-006a042cc0</RequestId><HostId>txg53f74b8a25214b32b262-006a042cc0</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg8f8fee6776564d75a989-006a0aead1</RequestId><HostId>txg8f8fee6776564d75a989-006a0aead1</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:16 GMT
+                - Mon, 18 May 2026 10:32:49 GMT
             X-Amz-Id-2:
-                - txg53f74b8a25214b32b262-006a042cc0
+                - txg8f8fee6776564d75a989-006a0aead1
             X-Amz-Request-Id:
-                - txg53f74b8a25214b32b262-006a042cc0
+                - txg8f8fee6776564d75a989-006a0aead1
         status: 404 Not Found
         code: 404
-        duration: 19.21175ms
+        duration: 22.1165ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1104,7 +1104,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1113,7 +1113,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - bbca1bd5-3851-496a-b2e5-8a678d8d0ec4
+                - 019936d0-7c3c-4241-ba20-6aabbb4e1c3b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1121,8 +1121,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074816Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
+                - 20260518T103249Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -1134,21 +1134,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:16 GMT
+                - Mon, 18 May 2026 10:32:49 GMT
             X-Amz-Id-2:
-                - txg218d7b4ddd6248a68146-006a042cc0
+                - txg84c01b94d9e947d6b9ae-006a0aead1
             X-Amz-Request-Id:
-                - txg218d7b4ddd6248a68146-006a042cc0
+                - txg84c01b94d9e947d6b9ae-006a0aead1
         status: 200 OK
         code: 200
-        duration: 49.656416ms
+        duration: 141.653625ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1157,7 +1157,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1166,7 +1166,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 40147079-50ad-4e26-a942-5e572a51ca0c
+                - bfe35906-f9c9-48aa-a5ce-4a838f282833
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1174,8 +1174,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074816Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T103249Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1185,21 +1185,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg1a17098a967d4d3b8f48-006a042cc0</RequestId><HostId>txg1a17098a967d4d3b8f48-006a042cc0</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgd67336f463704a5898c8-006a0aead1</RequestId><HostId>txgd67336f463704a5898c8-006a0aead1</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:16 GMT
+                - Mon, 18 May 2026 10:32:49 GMT
             X-Amz-Id-2:
-                - txg1a17098a967d4d3b8f48-006a042cc0
+                - txgd67336f463704a5898c8-006a0aead1
             X-Amz-Request-Id:
-                - txg1a17098a967d4d3b8f48-006a042cc0
+                - txgd67336f463704a5898c8-006a0aead1
         status: 404 Not Found
         code: 404
-        duration: 59.495292ms
+        duration: 21.083792ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1208,7 +1208,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1217,7 +1217,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 17c010a1-b819-4e14-a321-b7a879b7f692
+                - 2e0140da-15e1-46ed-89de-802f2fa621d1
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1225,8 +1225,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074816Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T103249Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1236,21 +1236,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgbf9d0181e04646daac73-006a042cc1</RequestId><HostId>txgbf9d0181e04646daac73-006a042cc1</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg3c06ba3b76e245769381-006a0aead1</RequestId><HostId>txg3c06ba3b76e245769381-006a0aead1</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:17 GMT
+                - Mon, 18 May 2026 10:32:49 GMT
             X-Amz-Id-2:
-                - txgbf9d0181e04646daac73-006a042cc1
+                - txg3c06ba3b76e245769381-006a0aead1
             X-Amz-Request-Id:
-                - txgbf9d0181e04646daac73-006a042cc1
+                - txg3c06ba3b76e245769381-006a0aead1
         status: 404 Not Found
         code: 404
-        duration: 58.983042ms
+        duration: 171.111167ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1259,7 +1259,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1268,7 +1268,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 118dc171-c8fa-4f10-9630-ec6845ea5ccd
+                - 8e7405d6-a64f-4afa-a3c3-75828c7beb5e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1276,8 +1276,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074817Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T103249Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1296,14 +1296,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:17 GMT
+                - Mon, 18 May 2026 10:32:50 GMT
             X-Amz-Id-2:
-                - txg9d3c67cb56d743418d14-006a042cc1
+                - txgf7182e5decbb46e8bac0-006a0aead2
             X-Amz-Request-Id:
-                - txg9d3c67cb56d743418d14-006a042cc1
+                - txgf7182e5decbb46e8bac0-006a0aead2
         status: 200 OK
         code: 200
-        duration: 48.517333ms
+        duration: 234.10325ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1312,7 +1312,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1321,7 +1321,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - bde78c96-182d-4202-a35b-527001733eb4
+                - 571073ec-106c-4934-bef4-82e6d47e2724
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1329,8 +1329,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074817Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T103250Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1338,43 +1338,43 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 276
+        content_length: 336
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
-                - "276"
+                - "336"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:17 GMT
+                - Mon, 18 May 2026 10:32:50 GMT
             X-Amz-Id-2:
-                - txgff19b5d44e844d538c99-006a042cc1
+                - txg5d51303425734880b8b0-006a0aead2
             X-Amz-Request-Id:
-                - txgff19b5d44e844d538c99-006a042cc1
+                - txg5d51303425734880b8b0-006a0aead2
         status: 200 OK
         code: 200
-        duration: 60.471041ms
+        duration: 246.733333ms
     - id: 26
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 306
+        content_length: 366
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
-        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition></Rule></LifecycleConfiguration>
+        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition></Rule></LifecycleConfiguration>
         form: {}
         headers:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 08fcce07-67f4-458d-90a8-9500c90ba012
+                - 79b48293-5891-47d3-ad45-8639693ba4ee
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
@@ -1382,12 +1382,12 @@ interactions:
             User-Agent:
                 - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,Z,e
             X-Amz-Checksum-Crc32:
-                - 3OVKEQ==
+                - o6dwOA==
             X-Amz-Content-Sha256:
-                - de1418e62a2680330e07a11a092b47b671d4ed12fe9fe6d9780b095b8f45d69c
+                - 1695287f0c18bfb8c0d3d10989fec9b3e430afbc2914de7c50f434a75491894c
             X-Amz-Date:
-                - 20260513T074817Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T103250Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -1402,14 +1402,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Wed, 13 May 2026 07:48:17 GMT
+                - Mon, 18 May 2026 10:32:50 GMT
             X-Amz-Id-2:
-                - txg92dd6b08e4d340e189c5-006a042cc1
+                - txg432d8011dca1463bb4a0-006a0aead2
             X-Amz-Request-Id:
-                - txg92dd6b08e4d340e189c5-006a042cc1
+                - txg432d8011dca1463bb4a0-006a0aead2
         status: 200 OK
         code: 200
-        duration: 36.007542ms
+        duration: 202.804958ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1418,7 +1418,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1427,7 +1427,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 17a3ac10-b47f-4d72-a51d-9540faee46a1
+                - 51b0ae9e-b2a9-4415-8569-a8fa99292cdf
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1435,8 +1435,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074817Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T103251Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1455,14 +1455,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:17 GMT
+                - Mon, 18 May 2026 10:32:51 GMT
             X-Amz-Id-2:
-                - txg3c6343421c6644c99592-006a042cc1
+                - txgff29fb772237453a831f-006a0aead3
             X-Amz-Request-Id:
-                - txg3c6343421c6644c99592-006a042cc1
+                - txgff29fb772237453a831f-006a0aead3
         status: 200 OK
         code: 200
-        duration: 36.070417ms
+        duration: 244.522875ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1471,7 +1471,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1480,7 +1480,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 6d0d542b-916d-4fda-8a67-c79cbea8073b
+                - e33a87ae-0f72-4661-b408-b602f287ae00
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1488,8 +1488,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074817Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T103251Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1499,21 +1499,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgb8f81b272bd14fe9b89b-006a042cc1</RequestId><HostId>txgb8f81b272bd14fe9b89b-006a042cc1</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgd23dcd26e1124340aa75-006a0aead3</RequestId><HostId>txgd23dcd26e1124340aa75-006a0aead3</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:17 GMT
+                - Mon, 18 May 2026 10:32:51 GMT
             X-Amz-Id-2:
-                - txgb8f81b272bd14fe9b89b-006a042cc1
+                - txgd23dcd26e1124340aa75-006a0aead3
             X-Amz-Request-Id:
-                - txgb8f81b272bd14fe9b89b-006a042cc1
+                - txgd23dcd26e1124340aa75-006a0aead3
         status: 404 Not Found
         code: 404
-        duration: 102.069542ms
+        duration: 95.062458ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1522,7 +1522,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1531,7 +1531,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 13a34a22-ccd3-497b-b80e-da66a561b884
+                - 25f561cc-7e22-465b-a8cf-dc7f31786446
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1539,8 +1539,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074817Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
+                - 20260518T103251Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -1552,21 +1552,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:17 GMT
+                - Mon, 18 May 2026 10:32:51 GMT
             X-Amz-Id-2:
-                - txgfc9388419fd7458f86c5-006a042cc1
+                - txg53eaa81254df4f9ebe64-006a0aead3
             X-Amz-Request-Id:
-                - txgfc9388419fd7458f86c5-006a042cc1
+                - txg53eaa81254df4f9ebe64-006a0aead3
         status: 200 OK
         code: 200
-        duration: 68.033125ms
+        duration: 269.791584ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1575,7 +1575,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1584,7 +1584,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 42f89609-f454-4830-bb51-cd5368168eea
+                - 55395e45-c6ee-44df-ab32-8f67f6aca0c4
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1592,8 +1592,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074817Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T103251Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1603,21 +1603,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgbe505783a54a48c89301-006a042cc1</RequestId><HostId>txgbe505783a54a48c89301-006a042cc1</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg462c977d16a94e8682e7-006a0aead3</RequestId><HostId>txg462c977d16a94e8682e7-006a0aead3</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:17 GMT
+                - Mon, 18 May 2026 10:32:51 GMT
             X-Amz-Id-2:
-                - txgbe505783a54a48c89301-006a042cc1
+                - txg462c977d16a94e8682e7-006a0aead3
             X-Amz-Request-Id:
-                - txgbe505783a54a48c89301-006a042cc1
+                - txg462c977d16a94e8682e7-006a0aead3
         status: 404 Not Found
         code: 404
-        duration: 49.626208ms
+        duration: 58.46775ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1626,7 +1626,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1635,7 +1635,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 09255db4-6b80-4881-a3df-69def5ffd980
+                - 3920a164-f3bf-4a54-b783-74c6d7b1cb58
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1643,8 +1643,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074817Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T103251Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1654,21 +1654,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg938b3508a9a94cbdbe96-006a042cc1</RequestId><HostId>txg938b3508a9a94cbdbe96-006a042cc1</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg5c83968383534081b0a3-006a0aead3</RequestId><HostId>txg5c83968383534081b0a3-006a0aead3</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:17 GMT
+                - Mon, 18 May 2026 10:32:51 GMT
             X-Amz-Id-2:
-                - txg938b3508a9a94cbdbe96-006a042cc1
+                - txg5c83968383534081b0a3-006a0aead3
             X-Amz-Request-Id:
-                - txg938b3508a9a94cbdbe96-006a042cc1
+                - txg5c83968383534081b0a3-006a0aead3
         status: 404 Not Found
         code: 404
-        duration: 66.505167ms
+        duration: 54.368042ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1677,7 +1677,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1686,7 +1686,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b22f1d29-81d7-4008-a3e5-ab9dfdfd5448
+                - ecb6c00f-face-45de-be99-ef2f62d5ae2a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1694,8 +1694,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074817Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T103251Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1714,14 +1714,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:17 GMT
+                - Mon, 18 May 2026 10:32:51 GMT
             X-Amz-Id-2:
-                - txga138806f5f3f4ec480a0-006a042cc1
+                - txgce71d52724864949bac8-006a0aead3
             X-Amz-Request-Id:
-                - txga138806f5f3f4ec480a0-006a042cc1
+                - txgce71d52724864949bac8-006a0aead3
         status: 200 OK
         code: 200
-        duration: 34.010791ms
+        duration: 150.142083ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1730,7 +1730,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1739,7 +1739,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 069a5561-82c4-48c3-8c46-33bb1a7bf760
+                - 560b423d-6add-4f72-9b0f-049a6ed16284
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1747,8 +1747,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074817Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T103251Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1756,25 +1756,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 279
+        content_length: 339
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
-                - "279"
+                - "339"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:17 GMT
+                - Mon, 18 May 2026 10:32:51 GMT
             X-Amz-Id-2:
-                - txgeba51595a76e473d8105-006a042cc1
+                - txg8b4dca0edc2046aabd00-006a0aead3
             X-Amz-Request-Id:
-                - txgeba51595a76e473d8105-006a042cc1
+                - txg8b4dca0edc2046aabd00-006a0aead3
         status: 200 OK
         code: 200
-        duration: 18.767042ms
+        duration: 163.643875ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1783,7 +1783,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1792,7 +1792,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 858aafa3-767a-49ca-a58b-b1d7d6a312eb
+                - c2ca17fb-b66c-4a41-816b-2638e98343ce
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1800,8 +1800,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074817Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
+                - 20260518T103252Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -1816,16 +1816,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:17 GMT
+                - Mon, 18 May 2026 10:32:52 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txg558b695eb59e4ac0a18c-006a042cc1
+                - txge9ff9b7d98554508b97a-006a0aead4
             X-Amz-Request-Id:
-                - txg558b695eb59e4ac0a18c-006a042cc1
+                - txge9ff9b7d98554508b97a-006a0aead4
         status: 200 OK
         code: 200
-        duration: 33.53275ms
+        duration: 331.380083ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1834,7 +1834,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1843,7 +1843,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d428d3cd-3aa7-44d3-9eb5-ee2bb9a7695b
+                - 1912a7c2-2d4f-44ef-8dce-5ed344cb8a83
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1851,8 +1851,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074817Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T103252Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1860,25 +1860,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 279
+        content_length: 339
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
-                - "279"
+                - "339"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:17 GMT
+                - Mon, 18 May 2026 10:32:52 GMT
             X-Amz-Id-2:
-                - txg71fb96a834b04d3aa602-006a042cc1
+                - txg46f3b99539864a0486f3-006a0aead4
             X-Amz-Request-Id:
-                - txg71fb96a834b04d3aa602-006a042cc1
+                - txg46f3b99539864a0486f3-006a0aead4
         status: 200 OK
         code: 200
-        duration: 82.476375ms
+        duration: 38.739833ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1887,7 +1887,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1896,7 +1896,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9ce53966-b32d-439f-a157-9d022a0356fb
+                - 48ccd124-43c4-47e0-949b-ba92c3e760e4
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1904,8 +1904,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074818Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T103252Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1924,14 +1924,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:18 GMT
+                - Mon, 18 May 2026 10:32:52 GMT
             X-Amz-Id-2:
-                - txgf4ea6c45b0454cff850d-006a042cc2
+                - txgb6ddd244e0bc4df08dbc-006a0aead4
             X-Amz-Request-Id:
-                - txgf4ea6c45b0454cff850d-006a042cc2
+                - txgb6ddd244e0bc4df08dbc-006a0aead4
         status: 200 OK
         code: 200
-        duration: 22.024083ms
+        duration: 108.29975ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1940,7 +1940,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1949,7 +1949,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 72b0fd53-15df-48fc-91df-5b78f9333e0a
+                - 0c22799b-8697-4479-af11-2a3394c2b623
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1957,8 +1957,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074818Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T103252Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1968,21 +1968,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg63c5bfe50eac42468380-006a042cc2</RequestId><HostId>txg63c5bfe50eac42468380-006a042cc2</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg6407ee196a8647d7bcd0-006a0aead4</RequestId><HostId>txg6407ee196a8647d7bcd0-006a0aead4</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:18 GMT
+                - Mon, 18 May 2026 10:32:52 GMT
             X-Amz-Id-2:
-                - txg63c5bfe50eac42468380-006a042cc2
+                - txg6407ee196a8647d7bcd0-006a0aead4
             X-Amz-Request-Id:
-                - txg63c5bfe50eac42468380-006a042cc2
+                - txg6407ee196a8647d7bcd0-006a0aead4
         status: 404 Not Found
         code: 404
-        duration: 51.018ms
+        duration: 185.254417ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1991,7 +1991,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2000,7 +2000,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d8bf758c-68a0-471f-997e-7b2f763b9a02
+                - 7be5f8cd-f5ac-4cbd-8e4a-604b26cdb2db
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2008,8 +2008,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074818Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
+                - 20260518T103252Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -2021,21 +2021,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:18 GMT
+                - Mon, 18 May 2026 10:32:53 GMT
             X-Amz-Id-2:
-                - txgc6866f9273b6450f9651-006a042cc2
+                - txg3b31223a73284934a776-006a0aead5
             X-Amz-Request-Id:
-                - txgc6866f9273b6450f9651-006a042cc2
+                - txg3b31223a73284934a776-006a0aead5
         status: 200 OK
         code: 200
-        duration: 53.117542ms
+        duration: 78.224ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -2044,7 +2044,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2053,7 +2053,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c55dedb1-a198-4120-8b2e-a2a2091f3206
+                - 74922969-0c8f-46b1-8319-20fb06ab6bf7
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2061,8 +2061,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074818Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T103253Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2072,21 +2072,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgc2c22544572a4c1d81cc-006a042cc2</RequestId><HostId>txgc2c22544572a4c1d81cc-006a042cc2</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg396ee12162d54811a10c-006a0aead5</RequestId><HostId>txg396ee12162d54811a10c-006a0aead5</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:18 GMT
+                - Mon, 18 May 2026 10:32:53 GMT
             X-Amz-Id-2:
-                - txgc2c22544572a4c1d81cc-006a042cc2
+                - txg396ee12162d54811a10c-006a0aead5
             X-Amz-Request-Id:
-                - txgc2c22544572a4c1d81cc-006a042cc2
+                - txg396ee12162d54811a10c-006a0aead5
         status: 404 Not Found
         code: 404
-        duration: 48.96525ms
+        duration: 159.608916ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -2095,7 +2095,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2104,7 +2104,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9c373155-faf6-402b-8e90-8e53ee187c32
+                - a86315ce-1a67-49d4-a8bd-ae185b637086
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2112,8 +2112,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074818Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T103253Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2123,21 +2123,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg2b7f75e5712a49708c2f-006a042cc2</RequestId><HostId>txg2b7f75e5712a49708c2f-006a042cc2</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgfd162e75241f40b58237-006a0aead5</RequestId><HostId>txgfd162e75241f40b58237-006a0aead5</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:18 GMT
+                - Mon, 18 May 2026 10:32:53 GMT
             X-Amz-Id-2:
-                - txg2b7f75e5712a49708c2f-006a042cc2
+                - txgfd162e75241f40b58237-006a0aead5
             X-Amz-Request-Id:
-                - txg2b7f75e5712a49708c2f-006a042cc2
+                - txgfd162e75241f40b58237-006a0aead5
         status: 404 Not Found
         code: 404
-        duration: 18.285833ms
+        duration: 250.430625ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -2146,7 +2146,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2155,7 +2155,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 174a646a-1e00-4b41-9b00-4d2d02c874c5
+                - afce0431-b4c6-43b6-b154-fdd793457114
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2163,8 +2163,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074818Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T103253Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2183,14 +2183,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:18 GMT
+                - Mon, 18 May 2026 10:32:53 GMT
             X-Amz-Id-2:
-                - txg5b53effff8ea40b499d3-006a042cc2
+                - txgf1290f69a7724bcfab84-006a0aead5
             X-Amz-Request-Id:
-                - txg5b53effff8ea40b499d3-006a042cc2
+                - txgf1290f69a7724bcfab84-006a0aead5
         status: 200 OK
         code: 200
-        duration: 50.49275ms
+        duration: 21.416584ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -2199,7 +2199,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2208,7 +2208,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - a13eeb5c-0cb6-4e18-bbcd-e7466b8cb84e
+                - 7c918243-9830-4c80-9dcd-9f667ff4e87e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2216,8 +2216,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074818Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T103253Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2225,25 +2225,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 279
+        content_length: 339
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
-                - "279"
+                - "339"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:18 GMT
+                - Mon, 18 May 2026 10:32:53 GMT
             X-Amz-Id-2:
-                - txg7b785dc2f53d4d86a5d2-006a042cc2
+                - txg9a06c08796c849499d5a-006a0aead5
             X-Amz-Request-Id:
-                - txg7b785dc2f53d4d86a5d2-006a042cc2
+                - txg9a06c08796c849499d5a-006a0aead5
         status: 200 OK
         code: 200
-        duration: 141.6625ms
+        duration: 90.827ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -2252,7 +2252,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2261,7 +2261,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c31f10d1-d605-4139-b7d6-9c68c60a911f
+                - 46fbb1e0-2823-47d5-9014-0635bfbbe6af
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2269,8 +2269,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074818Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T103253Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2289,14 +2289,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:18 GMT
+                - Mon, 18 May 2026 10:32:53 GMT
             X-Amz-Id-2:
-                - txg683615d1e4444a3daa8a-006a042cc2
+                - txg0f806fd1ccf04a83aa09-006a0aead5
             X-Amz-Request-Id:
-                - txg683615d1e4444a3daa8a-006a042cc2
+                - txg0f806fd1ccf04a83aa09-006a0aead5
         status: 200 OK
         code: 200
-        duration: 48.680625ms
+        duration: 146.175917ms
     - id: 44
       request:
         proto: HTTP/1.1
@@ -2305,7 +2305,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2314,7 +2314,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e58adac6-c8a3-4e70-ae54-05625379dbb1
+                - 6a7269c4-5c33-4b84-9bfe-d4ddf67cb2a3
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2322,8 +2322,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074818Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T103253Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2333,21 +2333,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgd713dc3066594208abf1-006a042cc2</RequestId><HostId>txgd713dc3066594208abf1-006a042cc2</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txge842802ca2c04ce095cf-006a0aead6</RequestId><HostId>txge842802ca2c04ce095cf-006a0aead6</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:18 GMT
+                - Mon, 18 May 2026 10:32:54 GMT
             X-Amz-Id-2:
-                - txgd713dc3066594208abf1-006a042cc2
+                - txge842802ca2c04ce095cf-006a0aead6
             X-Amz-Request-Id:
-                - txgd713dc3066594208abf1-006a042cc2
+                - txge842802ca2c04ce095cf-006a0aead6
         status: 404 Not Found
         code: 404
-        duration: 70.9235ms
+        duration: 176.987291ms
     - id: 45
       request:
         proto: HTTP/1.1
@@ -2356,7 +2356,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2365,7 +2365,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 37969cd1-8936-407b-82bf-fe703ab55e22
+                - 66d32cd5-9083-4835-8c0e-ee104e93e708
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2373,8 +2373,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074818Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
+                - 20260518T103254Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -2386,21 +2386,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:18 GMT
+                - Mon, 18 May 2026 10:32:54 GMT
             X-Amz-Id-2:
-                - txg9dec83662cde47c7bc29-006a042cc2
+                - txg3ca87414e0354b5e8a2a-006a0aead6
             X-Amz-Request-Id:
-                - txg9dec83662cde47c7bc29-006a042cc2
+                - txg3ca87414e0354b5e8a2a-006a0aead6
         status: 200 OK
         code: 200
-        duration: 33.989625ms
+        duration: 293.15475ms
     - id: 46
       request:
         proto: HTTP/1.1
@@ -2409,7 +2409,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2418,7 +2418,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b6444975-c11d-4f36-b8dd-08ebdd8a4112
+                - 8b6fd264-bc57-4744-942b-243c630e9690
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2426,8 +2426,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074818Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T103254Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2437,21 +2437,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg73fc1b47b5bb49e1b784-006a042cc2</RequestId><HostId>txg73fc1b47b5bb49e1b784-006a042cc2</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgfbb18a9aaef143a1a202-006a0aead6</RequestId><HostId>txgfbb18a9aaef143a1a202-006a0aead6</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:18 GMT
+                - Mon, 18 May 2026 10:32:54 GMT
             X-Amz-Id-2:
-                - txg73fc1b47b5bb49e1b784-006a042cc2
+                - txgfbb18a9aaef143a1a202-006a0aead6
             X-Amz-Request-Id:
-                - txg73fc1b47b5bb49e1b784-006a042cc2
+                - txgfbb18a9aaef143a1a202-006a0aead6
         status: 404 Not Found
         code: 404
-        duration: 65.054042ms
+        duration: 133.114667ms
     - id: 47
       request:
         proto: HTTP/1.1
@@ -2460,7 +2460,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2469,7 +2469,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ec37e775-65c1-4e9c-99ba-50cf6a4750fe
+                - 0be3c1f6-a2b0-4433-bbf7-ee11919e508f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2477,8 +2477,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074818Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T103254Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2488,21 +2488,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg5adbb8508b1546008706-006a042cc3</RequestId><HostId>txg5adbb8508b1546008706-006a042cc3</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg6e03d694589f42e1a36e-006a0aead6</RequestId><HostId>txg6e03d694589f42e1a36e-006a0aead6</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:19 GMT
+                - Mon, 18 May 2026 10:32:54 GMT
             X-Amz-Id-2:
-                - txg5adbb8508b1546008706-006a042cc3
+                - txg6e03d694589f42e1a36e-006a0aead6
             X-Amz-Request-Id:
-                - txg5adbb8508b1546008706-006a042cc3
+                - txg6e03d694589f42e1a36e-006a0aead6
         status: 404 Not Found
         code: 404
-        duration: 72.370334ms
+        duration: 308.198041ms
     - id: 48
       request:
         proto: HTTP/1.1
@@ -2511,7 +2511,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2520,7 +2520,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 6ad3296e-6ed6-428b-a6dc-f016b7b85026
+                - 3d8de7d6-996a-47d4-9224-117a8879caf7
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2528,8 +2528,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074819Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T103254Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2548,14 +2548,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:19 GMT
+                - Mon, 18 May 2026 10:32:54 GMT
             X-Amz-Id-2:
-                - txg3bf62556648042399730-006a042cc3
+                - txg4a3bce12d0ad41b3aade-006a0aead6
             X-Amz-Request-Id:
-                - txg3bf62556648042399730-006a042cc3
+                - txg4a3bce12d0ad41b3aade-006a0aead6
         status: 200 OK
         code: 200
-        duration: 97.487ms
+        duration: 112.336417ms
     - id: 49
       request:
         proto: HTTP/1.1
@@ -2564,7 +2564,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2573,7 +2573,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 95af853e-c0d6-46ba-9ee3-310c8806c281
+                - e3d611e4-d57c-460f-bbed-fb6f949ef1b4
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2581,8 +2581,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074819Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T103254Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2590,43 +2590,43 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 279
+        content_length: 339
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
-                - "279"
+                - "339"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:19 GMT
+                - Mon, 18 May 2026 10:32:55 GMT
             X-Amz-Id-2:
-                - txgb7546c71df7e45918bd5-006a042cc3
+                - txgefcbca56168a465897c7-006a0aead7
             X-Amz-Request-Id:
-                - txgb7546c71df7e45918bd5-006a042cc3
+                - txgefcbca56168a465897c7-006a0aead7
         status: 200 OK
         code: 200
-        duration: 20.4865ms
+        duration: 21.312166ms
     - id: 50
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 1132
+        content_length: 1312
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
-        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></LifecycleConfiguration>
+        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></LifecycleConfiguration>
         form: {}
         headers:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 37fe57a2-b904-4f40-84de-41e32dfc1654
+                - 99676815-f6e3-42b3-9eda-205ba0fd4bb4
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
@@ -2634,12 +2634,12 @@ interactions:
             User-Agent:
                 - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,Z,e
             X-Amz-Checksum-Crc32:
-                - Iut4Cw==
+                - 4NH0sw==
             X-Amz-Content-Sha256:
-                - abdb2689a9d25a928122283e4e5fdf5ef5744bed79f37794b44a3c66662be0c1
+                - 26f747e15ce1a1b780c6752abe8ce8948c374f5a893f30d1d89454d547619049
             X-Amz-Date:
-                - 20260513T074819Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T103255Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -2654,14 +2654,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Wed, 13 May 2026 07:48:19 GMT
+                - Mon, 18 May 2026 10:32:55 GMT
             X-Amz-Id-2:
-                - txg19bf561a00b24ba0bb2f-006a042cc3
+                - txg0a198e39bdbf46208696-006a0aead7
             X-Amz-Request-Id:
-                - txg19bf561a00b24ba0bb2f-006a042cc3
+                - txg0a198e39bdbf46208696-006a0aead7
         status: 200 OK
         code: 200
-        duration: 62.31425ms
+        duration: 420.2105ms
     - id: 51
       request:
         proto: HTTP/1.1
@@ -2670,7 +2670,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2679,7 +2679,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 47c65c63-4810-4cc5-8b2a-8a94802a44f3
+                - c5c78f68-2357-41d9-9b09-ded7795e0559
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2687,8 +2687,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074819Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T103255Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2707,14 +2707,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:19 GMT
+                - Mon, 18 May 2026 10:32:55 GMT
             X-Amz-Id-2:
-                - txg8ce7bdd0c5b641b2a29d-006a042cc3
+                - txgbf2bb6b13d5b486785ba-006a0aead7
             X-Amz-Request-Id:
-                - txg8ce7bdd0c5b641b2a29d-006a042cc3
+                - txgbf2bb6b13d5b486785ba-006a0aead7
         status: 200 OK
         code: 200
-        duration: 22.82575ms
+        duration: 50.600083ms
     - id: 52
       request:
         proto: HTTP/1.1
@@ -2723,7 +2723,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2732,7 +2732,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4020acf2-c497-4b1c-a009-956b18528a20
+                - d9021281-31fc-4afd-bd6c-20b940c23c99
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2740,8 +2740,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074819Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T103255Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2751,21 +2751,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg71a8d244966e4a5f82b7-006a042cc3</RequestId><HostId>txg71a8d244966e4a5f82b7-006a042cc3</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg4c1be19708ed45d9bb82-006a0aead7</RequestId><HostId>txg4c1be19708ed45d9bb82-006a0aead7</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:19 GMT
+                - Mon, 18 May 2026 10:32:55 GMT
             X-Amz-Id-2:
-                - txg71a8d244966e4a5f82b7-006a042cc3
+                - txg4c1be19708ed45d9bb82-006a0aead7
             X-Amz-Request-Id:
-                - txg71a8d244966e4a5f82b7-006a042cc3
+                - txg4c1be19708ed45d9bb82-006a0aead7
         status: 404 Not Found
         code: 404
-        duration: 54.006084ms
+        duration: 121.003333ms
     - id: 53
       request:
         proto: HTTP/1.1
@@ -2774,7 +2774,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2783,7 +2783,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7eae9336-663c-4c97-bd43-b16879c13e63
+                - 46fc5f68-b626-4d7f-8550-420f8ea90d02
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2791,8 +2791,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074819Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
+                - 20260518T103255Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -2804,21 +2804,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:19 GMT
+                - Mon, 18 May 2026 10:32:55 GMT
             X-Amz-Id-2:
-                - txg981809cb97a14763a8d9-006a042cc3
+                - txg9775a63bee30423bac76-006a0aead7
             X-Amz-Request-Id:
-                - txg981809cb97a14763a8d9-006a042cc3
+                - txg9775a63bee30423bac76-006a0aead7
         status: 200 OK
         code: 200
-        duration: 60.401333ms
+        duration: 79.175875ms
     - id: 54
       request:
         proto: HTTP/1.1
@@ -2827,7 +2827,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2836,7 +2836,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e8eeb3d9-85fb-4c5d-9b3d-4618d680fb6e
+                - 6d077fdc-100c-4362-9319-2779bc2ba3aa
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2844,8 +2844,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074819Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T103255Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2855,21 +2855,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg72c1ae4dec0c4c9c8b1e-006a042cc3</RequestId><HostId>txg72c1ae4dec0c4c9c8b1e-006a042cc3</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg636db28b8c9c41438c7a-006a0aead7</RequestId><HostId>txg636db28b8c9c41438c7a-006a0aead7</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:19 GMT
+                - Mon, 18 May 2026 10:32:55 GMT
             X-Amz-Id-2:
-                - txg72c1ae4dec0c4c9c8b1e-006a042cc3
+                - txg636db28b8c9c41438c7a-006a0aead7
             X-Amz-Request-Id:
-                - txg72c1ae4dec0c4c9c8b1e-006a042cc3
+                - txg636db28b8c9c41438c7a-006a0aead7
         status: 404 Not Found
         code: 404
-        duration: 26.214875ms
+        duration: 234.09925ms
     - id: 55
       request:
         proto: HTTP/1.1
@@ -2878,7 +2878,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2887,7 +2887,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4733cb84-29ec-4fd3-a7a3-fcd2dac77d77
+                - c06b3580-eb77-4f02-abb0-a650f41932a9
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2895,8 +2895,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074819Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T103255Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2906,21 +2906,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg1338f499d55c4f92b816-006a042cc3</RequestId><HostId>txg1338f499d55c4f92b816-006a042cc3</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg128e35a677aa49eda80a-006a0aead8</RequestId><HostId>txg128e35a677aa49eda80a-006a0aead8</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:19 GMT
+                - Mon, 18 May 2026 10:32:56 GMT
             X-Amz-Id-2:
-                - txg1338f499d55c4f92b816-006a042cc3
+                - txg128e35a677aa49eda80a-006a0aead8
             X-Amz-Request-Id:
-                - txg1338f499d55c4f92b816-006a042cc3
+                - txg128e35a677aa49eda80a-006a0aead8
         status: 404 Not Found
         code: 404
-        duration: 38.600417ms
+        duration: 90.021ms
     - id: 56
       request:
         proto: HTTP/1.1
@@ -2929,7 +2929,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2938,7 +2938,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e96d9ff6-5466-4571-82ec-1b3c9240d894
+                - 86a8a0bf-8d68-49b4-a7b4-ba75f6130db8
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2946,8 +2946,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074819Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T103256Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2966,14 +2966,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:19 GMT
+                - Mon, 18 May 2026 10:32:56 GMT
             X-Amz-Id-2:
-                - txg1d3ea7ea45ad4be0b4d7-006a042cc3
+                - txg61ecc483729d4d60be05-006a0aead8
             X-Amz-Request-Id:
-                - txg1d3ea7ea45ad4be0b4d7-006a042cc3
+                - txg61ecc483729d4d60be05-006a0aead8
         status: 200 OK
         code: 200
-        duration: 18.686542ms
+        duration: 21.898542ms
     - id: 57
       request:
         proto: HTTP/1.1
@@ -2982,7 +2982,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2991,7 +2991,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f4e0a111-a3ef-4025-8210-fd9b8e03b035
+                - 4b59f6f3-8067-41d2-b0ac-4a730e94f11c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2999,8 +2999,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074819Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T103256Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3008,25 +3008,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1105
+        content_length: 1285
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
-                - "1105"
+                - "1285"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:19 GMT
+                - Mon, 18 May 2026 10:32:56 GMT
             X-Amz-Id-2:
-                - txgd25ad196abd0416c80bf-006a042cc3
+                - txg8fab7dcff0cf4432a47d-006a0aead8
             X-Amz-Request-Id:
-                - txgd25ad196abd0416c80bf-006a042cc3
+                - txg8fab7dcff0cf4432a47d-006a0aead8
         status: 200 OK
         code: 200
-        duration: 18.793083ms
+        duration: 125.052375ms
     - id: 58
       request:
         proto: HTTP/1.1
@@ -3035,7 +3035,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3044,7 +3044,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e6f5cc1a-bb6d-4b4d-93e8-40f2dd68c1ab
+                - c655fbae-c7bf-46c9-b05e-bb593d5f2040
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3052,8 +3052,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074819Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
+                - 20260518T103256Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -3068,16 +3068,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:19 GMT
+                - Mon, 18 May 2026 10:32:56 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txg74a18d8175ff4611a3cb-006a042cc3
+                - txg05920a8065bb461aa719-006a0aead8
             X-Amz-Request-Id:
-                - txg74a18d8175ff4611a3cb-006a042cc3
+                - txg05920a8065bb461aa719-006a0aead8
         status: 200 OK
         code: 200
-        duration: 49.725208ms
+        duration: 30.58825ms
     - id: 59
       request:
         proto: HTTP/1.1
@@ -3086,7 +3086,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3095,7 +3095,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 50095aee-cada-4256-867f-8efbd855239f
+                - 9e91fe46-8a51-4f1f-913c-a17bf150d409
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3103,8 +3103,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074819Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T103256Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3112,25 +3112,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1105
+        content_length: 1285
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
-                - "1105"
+                - "1285"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:19 GMT
+                - Mon, 18 May 2026 10:32:56 GMT
             X-Amz-Id-2:
-                - txg599b096dde6446dbbbf5-006a042cc3
+                - txg21cd5c90571d4c0cb3ea-006a0aead8
             X-Amz-Request-Id:
-                - txg599b096dde6446dbbbf5-006a042cc3
+                - txg21cd5c90571d4c0cb3ea-006a0aead8
         status: 200 OK
         code: 200
-        duration: 76.08275ms
+        duration: 53.564791ms
     - id: 60
       request:
         proto: HTTP/1.1
@@ -3139,7 +3139,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3148,7 +3148,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e085cada-78db-487d-8e9c-a08727ae010a
+                - e0578d94-1b1f-417c-8110-153c36aed10d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3156,8 +3156,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074820Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T103256Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3176,14 +3176,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:20 GMT
+                - Mon, 18 May 2026 10:32:56 GMT
             X-Amz-Id-2:
-                - txg4a0d111d1296422a8f93-006a042cc4
+                - txg2900cc0280814d40aba8-006a0aead8
             X-Amz-Request-Id:
-                - txg4a0d111d1296422a8f93-006a042cc4
+                - txg2900cc0280814d40aba8-006a0aead8
         status: 200 OK
         code: 200
-        duration: 20.4895ms
+        duration: 22.627542ms
     - id: 61
       request:
         proto: HTTP/1.1
@@ -3192,7 +3192,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3201,7 +3201,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 407a632a-8a77-469e-8fe9-f679bcc0cec5
+                - 5967e5b6-898d-459a-834f-2f854bfdf8a5
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3209,8 +3209,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074820Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T103256Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3220,21 +3220,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg9c31fb0b5d90437a9690-006a042cc4</RequestId><HostId>txg9c31fb0b5d90437a9690-006a042cc4</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txge7ecc7e9160b4ad3a1ae-006a0aead8</RequestId><HostId>txge7ecc7e9160b4ad3a1ae-006a0aead8</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:20 GMT
+                - Mon, 18 May 2026 10:32:56 GMT
             X-Amz-Id-2:
-                - txg9c31fb0b5d90437a9690-006a042cc4
+                - txge7ecc7e9160b4ad3a1ae-006a0aead8
             X-Amz-Request-Id:
-                - txg9c31fb0b5d90437a9690-006a042cc4
+                - txge7ecc7e9160b4ad3a1ae-006a0aead8
         status: 404 Not Found
         code: 404
-        duration: 62.161541ms
+        duration: 58.60875ms
     - id: 62
       request:
         proto: HTTP/1.1
@@ -3243,7 +3243,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3252,7 +3252,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 97811574-7bbf-4931-9b9e-06469cfdcc92
+                - 772b91d7-43cb-4446-84f0-d5219304ddf9
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3260,8 +3260,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074820Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
+                - 20260518T103256Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -3273,21 +3273,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:20 GMT
+                - Mon, 18 May 2026 10:32:56 GMT
             X-Amz-Id-2:
-                - txgd5dcd7ec2e03448eba06-006a042cc4
+                - txg39646da1b4f54500bb33-006a0aead8
             X-Amz-Request-Id:
-                - txgd5dcd7ec2e03448eba06-006a042cc4
+                - txg39646da1b4f54500bb33-006a0aead8
         status: 200 OK
         code: 200
-        duration: 20.919042ms
+        duration: 330.737083ms
     - id: 63
       request:
         proto: HTTP/1.1
@@ -3296,7 +3296,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3305,7 +3305,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 25df477a-2ee9-4eb1-becb-b7f48384d3e3
+                - baa9987d-16a0-4698-b6f6-286d1ede1fd8
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3313,8 +3313,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074820Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T103256Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3324,21 +3324,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg8772b1c804c843b4adf3-006a042cc4</RequestId><HostId>txg8772b1c804c843b4adf3-006a042cc4</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg88a897369b33421fa86d-006a0aead9</RequestId><HostId>txg88a897369b33421fa86d-006a0aead9</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:20 GMT
+                - Mon, 18 May 2026 10:32:57 GMT
             X-Amz-Id-2:
-                - txg8772b1c804c843b4adf3-006a042cc4
+                - txg88a897369b33421fa86d-006a0aead9
             X-Amz-Request-Id:
-                - txg8772b1c804c843b4adf3-006a042cc4
+                - txg88a897369b33421fa86d-006a0aead9
         status: 404 Not Found
         code: 404
-        duration: 50.272875ms
+        duration: 21.180417ms
     - id: 64
       request:
         proto: HTTP/1.1
@@ -3347,7 +3347,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3356,7 +3356,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 2bbafd2f-6879-4dee-ba53-27e21907a7c6
+                - 6d4fb60d-6d97-4c41-8c14-5722de3fa3e3
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3364,8 +3364,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074820Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T103257Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3375,21 +3375,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg375488a0268a4256a800-006a042cc4</RequestId><HostId>txg375488a0268a4256a800-006a042cc4</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg0d72fc0b5c4745759e68-006a0aead9</RequestId><HostId>txg0d72fc0b5c4745759e68-006a0aead9</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:20 GMT
+                - Mon, 18 May 2026 10:32:57 GMT
             X-Amz-Id-2:
-                - txg375488a0268a4256a800-006a042cc4
+                - txg0d72fc0b5c4745759e68-006a0aead9
             X-Amz-Request-Id:
-                - txg375488a0268a4256a800-006a042cc4
+                - txg0d72fc0b5c4745759e68-006a0aead9
         status: 404 Not Found
         code: 404
-        duration: 19.4435ms
+        duration: 20.472875ms
     - id: 65
       request:
         proto: HTTP/1.1
@@ -3398,7 +3398,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3407,7 +3407,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0ed58415-89c6-4bd0-9459-988c0ee534bd
+                - d2c13169-9f3c-4edf-8585-a1384493ffe9
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3415,8 +3415,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074820Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T103257Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3435,14 +3435,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:20 GMT
+                - Mon, 18 May 2026 10:32:57 GMT
             X-Amz-Id-2:
-                - txgce08f4ef2c6c481088d9-006a042cc4
+                - txg4e9c53e70c1643838309-006a0aead9
             X-Amz-Request-Id:
-                - txgce08f4ef2c6c481088d9-006a042cc4
+                - txg4e9c53e70c1643838309-006a0aead9
         status: 200 OK
         code: 200
-        duration: 51.809125ms
+        duration: 224.113958ms
     - id: 66
       request:
         proto: HTTP/1.1
@@ -3451,7 +3451,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3460,7 +3460,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f9a6fe18-20d2-4ff1-b3c1-6715caad3e7a
+                - 4cfd68c6-0f16-4783-bb10-591492a97758
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3468,8 +3468,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074820Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T103257Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3477,25 +3477,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1105
+        content_length: 1285
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
-                - "1105"
+                - "1285"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:20 GMT
+                - Mon, 18 May 2026 10:32:57 GMT
             X-Amz-Id-2:
-                - txgfab97f5f4230426ca7d3-006a042cc4
+                - txg474e2192a0d749bca73b-006a0aead9
             X-Amz-Request-Id:
-                - txgfab97f5f4230426ca7d3-006a042cc4
+                - txg474e2192a0d749bca73b-006a0aead9
         status: 200 OK
         code: 200
-        duration: 50.786542ms
+        duration: 137.442125ms
     - id: 67
       request:
         proto: HTTP/1.1
@@ -3504,7 +3504,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3513,7 +3513,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 6f1bc441-c994-471e-acd1-687cb2ab3294
+                - 888bb445-3325-4641-8c01-4f500e2d4749
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3521,8 +3521,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074820Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T103257Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3541,14 +3541,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:20 GMT
+                - Mon, 18 May 2026 10:32:57 GMT
             X-Amz-Id-2:
-                - txgac0b816622e94a33bb0c-006a042cc4
+                - txg47f3dab0f92f4b919f49-006a0aead9
             X-Amz-Request-Id:
-                - txgac0b816622e94a33bb0c-006a042cc4
+                - txg47f3dab0f92f4b919f49-006a0aead9
         status: 200 OK
         code: 200
-        duration: 49.54475ms
+        duration: 24.121959ms
     - id: 68
       request:
         proto: HTTP/1.1
@@ -3557,7 +3557,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3566,7 +3566,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b8be9224-6a38-44fc-9c14-9e948a53fc8c
+                - 0a080c59-188c-4e01-8a6b-1d3f199b498b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3574,8 +3574,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074820Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T103257Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3585,21 +3585,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg47726daf41854d6d9f43-006a042cc4</RequestId><HostId>txg47726daf41854d6d9f43-006a042cc4</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgdf937c4bf38f4f1c9942-006a0aead9</RequestId><HostId>txgdf937c4bf38f4f1c9942-006a0aead9</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:20 GMT
+                - Mon, 18 May 2026 10:32:57 GMT
             X-Amz-Id-2:
-                - txg47726daf41854d6d9f43-006a042cc4
+                - txgdf937c4bf38f4f1c9942-006a0aead9
             X-Amz-Request-Id:
-                - txg47726daf41854d6d9f43-006a042cc4
+                - txgdf937c4bf38f4f1c9942-006a0aead9
         status: 404 Not Found
         code: 404
-        duration: 53.079375ms
+        duration: 88.717417ms
     - id: 69
       request:
         proto: HTTP/1.1
@@ -3608,7 +3608,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3617,7 +3617,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - eb9a25d5-01d0-4b42-801c-4ba2d60714a3
+                - 375bb115-4297-4476-8bf9-77e57e679e97
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3625,8 +3625,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074820Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
+                - 20260518T103257Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -3638,21 +3638,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:20 GMT
+                - Mon, 18 May 2026 10:32:57 GMT
             X-Amz-Id-2:
-                - txg299f3b19d44749d4ab66-006a042cc4
+                - txg4464d712945c4e798433-006a0aead9
             X-Amz-Request-Id:
-                - txg299f3b19d44749d4ab66-006a042cc4
+                - txg4464d712945c4e798433-006a0aead9
         status: 200 OK
         code: 200
-        duration: 259.691292ms
+        duration: 48.316ms
     - id: 70
       request:
         proto: HTTP/1.1
@@ -3661,7 +3661,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3670,7 +3670,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - deca9702-a689-4150-8474-ccc2703f408a
+                - 1949a122-a160-4dec-abf0-2c3682a965b7
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3678,8 +3678,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074820Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T103257Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3689,21 +3689,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgacaa4102bc16433b82a4-006a042cc5</RequestId><HostId>txgacaa4102bc16433b82a4-006a042cc5</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg793ef4e69a5c46d3981c-006a0aeada</RequestId><HostId>txg793ef4e69a5c46d3981c-006a0aeada</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:21 GMT
+                - Mon, 18 May 2026 10:32:58 GMT
             X-Amz-Id-2:
-                - txgacaa4102bc16433b82a4-006a042cc5
+                - txg793ef4e69a5c46d3981c-006a0aeada
             X-Amz-Request-Id:
-                - txgacaa4102bc16433b82a4-006a042cc5
+                - txg793ef4e69a5c46d3981c-006a0aeada
         status: 404 Not Found
         code: 404
-        duration: 19.710125ms
+        duration: 85.764375ms
     - id: 71
       request:
         proto: HTTP/1.1
@@ -3712,7 +3712,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3721,7 +3721,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c45956c7-034c-4e47-b630-43f1820f6f0a
+                - 60b7c1e6-f31c-4733-baaf-42847fa0dee8
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3729,8 +3729,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074821Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T103258Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3740,21 +3740,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg7006791408da47abb6c0-006a042cc5</RequestId><HostId>txg7006791408da47abb6c0-006a042cc5</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg3c6a6e7efc474751974c-006a0aeada</RequestId><HostId>txg3c6a6e7efc474751974c-006a0aeada</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:21 GMT
+                - Mon, 18 May 2026 10:32:58 GMT
             X-Amz-Id-2:
-                - txg7006791408da47abb6c0-006a042cc5
+                - txg3c6a6e7efc474751974c-006a0aeada
             X-Amz-Request-Id:
-                - txg7006791408da47abb6c0-006a042cc5
+                - txg3c6a6e7efc474751974c-006a0aeada
         status: 404 Not Found
         code: 404
-        duration: 22.71175ms
+        duration: 20.851209ms
     - id: 72
       request:
         proto: HTTP/1.1
@@ -3763,7 +3763,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3772,7 +3772,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4c596297-2857-4b98-bca6-da6f8a94cdd7
+                - 6624d4c4-053b-493e-a7e1-bd2089553736
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3780,8 +3780,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074821Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T103258Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3800,14 +3800,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:21 GMT
+                - Mon, 18 May 2026 10:32:58 GMT
             X-Amz-Id-2:
-                - txg5c71dca9c97a4e839b75-006a042cc5
+                - txgb71d4714c4cf4533a347-006a0aeada
             X-Amz-Request-Id:
-                - txg5c71dca9c97a4e839b75-006a042cc5
+                - txgb71d4714c4cf4533a347-006a0aeada
         status: 200 OK
         code: 200
-        duration: 46.447584ms
+        duration: 20.152ms
     - id: 73
       request:
         proto: HTTP/1.1
@@ -3816,7 +3816,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3825,7 +3825,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 15f6f5e3-7d2a-4a34-bab1-325aa070bf7f
+                - a526c22c-d486-4d25-8f04-6164853dd77e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3833,8 +3833,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074821Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T103258Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3842,25 +3842,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1105
+        content_length: 1285
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
-                - "1105"
+                - "1285"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:21 GMT
+                - Mon, 18 May 2026 10:32:58 GMT
             X-Amz-Id-2:
-                - txg507fc652967548b5b002-006a042cc5
+                - txg4790979463504821a4c0-006a0aeada
             X-Amz-Request-Id:
-                - txg507fc652967548b5b002-006a042cc5
+                - txg4790979463504821a4c0-006a0aeada
         status: 200 OK
         code: 200
-        duration: 26.534583ms
+        duration: 153.723042ms
     - id: 74
       request:
         proto: HTTP/1.1
@@ -3869,7 +3869,7 @@ interactions:
         content_length: 296
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
@@ -3878,7 +3878,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e3f9ad81-b470-49aa-83e0-40184026caea
+                - 6b1ce1b9-ae7e-45da-a753-6171f3578b1f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
@@ -3890,8 +3890,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - 7756d51b786b61edff20b7957d22346417f85f71d19eeca0d6d28d6df7b15bbc
             X-Amz-Date:
-                - 20260513T074821Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T103258Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -3906,14 +3906,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Wed, 13 May 2026 07:48:21 GMT
+                - Mon, 18 May 2026 10:32:58 GMT
             X-Amz-Id-2:
-                - txgd329469e8db64d608849-006a042cc5
+                - txgdb8a362ebdae44ee9bc0-006a0aeada
             X-Amz-Request-Id:
-                - txgd329469e8db64d608849-006a042cc5
+                - txgdb8a362ebdae44ee9bc0-006a0aeada
         status: 200 OK
         code: 200
-        duration: 64.367292ms
+        duration: 39.499ms
     - id: 75
       request:
         proto: HTTP/1.1
@@ -3922,7 +3922,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3931,7 +3931,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 2b626ac6-c9ec-4d89-91a4-951b7c8cba9c
+                - 723af911-494b-49eb-a4b0-3e7d31cf9d67
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3939,8 +3939,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074821Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T103258Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3959,14 +3959,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:21 GMT
+                - Mon, 18 May 2026 10:32:58 GMT
             X-Amz-Id-2:
-                - txg990f798e45834ec39fc5-006a042cc5
+                - txg23037ffd73d446699a41-006a0aeada
             X-Amz-Request-Id:
-                - txg990f798e45834ec39fc5-006a042cc5
+                - txg23037ffd73d446699a41-006a0aeada
         status: 200 OK
         code: 200
-        duration: 34.432458ms
+        duration: 114.08325ms
     - id: 76
       request:
         proto: HTTP/1.1
@@ -3975,7 +3975,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3984,7 +3984,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d2a6a5c8-2e43-4c80-b3be-766e8d6595ba
+                - 03595ad7-dd53-4ca6-b4f2-c93a8e859ae4
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3992,8 +3992,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074821Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T103258Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4003,21 +4003,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgb90791856c8e460b912d-006a042cc5</RequestId><HostId>txgb90791856c8e460b912d-006a042cc5</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgf89beebe8af94e4a9a93-006a0aeada</RequestId><HostId>txgf89beebe8af94e4a9a93-006a0aeada</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:21 GMT
+                - Mon, 18 May 2026 10:32:58 GMT
             X-Amz-Id-2:
-                - txgb90791856c8e460b912d-006a042cc5
+                - txgf89beebe8af94e4a9a93-006a0aeada
             X-Amz-Request-Id:
-                - txgb90791856c8e460b912d-006a042cc5
+                - txgf89beebe8af94e4a9a93-006a0aeada
         status: 404 Not Found
         code: 404
-        duration: 61.341334ms
+        duration: 179.164125ms
     - id: 77
       request:
         proto: HTTP/1.1
@@ -4026,7 +4026,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4035,7 +4035,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 417f36bf-06c0-4452-8cac-d3491222ab8e
+                - 6a5ac5c1-c7aa-497b-87da-50718e60fa84
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4043,8 +4043,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074821Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
+                - 20260518T103258Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -4056,21 +4056,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:21 GMT
+                - Mon, 18 May 2026 10:32:58 GMT
             X-Amz-Id-2:
-                - txg40a228eb542942b3a668-006a042cc5
+                - txgfc94f35b7f934e928f9c-006a0aeada
             X-Amz-Request-Id:
-                - txg40a228eb542942b3a668-006a042cc5
+                - txgfc94f35b7f934e928f9c-006a0aeada
         status: 200 OK
         code: 200
-        duration: 89.903084ms
+        duration: 158.856209ms
     - id: 78
       request:
         proto: HTTP/1.1
@@ -4079,7 +4079,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4088,7 +4088,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 18ac0952-d34b-4d14-87a1-06ae3a60ced6
+                - 7292236c-0a7d-491f-b783-c633ea27cfec
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4096,8 +4096,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074821Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T103258Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4107,21 +4107,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txga7c0a2c1c30b4419a7e4-006a042cc5</RequestId><HostId>txga7c0a2c1c30b4419a7e4-006a042cc5</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txge0e58f0b17ed48ee93cc-006a0aeadb</RequestId><HostId>txge0e58f0b17ed48ee93cc-006a0aeadb</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:21 GMT
+                - Mon, 18 May 2026 10:32:59 GMT
             X-Amz-Id-2:
-                - txga7c0a2c1c30b4419a7e4-006a042cc5
+                - txge0e58f0b17ed48ee93cc-006a0aeadb
             X-Amz-Request-Id:
-                - txga7c0a2c1c30b4419a7e4-006a042cc5
+                - txge0e58f0b17ed48ee93cc-006a0aeadb
         status: 404 Not Found
         code: 404
-        duration: 37.44725ms
+        duration: 247.005834ms
     - id: 79
       request:
         proto: HTTP/1.1
@@ -4130,7 +4130,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4139,7 +4139,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 8a8d8775-202d-40dc-8cb6-345a96471b4d
+                - 29996280-82d1-42e6-be2c-228b56303057
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4147,8 +4147,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074821Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T103259Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4158,21 +4158,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg6341274c3ba9448b8cc9-006a042cc5</RequestId><HostId>txg6341274c3ba9448b8cc9-006a042cc5</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txga3e45d5d6db04998b09b-006a0aeadb</RequestId><HostId>txga3e45d5d6db04998b09b-006a0aeadb</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:21 GMT
+                - Mon, 18 May 2026 10:32:59 GMT
             X-Amz-Id-2:
-                - txg6341274c3ba9448b8cc9-006a042cc5
+                - txga3e45d5d6db04998b09b-006a0aeadb
             X-Amz-Request-Id:
-                - txg6341274c3ba9448b8cc9-006a042cc5
+                - txga3e45d5d6db04998b09b-006a0aeadb
         status: 404 Not Found
         code: 404
-        duration: 50.196875ms
+        duration: 52.133083ms
     - id: 80
       request:
         proto: HTTP/1.1
@@ -4181,7 +4181,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4190,7 +4190,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 247909df-9989-467d-91f0-6b08140ac095
+                - 2fec7c55-167c-4f84-b6f4-9882b2ecc937
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4198,8 +4198,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074821Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T103259Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4218,14 +4218,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:21 GMT
+                - Mon, 18 May 2026 10:32:59 GMT
             X-Amz-Id-2:
-                - txg427204cd34a8432da1e8-006a042cc5
+                - txgdbb37ac0faa540348e34-006a0aeadb
             X-Amz-Request-Id:
-                - txg427204cd34a8432da1e8-006a042cc5
+                - txgdbb37ac0faa540348e34-006a0aeadb
         status: 200 OK
         code: 200
-        duration: 51.505291ms
+        duration: 20.43225ms
     - id: 81
       request:
         proto: HTTP/1.1
@@ -4234,7 +4234,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4243,7 +4243,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c222d532-8098-401f-8778-bb31b879976a
+                - 0b484fc7-97bd-4bb2-8d6f-797fce4faeae
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4251,8 +4251,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074821Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T103259Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4271,14 +4271,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:21 GMT
+                - Mon, 18 May 2026 10:32:59 GMT
             X-Amz-Id-2:
-                - txgfa327537947448ff9976-006a042cc5
+                - txg8a210cfd92844672a969-006a0aeadb
             X-Amz-Request-Id:
-                - txgfa327537947448ff9976-006a042cc5
+                - txg8a210cfd92844672a969-006a0aeadb
         status: 200 OK
         code: 200
-        duration: 50.43475ms
+        duration: 27.17725ms
     - id: 82
       request:
         proto: HTTP/1.1
@@ -4287,7 +4287,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4296,7 +4296,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0e29c93e-74d8-4dae-9504-eb37d3fd4822
+                - fa7a0c90-2043-435a-98f1-ddc47b210303
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4304,8 +4304,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074821Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
+                - 20260518T103259Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -4320,16 +4320,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:21 GMT
+                - Mon, 18 May 2026 10:32:59 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txgb203caa6d923422693d9-006a042cc5
+                - txg9f3de97c87a94f698a3b-006a0aeadb
             X-Amz-Request-Id:
-                - txgb203caa6d923422693d9-006a042cc5
+                - txg9f3de97c87a94f698a3b-006a0aeadb
         status: 200 OK
         code: 200
-        duration: 33.996167ms
+        duration: 20.5445ms
     - id: 83
       request:
         proto: HTTP/1.1
@@ -4338,7 +4338,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4347,7 +4347,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b4d47dc1-1dc3-499d-9644-504f509ab220
+                - 45354779-e687-4c9f-9d5a-7feff288df89
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4355,8 +4355,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074821Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T103259Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4375,14 +4375,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:21 GMT
+                - Mon, 18 May 2026 10:32:59 GMT
             X-Amz-Id-2:
-                - txg588929aba6a94204a073-006a042cc5
+                - txgcd35da98a6e34797bf3d-006a0aeadb
             X-Amz-Request-Id:
-                - txg588929aba6a94204a073-006a042cc5
+                - txgcd35da98a6e34797bf3d-006a0aeadb
         status: 200 OK
         code: 200
-        duration: 35.7095ms
+        duration: 22.399584ms
     - id: 84
       request:
         proto: HTTP/1.1
@@ -4391,7 +4391,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4400,7 +4400,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 237b5112-146c-41b1-af7c-fd61e24b3675
+                - 680de311-ea5c-4f22-9f00-64d9bcae5ca6
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4408,8 +4408,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074822Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T103259Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4428,14 +4428,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:22 GMT
+                - Mon, 18 May 2026 10:32:59 GMT
             X-Amz-Id-2:
-                - txgc479f8070a2e43c8bab4-006a042cc6
+                - txg5a55b9d48c254303a904-006a0aeadb
             X-Amz-Request-Id:
-                - txgc479f8070a2e43c8bab4-006a042cc6
+                - txg5a55b9d48c254303a904-006a0aeadb
         status: 200 OK
         code: 200
-        duration: 22.978917ms
+        duration: 33.894042ms
     - id: 85
       request:
         proto: HTTP/1.1
@@ -4444,7 +4444,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4453,7 +4453,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5485dd19-dfa8-42d6-a877-a7c213c65261
+                - 742bf7e3-ae3a-4eb0-b436-dec8b2e16e06
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4461,8 +4461,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074822Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T103259Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4472,21 +4472,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgff81dea521064a44a5c1-006a042cc6</RequestId><HostId>txgff81dea521064a44a5c1-006a042cc6</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg11d056991ee64e5897e6-006a0aeadb</RequestId><HostId>txg11d056991ee64e5897e6-006a0aeadb</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:22 GMT
+                - Mon, 18 May 2026 10:32:59 GMT
             X-Amz-Id-2:
-                - txgff81dea521064a44a5c1-006a042cc6
+                - txg11d056991ee64e5897e6-006a0aeadb
             X-Amz-Request-Id:
-                - txgff81dea521064a44a5c1-006a042cc6
+                - txg11d056991ee64e5897e6-006a0aeadb
         status: 404 Not Found
         code: 404
-        duration: 19.397458ms
+        duration: 21.624625ms
     - id: 86
       request:
         proto: HTTP/1.1
@@ -4495,7 +4495,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4504,7 +4504,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 70f20393-c6f6-4c57-a1b2-80029d7d6fc4
+                - 272b7fc8-e221-4dc4-a42b-4989a8a76db0
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4512,8 +4512,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074822Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
+                - 20260518T103259Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -4525,21 +4525,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:22 GMT
+                - Mon, 18 May 2026 10:32:59 GMT
             X-Amz-Id-2:
-                - txg092a709f79934270ba9e-006a042cc6
+                - txgaeb4e60d63cc4c94a2a3-006a0aeadb
             X-Amz-Request-Id:
-                - txg092a709f79934270ba9e-006a042cc6
+                - txgaeb4e60d63cc4c94a2a3-006a0aeadb
         status: 200 OK
         code: 200
-        duration: 37.547042ms
+        duration: 21.262833ms
     - id: 87
       request:
         proto: HTTP/1.1
@@ -4548,7 +4548,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4557,7 +4557,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e2d457b8-bb66-476f-8a88-dd091b790c2f
+                - e6e67699-ce75-49a2-a915-9f1e04b0b61a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4565,8 +4565,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074822Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T103259Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4576,21 +4576,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txge578e4e15d834f93a785-006a042cc6</RequestId><HostId>txge578e4e15d834f93a785-006a042cc6</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg0e2805d25f894f13aee1-006a0aeadb</RequestId><HostId>txg0e2805d25f894f13aee1-006a0aeadb</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:22 GMT
+                - Mon, 18 May 2026 10:32:59 GMT
             X-Amz-Id-2:
-                - txge578e4e15d834f93a785-006a042cc6
+                - txg0e2805d25f894f13aee1-006a0aeadb
             X-Amz-Request-Id:
-                - txge578e4e15d834f93a785-006a042cc6
+                - txg0e2805d25f894f13aee1-006a0aeadb
         status: 404 Not Found
         code: 404
-        duration: 124.006709ms
+        duration: 19.891459ms
     - id: 88
       request:
         proto: HTTP/1.1
@@ -4599,7 +4599,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4608,7 +4608,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5eb39bb1-7b5c-4463-91d5-d8c045242dad
+                - eec848fa-1d54-47f9-b33c-523cf1fa3794
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4616,8 +4616,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074822Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T103259Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4627,21 +4627,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg405caa180364435eb404-006a042cc6</RequestId><HostId>txg405caa180364435eb404-006a042cc6</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txge98d5c84cff94b068b1f-006a0aeadb</RequestId><HostId>txge98d5c84cff94b068b1f-006a0aeadb</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:22 GMT
+                - Mon, 18 May 2026 10:32:59 GMT
             X-Amz-Id-2:
-                - txg405caa180364435eb404-006a042cc6
+                - txge98d5c84cff94b068b1f-006a0aeadb
             X-Amz-Request-Id:
-                - txg405caa180364435eb404-006a042cc6
+                - txge98d5c84cff94b068b1f-006a0aeadb
         status: 404 Not Found
         code: 404
-        duration: 47.394458ms
+        duration: 20.964792ms
     - id: 89
       request:
         proto: HTTP/1.1
@@ -4650,7 +4650,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4659,7 +4659,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e63e2381-f2d8-4f4d-ab12-7cc2d6a9e460
+                - 217c1dc4-6142-478b-acf7-61fdb80c828a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4667,8 +4667,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074822Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T103259Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4687,14 +4687,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:22 GMT
+                - Mon, 18 May 2026 10:32:59 GMT
             X-Amz-Id-2:
-                - txg2404869d6420487ead38-006a042cc6
+                - txgd7d981d1709943c8b011-006a0aeadb
             X-Amz-Request-Id:
-                - txg2404869d6420487ead38-006a042cc6
+                - txgd7d981d1709943c8b011-006a0aeadb
         status: 200 OK
         code: 200
-        duration: 59.127125ms
+        duration: 20.569416ms
     - id: 90
       request:
         proto: HTTP/1.1
@@ -4703,7 +4703,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4712,7 +4712,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 35cfd616-8f43-4e4f-bdf7-33322cfea378
+                - 81ac707c-0d81-47a0-8c9b-50f46fc04917
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4720,8 +4720,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074822Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T103259Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4740,14 +4740,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:22 GMT
+                - Mon, 18 May 2026 10:32:59 GMT
             X-Amz-Id-2:
-                - txg6ea98a740d9b49f6a6e1-006a042cc6
+                - txg9230d4be316d498c893c-006a0aeadb
             X-Amz-Request-Id:
-                - txg6ea98a740d9b49f6a6e1-006a042cc6
+                - txg9230d4be316d498c893c-006a0aeadb
         status: 200 OK
         code: 200
-        duration: 59.483458ms
+        duration: 20.602625ms
     - id: 91
       request:
         proto: HTTP/1.1
@@ -4756,7 +4756,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4765,7 +4765,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 60e7e851-bf67-4a9b-90b3-fd0deed9dbd2
+                - c65b4fb5-02ab-42f1-bda7-401ff7bb2397
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4773,8 +4773,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074822Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T103300Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4793,14 +4793,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:22 GMT
+                - Mon, 18 May 2026 10:33:00 GMT
             X-Amz-Id-2:
-                - txg804ccec48e454eaa8625-006a042cc6
+                - txg9066d87ecc5640dc954b-006a0aeadc
             X-Amz-Request-Id:
-                - txg804ccec48e454eaa8625-006a042cc6
+                - txg9066d87ecc5640dc954b-006a0aeadc
         status: 200 OK
         code: 200
-        duration: 21.535958ms
+        duration: 20.46225ms
     - id: 92
       request:
         proto: HTTP/1.1
@@ -4809,7 +4809,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4818,7 +4818,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ad891575-0e4e-4aa5-aaed-dcb579c77bc2
+                - e7ea82e3-e995-4b66-8a45-c10eafd8b5ff
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4826,8 +4826,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074822Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T103300Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4837,21 +4837,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg5a28f6ffcb44434fb7eb-006a042cc6</RequestId><HostId>txg5a28f6ffcb44434fb7eb-006a042cc6</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg8be55af6c19d4394b8a6-006a0aeadc</RequestId><HostId>txg8be55af6c19d4394b8a6-006a0aeadc</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:22 GMT
+                - Mon, 18 May 2026 10:33:00 GMT
             X-Amz-Id-2:
-                - txg5a28f6ffcb44434fb7eb-006a042cc6
+                - txg8be55af6c19d4394b8a6-006a0aeadc
             X-Amz-Request-Id:
-                - txg5a28f6ffcb44434fb7eb-006a042cc6
+                - txg8be55af6c19d4394b8a6-006a0aeadc
         status: 404 Not Found
         code: 404
-        duration: 19.862625ms
+        duration: 20.405125ms
     - id: 93
       request:
         proto: HTTP/1.1
@@ -4860,7 +4860,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4869,7 +4869,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 244ed135-2a47-4f9e-b624-eb3d47a8c363
+                - 0e869fa4-d3ca-4bfc-93e6-48abaff09b69
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4877,8 +4877,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074822Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
+                - 20260518T103300Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -4890,21 +4890,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:22 GMT
+                - Mon, 18 May 2026 10:33:00 GMT
             X-Amz-Id-2:
-                - txg63e31bbd6ae543459be4-006a042cc6
+                - txg4efa7e7ce72e43299a01-006a0aeadc
             X-Amz-Request-Id:
-                - txg63e31bbd6ae543459be4-006a042cc6
+                - txg4efa7e7ce72e43299a01-006a0aeadc
         status: 200 OK
         code: 200
-        duration: 51.639625ms
+        duration: 21.130542ms
     - id: 94
       request:
         proto: HTTP/1.1
@@ -4913,7 +4913,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4922,7 +4922,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0d53ff14-096c-4e2c-a9d0-5d647970667a
+                - a5167c65-2c35-4ab9-95c5-43e3b36a1159
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4930,8 +4930,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074822Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T103300Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4941,21 +4941,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg1a47f2e86c914d14b7ca-006a042cc6</RequestId><HostId>txg1a47f2e86c914d14b7ca-006a042cc6</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg454e7076c01242e9a4ae-006a0aeadc</RequestId><HostId>txg454e7076c01242e9a4ae-006a0aeadc</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:22 GMT
+                - Mon, 18 May 2026 10:33:00 GMT
             X-Amz-Id-2:
-                - txg1a47f2e86c914d14b7ca-006a042cc6
+                - txg454e7076c01242e9a4ae-006a0aeadc
             X-Amz-Request-Id:
-                - txg1a47f2e86c914d14b7ca-006a042cc6
+                - txg454e7076c01242e9a4ae-006a0aeadc
         status: 404 Not Found
         code: 404
-        duration: 34.929791ms
+        duration: 20.54675ms
     - id: 95
       request:
         proto: HTTP/1.1
@@ -4964,7 +4964,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4973,7 +4973,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 499fb7c7-68df-4d25-b0b3-7ddd15643953
+                - a3666118-51ee-47b6-906c-07602037625c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4981,8 +4981,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074822Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T103300Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4992,21 +4992,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg88986618cb2b44de9318-006a042cc6</RequestId><HostId>txg88986618cb2b44de9318-006a042cc6</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg07338799148745f79252-006a0aeadc</RequestId><HostId>txg07338799148745f79252-006a0aeadc</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:22 GMT
+                - Mon, 18 May 2026 10:33:00 GMT
             X-Amz-Id-2:
-                - txg88986618cb2b44de9318-006a042cc6
+                - txg07338799148745f79252-006a0aeadc
             X-Amz-Request-Id:
-                - txg88986618cb2b44de9318-006a042cc6
+                - txg07338799148745f79252-006a0aeadc
         status: 404 Not Found
         code: 404
-        duration: 18.928667ms
+        duration: 19.395167ms
     - id: 96
       request:
         proto: HTTP/1.1
@@ -5015,7 +5015,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5024,7 +5024,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 6090b13b-efce-43d8-ab58-f8e8f3d0a9c0
+                - c646ac1c-c7f6-4e36-8ab4-f0fc35c8f9e5
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5032,8 +5032,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074822Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T103300Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5052,14 +5052,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:22 GMT
+                - Mon, 18 May 2026 10:33:00 GMT
             X-Amz-Id-2:
-                - txga706be90af5e492a971e-006a042cc6
+                - txg46e1e9827ca045869d4e-006a0aeadc
             X-Amz-Request-Id:
-                - txga706be90af5e492a971e-006a042cc6
+                - txg46e1e9827ca045869d4e-006a0aeadc
         status: 200 OK
         code: 200
-        duration: 50.972125ms
+        duration: 92.125834ms
     - id: 97
       request:
         proto: HTTP/1.1
@@ -5068,7 +5068,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5077,7 +5077,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 167b3bf0-39f7-4ca7-a815-5378a9d75825
+                - 60eefe44-517d-48a3-b64b-bcebb8878544
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5085,8 +5085,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074822Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T103300Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5105,14 +5105,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:22 GMT
+                - Mon, 18 May 2026 10:33:00 GMT
             X-Amz-Id-2:
-                - txgc3217b0616ae469dabe7-006a042cc6
+                - txg0c19572d3ae94b16a5ca-006a0aeadc
             X-Amz-Request-Id:
-                - txgc3217b0616ae469dabe7-006a042cc6
+                - txg0c19572d3ae94b16a5ca-006a0aeadc
         status: 200 OK
         code: 200
-        duration: 26.402916ms
+        duration: 159.451542ms
     - id: 98
       request:
         proto: HTTP/1.1
@@ -5121,7 +5121,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5130,7 +5130,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4d792364-a129-434c-b76c-c07ba5166e42
+                - e7556cd6-aac8-4d85-9341-dabaa8a96084
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5138,8 +5138,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074823Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
+                - 20260518T103300Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -5154,16 +5154,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:23 GMT
+                - Mon, 18 May 2026 10:33:00 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txg299f201b5bb546c4a3f0-006a042cc7
+                - txg31de8f6f732544349638-006a0aeadc
             X-Amz-Request-Id:
-                - txg299f201b5bb546c4a3f0-006a042cc7
+                - txg31de8f6f732544349638-006a0aeadc
         status: 200 OK
         code: 200
-        duration: 73.25675ms
+        duration: 235.836292ms
     - id: 99
       request:
         proto: HTTP/1.1
@@ -5172,7 +5172,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5181,7 +5181,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 99c63966-ff11-482b-ac1b-83bc4cb0c101
+                - cb105fd6-238c-4c2d-966c-124068cf9dcb
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5189,8 +5189,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074823Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T103300Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5209,14 +5209,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:23 GMT
+                - Mon, 18 May 2026 10:33:00 GMT
             X-Amz-Id-2:
-                - txg1c819f3ba809428cb14f-006a042cc7
+                - txg7bd2805711594d838873-006a0aeadc
             X-Amz-Request-Id:
-                - txg1c819f3ba809428cb14f-006a042cc7
+                - txg7bd2805711594d838873-006a0aeadc
         status: 200 OK
         code: 200
-        duration: 53.568709ms
+        duration: 21.910833ms
     - id: 100
       request:
         proto: HTTP/1.1
@@ -5225,7 +5225,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5234,7 +5234,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9c9ddf69-712f-4086-aafd-2609601277aa
+                - 07cde1ad-090e-4bd1-afbc-f1ee9d2ae31e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5242,8 +5242,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074823Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T103301Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5262,14 +5262,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:23 GMT
+                - Mon, 18 May 2026 10:33:01 GMT
             X-Amz-Id-2:
-                - txga56cf04b7a4046ae927c-006a042cc7
+                - txg3e2015aa67e34721a148-006a0aeadd
             X-Amz-Request-Id:
-                - txga56cf04b7a4046ae927c-006a042cc7
+                - txg3e2015aa67e34721a148-006a0aeadd
         status: 200 OK
         code: 200
-        duration: 60.942125ms
+        duration: 31.39325ms
     - id: 101
       request:
         proto: HTTP/1.1
@@ -5278,7 +5278,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5287,7 +5287,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 894cb037-01ce-4619-9e27-735db1d306a9
+                - 48d2bb57-ccca-4d1c-a0ea-f7c756d654c4
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5295,8 +5295,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074823Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T103301Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5306,21 +5306,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg0423504459ea48a88fb0-006a042cc7</RequestId><HostId>txg0423504459ea48a88fb0-006a042cc7</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg1f7c9bef662a4af6a4cf-006a0aeadd</RequestId><HostId>txg1f7c9bef662a4af6a4cf-006a0aeadd</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:23 GMT
+                - Mon, 18 May 2026 10:33:01 GMT
             X-Amz-Id-2:
-                - txg0423504459ea48a88fb0-006a042cc7
+                - txg1f7c9bef662a4af6a4cf-006a0aeadd
             X-Amz-Request-Id:
-                - txg0423504459ea48a88fb0-006a042cc7
+                - txg1f7c9bef662a4af6a4cf-006a0aeadd
         status: 404 Not Found
         code: 404
-        duration: 19.586125ms
+        duration: 21.63775ms
     - id: 102
       request:
         proto: HTTP/1.1
@@ -5329,7 +5329,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5338,7 +5338,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 25b8a87b-c0a1-47ad-a0a0-fe86535e5de3
+                - 124317a7-db1d-498c-93b0-d38f6a91c035
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5346,8 +5346,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074823Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
+                - 20260518T103301Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -5359,21 +5359,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:23 GMT
+                - Mon, 18 May 2026 10:33:01 GMT
             X-Amz-Id-2:
-                - txga69061d8c50243e78c29-006a042cc7
+                - txg03d3a97eb7874282bb91-006a0aeadd
             X-Amz-Request-Id:
-                - txga69061d8c50243e78c29-006a042cc7
+                - txg03d3a97eb7874282bb91-006a0aeadd
         status: 200 OK
         code: 200
-        duration: 20.13575ms
+        duration: 239.383625ms
     - id: 103
       request:
         proto: HTTP/1.1
@@ -5382,7 +5382,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5391,7 +5391,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 90bb1ada-e14a-4c8b-b2c2-2abd88d773d9
+                - b52a165d-0354-4952-9729-bed4af2bdcf7
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5399,8 +5399,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074823Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T103301Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5410,21 +5410,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg2698a7efcb184188bd60-006a042cc7</RequestId><HostId>txg2698a7efcb184188bd60-006a042cc7</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgf6a42e4433214fcc9012-006a0aeadd</RequestId><HostId>txgf6a42e4433214fcc9012-006a0aeadd</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:23 GMT
+                - Mon, 18 May 2026 10:33:01 GMT
             X-Amz-Id-2:
-                - txg2698a7efcb184188bd60-006a042cc7
+                - txgf6a42e4433214fcc9012-006a0aeadd
             X-Amz-Request-Id:
-                - txg2698a7efcb184188bd60-006a042cc7
+                - txgf6a42e4433214fcc9012-006a0aeadd
         status: 404 Not Found
         code: 404
-        duration: 21.500708ms
+        duration: 159.813167ms
     - id: 104
       request:
         proto: HTTP/1.1
@@ -5433,7 +5433,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5442,7 +5442,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 15dd2fdc-da42-42c9-9796-9897b840786d
+                - a0a475e1-b6c7-4c6e-87a9-2ce0399140e4
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5450,8 +5450,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074823Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T103301Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5461,21 +5461,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg2c96aa05715144e8996f-006a042cc7</RequestId><HostId>txg2c96aa05715144e8996f-006a042cc7</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg27235c37e07b4d70ad36-006a0aeadd</RequestId><HostId>txg27235c37e07b4d70ad36-006a0aeadd</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:23 GMT
+                - Mon, 18 May 2026 10:33:01 GMT
             X-Amz-Id-2:
-                - txg2c96aa05715144e8996f-006a042cc7
+                - txg27235c37e07b4d70ad36-006a0aeadd
             X-Amz-Request-Id:
-                - txg2c96aa05715144e8996f-006a042cc7
+                - txg27235c37e07b4d70ad36-006a0aeadd
         status: 404 Not Found
         code: 404
-        duration: 31.157ms
+        duration: 245.5335ms
     - id: 105
       request:
         proto: HTTP/1.1
@@ -5484,7 +5484,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5493,7 +5493,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 1a4975c1-73e1-4136-9974-2f2bd5bfe702
+                - 6aef73de-f3a4-4e59-a704-b1994dc14ceb
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5501,8 +5501,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074823Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T103301Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5521,14 +5521,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:23 GMT
+                - Mon, 18 May 2026 10:33:01 GMT
             X-Amz-Id-2:
-                - txg633f6de82eef4b029bfd-006a042cc7
+                - txg4ddb9fc50bc7425280ff-006a0aeadd
             X-Amz-Request-Id:
-                - txg633f6de82eef4b029bfd-006a042cc7
+                - txg4ddb9fc50bc7425280ff-006a0aeadd
         status: 200 OK
         code: 200
-        duration: 19.315625ms
+        duration: 21.431041ms
     - id: 106
       request:
         proto: HTTP/1.1
@@ -5537,7 +5537,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5546,7 +5546,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 89f0f673-a048-4989-9ffa-35e4e337be2c
+                - b90da4c2-c4df-4eba-83b9-02e6e55e0ca6
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5554,8 +5554,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074823Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T103301Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5574,14 +5574,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:23 GMT
+                - Mon, 18 May 2026 10:33:01 GMT
             X-Amz-Id-2:
-                - txg59df72539b1f49f0986d-006a042cc7
+                - txg21944da3a3b4487192d0-006a0aeadd
             X-Amz-Request-Id:
-                - txg59df72539b1f49f0986d-006a042cc7
+                - txg21944da3a3b4487192d0-006a0aeadd
         status: 200 OK
         code: 200
-        duration: 57.857875ms
+        duration: 73.99525ms
     - id: 107
       request:
         proto: HTTP/1.1
@@ -5590,7 +5590,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5599,7 +5599,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 344040f2-4c91-48f5-9818-d2ec400b03fb
+                - cf9583e4-b24a-429f-8b22-10e60fd6260e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5607,8 +5607,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074823Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T103302Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5627,14 +5627,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:23 GMT
+                - Mon, 18 May 2026 10:33:02 GMT
             X-Amz-Id-2:
-                - txg8100d4940ab740f6a68f-006a042cc7
+                - txg75e39bad7a6a43ab8ccf-006a0aeade
             X-Amz-Request-Id:
-                - txg8100d4940ab740f6a68f-006a042cc7
+                - txg75e39bad7a6a43ab8ccf-006a0aeade
         status: 200 OK
         code: 200
-        duration: 19.225291ms
+        duration: 261.741333ms
     - id: 108
       request:
         proto: HTTP/1.1
@@ -5643,7 +5643,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5652,7 +5652,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - bb8e492b-ce0c-4b1e-9c33-4239b13949ca
+                - e560caea-2614-4167-8205-74dc067d2447
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5660,8 +5660,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074823Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T103302Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5671,21 +5671,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgef06b583e9e648bf9471-006a042cc7</RequestId><HostId>txgef06b583e9e648bf9471-006a042cc7</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg644be24963d84de5bd52-006a0aeade</RequestId><HostId>txg644be24963d84de5bd52-006a0aeade</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:23 GMT
+                - Mon, 18 May 2026 10:33:02 GMT
             X-Amz-Id-2:
-                - txgef06b583e9e648bf9471-006a042cc7
+                - txg644be24963d84de5bd52-006a0aeade
             X-Amz-Request-Id:
-                - txgef06b583e9e648bf9471-006a042cc7
+                - txg644be24963d84de5bd52-006a0aeade
         status: 404 Not Found
         code: 404
-        duration: 19.522292ms
+        duration: 21.92125ms
     - id: 109
       request:
         proto: HTTP/1.1
@@ -5694,7 +5694,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5703,7 +5703,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4b02966e-61d4-45de-b08a-5d5dc3dcac42
+                - 9f3c206b-06d6-4610-8ebe-94aee5d48a38
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5711,8 +5711,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074823Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
+                - 20260518T103302Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -5724,21 +5724,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:23 GMT
+                - Mon, 18 May 2026 10:33:02 GMT
             X-Amz-Id-2:
-                - txg83fcd0d44524421bb271-006a042cc7
+                - txg2bef5b9dc4f645d9bd42-006a0aeade
             X-Amz-Request-Id:
-                - txg83fcd0d44524421bb271-006a042cc7
+                - txg2bef5b9dc4f645d9bd42-006a0aeade
         status: 200 OK
         code: 200
-        duration: 49.002333ms
+        duration: 21.114417ms
     - id: 110
       request:
         proto: HTTP/1.1
@@ -5747,7 +5747,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5756,7 +5756,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 2dcce056-7558-465c-85eb-11824a92c26a
+                - 0b8f8865-fa71-4c49-b867-0607b54008ab
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5764,8 +5764,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074823Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T103302Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5775,21 +5775,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg1bf50ea11c8a416b8f5c-006a042cc8</RequestId><HostId>txg1bf50ea11c8a416b8f5c-006a042cc8</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgc4dd6c33ee814a849d96-006a0aeade</RequestId><HostId>txgc4dd6c33ee814a849d96-006a0aeade</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:24 GMT
+                - Mon, 18 May 2026 10:33:02 GMT
             X-Amz-Id-2:
-                - txg1bf50ea11c8a416b8f5c-006a042cc8
+                - txgc4dd6c33ee814a849d96-006a0aeade
             X-Amz-Request-Id:
-                - txg1bf50ea11c8a416b8f5c-006a042cc8
+                - txgc4dd6c33ee814a849d96-006a0aeade
         status: 404 Not Found
         code: 404
-        duration: 19.678375ms
+        duration: 21.072542ms
     - id: 111
       request:
         proto: HTTP/1.1
@@ -5798,7 +5798,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5807,7 +5807,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0dd8e7fb-8596-493d-bd17-4f29d010c232
+                - 6758e217-7209-447c-9d40-5741dffcaa83
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5815,8 +5815,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074824Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T103302Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5826,21 +5826,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgc36cf2f72c444913864b-006a042cc8</RequestId><HostId>txgc36cf2f72c444913864b-006a042cc8</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgf1931029f40a43e184d1-006a0aeade</RequestId><HostId>txgf1931029f40a43e184d1-006a0aeade</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:24 GMT
+                - Mon, 18 May 2026 10:33:02 GMT
             X-Amz-Id-2:
-                - txgc36cf2f72c444913864b-006a042cc8
+                - txgf1931029f40a43e184d1-006a0aeade
             X-Amz-Request-Id:
-                - txgc36cf2f72c444913864b-006a042cc8
+                - txgf1931029f40a43e184d1-006a0aeade
         status: 404 Not Found
         code: 404
-        duration: 19.733959ms
+        duration: 21.981541ms
     - id: 112
       request:
         proto: HTTP/1.1
@@ -5849,7 +5849,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5858,7 +5858,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 3c2263ce-589a-4e13-b943-a33ddad2cb89
+                - 322487c5-3fb7-4fe9-b8d9-0d815c9c9c43
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5866,8 +5866,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074824Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T103302Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5886,14 +5886,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:24 GMT
+                - Mon, 18 May 2026 10:33:02 GMT
             X-Amz-Id-2:
-                - txg3a675e17768b4d28b58f-006a042cc8
+                - txgcf9ee8429b3a4ad5b45d-006a0aeade
             X-Amz-Request-Id:
-                - txg3a675e17768b4d28b58f-006a042cc8
+                - txgcf9ee8429b3a4ad5b45d-006a0aeade
         status: 200 OK
         code: 200
-        duration: 19.672375ms
+        duration: 166.968542ms
     - id: 113
       request:
         proto: HTTP/1.1
@@ -5902,7 +5902,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5911,7 +5911,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c25c60d2-3b02-4ec8-9aa5-dab9d556df10
+                - 06c3a7b2-0ce7-4363-a223-cfc68409ff27
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5919,8 +5919,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074824Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T103302Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5939,32 +5939,32 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:24 GMT
+                - Mon, 18 May 2026 10:33:02 GMT
             X-Amz-Id-2:
-                - txgc9ee7b7318ed47f587c7-006a042cc8
+                - txg19e6d62d8b2341bbbcb7-006a0aeade
             X-Amz-Request-Id:
-                - txgc9ee7b7318ed47f587c7-006a042cc8
+                - txg19e6d62d8b2341bbbcb7-006a0aeade
         status: 200 OK
         code: 200
-        duration: 50.865208ms
+        duration: 20.977125ms
     - id: 114
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 284
+        content_length: 344
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
-        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path1/</Prefix><Tag><Key>deleted</Key><Value>true</Value></Tag></And></Filter><ID>id1</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
+        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path1/</Prefix><Tag><Key>deleted</Key><Value>true</Value></Tag></And></Filter><ID>id1</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
         form: {}
         headers:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 3b841a2d-0533-4ee9-863e-ed363a859656
+                - 7ea35ffc-7f01-47dd-b6a6-a9d92d7b83af
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
@@ -5972,12 +5972,12 @@ interactions:
             User-Agent:
                 - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,Z,e
             X-Amz-Checksum-Crc32:
-                - UfU/dQ==
+                - /SEMnQ==
             X-Amz-Content-Sha256:
-                - c66696878cc52fbe5f1b5468d871024fe4d94447494e4b1797bc44a183ccc313
+                - b0de451c31309fbdd3611c566f2f38ddccf0dd237feb3e8d186422993ecf7a1f
             X-Amz-Date:
-                - 20260513T074824Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T103302Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -5992,14 +5992,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Wed, 13 May 2026 07:48:24 GMT
+                - Mon, 18 May 2026 10:33:02 GMT
             X-Amz-Id-2:
-                - txg4b2eb4ffb15f485cb40f-006a042cc8
+                - txg691e2bdc786f4866a6d4-006a0aeade
             X-Amz-Request-Id:
-                - txg4b2eb4ffb15f485cb40f-006a042cc8
+                - txg691e2bdc786f4866a6d4-006a0aeade
         status: 200 OK
         code: 200
-        duration: 54.551125ms
+        duration: 22.800709ms
     - id: 115
       request:
         proto: HTTP/1.1
@@ -6008,7 +6008,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6017,7 +6017,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ae568be5-ad8b-4b1b-9bbb-63a032ba28ad
+                - c944bc15-c71e-44a7-9351-51cb11887d4b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6025,8 +6025,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074824Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T103302Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6045,14 +6045,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:24 GMT
+                - Mon, 18 May 2026 10:33:02 GMT
             X-Amz-Id-2:
-                - txgd2e7862d39c6488880b0-006a042cc8
+                - txge2707ae093174eefa24d-006a0aeade
             X-Amz-Request-Id:
-                - txgd2e7862d39c6488880b0-006a042cc8
+                - txge2707ae093174eefa24d-006a0aeade
         status: 200 OK
         code: 200
-        duration: 19.81875ms
+        duration: 20.513667ms
     - id: 116
       request:
         proto: HTTP/1.1
@@ -6061,7 +6061,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6070,7 +6070,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 3de7e8a1-b7ab-45a8-b938-fb26b3bb80d1
+                - 8f197b1f-2963-4192-9d1c-6482722a1c76
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6078,8 +6078,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074824Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T103302Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6089,21 +6089,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgb35d024a0e85448daa6b-006a042cc8</RequestId><HostId>txgb35d024a0e85448daa6b-006a042cc8</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg20375f35046746ef9b9a-006a0aeade</RequestId><HostId>txg20375f35046746ef9b9a-006a0aeade</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:24 GMT
+                - Mon, 18 May 2026 10:33:02 GMT
             X-Amz-Id-2:
-                - txgb35d024a0e85448daa6b-006a042cc8
+                - txg20375f35046746ef9b9a-006a0aeade
             X-Amz-Request-Id:
-                - txgb35d024a0e85448daa6b-006a042cc8
+                - txg20375f35046746ef9b9a-006a0aeade
         status: 404 Not Found
         code: 404
-        duration: 19.401417ms
+        duration: 100.272583ms
     - id: 117
       request:
         proto: HTTP/1.1
@@ -6112,7 +6112,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6121,7 +6121,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 95ca7caf-9e95-4233-9b2e-659f03477aed
+                - 785ab30a-fc16-416b-bbac-388023f56ff5
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6129,8 +6129,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074824Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
+                - 20260518T103302Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -6142,21 +6142,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:24 GMT
+                - Mon, 18 May 2026 10:33:02 GMT
             X-Amz-Id-2:
-                - txgdcff7c146a5c4f958510-006a042cc8
+                - txga5e912aa9a3d47fea80c-006a0aeade
             X-Amz-Request-Id:
-                - txgdcff7c146a5c4f958510-006a042cc8
+                - txga5e912aa9a3d47fea80c-006a0aeade
         status: 200 OK
         code: 200
-        duration: 21.319917ms
+        duration: 59.242792ms
     - id: 118
       request:
         proto: HTTP/1.1
@@ -6165,7 +6165,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6174,7 +6174,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 43829665-8f48-4e43-baf0-13bf781b3acb
+                - 1d3407c5-1c9f-4b9f-9bf5-76a44a77a142
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6182,8 +6182,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074824Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T103302Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6193,21 +6193,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgeb6172da2b8a4353a841-006a042cc8</RequestId><HostId>txgeb6172da2b8a4353a841-006a042cc8</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg3780e790f73d44329550-006a0aeadf</RequestId><HostId>txg3780e790f73d44329550-006a0aeadf</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:24 GMT
+                - Mon, 18 May 2026 10:33:03 GMT
             X-Amz-Id-2:
-                - txgeb6172da2b8a4353a841-006a042cc8
+                - txg3780e790f73d44329550-006a0aeadf
             X-Amz-Request-Id:
-                - txgeb6172da2b8a4353a841-006a042cc8
+                - txg3780e790f73d44329550-006a0aeadf
         status: 404 Not Found
         code: 404
-        duration: 28.31075ms
+        duration: 77.781208ms
     - id: 119
       request:
         proto: HTTP/1.1
@@ -6216,7 +6216,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6225,7 +6225,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0f6ca624-ef46-4bd4-b028-63d5e7ae6053
+                - e81ab851-ba37-470e-99d5-38e5928ec44a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6233,8 +6233,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074824Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T103303Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6244,21 +6244,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txge8d3cceff37a41b78c47-006a042cc8</RequestId><HostId>txge8d3cceff37a41b78c47-006a042cc8</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg59f26068d7f648e3bae9-006a0aeadf</RequestId><HostId>txg59f26068d7f648e3bae9-006a0aeadf</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:24 GMT
+                - Mon, 18 May 2026 10:33:03 GMT
             X-Amz-Id-2:
-                - txge8d3cceff37a41b78c47-006a042cc8
+                - txg59f26068d7f648e3bae9-006a0aeadf
             X-Amz-Request-Id:
-                - txge8d3cceff37a41b78c47-006a042cc8
+                - txg59f26068d7f648e3bae9-006a0aeadf
         status: 404 Not Found
         code: 404
-        duration: 18.648625ms
+        duration: 139.597625ms
     - id: 120
       request:
         proto: HTTP/1.1
@@ -6267,7 +6267,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6276,7 +6276,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - efb978ec-bb42-4f76-adcb-81028ef43cbe
+                - 47b4277a-f051-4eda-88f2-c867adad6d47
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6284,8 +6284,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074824Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T103303Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6304,14 +6304,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:24 GMT
+                - Mon, 18 May 2026 10:33:03 GMT
             X-Amz-Id-2:
-                - txge6e8d5fbcee54bb7bece-006a042cc8
+                - txg8793299c86854b5b948e-006a0aeadf
             X-Amz-Request-Id:
-                - txge6e8d5fbcee54bb7bece-006a042cc8
+                - txg8793299c86854b5b948e-006a0aeadf
         status: 200 OK
         code: 200
-        duration: 51.5015ms
+        duration: 170.103334ms
     - id: 121
       request:
         proto: HTTP/1.1
@@ -6320,7 +6320,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6329,7 +6329,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 2bf12149-3a69-4ff5-97bc-90d56b2aef74
+                - d49ccaaf-a7d8-4307-9049-fa2e4f195260
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6337,8 +6337,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074824Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T103303Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6346,25 +6346,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 257
+        content_length: 317
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path1/</Prefix><Tag><Key>deleted</Key><Value>true</Value></Tag></And></Filter><ID>id1</ID><Status>Enabled</Status></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path1/</Prefix><Tag><Key>deleted</Key><Value>true</Value></Tag></And></Filter><ID>id1</ID><Status>Enabled</Status></Rule></Configuration>
         headers:
             Content-Length:
-                - "257"
+                - "317"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:24 GMT
+                - Mon, 18 May 2026 10:33:03 GMT
             X-Amz-Id-2:
-                - txg15dd93800d0a4f0cbf91-006a042cc8
+                - txg31730813c9204cefb350-006a0aeadf
             X-Amz-Request-Id:
-                - txg15dd93800d0a4f0cbf91-006a042cc8
+                - txg31730813c9204cefb350-006a0aeadf
         status: 200 OK
         code: 200
-        duration: 18.789208ms
+        duration: 21.312209ms
     - id: 122
       request:
         proto: HTTP/1.1
@@ -6373,7 +6373,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6382,7 +6382,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 1fabfbd3-3cfa-4e07-9e34-8031d546cfb4
+                - a6e38b46-f71e-4c75-9849-357f251d47be
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6390,8 +6390,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074824Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
+                - 20260518T103303Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -6406,16 +6406,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:24 GMT
+                - Mon, 18 May 2026 10:33:03 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txgc9edf3f96fa948d1a3bb-006a042cc8
+                - txg586527cecae84dfaa232-006a0aeadf
             X-Amz-Request-Id:
-                - txgc9edf3f96fa948d1a3bb-006a042cc8
+                - txg586527cecae84dfaa232-006a0aeadf
         status: 200 OK
         code: 200
-        duration: 36.026375ms
+        duration: 20.509416ms
     - id: 123
       request:
         proto: HTTP/1.1
@@ -6424,7 +6424,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6433,7 +6433,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9bdc4548-d445-4ca4-9ca4-50826e7add9a
+                - 477b7cbc-c77d-47f3-8f16-92531fa16f5f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6441,8 +6441,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074824Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T103303Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6450,25 +6450,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 257
+        content_length: 317
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path1/</Prefix><Tag><Key>deleted</Key><Value>true</Value></Tag></And></Filter><ID>id1</ID><Status>Enabled</Status></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path1/</Prefix><Tag><Key>deleted</Key><Value>true</Value></Tag></And></Filter><ID>id1</ID><Status>Enabled</Status></Rule></Configuration>
         headers:
             Content-Length:
-                - "257"
+                - "317"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:24 GMT
+                - Mon, 18 May 2026 10:33:03 GMT
             X-Amz-Id-2:
-                - txg4d47909f228a4b9a8041-006a042cc8
+                - txgded9bf927fd24986b30e-006a0aeadf
             X-Amz-Request-Id:
-                - txg4d47909f228a4b9a8041-006a042cc8
+                - txgded9bf927fd24986b30e-006a0aeadf
         status: 200 OK
         code: 200
-        duration: 177.874625ms
+        duration: 21.046791ms
     - id: 124
       request:
         proto: HTTP/1.1
@@ -6477,7 +6477,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6486,7 +6486,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9b4375d2-6e96-45c9-83f7-3c2d24dd6423
+                - d948a1dc-d39f-43ec-bc2a-8fb96bbfcdb0
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6494,8 +6494,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074825Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T103303Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6514,14 +6514,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:25 GMT
+                - Mon, 18 May 2026 10:33:03 GMT
             X-Amz-Id-2:
-                - txg418f8e4d66a24692be94-006a042cc9
+                - txg394846b907d44dc6ac44-006a0aeadf
             X-Amz-Request-Id:
-                - txg418f8e4d66a24692be94-006a042cc9
+                - txg394846b907d44dc6ac44-006a0aeadf
         status: 200 OK
         code: 200
-        duration: 30.025709ms
+        duration: 30.000917ms
     - id: 125
       request:
         proto: HTTP/1.1
@@ -6530,7 +6530,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6539,7 +6539,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f8146d75-c220-489e-84f6-4d7282319229
+                - 70b18353-32f0-42cc-b372-6bf6198e57dc
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6547,8 +6547,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074825Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T103303Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6558,21 +6558,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg2bc03a257fd84fd595e8-006a042cc9</RequestId><HostId>txg2bc03a257fd84fd595e8-006a042cc9</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg8ee65063a43f47ad9ced-006a0aeadf</RequestId><HostId>txg8ee65063a43f47ad9ced-006a0aeadf</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:25 GMT
+                - Mon, 18 May 2026 10:33:03 GMT
             X-Amz-Id-2:
-                - txg2bc03a257fd84fd595e8-006a042cc9
+                - txg8ee65063a43f47ad9ced-006a0aeadf
             X-Amz-Request-Id:
-                - txg2bc03a257fd84fd595e8-006a042cc9
+                - txg8ee65063a43f47ad9ced-006a0aeadf
         status: 404 Not Found
         code: 404
-        duration: 19.301542ms
+        duration: 21.332042ms
     - id: 126
       request:
         proto: HTTP/1.1
@@ -6581,7 +6581,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6590,7 +6590,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 2959f165-55fc-4e3e-b38e-79294cbbd21e
+                - b57cb951-88fe-4e6c-adec-58622cb06a3a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6598,8 +6598,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074825Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
+                - 20260518T103303Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -6611,21 +6611,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:25 GMT
+                - Mon, 18 May 2026 10:33:03 GMT
             X-Amz-Id-2:
-                - txgc7706447d78b49b9876b-006a042cc9
+                - txgb41926ae5cde49959bf9-006a0aeadf
             X-Amz-Request-Id:
-                - txgc7706447d78b49b9876b-006a042cc9
+                - txgb41926ae5cde49959bf9-006a0aeadf
         status: 200 OK
         code: 200
-        duration: 19.309708ms
+        duration: 271.063292ms
     - id: 127
       request:
         proto: HTTP/1.1
@@ -6634,7 +6634,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6643,7 +6643,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 2e731150-bdaa-485a-8260-6030c46a3835
+                - 176a1f30-9060-47fb-8d92-47b9adb2ea07
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6651,8 +6651,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074825Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T103303Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6662,21 +6662,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg78daf4a435874c5bba87-006a042cc9</RequestId><HostId>txg78daf4a435874c5bba87-006a042cc9</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg18c56dd2e0804766816e-006a0aeae0</RequestId><HostId>txg18c56dd2e0804766816e-006a0aeae0</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:25 GMT
+                - Mon, 18 May 2026 10:33:04 GMT
             X-Amz-Id-2:
-                - txg78daf4a435874c5bba87-006a042cc9
+                - txg18c56dd2e0804766816e-006a0aeae0
             X-Amz-Request-Id:
-                - txg78daf4a435874c5bba87-006a042cc9
+                - txg18c56dd2e0804766816e-006a0aeae0
         status: 404 Not Found
         code: 404
-        duration: 19.004791ms
+        duration: 20.547458ms
     - id: 128
       request:
         proto: HTTP/1.1
@@ -6685,7 +6685,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6694,7 +6694,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 3fa9530a-8849-4707-97c6-99ea86869a27
+                - 3e767e3f-c99a-4dd7-bce6-dbf800af81d7
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6702,8 +6702,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074825Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T103304Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6713,21 +6713,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg1385e3b72a2b45c398b8-006a042cc9</RequestId><HostId>txg1385e3b72a2b45c398b8-006a042cc9</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgb04286331a5f4a8db3e8-006a0aeae0</RequestId><HostId>txgb04286331a5f4a8db3e8-006a0aeae0</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:25 GMT
+                - Mon, 18 May 2026 10:33:04 GMT
             X-Amz-Id-2:
-                - txg1385e3b72a2b45c398b8-006a042cc9
+                - txgb04286331a5f4a8db3e8-006a0aeae0
             X-Amz-Request-Id:
-                - txg1385e3b72a2b45c398b8-006a042cc9
+                - txgb04286331a5f4a8db3e8-006a0aeae0
         status: 404 Not Found
         code: 404
-        duration: 19.099167ms
+        duration: 21.058792ms
     - id: 129
       request:
         proto: HTTP/1.1
@@ -6736,7 +6736,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6745,7 +6745,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 761b4148-0888-4baa-83b5-8b2f117528ec
+                - 29adb2a6-518a-402e-8df5-adb019eb4bd7
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6753,8 +6753,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074825Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T103304Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6773,14 +6773,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:25 GMT
+                - Mon, 18 May 2026 10:33:04 GMT
             X-Amz-Id-2:
-                - txg80c6f0be51a84fd4aa0e-006a042cc9
+                - txg6a7d6223e1154e79a4e0-006a0aeae0
             X-Amz-Request-Id:
-                - txg80c6f0be51a84fd4aa0e-006a042cc9
+                - txg6a7d6223e1154e79a4e0-006a0aeae0
         status: 200 OK
         code: 200
-        duration: 32.590875ms
+        duration: 137.600125ms
     - id: 130
       request:
         proto: HTTP/1.1
@@ -6789,7 +6789,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6798,7 +6798,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c06877ed-cd13-48d1-a8fe-9fe1c8abbb1d
+                - 41ed37e1-3e5f-41ff-8407-05b330506f97
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6806,8 +6806,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074825Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T103304Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6815,25 +6815,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 257
+        content_length: 317
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path1/</Prefix><Tag><Key>deleted</Key><Value>true</Value></Tag></And></Filter><ID>id1</ID><Status>Enabled</Status></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path1/</Prefix><Tag><Key>deleted</Key><Value>true</Value></Tag></And></Filter><ID>id1</ID><Status>Enabled</Status></Rule></Configuration>
         headers:
             Content-Length:
-                - "257"
+                - "317"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:25 GMT
+                - Mon, 18 May 2026 10:33:04 GMT
             X-Amz-Id-2:
-                - txgaa6eba2a92ef46b4a7b4-006a042cc9
+                - txgba22ed3a873f4bafb52f-006a0aeae0
             X-Amz-Request-Id:
-                - txgaa6eba2a92ef46b4a7b4-006a042cc9
+                - txgba22ed3a873f4bafb52f-006a0aeae0
         status: 200 OK
         code: 200
-        duration: 68.198584ms
+        duration: 24.55275ms
     - id: 131
       request:
         proto: HTTP/1.1
@@ -6842,7 +6842,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6851,7 +6851,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - eecf3fb5-5b38-442a-8d74-f2b14d43dd53
+                - 854e8a25-750b-4315-a44e-35311cb8b45b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6859,8 +6859,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074825Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T103304Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6879,14 +6879,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:25 GMT
+                - Mon, 18 May 2026 10:33:04 GMT
             X-Amz-Id-2:
-                - txg77d91ad23c8d482b8cf7-006a042cc9
+                - txgbecd93e963764e569160-006a0aeae0
             X-Amz-Request-Id:
-                - txg77d91ad23c8d482b8cf7-006a042cc9
+                - txgbecd93e963764e569160-006a0aeae0
         status: 200 OK
         code: 200
-        duration: 22.86925ms
+        duration: 20.643ms
     - id: 132
       request:
         proto: HTTP/1.1
@@ -6895,7 +6895,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6904,7 +6904,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0237d208-5d92-4833-a638-0d12a1189806
+                - 308ca343-c665-44aa-b002-f34cdca5add5
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6912,8 +6912,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074825Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T103304Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6923,21 +6923,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg3c2e4b6df6244eb49295-006a042cc9</RequestId><HostId>txg3c2e4b6df6244eb49295-006a042cc9</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgd092787c6f2d46c59d6f-006a0aeae0</RequestId><HostId>txgd092787c6f2d46c59d6f-006a0aeae0</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:25 GMT
+                - Mon, 18 May 2026 10:33:04 GMT
             X-Amz-Id-2:
-                - txg3c2e4b6df6244eb49295-006a042cc9
+                - txgd092787c6f2d46c59d6f-006a0aeae0
             X-Amz-Request-Id:
-                - txg3c2e4b6df6244eb49295-006a042cc9
+                - txgd092787c6f2d46c59d6f-006a0aeae0
         status: 404 Not Found
         code: 404
-        duration: 35.521416ms
+        duration: 23.778416ms
     - id: 133
       request:
         proto: HTTP/1.1
@@ -6946,7 +6946,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6955,7 +6955,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 71e23b62-f8fc-42df-850f-f6e882e42792
+                - 725ad7cc-c5f3-4301-b051-bfe310cdef8c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6963,8 +6963,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074825Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
+                - 20260518T103304Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -6976,21 +6976,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:25 GMT
+                - Mon, 18 May 2026 10:33:04 GMT
             X-Amz-Id-2:
-                - txg988dfeb3bb1444bebefe-006a042cc9
+                - txg08dfe6d04830420789a2-006a0aeae0
             X-Amz-Request-Id:
-                - txg988dfeb3bb1444bebefe-006a042cc9
+                - txg08dfe6d04830420789a2-006a0aeae0
         status: 200 OK
         code: 200
-        duration: 61.178042ms
+        duration: 92.270167ms
     - id: 134
       request:
         proto: HTTP/1.1
@@ -6999,7 +6999,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7008,7 +7008,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 199504f6-b8e9-4081-8858-6d33abed12b7
+                - 8c4d9209-b3b9-4622-a7d4-1dfca05b1d88
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7016,8 +7016,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074825Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T103304Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7027,21 +7027,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg392d1527ae764374bb79-006a042cc9</RequestId><HostId>txg392d1527ae764374bb79-006a042cc9</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgde9844c7ce654880ad88-006a0aeae0</RequestId><HostId>txgde9844c7ce654880ad88-006a0aeae0</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:25 GMT
+                - Mon, 18 May 2026 10:33:04 GMT
             X-Amz-Id-2:
-                - txg392d1527ae764374bb79-006a042cc9
+                - txgde9844c7ce654880ad88-006a0aeae0
             X-Amz-Request-Id:
-                - txg392d1527ae764374bb79-006a042cc9
+                - txgde9844c7ce654880ad88-006a0aeae0
         status: 404 Not Found
         code: 404
-        duration: 34.526833ms
+        duration: 20.825292ms
     - id: 135
       request:
         proto: HTTP/1.1
@@ -7050,7 +7050,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7059,7 +7059,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 8ebb3132-e139-45e9-94fd-28c593b60b5a
+                - cae6e91d-2690-4a04-a3bd-1941cb323257
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7067,8 +7067,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074825Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T103304Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7078,21 +7078,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg71e4462a04274761b297-006a042cc9</RequestId><HostId>txg71e4462a04274761b297-006a042cc9</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg1318f8282ec840d59540-006a0aeae0</RequestId><HostId>txg1318f8282ec840d59540-006a0aeae0</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:25 GMT
+                - Mon, 18 May 2026 10:33:04 GMT
             X-Amz-Id-2:
-                - txg71e4462a04274761b297-006a042cc9
+                - txg1318f8282ec840d59540-006a0aeae0
             X-Amz-Request-Id:
-                - txg71e4462a04274761b297-006a042cc9
+                - txg1318f8282ec840d59540-006a0aeae0
         status: 404 Not Found
         code: 404
-        duration: 34.645917ms
+        duration: 20.631667ms
     - id: 136
       request:
         proto: HTTP/1.1
@@ -7101,7 +7101,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7110,7 +7110,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 77d18382-523c-4b94-9b44-3c6df219d025
+                - 49055b1f-2af8-4222-bfb8-e0f76f9821a4
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7118,8 +7118,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074825Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T103304Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7138,14 +7138,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:25 GMT
+                - Mon, 18 May 2026 10:33:04 GMT
             X-Amz-Id-2:
-                - txga2e5145b66174b25a099-006a042cc9
+                - txg58d0ac520ece43a48d66-006a0aeae0
             X-Amz-Request-Id:
-                - txga2e5145b66174b25a099-006a042cc9
+                - txg58d0ac520ece43a48d66-006a0aeae0
         status: 200 OK
         code: 200
-        duration: 19.494791ms
+        duration: 20.852709ms
     - id: 137
       request:
         proto: HTTP/1.1
@@ -7154,7 +7154,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7163,7 +7163,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7c553a90-6a75-468f-9805-02054d79b3a5
+                - 44bb72a2-432f-4fd1-84ad-c73543d5c28c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7171,8 +7171,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074825Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T103304Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7180,25 +7180,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 257
+        content_length: 317
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path1/</Prefix><Tag><Key>deleted</Key><Value>true</Value></Tag></And></Filter><ID>id1</ID><Status>Enabled</Status></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path1/</Prefix><Tag><Key>deleted</Key><Value>true</Value></Tag></And></Filter><ID>id1</ID><Status>Enabled</Status></Rule></Configuration>
         headers:
             Content-Length:
-                - "257"
+                - "317"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:25 GMT
+                - Mon, 18 May 2026 10:33:04 GMT
             X-Amz-Id-2:
-                - txgec1c15268d3a430da8b5-006a042cc9
+                - txgc1c2ba7b56a04273ad1b-006a0aeae0
             X-Amz-Request-Id:
-                - txgec1c15268d3a430da8b5-006a042cc9
+                - txgc1c2ba7b56a04273ad1b-006a0aeae0
         status: 200 OK
         code: 200
-        duration: 18.617791ms
+        duration: 20.335791ms
     - id: 138
       request:
         proto: HTTP/1.1
@@ -7207,7 +7207,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7216,7 +7216,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e2989ed0-3bf7-4e2b-b6e3-c41671a8cb57
+                - 0fa4e3ba-f2f3-466f-a820-0a1f0c1fe849
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7224,8 +7224,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074825Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
+                - 20260518T103304Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -7238,14 +7238,14 @@ interactions:
         body: ""
         headers:
             Date:
-                - Wed, 13 May 2026 07:48:25 GMT
+                - Mon, 18 May 2026 10:33:04 GMT
             X-Amz-Id-2:
-                - txg31456f1a35824277bac0-006a042cc9
+                - txgc1852804beaf4ced865b-006a0aeae0
             X-Amz-Request-Id:
-                - txg31456f1a35824277bac0-006a042cc9
+                - txgc1852804beaf4ced865b-006a0aeae0
         status: 204 No Content
         code: 204
-        duration: 165.90975ms
+        duration: 304.217209ms
     - id: 139
       request:
         proto: HTTP/1.1
@@ -7254,7 +7254,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7263,7 +7263,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - be792806-d17d-4d53-9082-6548ef1d9959
+                - ec105e2f-c4f0-4ff7-b609-10e56c245e56
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7273,8 +7273,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074826Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
+                - 20260518T103305Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
         method: PUT
       response:
         proto: HTTP/2.0
@@ -7289,16 +7289,16 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Wed, 13 May 2026 07:48:26 GMT
+                - Mon, 18 May 2026 10:33:05 GMT
             Location:
-                - /tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985
+                - /tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018
             X-Amz-Id-2:
-                - txg317cc22dee7a4d4194b4-006a042cca
+                - txg058e006c1b2e43b49943-006a0aeae1
             X-Amz-Request-Id:
-                - txg317cc22dee7a4d4194b4-006a042cca
+                - txg058e006c1b2e43b49943-006a0aeae1
         status: 200 OK
         code: 200
-        duration: 5.472016625s
+        duration: 6.623443708s
     - id: 140
       request:
         proto: HTTP/1.1
@@ -7307,7 +7307,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7316,7 +7316,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ff62e25f-bb49-4cbc-ba0f-34fa49e12326
+                - f3798a8e-e472-4a59-9df5-823c9d5a2521
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7328,8 +7328,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074831Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T103311Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?acl=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -7344,32 +7344,32 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Wed, 13 May 2026 07:48:31 GMT
+                - Mon, 18 May 2026 10:33:11 GMT
             X-Amz-Id-2:
-                - txg43cd9ef2bae04d25b676-006a042ccf
+                - txg199edc6ef3234c47b0a7-006a0aeae7
             X-Amz-Request-Id:
-                - txg43cd9ef2bae04d25b676-006a042ccf
+                - txg199edc6ef3234c47b0a7-006a0aeae7
         status: 200 OK
         code: 200
-        duration: 71.118708ms
+        duration: 2.084652125s
     - id: 141
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 472
+        content_length: 532
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
-        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>2</Days></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260513074831661600000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260513074831661600000002</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
+        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>2</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260518103313987200000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260518103313987300000002</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
         form: {}
         headers:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 36fae49e-8a98-4890-b518-d6e4d34c4146
+                - cf958ac5-1511-45c6-be0b-171c58c60d50
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
@@ -7377,12 +7377,12 @@ interactions:
             User-Agent:
                 - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,Z,e
             X-Amz-Checksum-Crc32:
-                - h/0tLg==
+                - QCBdtA==
             X-Amz-Content-Sha256:
-                - 5d45c7b68c03071c79b583a8f2f892b3fad5be399dd8622107f2068e425fd6c8
+                - bd197515a5bbdbfbbdcd8b19bf2b1c0b0b72b958b359436e3274692df93c1055
             X-Amz-Date:
-                - 20260513T074831Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T103311Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -7397,14 +7397,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Wed, 13 May 2026 07:48:31 GMT
+                - Mon, 18 May 2026 10:33:14 GMT
             X-Amz-Id-2:
-                - txg4ef7941df8a940889189-006a042ccf
+                - txgbe6d30bb9d604ad3965a-006a0aeaea
             X-Amz-Request-Id:
-                - txg4ef7941df8a940889189-006a042ccf
+                - txgbe6d30bb9d604ad3965a-006a0aeaea
         status: 200 OK
         code: 200
-        duration: 72.734416ms
+        duration: 1.227554709s
     - id: 142
       request:
         proto: HTTP/1.1
@@ -7413,7 +7413,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7422,7 +7422,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 41e72d8e-14ad-4925-88e9-685c7ddb6262
+                - d632be9e-f030-4336-b83b-acd8d0d32e4b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7430,8 +7430,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074831Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T103315Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7450,14 +7450,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:31 GMT
+                - Mon, 18 May 2026 10:33:15 GMT
             X-Amz-Id-2:
-                - txg2cf8fdc8646d4022bcd9-006a042ccf
+                - txge6a0b89de4094422a805-006a0aeaeb
             X-Amz-Request-Id:
-                - txg2cf8fdc8646d4022bcd9-006a042ccf
+                - txge6a0b89de4094422a805-006a0aeaeb
         status: 200 OK
         code: 200
-        duration: 18.726666ms
+        duration: 1.106076333s
     - id: 143
       request:
         proto: HTTP/1.1
@@ -7466,7 +7466,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7475,7 +7475,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 3b2d5667-ed2c-4fe4-a2e0-09bb3c53164a
+                - 075240e8-96ac-4fb2-b25e-d84800019d3e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7483,8 +7483,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074831Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T103315Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7503,14 +7503,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:31 GMT
+                - Mon, 18 May 2026 10:33:16 GMT
             X-Amz-Id-2:
-                - txg43d1369f21e34686a647-006a042ccf
+                - txgd1d83c93c2f54851893a-006a0aeaec
             X-Amz-Request-Id:
-                - txg43d1369f21e34686a647-006a042ccf
+                - txgd1d83c93c2f54851893a-006a0aeaec
         status: 200 OK
         code: 200
-        duration: 24.61925ms
+        duration: 1.348184459s
     - id: 144
       request:
         proto: HTTP/1.1
@@ -7519,7 +7519,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7528,7 +7528,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 968ab00e-862f-4eaf-9869-14a948d0befd
+                - d154343f-2163-4fac-9aac-5763b163b703
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7536,8 +7536,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074831Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
+                - 20260518T103316Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -7549,21 +7549,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:31 GMT
+                - Mon, 18 May 2026 10:33:17 GMT
             X-Amz-Id-2:
-                - txge6a4018801db4d139d0a-006a042ccf
+                - txg776e3fdfc4a4403599ae-006a0aeaed
             X-Amz-Request-Id:
-                - txge6a4018801db4d139d0a-006a042ccf
+                - txg776e3fdfc4a4403599ae-006a0aeaed
         status: 200 OK
         code: 200
-        duration: 19.305833ms
+        duration: 246.652333ms
     - id: 145
       request:
         proto: HTTP/1.1
@@ -7572,7 +7572,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7581,7 +7581,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0af4c56b-4b48-4269-8698-9ac2d9490389
+                - bcc74c7c-aab9-4cd2-863d-0e3c17ac8b39
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7589,8 +7589,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074831Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T103317Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7600,21 +7600,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg20fd2b1b087142928dcb-006a042ccf</RequestId><HostId>txg20fd2b1b087142928dcb-006a042ccf</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg5076c164504f4d8ab6e6-006a0aeaed</RequestId><HostId>txg5076c164504f4d8ab6e6-006a0aeaed</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:31 GMT
+                - Mon, 18 May 2026 10:33:17 GMT
             X-Amz-Id-2:
-                - txg20fd2b1b087142928dcb-006a042ccf
+                - txg5076c164504f4d8ab6e6-006a0aeaed
             X-Amz-Request-Id:
-                - txg20fd2b1b087142928dcb-006a042ccf
+                - txg5076c164504f4d8ab6e6-006a0aeaed
         status: 404 Not Found
         code: 404
-        duration: 19.589375ms
+        duration: 1.104151125s
     - id: 146
       request:
         proto: HTTP/1.1
@@ -7623,7 +7623,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7632,7 +7632,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 57461287-de26-49ca-8161-240308962ffb
+                - cb581e93-5210-405a-9848-4073f6c9814e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7640,8 +7640,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074831Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T103317Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7651,21 +7651,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg6a8003a19ee449cd8fc7-006a042ccf</RequestId><HostId>txg6a8003a19ee449cd8fc7-006a042ccf</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg6cf2c3325b3346e6b2e6-006a0aeaef</RequestId><HostId>txg6cf2c3325b3346e6b2e6-006a0aeaef</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:31 GMT
+                - Mon, 18 May 2026 10:33:19 GMT
             X-Amz-Id-2:
-                - txg6a8003a19ee449cd8fc7-006a042ccf
+                - txg6cf2c3325b3346e6b2e6-006a0aeaef
             X-Amz-Request-Id:
-                - txg6a8003a19ee449cd8fc7-006a042ccf
+                - txg6cf2c3325b3346e6b2e6-006a0aeaef
         status: 404 Not Found
         code: 404
-        duration: 19.423792ms
+        duration: 1.095099791s
     - id: 147
       request:
         proto: HTTP/1.1
@@ -7674,7 +7674,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7683,7 +7683,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0839a32a-bc8d-4e33-9c0d-652fd4304a9a
+                - 46604555-8423-4e68-836a-cbacf2e31b60
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7691,8 +7691,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074831Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T103319Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7711,14 +7711,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:31 GMT
+                - Mon, 18 May 2026 10:33:20 GMT
             X-Amz-Id-2:
-                - txg207b42963c924e63af14-006a042ccf
+                - txg077278964858423dadaf-006a0aeaf0
             X-Amz-Request-Id:
-                - txg207b42963c924e63af14-006a042ccf
+                - txg077278964858423dadaf-006a0aeaf0
         status: 200 OK
         code: 200
-        duration: 18.49975ms
+        duration: 190.706917ms
     - id: 148
       request:
         proto: HTTP/1.1
@@ -7727,7 +7727,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7736,7 +7736,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4fbf3a14-bd4b-469c-aeb4-30608432743d
+                - 86ad0f90-d938-470f-aa59-63d75ea5ed3e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7744,8 +7744,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074831Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T103320Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7753,25 +7753,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 445
+        content_length: 505
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>2</Days></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260513074831661600000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260513074831661600000002</ID><Status>Enabled</Status></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>2</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260518103313987200000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260518103313987300000002</ID><Status>Enabled</Status></Rule></Configuration>
         headers:
             Content-Length:
-                - "445"
+                - "505"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:31 GMT
+                - Mon, 18 May 2026 10:33:20 GMT
             X-Amz-Id-2:
-                - txg24e69d1b46a0458da039-006a042ccf
+                - txg3f4bffcc78a04d7a95da-006a0aeaf0
             X-Amz-Request-Id:
-                - txg24e69d1b46a0458da039-006a042ccf
+                - txg3f4bffcc78a04d7a95da-006a0aeaf0
         status: 200 OK
         code: 200
-        duration: 19.435875ms
+        duration: 309.994833ms
     - id: 149
       request:
         proto: HTTP/1.1
@@ -7780,7 +7780,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7789,7 +7789,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - aed40fcb-f78d-4edd-9b41-780be118e4f3
+                - b690f0c6-5cfe-4438-8306-48bc3602321e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7797,8 +7797,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074831Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
+                - 20260518T103320Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -7813,16 +7813,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:32 GMT
+                - Mon, 18 May 2026 10:33:20 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txgd50d2c2c8f274f3ca762-006a042cd0
+                - txg401ac5d11f6b49fb9824-006a0aeaf0
             X-Amz-Request-Id:
-                - txgd50d2c2c8f274f3ca762-006a042cd0
+                - txg401ac5d11f6b49fb9824-006a0aeaf0
         status: 200 OK
         code: 200
-        duration: 20.530834ms
+        duration: 1.125599625s
     - id: 150
       request:
         proto: HTTP/1.1
@@ -7831,7 +7831,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7840,7 +7840,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 3551f5cf-8383-474b-8a45-b030d699d0f1
+                - db876194-cfa6-4859-9a24-7467baf6abd3
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7848,8 +7848,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074832Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T103321Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7857,25 +7857,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 445
+        content_length: 505
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>2</Days></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260513074831661600000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260513074831661600000002</ID><Status>Enabled</Status></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>2</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260518103313987200000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260518103313987300000002</ID><Status>Enabled</Status></Rule></Configuration>
         headers:
             Content-Length:
-                - "445"
+                - "505"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:32 GMT
+                - Mon, 18 May 2026 10:33:21 GMT
             X-Amz-Id-2:
-                - txga9bef97df96445f48d30-006a042cd0
+                - txg9fbab9ebdca2416195ea-006a0aeaf1
             X-Amz-Request-Id:
-                - txga9bef97df96445f48d30-006a042cd0
+                - txg9fbab9ebdca2416195ea-006a0aeaf1
         status: 200 OK
         code: 200
-        duration: 49.327792ms
+        duration: 1.105517458s
     - id: 151
       request:
         proto: HTTP/1.1
@@ -7884,7 +7884,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7893,7 +7893,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ebae6d64-7a72-4ad0-adc9-f9236c9387d9
+                - eb173eda-d967-437b-970e-daf22aeb0724
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7901,8 +7901,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074832Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T103323Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7921,14 +7921,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:32 GMT
+                - Mon, 18 May 2026 10:33:23 GMT
             X-Amz-Id-2:
-                - txg4419f596885f4e2d9c10-006a042cd0
+                - txg42c0ac59c66a4f748d84-006a0aeaf3
             X-Amz-Request-Id:
-                - txg4419f596885f4e2d9c10-006a042cd0
+                - txg42c0ac59c66a4f748d84-006a0aeaf3
         status: 200 OK
         code: 200
-        duration: 27.974291ms
+        duration: 1.032293709s
     - id: 152
       request:
         proto: HTTP/1.1
@@ -7937,7 +7937,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7946,7 +7946,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9d511b48-b521-400e-aa90-f47e27e1d110
+                - e2b56d77-e7ee-405e-96c6-e9e68564440e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7954,8 +7954,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074832Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T103323Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7974,14 +7974,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:32 GMT
+                - Mon, 18 May 2026 10:33:24 GMT
             X-Amz-Id-2:
-                - txg145280bae6f346ff9978-006a042cd0
+                - txg740bb4dfd3864f34a058-006a0aeaf4
             X-Amz-Request-Id:
-                - txg145280bae6f346ff9978-006a042cd0
+                - txg740bb4dfd3864f34a058-006a0aeaf4
         status: 200 OK
         code: 200
-        duration: 50.441708ms
+        duration: 549.219375ms
     - id: 153
       request:
         proto: HTTP/1.1
@@ -7990,7 +7990,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7999,7 +7999,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - efcf78b4-0b9f-4e60-ab32-af3bda6ad0ac
+                - 551193b2-3821-4a14-bb36-0e7d674883d3
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8007,8 +8007,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074832Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
+                - 20260518T103324Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -8020,21 +8020,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:32 GMT
+                - Mon, 18 May 2026 10:33:24 GMT
             X-Amz-Id-2:
-                - txg8bf7ab862e7d4e279c69-006a042cd0
+                - txg726eb2b567e04d5981d6-006a0aeaf4
             X-Amz-Request-Id:
-                - txg8bf7ab862e7d4e279c69-006a042cd0
+                - txg726eb2b567e04d5981d6-006a0aeaf4
         status: 200 OK
         code: 200
-        duration: 19.554917ms
+        duration: 1.096914459s
     - id: 154
       request:
         proto: HTTP/1.1
@@ -8043,7 +8043,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8052,7 +8052,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 794d4f69-7dee-41d9-8cb2-c700c7169df2
+                - aa9fbcc7-c236-4f66-90bd-bc65a01cade4
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8060,8 +8060,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074832Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T103324Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8071,21 +8071,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg57ed42402eac4c7fa755-006a042cd0</RequestId><HostId>txg57ed42402eac4c7fa755-006a042cd0</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgbefe8e3b23f24e468525-006a0aeaf5</RequestId><HostId>txgbefe8e3b23f24e468525-006a0aeaf5</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:32 GMT
+                - Mon, 18 May 2026 10:33:25 GMT
             X-Amz-Id-2:
-                - txg57ed42402eac4c7fa755-006a042cd0
+                - txgbefe8e3b23f24e468525-006a0aeaf5
             X-Amz-Request-Id:
-                - txg57ed42402eac4c7fa755-006a042cd0
+                - txgbefe8e3b23f24e468525-006a0aeaf5
         status: 404 Not Found
         code: 404
-        duration: 21.441083ms
+        duration: 1.024578458s
     - id: 155
       request:
         proto: HTTP/1.1
@@ -8094,7 +8094,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8103,7 +8103,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 260ae06f-87ba-4eeb-9cd9-436aec4c715e
+                - ee57e0a5-f2b4-4cb7-83ab-4eacc39ecba6
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8111,8 +8111,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074832Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T103325Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8122,21 +8122,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg7b6281db7f8a4effb283-006a042cd0</RequestId><HostId>txg7b6281db7f8a4effb283-006a042cd0</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg1cce3103dcb149a99807-006a0aeaf6</RequestId><HostId>txg1cce3103dcb149a99807-006a0aeaf6</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:32 GMT
+                - Mon, 18 May 2026 10:33:26 GMT
             X-Amz-Id-2:
-                - txg7b6281db7f8a4effb283-006a042cd0
+                - txg1cce3103dcb149a99807-006a0aeaf6
             X-Amz-Request-Id:
-                - txg7b6281db7f8a4effb283-006a042cd0
+                - txg1cce3103dcb149a99807-006a0aeaf6
         status: 404 Not Found
         code: 404
-        duration: 19.1605ms
+        duration: 71.806708ms
     - id: 156
       request:
         proto: HTTP/1.1
@@ -8145,7 +8145,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8154,7 +8154,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 26c97ba6-2c19-40ab-86d4-636eb722ba69
+                - 254873c3-9134-4103-a722-6a518a720ba1
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8162,8 +8162,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074832Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T103326Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8182,14 +8182,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:32 GMT
+                - Mon, 18 May 2026 10:33:27 GMT
             X-Amz-Id-2:
-                - txgfb1d0f0d3c804565a179-006a042cd0
+                - txg9c613dda64624fcd8883-006a0aeaf7
             X-Amz-Request-Id:
-                - txgfb1d0f0d3c804565a179-006a042cd0
+                - txg9c613dda64624fcd8883-006a0aeaf7
         status: 200 OK
         code: 200
-        duration: 30.52075ms
+        duration: 1.105907625s
     - id: 157
       request:
         proto: HTTP/1.1
@@ -8198,7 +8198,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8207,7 +8207,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - a4a9a660-6915-4e6e-99e9-4abd961b8e23
+                - e040b7a8-bfcc-47f4-a2e3-ae0898530ac8
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8215,8 +8215,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074832Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T103327Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8224,25 +8224,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 445
+        content_length: 505
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>2</Days></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260513074831661600000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260513074831661600000002</ID><Status>Enabled</Status></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>2</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260518103313987200000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260518103313987300000002</ID><Status>Enabled</Status></Rule></Configuration>
         headers:
             Content-Length:
-                - "445"
+                - "505"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:32 GMT
+                - Mon, 18 May 2026 10:33:28 GMT
             X-Amz-Id-2:
-                - txg0717a09c43cc4079aa6a-006a042cd0
+                - txg1d34f8bb53684630b797-006a0aeaf8
             X-Amz-Request-Id:
-                - txg0717a09c43cc4079aa6a-006a042cd0
+                - txg1d34f8bb53684630b797-006a0aeaf8
         status: 200 OK
         code: 200
-        duration: 19.018459ms
+        duration: 1.02378325s
     - id: 158
       request:
         proto: HTTP/1.1
@@ -8251,7 +8251,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8260,7 +8260,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 856d027c-89ad-42c2-8d16-2bd9f0ac0b81
+                - 7b25cb46-080c-4226-bad1-fc625b58db38
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8268,8 +8268,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074832Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T103329Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8288,14 +8288,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:32 GMT
+                - Mon, 18 May 2026 10:33:29 GMT
             X-Amz-Id-2:
-                - txg850e10e7ccf24f2ba436-006a042cd0
+                - txg01ebe9087157422ebc4e-006a0aeaf9
             X-Amz-Request-Id:
-                - txg850e10e7ccf24f2ba436-006a042cd0
+                - txg01ebe9087157422ebc4e-006a0aeaf9
         status: 200 OK
         code: 200
-        duration: 19.831083ms
+        duration: 1.143612125s
     - id: 159
       request:
         proto: HTTP/1.1
@@ -8304,7 +8304,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8313,7 +8313,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ed45596b-fb4e-4f5c-98c2-2c7801b94da1
+                - 815e40bb-86ed-4d5a-93e9-e66c08352d6d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8321,8 +8321,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074832Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T103329Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8341,14 +8341,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:32 GMT
+                - Mon, 18 May 2026 10:33:30 GMT
             X-Amz-Id-2:
-                - txg54fda9b34e234a2c8ef7-006a042cd0
+                - txg25db23bbb65a4bf88f59-006a0aeafa
             X-Amz-Request-Id:
-                - txg54fda9b34e234a2c8ef7-006a042cd0
+                - txg25db23bbb65a4bf88f59-006a0aeafa
         status: 200 OK
         code: 200
-        duration: 18.827083ms
+        duration: 35.676625ms
     - id: 160
       request:
         proto: HTTP/1.1
@@ -8357,7 +8357,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8366,7 +8366,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e4af4b41-2ad7-4d24-95ba-aeec7396ba21
+                - b3e136c5-d3df-45f9-8113-6832b5b5df22
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8374,8 +8374,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074832Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
+                - 20260518T103330Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -8387,21 +8387,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:32 GMT
+                - Mon, 18 May 2026 10:33:30 GMT
             X-Amz-Id-2:
-                - txg2670243e82344cd69f51-006a042cd0
+                - txg88d877c72d544c4c8e4e-006a0aeafa
             X-Amz-Request-Id:
-                - txg2670243e82344cd69f51-006a042cd0
+                - txg88d877c72d544c4c8e4e-006a0aeafa
         status: 200 OK
         code: 200
-        duration: 32.053125ms
+        duration: 1.148444834s
     - id: 161
       request:
         proto: HTTP/1.1
@@ -8410,7 +8410,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8419,7 +8419,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 1b19a040-ec70-4d26-865e-9a1debf04a36
+                - eedf59cb-b178-4bd2-862a-68f98f14661c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8427,8 +8427,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074832Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T103330Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8438,21 +8438,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg1fbe7a0011904df98b2c-006a042cd0</RequestId><HostId>txg1fbe7a0011904df98b2c-006a042cd0</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgd8799066a1644821b94c-006a0aeafb</RequestId><HostId>txgd8799066a1644821b94c-006a0aeafb</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:32 GMT
+                - Mon, 18 May 2026 10:33:31 GMT
             X-Amz-Id-2:
-                - txg1fbe7a0011904df98b2c-006a042cd0
+                - txgd8799066a1644821b94c-006a0aeafb
             X-Amz-Request-Id:
-                - txg1fbe7a0011904df98b2c-006a042cd0
+                - txgd8799066a1644821b94c-006a0aeafb
         status: 404 Not Found
         code: 404
-        duration: 18.763791ms
+        duration: 31.889292ms
     - id: 162
       request:
         proto: HTTP/1.1
@@ -8461,7 +8461,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8470,7 +8470,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 8552eee5-700e-4d13-80ef-580707f1f70b
+                - eaf9ae7f-29ff-4ce8-871f-e93cf95d6fc9
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8478,8 +8478,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074832Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T103331Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8489,21 +8489,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg3e53fd3c41cd479f888b-006a042cd0</RequestId><HostId>txg3e53fd3c41cd479f888b-006a042cd0</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgca812d1da5b44a56a739-006a0aeafb</RequestId><HostId>txgca812d1da5b44a56a739-006a0aeafb</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:32 GMT
+                - Mon, 18 May 2026 10:33:31 GMT
             X-Amz-Id-2:
-                - txg3e53fd3c41cd479f888b-006a042cd0
+                - txgca812d1da5b44a56a739-006a0aeafb
             X-Amz-Request-Id:
-                - txg3e53fd3c41cd479f888b-006a042cd0
+                - txgca812d1da5b44a56a739-006a0aeafb
         status: 404 Not Found
         code: 404
-        duration: 20.293208ms
+        duration: 1.114490916s
     - id: 163
       request:
         proto: HTTP/1.1
@@ -8512,7 +8512,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8521,7 +8521,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 24d92875-0b68-4ca2-94df-f3bd09926643
+                - 503b826d-4b9c-4ad7-9fd5-667a0790569d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8529,8 +8529,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074832Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T103331Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8549,14 +8549,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:32 GMT
+                - Mon, 18 May 2026 10:33:32 GMT
             X-Amz-Id-2:
-                - txg774837db87dc448ca7dd-006a042cd0
+                - txgc1573d658df64c909e23-006a0aeafc
             X-Amz-Request-Id:
-                - txg774837db87dc448ca7dd-006a042cd0
+                - txgc1573d658df64c909e23-006a0aeafc
         status: 200 OK
         code: 200
-        duration: 31.608542ms
+        duration: 1.022142125s
     - id: 164
       request:
         proto: HTTP/1.1
@@ -8565,7 +8565,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8574,7 +8574,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 72c903d4-4092-4a5a-8786-073c61bb81df
+                - 2e178e56-16fa-43d2-a354-410df32c1a7f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8582,8 +8582,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074832Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T103332Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8591,25 +8591,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 445
+        content_length: 505
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>2</Days></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260513074831661600000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260513074831661600000002</ID><Status>Enabled</Status></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>2</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260518103313987200000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260518103313987300000002</ID><Status>Enabled</Status></Rule></Configuration>
         headers:
             Content-Length:
-                - "445"
+                - "505"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:32 GMT
+                - Mon, 18 May 2026 10:33:33 GMT
             X-Amz-Id-2:
-                - txga69846b61a4b45fd8928-006a042cd0
+                - txg61d469be9085412ca573-006a0aeafd
             X-Amz-Request-Id:
-                - txga69846b61a4b45fd8928-006a042cd0
+                - txg61d469be9085412ca573-006a0aeafd
         status: 200 OK
         code: 200
-        duration: 154.836166ms
+        duration: 1.02136575s
     - id: 165
       request:
         proto: HTTP/1.1
@@ -8618,7 +8618,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8627,7 +8627,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 031ee7ce-be6a-47aa-a5a2-f75d6abb3b8d
+                - 97ee5cea-5022-43c5-b9f0-703f0e849b0c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8635,8 +8635,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074833Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
+                - 20260518T103335Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -8649,14 +8649,14 @@ interactions:
         body: ""
         headers:
             Date:
-                - Wed, 13 May 2026 07:48:33 GMT
+                - Mon, 18 May 2026 10:33:35 GMT
             X-Amz-Id-2:
-                - txgd3e4e0eafbed494fbe32-006a042cd1
+                - txgd14ae818a8944a5f9a30-006a0aeaff
             X-Amz-Request-Id:
-                - txgd3e4e0eafbed494fbe32-006a042cd1
+                - txgd14ae818a8944a5f9a30-006a0aeaff
         status: 204 No Content
         code: 204
-        duration: 233.905792ms
+        duration: 227.17975ms
     - id: 166
       request:
         proto: HTTP/1.1
@@ -8665,7 +8665,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8674,7 +8674,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 1adffb0d-823e-4192-bbcf-c35d1b4837da
+                - c28fb271-1510-4e20-864d-692c09379bbd
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8682,8 +8682,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074833Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
+                - 20260518T103335Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
         method: PUT
       response:
         proto: HTTP/2.0
@@ -8698,16 +8698,16 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Wed, 13 May 2026 07:48:33 GMT
+                - Mon, 18 May 2026 10:33:35 GMT
             Location:
-                - /tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985
+                - /tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018
             X-Amz-Id-2:
-                - txgc2f935613f7e4666baea-006a042cd1
+                - txgff9b2ce38b0542a2aac2-006a0aeaff
             X-Amz-Request-Id:
-                - txgc2f935613f7e4666baea-006a042cd1
+                - txgff9b2ce38b0542a2aac2-006a0aeaff
         status: 200 OK
         code: 200
-        duration: 5.077956375s
+        duration: 1.576820667s
     - id: 167
       request:
         proto: HTTP/1.1
@@ -8716,7 +8716,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8725,7 +8725,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c751efcd-512b-4db8-8e30-9dbb74cf2bf6
+                - 8ff1b6cd-a68d-469a-b9e5-8be456c544f7
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8737,8 +8737,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074838Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T103336Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?acl=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -8753,32 +8753,32 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Wed, 13 May 2026 07:48:38 GMT
+                - Mon, 18 May 2026 10:33:36 GMT
             X-Amz-Id-2:
-                - txg9d858e1a2f2547158e5e-006a042cd6
+                - txg7be96f451e60470e879c-006a0aeb00
             X-Amz-Request-Id:
-                - txg9d858e1a2f2547158e5e-006a042cd6
+                - txg7be96f451e60470e879c-006a0aeb00
         status: 200 OK
         code: 200
-        duration: 2.023114333s
+        duration: 2.089136166s
     - id: 168
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 1649
+        content_length: 1829
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
-        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>30</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition><Transition><Days>210</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>95</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Date>2016-01-12T00:00:00Z</Date></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Filter><Prefix>path3/</Prefix></Filter><ID>id3</ID><Status>Enabled</Status><Transition><Days>130</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Date>2016-01-12T00:00:00Z</Date></Expiration><Filter><And><Prefix>path4/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>155</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id6</ID><Status>Enabled</Status><Transition><Days>156</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></LifecycleConfiguration>
+        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>30</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition><Transition><Days>210</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>95</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Date>2016-01-12T00:00:00Z</Date><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Filter><Prefix>path3/</Prefix></Filter><ID>id3</ID><Status>Enabled</Status><Transition><Days>130</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Date>2016-01-12T00:00:00Z</Date><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path4/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>155</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id6</ID><Status>Enabled</Status><Transition><Days>156</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></LifecycleConfiguration>
         form: {}
         headers:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b594eeff-a1ad-4bfa-a60a-34877cf0bce4
+                - 81d23610-0c8b-491b-bbd4-d522ed6f3811
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
@@ -8786,12 +8786,12 @@ interactions:
             User-Agent:
                 - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,Z,e
             X-Amz-Checksum-Crc32:
-                - kHT1mg==
+                - N+yQ4g==
             X-Amz-Content-Sha256:
-                - 711742cac597b38760bd43e3c9819ae8c0a1ef8e752194e24b79795e8d155f3b
+                - 38b14e9de843e5a2c2fe4ff0e368fdc7fa7ad53552471a7082320b8f609ab675
             X-Amz-Date:
-                - 20260513T074838Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T103336Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -8806,14 +8806,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Wed, 13 May 2026 07:48:40 GMT
+                - Mon, 18 May 2026 10:33:38 GMT
             X-Amz-Id-2:
-                - txgba7075bc37f94d909725-006a042cd8
+                - txg7f64a0003f35466ba19a-006a0aeb02
             X-Amz-Request-Id:
-                - txgba7075bc37f94d909725-006a042cd8
+                - txg7f64a0003f35466ba19a-006a0aeb02
         status: 200 OK
         code: 200
-        duration: 1.070276459s
+        duration: 1.175113083s
     - id: 169
       request:
         proto: HTTP/1.1
@@ -8822,7 +8822,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8831,7 +8831,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b34f8bab-f507-4236-bc8a-1c011ba5bbe1
+                - abd938b2-457a-46b5-8b94-1ee707fff842
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8839,8 +8839,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074841Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T103340Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8859,14 +8859,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:41 GMT
+                - Mon, 18 May 2026 10:33:40 GMT
             X-Amz-Id-2:
-                - txgb4b8f3c924d84cb0b181-006a042cd9
+                - txgead31256ff194e88b097-006a0aeb04
             X-Amz-Request-Id:
-                - txgb4b8f3c924d84cb0b181-006a042cd9
+                - txgead31256ff194e88b097-006a0aeb04
         status: 200 OK
         code: 200
-        duration: 1.075334917s
+        duration: 1.159439292s
     - id: 170
       request:
         proto: HTTP/1.1
@@ -8875,7 +8875,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8884,7 +8884,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 71812e02-9201-48a5-8fdc-e015872937bb
+                - 0af97e09-88ab-4609-8ac6-7237c11ee40a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8892,8 +8892,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074841Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T103340Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8903,21 +8903,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg725c04291f6642efb5a2-006a042cda</RequestId><HostId>txg725c04291f6642efb5a2-006a042cda</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg157286aea37b47f9943b-006a0aeb05</RequestId><HostId>txg157286aea37b47f9943b-006a0aeb05</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:42 GMT
+                - Mon, 18 May 2026 10:33:41 GMT
             X-Amz-Id-2:
-                - txg725c04291f6642efb5a2-006a042cda
+                - txg157286aea37b47f9943b-006a0aeb05
             X-Amz-Request-Id:
-                - txg725c04291f6642efb5a2-006a042cda
+                - txg157286aea37b47f9943b-006a0aeb05
         status: 404 Not Found
         code: 404
-        duration: 1.10287475s
+        duration: 1.038956375s
     - id: 171
       request:
         proto: HTTP/1.1
@@ -8926,7 +8926,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8935,7 +8935,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 874637af-8311-4b2f-a26e-b9b29f9ad013
+                - 1b4d1774-dc54-49b4-8b14-ae2f0f8f7ad1
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8943,8 +8943,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074842Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
+                - 20260518T103341Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -8956,21 +8956,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:43 GMT
+                - Mon, 18 May 2026 10:33:42 GMT
             X-Amz-Id-2:
-                - txg302b12a2b5264979969b-006a042cdb
+                - txgc054c2891ae54c9aae4a-006a0aeb06
             X-Amz-Request-Id:
-                - txg302b12a2b5264979969b-006a042cdb
+                - txgc054c2891ae54c9aae4a-006a0aeb06
         status: 200 OK
         code: 200
-        duration: 2.088223417s
+        duration: 2.150766166s
     - id: 172
       request:
         proto: HTTP/1.1
@@ -8979,7 +8979,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8988,7 +8988,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 857877c4-15b9-4ff1-999a-c7aa1344e2c5
+                - 9823c15f-07db-4f20-a60e-9a5348b0e5ea
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8996,8 +8996,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074843Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T103342Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -9007,21 +9007,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg368a73e8d827468a866c-006a042cdd</RequestId><HostId>txg368a73e8d827468a866c-006a042cdd</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgdc1d4f4e83084268af86-006a0aeb08</RequestId><HostId>txgdc1d4f4e83084268af86-006a0aeb08</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:45 GMT
+                - Mon, 18 May 2026 10:33:44 GMT
             X-Amz-Id-2:
-                - txg368a73e8d827468a866c-006a042cdd
+                - txgdc1d4f4e83084268af86-006a0aeb08
             X-Amz-Request-Id:
-                - txg368a73e8d827468a866c-006a042cdd
+                - txgdc1d4f4e83084268af86-006a0aeb08
         status: 404 Not Found
         code: 404
-        duration: 1.1051855s
+        duration: 1.105654917s
     - id: 173
       request:
         proto: HTTP/1.1
@@ -9030,7 +9030,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -9039,7 +9039,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - edad08f0-0d21-4a02-8be1-e241825329ae
+                - 8253045c-14b9-4602-a92a-01ae439ae74c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -9047,8 +9047,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074845Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T103344Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -9058,21 +9058,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg7e6bd239ee384e0f8a3d-006a042cdf</RequestId><HostId>txg7e6bd239ee384e0f8a3d-006a042cdf</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txga9fd564284df4b1f8957-006a0aeb09</RequestId><HostId>txga9fd564284df4b1f8957-006a0aeb09</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:47 GMT
+                - Mon, 18 May 2026 10:33:45 GMT
             X-Amz-Id-2:
-                - txg7e6bd239ee384e0f8a3d-006a042cdf
+                - txga9fd564284df4b1f8957-006a0aeb09
             X-Amz-Request-Id:
-                - txg7e6bd239ee384e0f8a3d-006a042cdf
+                - txga9fd564284df4b1f8957-006a0aeb09
         status: 404 Not Found
         code: 404
-        duration: 1.058982709s
+        duration: 22.094667ms
     - id: 174
       request:
         proto: HTTP/1.1
@@ -9081,7 +9081,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -9090,7 +9090,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - afd4d76f-310f-457f-bddb-26a808bf2b0d
+                - ebb08a56-fb3b-400a-bb35-09d6962a2784
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -9098,8 +9098,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074847Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T103345Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -9118,14 +9118,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:48 GMT
+                - Mon, 18 May 2026 10:33:45 GMT
             X-Amz-Id-2:
-                - txg58c92c6ceb0e44798334-006a042ce0
+                - txg0ba2afd5f4644d1a8fda-006a0aeb09
             X-Amz-Request-Id:
-                - txg58c92c6ceb0e44798334-006a042ce0
+                - txg0ba2afd5f4644d1a8fda-006a0aeb09
         status: 200 OK
         code: 200
-        duration: 1.15020825s
+        duration: 113.575916ms
     - id: 175
       request:
         proto: HTTP/1.1
@@ -9134,7 +9134,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -9143,7 +9143,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e9a8d40a-c843-43ed-8dd7-457086e3c77c
+                - 62d1f2b9-d7c4-4a42-82b0-5a6ce7ced200
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -9151,8 +9151,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074848Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T103345Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -9160,25 +9160,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1622
+        content_length: 1802
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>30</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition><Transition><Days>210</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>95</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Date>2016-01-12T00:00:00Z</Date></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Filter><Prefix>path3/</Prefix></Filter><ID>id3</ID><Status>Enabled</Status><Transition><Days>130</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Date>2016-01-12T00:00:00Z</Date></Expiration><Filter><And><Prefix>path4/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>155</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id6</ID><Status>Enabled</Status><Transition><Days>156</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>30</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition><Transition><Days>210</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>95</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Date>2016-01-12T00:00:00Z</Date><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Filter><Prefix>path3/</Prefix></Filter><ID>id3</ID><Status>Enabled</Status><Transition><Days>130</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Date>2016-01-12T00:00:00Z</Date><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path4/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>155</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id6</ID><Status>Enabled</Status><Transition><Days>156</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
-                - "1622"
+                - "1802"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:49 GMT
+                - Mon, 18 May 2026 10:33:45 GMT
             X-Amz-Id-2:
-                - txgfdf4bd846b8d4c19a3f2-006a042ce1
+                - txgf612a20d850842ef9ef7-006a0aeb09
             X-Amz-Request-Id:
-                - txgfdf4bd846b8d4c19a3f2-006a042ce1
+                - txgf612a20d850842ef9ef7-006a0aeb09
         status: 200 OK
         code: 200
-        duration: 1.108319916s
+        duration: 1.027390541s
     - id: 176
       request:
         proto: HTTP/1.1
@@ -9187,7 +9187,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -9196,7 +9196,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 6cfa5003-0ee0-41ac-89c0-9e316caadbc4
+                - 1a272055-c60c-44bc-809e-8440ba110498
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -9204,8 +9204,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074850Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
+                - 20260518T103346Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -9220,16 +9220,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:50 GMT
+                - Mon, 18 May 2026 10:33:46 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txgf96eba6365224831a1e4-006a042ce2
+                - txg1c6fcc5b1da84d83b15f-006a0aeb0a
             X-Amz-Request-Id:
-                - txgf96eba6365224831a1e4-006a042ce2
+                - txg1c6fcc5b1da84d83b15f-006a0aeb0a
         status: 200 OK
         code: 200
-        duration: 1.022027708s
+        duration: 114.358083ms
     - id: 177
       request:
         proto: HTTP/1.1
@@ -9238,7 +9238,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -9247,7 +9247,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 1b1f5ff5-87df-41dd-9cc0-5d2be204f36e
+                - 5bcf6340-c5e0-4fed-8c0c-9a1fe849ca44
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -9255,8 +9255,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074851Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T103347Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -9275,14 +9275,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:51 GMT
+                - Mon, 18 May 2026 10:33:47 GMT
             X-Amz-Id-2:
-                - txg38138d9b84fd432d9306-006a042ce3
+                - txg10ef656aa0f14afdaa7b-006a0aeb0b
             X-Amz-Request-Id:
-                - txg38138d9b84fd432d9306-006a042ce3
+                - txg10ef656aa0f14afdaa7b-006a0aeb0b
         status: 200 OK
         code: 200
-        duration: 57.543792ms
+        duration: 1.021324958s
     - id: 178
       request:
         proto: HTTP/1.1
@@ -9291,7 +9291,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -9300,7 +9300,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f4c5e0a9-2d7c-402d-b343-b49efcfe5785
+                - 9ac0c79c-4568-4398-a045-73569a4970d3
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -9308,8 +9308,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074851Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T103347Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -9319,21 +9319,21 @@ interactions:
         trailer: {}
         content_length: 330
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg55b4fdf88388495f9ee8-006a042ce3</RequestId><HostId>txg55b4fdf88388495f9ee8-006a042ce3</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg091e093c3c084390851d-006a0aeb0c</RequestId><HostId>txg091e093c3c084390851d-006a0aeb0c</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
         headers:
             Content-Length:
                 - "330"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:51 GMT
+                - Mon, 18 May 2026 10:33:48 GMT
             X-Amz-Id-2:
-                - txg55b4fdf88388495f9ee8-006a042ce3
+                - txg091e093c3c084390851d-006a0aeb0c
             X-Amz-Request-Id:
-                - txg55b4fdf88388495f9ee8-006a042ce3
+                - txg091e093c3c084390851d-006a0aeb0c
         status: 404 Not Found
         code: 404
-        duration: 1.052115834s
+        duration: 92.883ms
     - id: 179
       request:
         proto: HTTP/1.1
@@ -9342,7 +9342,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -9351,7 +9351,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 3bd56216-cfd2-468a-90e4-53390e4d4271
+                - e6f09272-3add-4c4a-a72a-91a7a5ae6289
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -9359,8 +9359,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074851Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
+                - 20260518T103348Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -9372,21 +9372,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "287"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:52 GMT
+                - Mon, 18 May 2026 10:33:48 GMT
             X-Amz-Id-2:
-                - txgbce8a19871b04fffad38-006a042ce4
+                - txg8f3de702f3d94e17ab1a-006a0aeb0c
             X-Amz-Request-Id:
-                - txgbce8a19871b04fffad38-006a042ce4
+                - txg8f3de702f3d94e17ab1a-006a0aeb0c
         status: 200 OK
         code: 200
-        duration: 1.051386083s
+        duration: 2.1312345s
     - id: 180
       request:
         proto: HTTP/1.1
@@ -9395,7 +9395,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -9404,7 +9404,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - a2a4c7cc-8412-454e-80b6-df8b9dfcacf1
+                - 2001b76d-fdbc-4690-8e39-57f01d77311e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -9412,8 +9412,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074852Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T103348Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -9423,21 +9423,21 @@ interactions:
         trailer: {}
         content_length: 361
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg275c1a1c1d8d44888d8b-006a042ce5</RequestId><HostId>txg275c1a1c1d8d44888d8b-006a042ce5</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txge129f6df51f64355acf7-006a0aeb0e</RequestId><HostId>txge129f6df51f64355acf7-006a0aeb0e</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</BucketName></Error>
         headers:
             Content-Length:
                 - "361"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:53 GMT
+                - Mon, 18 May 2026 10:33:50 GMT
             X-Amz-Id-2:
-                - txg275c1a1c1d8d44888d8b-006a042ce5
+                - txge129f6df51f64355acf7-006a0aeb0e
             X-Amz-Request-Id:
-                - txg275c1a1c1d8d44888d8b-006a042ce5
+                - txge129f6df51f64355acf7-006a0aeb0e
         status: 404 Not Found
         code: 404
-        duration: 32.3685ms
+        duration: 21.775041ms
     - id: 181
       request:
         proto: HTTP/1.1
@@ -9446,7 +9446,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -9455,7 +9455,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7a1234aa-4ad8-42c6-9ad1-f64856c594f6
+                - f2f9d702-7751-404b-867f-669a67e440fd
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -9463,8 +9463,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074853Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T103350Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -9474,21 +9474,21 @@ interactions:
         trailer: {}
         content_length: 298
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgae39a14e048641cca121-006a042ce5</RequestId><HostId>txgae39a14e048641cca121-006a042ce5</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txge38803462d574c238c2a-006a0aeb0e</RequestId><HostId>txge38803462d574c238c2a-006a0aeb0e</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018</Resource></Error>
         headers:
             Content-Length:
                 - "298"
             Content-Type:
                 - application/xml
             Date:
-                - Wed, 13 May 2026 07:48:53 GMT
+                - Mon, 18 May 2026 10:33:50 GMT
             X-Amz-Id-2:
-                - txgae39a14e048641cca121-006a042ce5
+                - txge38803462d574c238c2a-006a0aeb0e
             X-Amz-Request-Id:
-                - txgae39a14e048641cca121-006a042ce5
+                - txge38803462d574c238c2a-006a0aeb0e
         status: 404 Not Found
         code: 404
-        duration: 59.573625ms
+        duration: 78.490833ms
     - id: 182
       request:
         proto: HTTP/1.1
@@ -9497,7 +9497,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -9506,7 +9506,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f1398667-fc7e-4c17-af72-898246de8e27
+                - b4f40b5e-c717-48a1-850a-d9c84dc2485f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -9514,8 +9514,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074853Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T103350Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -9534,14 +9534,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:53 GMT
+                - Mon, 18 May 2026 10:33:50 GMT
             X-Amz-Id-2:
-                - txg0a97284ec2064d959f9a-006a042ce5
+                - txg5484323753e64cea9427-006a0aeb0e
             X-Amz-Request-Id:
-                - txg0a97284ec2064d959f9a-006a042ce5
+                - txg5484323753e64cea9427-006a0aeb0e
         status: 200 OK
         code: 200
-        duration: 1.0959155s
+        duration: 1.137410584s
     - id: 183
       request:
         proto: HTTP/1.1
@@ -9550,7 +9550,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -9559,7 +9559,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b81e5362-0325-4779-93ac-e6010f00cf31
+                - 925c6438-8ec4-4984-826f-b98dd3487c99
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -9567,8 +9567,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074853Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T103350Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -9576,25 +9576,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1622
+        content_length: 1802
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>30</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition><Transition><Days>210</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>95</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Date>2016-01-12T00:00:00Z</Date></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Filter><Prefix>path3/</Prefix></Filter><ID>id3</ID><Status>Enabled</Status><Transition><Days>130</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Date>2016-01-12T00:00:00Z</Date></Expiration><Filter><And><Prefix>path4/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>155</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id6</ID><Status>Enabled</Status><Transition><Days>156</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>30</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition><Transition><Days>210</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>95</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Date>2016-01-12T00:00:00Z</Date><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Filter><Prefix>path3/</Prefix></Filter><ID>id3</ID><Status>Enabled</Status><Transition><Days>130</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Date>2016-01-12T00:00:00Z</Date><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path4/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>155</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id6</ID><Status>Enabled</Status><Transition><Days>156</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
-                - "1622"
+                - "1802"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Wed, 13 May 2026 07:48:55 GMT
+                - Mon, 18 May 2026 10:33:51 GMT
             X-Amz-Id-2:
-                - txg1390029917ff45968078-006a042ce7
+                - txgd0cb68695cdc49cf9d6d-006a0aeb0f
             X-Amz-Request-Id:
-                - txg1390029917ff45968078-006a042ce7
+                - txgd0cb68695cdc49cf9d6d-006a0aeb0f
         status: 200 OK
         code: 200
-        duration: 98.716209ms
+        duration: 1.109110458s
     - id: 184
       request:
         proto: HTTP/1.1
@@ -9603,7 +9603,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -9612,7 +9612,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5069afe0-3742-40e7-b6c4-8eb857e15730
+                - 60727178-06b4-42e3-8521-ec2094a3af94
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -9620,8 +9620,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260513T074855Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-4513057811274224985.s3.nl-ams.scw.cloud/
+                - 20260518T103353Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-6752684579605881018.s3.nl-ams.scw.cloud/
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -9634,11 +9634,11 @@ interactions:
         body: ""
         headers:
             Date:
-                - Wed, 13 May 2026 07:48:55 GMT
+                - Mon, 18 May 2026 10:33:53 GMT
             X-Amz-Id-2:
-                - txgf0bbf3e93bb84475b35c-006a042ce7
+                - txg02fffc5fec774364b86a-006a0aeb11
             X-Amz-Request-Id:
-                - txgf0bbf3e93bb84475b35c-006a042ce7
+                - txg02fffc5fec774364b86a-006a0aeb11
         status: 204 No Content
         code: 204
-        duration: 196.99975ms
+        duration: 240.324459ms

--- a/internal/services/object/testdata/object-bucket-lifecycle.cassette.yaml
+++ b/internal/services/object/testdata/object-bucket-lifecycle.cassette.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -18,16 +18,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9b143330-6fce-4b06-a2ad-0c2332a0aaa0
+                - 10ff8802-1044-4c4d-9e55-8336e781dc3f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162235Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/
+                - 20260512T135508Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
         method: PUT
       response:
         proto: HTTP/2.0
@@ -42,16 +42,16 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 10 Dec 2024 16:22:35 GMT
+                - Tue, 12 May 2026 13:55:08 GMT
             Location:
-                - /tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731
+                - /tf-tests-scaleway-object-bucket-lifecycle-152264452529566496
             X-Amz-Id-2:
-                - txg50c5575c77f747c0a1bb-0067586acb
+                - txge6e4b9e67903436eaa48-006a03313c
             X-Amz-Request-Id:
-                - txg50c5575c77f747c0a1bb-0067586acb
+                - txge6e4b9e67903436eaa48-006a03313c
         status: 200 OK
         code: 200
-        duration: 425.009333ms
+        duration: 4.07021725s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -60,7 +60,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -69,18 +69,20 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 11711f70-ef77-4b95-83bf-5f6b463ce702
+                - b98a3b25-9aca-4228-9569-cf6ec43a96cf
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,Z,e
             X-Amz-Acl:
                 - private
+            X-Amz-Checksum-Crc32:
+                - AAAAAA==
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162235Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?acl=
+                - 20260512T135512Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?acl=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -95,14 +97,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 10 Dec 2024 16:22:36 GMT
+                - Tue, 12 May 2026 13:55:12 GMT
             X-Amz-Id-2:
-                - txg142d763989a04252ab48-0067586acc
+                - txg9ec651c97d73445e9c5a-006a033140
             X-Amz-Request-Id:
-                - txg142d763989a04252ab48-0067586acc
+                - txg9ec651c97d73445e9c5a-006a033140
         status: 200 OK
         code: 200
-        duration: 38.97675ms
+        duration: 152.673833ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -111,29 +113,29 @@ interactions:
         content_length: 303
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
-        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>30</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></LifecycleConfiguration>
+        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></LifecycleConfiguration>
         form: {}
         headers:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 2295ad74-9a39-4c87-baf8-ca47c6f6d636
+                - 427d9555-725b-4476-86da-e09ce53f99cd
             Amz-Sdk-Request:
                 - attempt=1; max=3
-            Content-Md5:
-                - LlQ8ZaZi/ACKYEQx3dDLPg==
             Content-Type:
                 - application/xml
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,Z,e
+            X-Amz-Checksum-Crc32:
+                - PjCcoA==
             X-Amz-Content-Sha256:
-                - 9b46c25d8077b9145b6fbb5c6ad09be8defd33ee8323ce63b7d3af82564f1398
+                - 13feec03c398f242f302d24e62c26ce8c47f46e3921d2bf7a84ca9914cd3488a
             X-Amz-Date:
-                - 20241210T162236Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T135512Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -148,14 +150,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 10 Dec 2024 16:22:36 GMT
+                - Tue, 12 May 2026 13:55:12 GMT
             X-Amz-Id-2:
-                - txgef063097c502440aa637-0067586acc
+                - txg89ad8558f3924d6cb58a-006a033140
             X-Amz-Request-Id:
-                - txgef063097c502440aa637-0067586acc
+                - txg89ad8558f3924d6cb58a-006a033140
         status: 200 OK
         code: 200
-        duration: 66.104208ms
+        duration: 157.34225ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -164,7 +166,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -173,16 +175,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d129a949-6340-41be-8ea7-494d073685e7
+                - d49ec74d-e2ba-4c4b-9f64-4e703ecdedac
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162236Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?acl=
+                - 20260512T135512Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -194,21 +196,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
                 - "698"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:36 GMT
+                - Tue, 12 May 2026 13:55:12 GMT
             X-Amz-Id-2:
-                - txg424092937a6340e392a0-0067586acc
+                - txgb0d15435ffef45b9841a-006a033140
             X-Amz-Request-Id:
-                - txg424092937a6340e392a0-0067586acc
+                - txgb0d15435ffef45b9841a-006a033140
         status: 200 OK
         code: 200
-        duration: 25.337208ms
+        duration: 62.504084ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -217,7 +219,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -226,16 +228,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 379eda31-d4ea-4220-be1a-26af4be88c7b
+                - 5a4f97cb-edbd-423e-b835-8af1c3489f10
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162236Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260512T135512Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -243,23 +245,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 330
+        content_length: 329
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgd0bb09dc8cf1412fbb88-0067586acc</RequestId><HostId>txgd0bb09dc8cf1412fbb88-0067586acc</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txga9daa465b4b34c4eac9e-006a033140</RequestId><HostId>txga9daa465b4b34c4eac9e-006a033140</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
         headers:
             Content-Length:
-                - "330"
+                - "329"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:36 GMT
+                - Tue, 12 May 2026 13:55:12 GMT
             X-Amz-Id-2:
-                - txgd0bb09dc8cf1412fbb88-0067586acc
+                - txga9daa465b4b34c4eac9e-006a033140
             X-Amz-Request-Id:
-                - txgd0bb09dc8cf1412fbb88-0067586acc
+                - txga9daa465b4b34c4eac9e-006a033140
         status: 404 Not Found
         code: 404
-        duration: 25.871792ms
+        duration: 57.964334ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -268,7 +270,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -277,16 +279,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - bf6ed70a-07f7-402b-ae75-1cce4df133f8
+                - d33eff1f-b090-43f2-a480-a22faa06b429
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162236Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/
+                - 20260512T135512Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -294,25 +296,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 287
+        content_length: 286
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "287"
+                - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:36 GMT
+                - Tue, 12 May 2026 13:55:12 GMT
             X-Amz-Id-2:
-                - txg68d6389ac08241f6902e-0067586acc
+                - txgaf9e0935b373468d937f-006a033140
             X-Amz-Request-Id:
-                - txg68d6389ac08241f6902e-0067586acc
+                - txgaf9e0935b373468d937f-006a033140
         status: 200 OK
         code: 200
-        duration: 40.515167ms
+        duration: 94.300833ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -321,7 +323,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -330,16 +332,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5edb6034-e4af-4ee3-8459-7c09c9b0796d
+                - 2b104eac-ae72-411c-9588-748006adf98f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162236Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?tagging=
+                - 20260512T135512Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -347,23 +349,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 361
+        content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg49c2e58b65f440668c10-0067586acc</RequestId><HostId>txg49c2e58b65f440668c10-0067586acc</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg097a7a68391542ffb57a-006a033140</RequestId><HostId>txg097a7a68391542ffb57a-006a033140</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</BucketName></Error>
         headers:
             Content-Length:
-                - "361"
+                - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:36 GMT
+                - Tue, 12 May 2026 13:55:12 GMT
             X-Amz-Id-2:
-                - txg49c2e58b65f440668c10-0067586acc
+                - txg097a7a68391542ffb57a-006a033140
             X-Amz-Request-Id:
-                - txg49c2e58b65f440668c10-0067586acc
+                - txg097a7a68391542ffb57a-006a033140
         status: 404 Not Found
         code: 404
-        duration: 27.544333ms
+        duration: 19.149ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -372,7 +374,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -381,16 +383,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b1092519-4dcc-4ecd-a1d8-0769ac26f615
+                - 38789bdb-6152-447f-9cb8-306a9346f394
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162236Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?cors=
+                - 20260512T135512Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -398,23 +400,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 298
+        content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg2d4465b40b9d40ed9015-0067586acc</RequestId><HostId>txg2d4465b40b9d40ed9015-0067586acc</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg113b0d67350b42b7aa56-006a033140</RequestId><HostId>txg113b0d67350b42b7aa56-006a033140</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
         headers:
             Content-Length:
-                - "298"
+                - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:36 GMT
+                - Tue, 12 May 2026 13:55:12 GMT
             X-Amz-Id-2:
-                - txg2d4465b40b9d40ed9015-0067586acc
+                - txg113b0d67350b42b7aa56-006a033140
             X-Amz-Request-Id:
-                - txg2d4465b40b9d40ed9015-0067586acc
+                - txg113b0d67350b42b7aa56-006a033140
         status: 404 Not Found
         code: 404
-        duration: 26.0855ms
+        duration: 28.97875ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -423,7 +425,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -432,16 +434,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b65e3a8a-f1c4-4829-ab41-dde5d5823535
+                - 9bd6b0c5-616b-4aa1-a15c-caba6baefd1d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162236Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?versioning=
+                - 20260512T135512Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -449,25 +451,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 155
+        content_length: 107
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Status></Status></VersioningConfiguration>
+            <VersioningConfiguration><Status></Status></VersioningConfiguration>
         headers:
             Content-Length:
-                - "155"
+                - "107"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:36 GMT
+                - Tue, 12 May 2026 13:55:12 GMT
             X-Amz-Id-2:
-                - txg50d9a3ce267c440ca71a-0067586acc
+                - txg35efc3fbeaea4e988f16-006a033140
             X-Amz-Request-Id:
-                - txg50d9a3ce267c440ca71a-0067586acc
+                - txg35efc3fbeaea4e988f16-006a033140
         status: 200 OK
         code: 200
-        duration: 28.00025ms
+        duration: 47.364666ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -476,7 +478,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -485,16 +487,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c25f55aa-44c8-4cb9-a21a-df3830c60e78
+                - 5846af6b-a218-478a-9cfd-0d9667c2e258
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162236Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T135512Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -502,25 +504,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 390
+        content_length: 276
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Days>30</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></LifecycleConfiguration>
+            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
-                - "390"
+                - "276"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:36 GMT
+                - Tue, 12 May 2026 13:55:12 GMT
             X-Amz-Id-2:
-                - txg96838fdbfab64dfcb24a-0067586acc
+                - txga4b0af80336c47b0a6ad-006a033140
             X-Amz-Request-Id:
-                - txg96838fdbfab64dfcb24a-0067586acc
+                - txga4b0af80336c47b0a6ad-006a033140
         status: 200 OK
         code: 200
-        duration: 26.79975ms
+        duration: 29.28225ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -529,7 +531,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -538,16 +540,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 022b26eb-29a7-4c99-8e66-a7b906169a3c
+                - 0de75463-9683-4d54-9b0c-c0ebb2f57cc6
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162236Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/
+                - 20260512T135513Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -562,16 +564,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:36 GMT
+                - Tue, 12 May 2026 13:55:13 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txg9c87126e96854498b6f2-0067586acc
+                - txg997c4ed92f7c4645bc78-006a033141
             X-Amz-Request-Id:
-                - txg9c87126e96854498b6f2-0067586acc
+                - txg997c4ed92f7c4645bc78-006a033141
         status: 200 OK
         code: 200
-        duration: 25.37025ms
+        duration: 61.348041ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -580,7 +582,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -589,16 +591,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 3cc4cb97-8fdc-48e4-be38-31234a9d200e
+                - 9d68c02d-259d-40cf-84df-94857398e4d8
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162236Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T135513Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -606,25 +608,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 390
+        content_length: 276
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Days>30</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></LifecycleConfiguration>
+            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
-                - "390"
+                - "276"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:36 GMT
+                - Tue, 12 May 2026 13:55:13 GMT
             X-Amz-Id-2:
-                - txg12fb62354eae4ce0a1c5-0067586acc
+                - txgcc4464392dc24039b046-006a033141
             X-Amz-Request-Id:
-                - txg12fb62354eae4ce0a1c5-0067586acc
+                - txgcc4464392dc24039b046-006a033141
         status: 200 OK
         code: 200
-        duration: 26.163417ms
+        duration: 70.12975ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -633,7 +635,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -642,16 +644,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 12da503c-03e3-4c0f-b86d-960a997a6760
+                - dcc1e2d8-4b6e-4a01-8ab5-3cafff3682e3
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162237Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?acl=
+                - 20260512T135513Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -663,21 +665,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
                 - "698"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:37 GMT
+                - Tue, 12 May 2026 13:55:13 GMT
             X-Amz-Id-2:
-                - txg37663a3978cf4a3b8920-0067586acd
+                - txg787781c502f94b769369-006a033141
             X-Amz-Request-Id:
-                - txg37663a3978cf4a3b8920-0067586acd
+                - txg787781c502f94b769369-006a033141
         status: 200 OK
         code: 200
-        duration: 27.883291ms
+        duration: 144.294291ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -686,7 +688,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -695,16 +697,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 1c46f5ab-45f2-40a6-8b8c-85c0f85e71dc
+                - 7e03b120-a8b3-46d8-b2d8-a364fbb38195
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162237Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260512T135513Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -712,23 +714,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 330
+        content_length: 329
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgd0ced5fd4228471d933e-0067586acd</RequestId><HostId>txgd0ced5fd4228471d933e-0067586acd</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg5a09d89fb80b4dbd9bc2-006a033141</RequestId><HostId>txg5a09d89fb80b4dbd9bc2-006a033141</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
         headers:
             Content-Length:
-                - "330"
+                - "329"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:37 GMT
+                - Tue, 12 May 2026 13:55:13 GMT
             X-Amz-Id-2:
-                - txgd0ced5fd4228471d933e-0067586acd
+                - txg5a09d89fb80b4dbd9bc2-006a033141
             X-Amz-Request-Id:
-                - txgd0ced5fd4228471d933e-0067586acd
+                - txg5a09d89fb80b4dbd9bc2-006a033141
         status: 404 Not Found
         code: 404
-        duration: 32.276208ms
+        duration: 37.304917ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -737,7 +739,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -746,16 +748,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5beb1590-9c51-4146-9a07-af0dfb23cacb
+                - e678dc6d-3e6b-4206-9f74-70210c8a09b9
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162237Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/
+                - 20260512T135513Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -763,25 +765,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 287
+        content_length: 286
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "287"
+                - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:37 GMT
+                - Tue, 12 May 2026 13:55:13 GMT
             X-Amz-Id-2:
-                - txga97d7dc514624664a2d9-0067586acd
+                - txg2e64fc761bc14c4c8e42-006a033141
             X-Amz-Request-Id:
-                - txga97d7dc514624664a2d9-0067586acd
+                - txg2e64fc761bc14c4c8e42-006a033141
         status: 200 OK
         code: 200
-        duration: 39.1005ms
+        duration: 101.267125ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -790,7 +792,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -799,16 +801,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d425aa39-271d-462e-86b3-642c931d198b
+                - 8663ad2c-9885-409e-9dc8-c97c5a6c7c26
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162237Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?tagging=
+                - 20260512T135513Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -816,23 +818,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 361
+        content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgcf20745cbc4945978297-0067586acd</RequestId><HostId>txgcf20745cbc4945978297-0067586acd</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg5ea3b2f30f4e410d9a8e-006a033141</RequestId><HostId>txg5ea3b2f30f4e410d9a8e-006a033141</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</BucketName></Error>
         headers:
             Content-Length:
-                - "361"
+                - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:37 GMT
+                - Tue, 12 May 2026 13:55:13 GMT
             X-Amz-Id-2:
-                - txgcf20745cbc4945978297-0067586acd
+                - txg5ea3b2f30f4e410d9a8e-006a033141
             X-Amz-Request-Id:
-                - txgcf20745cbc4945978297-0067586acd
+                - txg5ea3b2f30f4e410d9a8e-006a033141
         status: 404 Not Found
         code: 404
-        duration: 24.930583ms
+        duration: 46.388ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -841,7 +843,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -850,16 +852,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 738843e8-414e-4322-8114-f690e8d36d40
+                - 9e66ec0e-5ba1-44a3-9ff9-5e2cd6511936
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162237Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?cors=
+                - 20260512T135513Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -867,23 +869,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 298
+        content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg5e09214e8ee6438d9fbd-0067586acd</RequestId><HostId>txg5e09214e8ee6438d9fbd-0067586acd</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgcbc074546ad541ce98c3-006a033141</RequestId><HostId>txgcbc074546ad541ce98c3-006a033141</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
         headers:
             Content-Length:
-                - "298"
+                - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:37 GMT
+                - Tue, 12 May 2026 13:55:13 GMT
             X-Amz-Id-2:
-                - txg5e09214e8ee6438d9fbd-0067586acd
+                - txgcbc074546ad541ce98c3-006a033141
             X-Amz-Request-Id:
-                - txg5e09214e8ee6438d9fbd-0067586acd
+                - txgcbc074546ad541ce98c3-006a033141
         status: 404 Not Found
         code: 404
-        duration: 29.274125ms
+        duration: 32.945292ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -892,7 +894,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -901,16 +903,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 34282e6e-84b2-443a-a19a-f0cd85e230d3
+                - 901a1d99-0711-4155-b562-bf44083666de
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162237Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?versioning=
+                - 20260512T135513Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -918,25 +920,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 155
+        content_length: 107
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Status></Status></VersioningConfiguration>
+            <VersioningConfiguration><Status></Status></VersioningConfiguration>
         headers:
             Content-Length:
-                - "155"
+                - "107"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:38 GMT
+                - Tue, 12 May 2026 13:55:13 GMT
             X-Amz-Id-2:
-                - txg8da8da28e1df4024b80f-0067586ace
+                - txgd8d5215728924fae8428-006a033141
             X-Amz-Request-Id:
-                - txg8da8da28e1df4024b80f-0067586ace
+                - txgd8d5215728924fae8428-006a033141
         status: 200 OK
         code: 200
-        duration: 26.165583ms
+        duration: 103.211375ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -945,7 +947,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -954,16 +956,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c1c7c6f5-a39b-4b60-bab0-00e74b875481
+                - 33a1d5b9-7e2e-480a-ab87-19aff2ff1231
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162238Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T135513Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -971,25 +973,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 390
+        content_length: 276
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Days>30</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></LifecycleConfiguration>
+            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
-                - "390"
+                - "276"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:38 GMT
+                - Tue, 12 May 2026 13:55:13 GMT
             X-Amz-Id-2:
-                - txg530103e498a54a7abb13-0067586ace
+                - txg3c859ef92db341a89b2d-006a033141
             X-Amz-Request-Id:
-                - txg530103e498a54a7abb13-0067586ace
+                - txg3c859ef92db341a89b2d-006a033141
         status: 200 OK
         code: 200
-        duration: 24.834375ms
+        duration: 20.011167ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -998,7 +1000,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1007,16 +1009,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - dea25eeb-5c8a-49e3-af6a-990cad85d263
+                - c3a533d4-41e4-4640-9e57-3a3135bc5aed
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162239Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?acl=
+                - 20260512T135514Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1028,21 +1030,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
                 - "698"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:39 GMT
+                - Tue, 12 May 2026 13:55:14 GMT
             X-Amz-Id-2:
-                - txg508fc94f28b74f92ba17-0067586acf
+                - txg285bbd23b6d54dab9527-006a033142
             X-Amz-Request-Id:
-                - txg508fc94f28b74f92ba17-0067586acf
+                - txg285bbd23b6d54dab9527-006a033142
         status: 200 OK
         code: 200
-        duration: 26.884792ms
+        duration: 139.159541ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1051,7 +1053,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1060,16 +1062,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 3ad079dd-a2f2-414c-ae92-0467a71739f2
+                - 9f433b90-f51b-4336-b0de-4b80652e4e0a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162239Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260512T135514Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1077,23 +1079,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 330
+        content_length: 329
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg1d7017993dbc42e99457-0067586acf</RequestId><HostId>txg1d7017993dbc42e99457-0067586acf</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgb632e051c9ac4609bf64-006a033142</RequestId><HostId>txgb632e051c9ac4609bf64-006a033142</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
         headers:
             Content-Length:
-                - "330"
+                - "329"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:39 GMT
+                - Tue, 12 May 2026 13:55:14 GMT
             X-Amz-Id-2:
-                - txg1d7017993dbc42e99457-0067586acf
+                - txgb632e051c9ac4609bf64-006a033142
             X-Amz-Request-Id:
-                - txg1d7017993dbc42e99457-0067586acf
+                - txgb632e051c9ac4609bf64-006a033142
         status: 404 Not Found
         code: 404
-        duration: 17.113458ms
+        duration: 21.310209ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1102,7 +1104,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1111,16 +1113,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 92d02239-090d-42bc-9d7d-d6b487fee83b
+                - af624c3d-b6b1-40d7-9e3b-210b349108af
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162239Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/
+                - 20260512T135514Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -1128,25 +1130,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 287
+        content_length: 286
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "287"
+                - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:39 GMT
+                - Tue, 12 May 2026 13:55:14 GMT
             X-Amz-Id-2:
-                - txg30a6d338b2fc44b3a926-0067586acf
+                - txg82b68b73df604901ba84-006a033142
             X-Amz-Request-Id:
-                - txg30a6d338b2fc44b3a926-0067586acf
+                - txg82b68b73df604901ba84-006a033142
         status: 200 OK
         code: 200
-        duration: 86.820791ms
+        duration: 145.293875ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1155,7 +1157,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1164,16 +1166,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 3a121bdf-5cb8-4ff4-98c3-fa7bc0d6a5fa
+                - df01f45f-3546-466c-9211-6d68da0dc475
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162239Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?tagging=
+                - 20260512T135514Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1181,23 +1183,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 361
+        content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgaf2c7ec5fedd4138aa69-0067586acf</RequestId><HostId>txgaf2c7ec5fedd4138aa69-0067586acf</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg79b33180c8aa4207a05c-006a033142</RequestId><HostId>txg79b33180c8aa4207a05c-006a033142</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</BucketName></Error>
         headers:
             Content-Length:
-                - "361"
+                - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:39 GMT
+                - Tue, 12 May 2026 13:55:14 GMT
             X-Amz-Id-2:
-                - txgaf2c7ec5fedd4138aa69-0067586acf
+                - txg79b33180c8aa4207a05c-006a033142
             X-Amz-Request-Id:
-                - txgaf2c7ec5fedd4138aa69-0067586acf
+                - txg79b33180c8aa4207a05c-006a033142
         status: 404 Not Found
         code: 404
-        duration: 29.456ms
+        duration: 163.555916ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1206,7 +1208,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1215,16 +1217,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 01a4c559-1972-4224-8f0d-a1e5bab0adef
+                - 5a402656-d208-4ba7-b238-d25515c452d3
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162239Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?cors=
+                - 20260512T135514Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1232,23 +1234,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 298
+        content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg08e4a3f22bba43ddb8e8-0067586acf</RequestId><HostId>txg08e4a3f22bba43ddb8e8-0067586acf</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg0617794471f14083a707-006a033142</RequestId><HostId>txg0617794471f14083a707-006a033142</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
         headers:
             Content-Length:
-                - "298"
+                - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:39 GMT
+                - Tue, 12 May 2026 13:55:14 GMT
             X-Amz-Id-2:
-                - txg08e4a3f22bba43ddb8e8-0067586acf
+                - txg0617794471f14083a707-006a033142
             X-Amz-Request-Id:
-                - txg08e4a3f22bba43ddb8e8-0067586acf
+                - txg0617794471f14083a707-006a033142
         status: 404 Not Found
         code: 404
-        duration: 30.137292ms
+        duration: 50.645375ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1257,7 +1259,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1266,16 +1268,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7ce9af4b-0408-487d-b035-0e8c81bdb714
+                - 32746616-e06d-4de3-9c3d-030f1dba4682
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162239Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?versioning=
+                - 20260512T135514Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1283,25 +1285,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 155
+        content_length: 107
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Status></Status></VersioningConfiguration>
+            <VersioningConfiguration><Status></Status></VersioningConfiguration>
         headers:
             Content-Length:
-                - "155"
+                - "107"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:39 GMT
+                - Tue, 12 May 2026 13:55:14 GMT
             X-Amz-Id-2:
-                - txgf58cf447be304523bfa6-0067586acf
+                - txg3ace0365ba1a4e55b2ae-006a033142
             X-Amz-Request-Id:
-                - txgf58cf447be304523bfa6-0067586acf
+                - txg3ace0365ba1a4e55b2ae-006a033142
         status: 200 OK
         code: 200
-        duration: 26.424333ms
+        duration: 19.085166ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1310,7 +1312,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1319,16 +1321,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - bb54cb49-00b9-4a6b-9ffe-d08faa3a5bc7
+                - 9b62c1fc-bb63-4e15-b22d-4e8f112cadd6
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162239Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T135514Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1336,25 +1338,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 390
+        content_length: 276
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Days>30</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></LifecycleConfiguration>
+            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
-                - "390"
+                - "276"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:39 GMT
+                - Tue, 12 May 2026 13:55:14 GMT
             X-Amz-Id-2:
-                - txgb37af9f4699045668c87-0067586acf
+                - txg0ba38a08a5e44023af8e-006a033142
             X-Amz-Request-Id:
-                - txgb37af9f4699045668c87-0067586acf
+                - txg0ba38a08a5e44023af8e-006a033142
         status: 200 OK
         code: 200
-        duration: 25.023833ms
+        duration: 56.135458ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1363,7 +1365,7 @@ interactions:
         content_length: 306
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition></Rule></LifecycleConfiguration>
@@ -1372,20 +1374,20 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7697d102-b875-490c-820f-0c16eeed87d2
+                - fb9dad23-b875-47d0-9b6c-f93cd613f896
             Amz-Sdk-Request:
                 - attempt=1; max=3
-            Content-Md5:
-                - k04v/3ylJ2D61dgycOjeTg==
             Content-Type:
                 - application/xml
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,Z,e
+            X-Amz-Checksum-Crc32:
+                - 3OVKEQ==
             X-Amz-Content-Sha256:
                 - de1418e62a2680330e07a11a092b47b671d4ed12fe9fe6d9780b095b8f45d69c
             X-Amz-Date:
-                - 20241210T162241Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T135514Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -1400,14 +1402,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 10 Dec 2024 16:22:41 GMT
+                - Tue, 12 May 2026 13:55:14 GMT
             X-Amz-Id-2:
-                - txg2caf5b8bd4534b9e8b85-0067586ad1
+                - txg20c64d4721cd486a8d25-006a033142
             X-Amz-Request-Id:
-                - txg2caf5b8bd4534b9e8b85-0067586ad1
+                - txg20c64d4721cd486a8d25-006a033142
         status: 200 OK
         code: 200
-        duration: 42.492375ms
+        duration: 69.094583ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1416,7 +1418,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1425,16 +1427,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 75a35f03-a175-4f12-856c-56054aa96ed1
+                - 2621bfb9-cc7d-4acb-95d5-fea896353869
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162241Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?acl=
+                - 20260512T135514Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1446,21 +1448,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
                 - "698"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:41 GMT
+                - Tue, 12 May 2026 13:55:14 GMT
             X-Amz-Id-2:
-                - txg62d6b08c437a40a780fa-0067586ad1
+                - txg57b1e482a8f545549e29-006a033142
             X-Amz-Request-Id:
-                - txg62d6b08c437a40a780fa-0067586ad1
+                - txg57b1e482a8f545549e29-006a033142
         status: 200 OK
         code: 200
-        duration: 46.670417ms
+        duration: 73.743833ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1469,7 +1471,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1478,16 +1480,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5919f09f-ca56-42f6-b2e3-c6d9a67e87ee
+                - 871573cf-6762-40f6-9914-2a618e9aace9
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162241Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260512T135514Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1495,23 +1497,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 330
+        content_length: 329
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg1f378cc7617c438eaf6a-0067586ad1</RequestId><HostId>txg1f378cc7617c438eaf6a-0067586ad1</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgdc57b7410ebb45e3ad5d-006a033143</RequestId><HostId>txgdc57b7410ebb45e3ad5d-006a033143</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
         headers:
             Content-Length:
-                - "330"
+                - "329"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:41 GMT
+                - Tue, 12 May 2026 13:55:15 GMT
             X-Amz-Id-2:
-                - txg1f378cc7617c438eaf6a-0067586ad1
+                - txgdc57b7410ebb45e3ad5d-006a033143
             X-Amz-Request-Id:
-                - txg1f378cc7617c438eaf6a-0067586ad1
+                - txgdc57b7410ebb45e3ad5d-006a033143
         status: 404 Not Found
         code: 404
-        duration: 24.872875ms
+        duration: 64.884292ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1520,7 +1522,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1529,16 +1531,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7c82c05d-dbb6-444a-9d91-5699ca87b8f5
+                - 6668d67d-6465-4426-957f-635026f0e66c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162241Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/
+                - 20260512T135515Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -1546,25 +1548,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 287
+        content_length: 286
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "287"
+                - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:41 GMT
+                - Tue, 12 May 2026 13:55:15 GMT
             X-Amz-Id-2:
-                - txgbe29b78a19cd4b36aa7a-0067586ad1
+                - txg2d14f0394d9f4e78926b-006a033143
             X-Amz-Request-Id:
-                - txgbe29b78a19cd4b36aa7a-0067586ad1
+                - txg2d14f0394d9f4e78926b-006a033143
         status: 200 OK
         code: 200
-        duration: 16.670084ms
+        duration: 64.7735ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1573,7 +1575,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1582,16 +1584,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f050d56c-3931-47e0-a88b-8e08c9d5e6d0
+                - 4c505056-53d4-4ef8-a68d-ef53091d1b5a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162241Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?tagging=
+                - 20260512T135515Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1599,23 +1601,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 361
+        content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgdfc477c8b16844329908-0067586ad1</RequestId><HostId>txgdfc477c8b16844329908-0067586ad1</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg2a5642d5be884aa89af9-006a033143</RequestId><HostId>txg2a5642d5be884aa89af9-006a033143</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</BucketName></Error>
         headers:
             Content-Length:
-                - "361"
+                - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:41 GMT
+                - Tue, 12 May 2026 13:55:15 GMT
             X-Amz-Id-2:
-                - txgdfc477c8b16844329908-0067586ad1
+                - txg2a5642d5be884aa89af9-006a033143
             X-Amz-Request-Id:
-                - txgdfc477c8b16844329908-0067586ad1
+                - txg2a5642d5be884aa89af9-006a033143
         status: 404 Not Found
         code: 404
-        duration: 15.598333ms
+        duration: 33.246209ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1624,7 +1626,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1633,16 +1635,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f4f0a32f-be69-406f-bd2a-a7dd8f6699dd
+                - 0756056a-4dc2-499b-9d34-21afb8ad8697
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162241Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?cors=
+                - 20260512T135515Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1650,23 +1652,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 298
+        content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgb98ac86dcca648198773-0067586ad1</RequestId><HostId>txgb98ac86dcca648198773-0067586ad1</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg779c84fdf302412cb62d-006a033143</RequestId><HostId>txg779c84fdf302412cb62d-006a033143</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
         headers:
             Content-Length:
-                - "298"
+                - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:41 GMT
+                - Tue, 12 May 2026 13:55:15 GMT
             X-Amz-Id-2:
-                - txgb98ac86dcca648198773-0067586ad1
+                - txg779c84fdf302412cb62d-006a033143
             X-Amz-Request-Id:
-                - txgb98ac86dcca648198773-0067586ad1
+                - txg779c84fdf302412cb62d-006a033143
         status: 404 Not Found
         code: 404
-        duration: 26.2035ms
+        duration: 24.133292ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1675,7 +1677,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1684,16 +1686,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 08841182-ef02-482c-aaa0-86976f1e8299
+                - 0edf3725-00c2-45c3-a4a7-42d46b5b6ad0
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162241Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?versioning=
+                - 20260512T135515Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1701,25 +1703,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 155
+        content_length: 107
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Status></Status></VersioningConfiguration>
+            <VersioningConfiguration><Status></Status></VersioningConfiguration>
         headers:
             Content-Length:
-                - "155"
+                - "107"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:41 GMT
+                - Tue, 12 May 2026 13:55:15 GMT
             X-Amz-Id-2:
-                - txg026bccc87b394b2eac2e-0067586ad1
+                - txg4724c5ab0874440e8916-006a033143
             X-Amz-Request-Id:
-                - txg026bccc87b394b2eac2e-0067586ad1
+                - txg4724c5ab0874440e8916-006a033143
         status: 200 OK
         code: 200
-        duration: 25.405625ms
+        duration: 31.6515ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1728,7 +1730,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1737,16 +1739,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - cb45bc53-6d74-4d8e-842e-7a11f6288cea
+                - 7a392648-696f-447c-b5d3-e08ad6a1d2eb
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162241Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T135515Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1754,25 +1756,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 393
+        content_length: 279
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition></Rule></LifecycleConfiguration>
+            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
-                - "393"
+                - "279"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:41 GMT
+                - Tue, 12 May 2026 13:55:15 GMT
             X-Amz-Id-2:
-                - txgfc2e8da6d2c74287a899-0067586ad1
+                - txgbe9725ca19504289809c-006a033143
             X-Amz-Request-Id:
-                - txgfc2e8da6d2c74287a899-0067586ad1
+                - txgbe9725ca19504289809c-006a033143
         status: 200 OK
         code: 200
-        duration: 27.776667ms
+        duration: 39.535125ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1781,7 +1783,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1790,16 +1792,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 722d5ade-0236-43b0-be9a-6f9131cc0b73
+                - 003cde31-3830-42a9-bd3a-791b1a4068e8
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162241Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/
+                - 20260512T135515Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -1814,16 +1816,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:41 GMT
+                - Tue, 12 May 2026 13:55:15 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txg0d4486378b824d9a94a5-0067586ad1
+                - txgb0bfd0e3eb6c4ee88285-006a033143
             X-Amz-Request-Id:
-                - txg0d4486378b824d9a94a5-0067586ad1
+                - txgb0bfd0e3eb6c4ee88285-006a033143
         status: 200 OK
         code: 200
-        duration: 28.257875ms
+        duration: 57.452833ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1832,7 +1834,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1841,16 +1843,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 6ca44471-18bb-4148-8070-330b501e71d9
+                - 68873e01-3529-42c8-989e-f6b8c4886442
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162241Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T135515Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1858,25 +1860,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 393
+        content_length: 279
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition></Rule></LifecycleConfiguration>
+            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
-                - "393"
+                - "279"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:41 GMT
+                - Tue, 12 May 2026 13:55:15 GMT
             X-Amz-Id-2:
-                - txg79cb144ac2ac49cf9936-0067586ad1
+                - txg50addbad5e3d4d98a9d5-006a033143
             X-Amz-Request-Id:
-                - txg79cb144ac2ac49cf9936-0067586ad1
+                - txg50addbad5e3d4d98a9d5-006a033143
         status: 200 OK
         code: 200
-        duration: 26.979791ms
+        duration: 26.169916ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1885,7 +1887,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1894,16 +1896,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4ec26e97-2b6c-47e2-8570-e6531339705e
+                - 98bce07a-5c5d-4cce-9ec7-b82c70ea7eba
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162242Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?acl=
+                - 20260512T135515Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1915,21 +1917,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
                 - "698"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:42 GMT
+                - Tue, 12 May 2026 13:55:15 GMT
             X-Amz-Id-2:
-                - txge9ee01dbe3db4fc0bfa5-0067586ad2
+                - txg8043c1c1aab7441cb201-006a033143
             X-Amz-Request-Id:
-                - txge9ee01dbe3db4fc0bfa5-0067586ad2
+                - txg8043c1c1aab7441cb201-006a033143
         status: 200 OK
         code: 200
-        duration: 26.24775ms
+        duration: 48.389709ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1938,7 +1940,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1947,16 +1949,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c6ceae43-bbba-4910-9785-1dcaef4ddf79
+                - d7632aab-4c47-4444-9904-a8aae2696ba7
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162242Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260512T135515Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1964,23 +1966,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 330
+        content_length: 329
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg2a8a815c6f6c4064803d-0067586ad2</RequestId><HostId>txg2a8a815c6f6c4064803d-0067586ad2</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgfeda056c03ce4f23b569-006a033143</RequestId><HostId>txgfeda056c03ce4f23b569-006a033143</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
         headers:
             Content-Length:
-                - "330"
+                - "329"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:42 GMT
+                - Tue, 12 May 2026 13:55:15 GMT
             X-Amz-Id-2:
-                - txg2a8a815c6f6c4064803d-0067586ad2
+                - txgfeda056c03ce4f23b569-006a033143
             X-Amz-Request-Id:
-                - txg2a8a815c6f6c4064803d-0067586ad2
+                - txgfeda056c03ce4f23b569-006a033143
         status: 404 Not Found
         code: 404
-        duration: 26.961792ms
+        duration: 55.827333ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1989,7 +1991,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1998,16 +2000,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - a0ad26d6-c274-4263-950d-e8e6472e9377
+                - 886d074e-58b4-4125-94aa-21d0e49082c4
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162242Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/
+                - 20260512T135515Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -2015,25 +2017,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 287
+        content_length: 286
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "287"
+                - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:42 GMT
+                - Tue, 12 May 2026 13:55:15 GMT
             X-Amz-Id-2:
-                - txg7d9a91b1e75d42a98a94-0067586ad2
+                - txg81125a9b605f42209f5c-006a033143
             X-Amz-Request-Id:
-                - txg7d9a91b1e75d42a98a94-0067586ad2
+                - txg81125a9b605f42209f5c-006a033143
         status: 200 OK
         code: 200
-        duration: 130.704125ms
+        duration: 34.095833ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -2042,7 +2044,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2051,16 +2053,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ae18b3c5-55b1-4aa6-8157-b9718f3d8744
+                - 0dfd9786-e8bd-4171-92f7-66e70e1238a8
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162242Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?tagging=
+                - 20260512T135515Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2068,23 +2070,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 361
+        content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg94919a559bdd463c98d8-0067586ad2</RequestId><HostId>txg94919a559bdd463c98d8-0067586ad2</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg6da07cdf9aae445a98a3-006a033143</RequestId><HostId>txg6da07cdf9aae445a98a3-006a033143</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</BucketName></Error>
         headers:
             Content-Length:
-                - "361"
+                - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:42 GMT
+                - Tue, 12 May 2026 13:55:15 GMT
             X-Amz-Id-2:
-                - txg94919a559bdd463c98d8-0067586ad2
+                - txg6da07cdf9aae445a98a3-006a033143
             X-Amz-Request-Id:
-                - txg94919a559bdd463c98d8-0067586ad2
+                - txg6da07cdf9aae445a98a3-006a033143
         status: 404 Not Found
         code: 404
-        duration: 27.996583ms
+        duration: 29.990625ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -2093,7 +2095,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2102,16 +2104,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - abbe4852-b951-49fb-a319-418ba491298f
+                - 754156fc-55f9-4485-8030-a4fa42f94eda
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162242Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?cors=
+                - 20260512T135515Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2119,23 +2121,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 298
+        content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg619f9e9ff2bc4ea1b1b9-0067586ad3</RequestId><HostId>txg619f9e9ff2bc4ea1b1b9-0067586ad3</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg916e5a63b03247d3bafe-006a033143</RequestId><HostId>txg916e5a63b03247d3bafe-006a033143</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
         headers:
             Content-Length:
-                - "298"
+                - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:43 GMT
+                - Tue, 12 May 2026 13:55:15 GMT
             X-Amz-Id-2:
-                - txg619f9e9ff2bc4ea1b1b9-0067586ad3
+                - txg916e5a63b03247d3bafe-006a033143
             X-Amz-Request-Id:
-                - txg619f9e9ff2bc4ea1b1b9-0067586ad3
+                - txg916e5a63b03247d3bafe-006a033143
         status: 404 Not Found
         code: 404
-        duration: 25.544375ms
+        duration: 22.27375ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -2144,7 +2146,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2153,16 +2155,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5965d195-7014-420e-93a8-4fa479993686
+                - 59ce8466-0681-422e-8531-8a4da3f71617
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162243Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?versioning=
+                - 20260512T135515Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2170,25 +2172,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 155
+        content_length: 107
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Status></Status></VersioningConfiguration>
+            <VersioningConfiguration><Status></Status></VersioningConfiguration>
         headers:
             Content-Length:
-                - "155"
+                - "107"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:43 GMT
+                - Tue, 12 May 2026 13:55:15 GMT
             X-Amz-Id-2:
-                - txg5bcf307db60e4a9386e1-0067586ad3
+                - txgfce8d4c3639d49d1b842-006a033143
             X-Amz-Request-Id:
-                - txg5bcf307db60e4a9386e1-0067586ad3
+                - txgfce8d4c3639d49d1b842-006a033143
         status: 200 OK
         code: 200
-        duration: 25.736125ms
+        duration: 60.574792ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -2197,7 +2199,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2206,16 +2208,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 46cba0ec-49ee-4c70-bb4c-ca621191bad6
+                - 1f18b9d1-c741-4c54-af8b-0e3b5d42f8aa
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162243Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T135515Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2223,25 +2225,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 393
+        content_length: 279
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition></Rule></LifecycleConfiguration>
+            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
-                - "393"
+                - "279"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:43 GMT
+                - Tue, 12 May 2026 13:55:16 GMT
             X-Amz-Id-2:
-                - txgccbd190a036c4b4e8831-0067586ad3
+                - txgabda9d76ba4c46f488a4-006a033144
             X-Amz-Request-Id:
-                - txgccbd190a036c4b4e8831-0067586ad3
+                - txgabda9d76ba4c46f488a4-006a033144
         status: 200 OK
         code: 200
-        duration: 24.990458ms
+        duration: 58.660625ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -2250,7 +2252,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2259,16 +2261,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 3baf0183-98c0-4a85-b169-d17a6db29b3f
+                - 9222afac-ba9a-4c32-b519-4bdd5dbed1dc
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162244Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?acl=
+                - 20260512T135516Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2280,21 +2282,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
                 - "698"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:44 GMT
+                - Tue, 12 May 2026 13:55:16 GMT
             X-Amz-Id-2:
-                - txgf990d368d414457190d6-0067586ad4
+                - txg86e76ad194024421b8b2-006a033144
             X-Amz-Request-Id:
-                - txgf990d368d414457190d6-0067586ad4
+                - txg86e76ad194024421b8b2-006a033144
         status: 200 OK
         code: 200
-        duration: 26.507291ms
+        duration: 80.913291ms
     - id: 44
       request:
         proto: HTTP/1.1
@@ -2303,7 +2305,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2312,16 +2314,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 21b1726b-5033-4799-878e-69e622d5d93e
+                - bb19eb51-63c9-4064-b8f4-1fbea293dcd3
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162244Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260512T135516Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2329,23 +2331,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 330
+        content_length: 329
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg082cc3ed38fe4507b780-0067586ad4</RequestId><HostId>txg082cc3ed38fe4507b780-0067586ad4</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg0edd3ab24f5a404db98d-006a033144</RequestId><HostId>txg0edd3ab24f5a404db98d-006a033144</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
         headers:
             Content-Length:
-                - "330"
+                - "329"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:44 GMT
+                - Tue, 12 May 2026 13:55:16 GMT
             X-Amz-Id-2:
-                - txg082cc3ed38fe4507b780-0067586ad4
+                - txg0edd3ab24f5a404db98d-006a033144
             X-Amz-Request-Id:
-                - txg082cc3ed38fe4507b780-0067586ad4
+                - txg0edd3ab24f5a404db98d-006a033144
         status: 404 Not Found
         code: 404
-        duration: 26.026375ms
+        duration: 96.670042ms
     - id: 45
       request:
         proto: HTTP/1.1
@@ -2354,7 +2356,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2363,16 +2365,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 401329a8-9536-4998-9019-3028c7857490
+                - 4b383b44-f236-4e54-8855-62519a2d5f0f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162244Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/
+                - 20260512T135516Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -2380,25 +2382,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 287
+        content_length: 286
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "287"
+                - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:44 GMT
+                - Tue, 12 May 2026 13:55:16 GMT
             X-Amz-Id-2:
-                - txge387b41745444d40a2cf-0067586ad4
+                - txgb3eb63f6065b425b9c33-006a033144
             X-Amz-Request-Id:
-                - txge387b41745444d40a2cf-0067586ad4
+                - txgb3eb63f6065b425b9c33-006a033144
         status: 200 OK
         code: 200
-        duration: 32.166375ms
+        duration: 47.771ms
     - id: 46
       request:
         proto: HTTP/1.1
@@ -2407,7 +2409,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2416,16 +2418,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - a342a0ab-c0bc-403c-bf60-3ad6cefa60e8
+                - 9c166ecd-5e81-42f3-b2aa-90ebdba9def7
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162244Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?tagging=
+                - 20260512T135516Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2433,23 +2435,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 361
+        content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg6bfeae2a4fca4e3e9069-0067586ad4</RequestId><HostId>txg6bfeae2a4fca4e3e9069-0067586ad4</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgf27359f53ba84103a9af-006a033144</RequestId><HostId>txgf27359f53ba84103a9af-006a033144</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</BucketName></Error>
         headers:
             Content-Length:
-                - "361"
+                - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:44 GMT
+                - Tue, 12 May 2026 13:55:16 GMT
             X-Amz-Id-2:
-                - txg6bfeae2a4fca4e3e9069-0067586ad4
+                - txgf27359f53ba84103a9af-006a033144
             X-Amz-Request-Id:
-                - txg6bfeae2a4fca4e3e9069-0067586ad4
+                - txgf27359f53ba84103a9af-006a033144
         status: 404 Not Found
         code: 404
-        duration: 26.199125ms
+        duration: 20.249625ms
     - id: 47
       request:
         proto: HTTP/1.1
@@ -2458,7 +2460,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2467,16 +2469,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5508f1bc-d1df-4803-8593-c831a22cd765
+                - e667c8e5-a063-4d2b-85a5-4ec50ffc6047
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162244Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?cors=
+                - 20260512T135516Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2484,23 +2486,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 298
+        content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg1885aa63dc4e4cc4819d-0067586ad4</RequestId><HostId>txg1885aa63dc4e4cc4819d-0067586ad4</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg228f69e5217846279860-006a033144</RequestId><HostId>txg228f69e5217846279860-006a033144</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
         headers:
             Content-Length:
-                - "298"
+                - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:44 GMT
+                - Tue, 12 May 2026 13:55:16 GMT
             X-Amz-Id-2:
-                - txg1885aa63dc4e4cc4819d-0067586ad4
+                - txg228f69e5217846279860-006a033144
             X-Amz-Request-Id:
-                - txg1885aa63dc4e4cc4819d-0067586ad4
+                - txg228f69e5217846279860-006a033144
         status: 404 Not Found
         code: 404
-        duration: 28.154417ms
+        duration: 24.762166ms
     - id: 48
       request:
         proto: HTTP/1.1
@@ -2509,7 +2511,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2518,16 +2520,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 2c044dd6-59f2-4348-86a9-94c35f5e0dd1
+                - a079cbab-bac9-4214-b000-2cdfeede01f2
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162244Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?versioning=
+                - 20260512T135516Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2535,25 +2537,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 155
+        content_length: 107
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Status></Status></VersioningConfiguration>
+            <VersioningConfiguration><Status></Status></VersioningConfiguration>
         headers:
             Content-Length:
-                - "155"
+                - "107"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:44 GMT
+                - Tue, 12 May 2026 13:55:16 GMT
             X-Amz-Id-2:
-                - txg1c54b9da04c146d293b2-0067586ad4
+                - txg8d8d9da541b74cb1ac65-006a033144
             X-Amz-Request-Id:
-                - txg1c54b9da04c146d293b2-0067586ad4
+                - txg8d8d9da541b74cb1ac65-006a033144
         status: 200 OK
         code: 200
-        duration: 31.839791ms
+        duration: 22.489208ms
     - id: 49
       request:
         proto: HTTP/1.1
@@ -2562,7 +2564,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2571,16 +2573,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 687b2556-42e3-487c-a0fe-24af9f0eb180
+                - 2feaea92-fdb5-4213-83ec-2714003212d0
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162244Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T135516Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2588,56 +2590,56 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 393
+        content_length: 279
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition></Rule></LifecycleConfiguration>
+            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
-                - "393"
+                - "279"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:44 GMT
+                - Tue, 12 May 2026 13:55:16 GMT
             X-Amz-Id-2:
-                - txgbe7ef2e404af469caa18-0067586ad4
+                - txgb96efba23cb54285a0e1-006a033144
             X-Amz-Request-Id:
-                - txgbe7ef2e404af469caa18-0067586ad4
+                - txgb96efba23cb54285a0e1-006a033144
         status: 200 OK
         code: 200
-        duration: 26.146416ms
+        duration: 74.399916ms
     - id: 50
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 1128
+        content_length: 1132
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
-        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>1</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>1</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></LifecycleConfiguration>
+        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></LifecycleConfiguration>
         form: {}
         headers:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f36d3f07-958c-4c55-a547-06b95aacbd8b
+                - a6fe50e4-d449-447f-8566-6c0b5f870ebc
             Amz-Sdk-Request:
                 - attempt=1; max=3
-            Content-Md5:
-                - 6u0bJI7/DWz9jGskl8JwXA==
             Content-Type:
                 - application/xml
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,Z,e
+            X-Amz-Checksum-Crc32:
+                - Zsh9Ug==
             X-Amz-Content-Sha256:
-                - a6a0776a6d1b68d776c49aa00042cdfe22dfc8ad54fbb8ca980403d5809ac6db
+                - 5f9243f4f931bea9c2119f4e79c617a5c5220b643a54f2c4e442edaf30ca867a
             X-Amz-Date:
-                - 20241210T162245Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T135516Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -2652,14 +2654,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 10 Dec 2024 16:22:45 GMT
+                - Tue, 12 May 2026 13:55:16 GMT
             X-Amz-Id-2:
-                - txg826b5c32bc28436c85ef-0067586ad5
+                - txgb34b4c1e7bb64e8782c0-006a033144
             X-Amz-Request-Id:
-                - txg826b5c32bc28436c85ef-0067586ad5
+                - txgb34b4c1e7bb64e8782c0-006a033144
         status: 200 OK
         code: 200
-        duration: 93.230708ms
+        duration: 196.586ms
     - id: 51
       request:
         proto: HTTP/1.1
@@ -2668,7 +2670,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2677,16 +2679,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 59728888-14db-46fd-a76a-037579f117c9
+                - b5452d9a-35f9-4e45-81f4-172b238aac1f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162245Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?acl=
+                - 20260512T135516Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2698,21 +2700,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
                 - "698"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:45 GMT
+                - Tue, 12 May 2026 13:55:17 GMT
             X-Amz-Id-2:
-                - txg3b67eb2114724e058b42-0067586ad5
+                - txg566a3cc597724223a5f4-006a033145
             X-Amz-Request-Id:
-                - txg3b67eb2114724e058b42-0067586ad5
+                - txg566a3cc597724223a5f4-006a033145
         status: 200 OK
         code: 200
-        duration: 15.791333ms
+        duration: 157.720291ms
     - id: 52
       request:
         proto: HTTP/1.1
@@ -2721,7 +2723,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2730,16 +2732,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5d891fdd-b2e3-4441-8631-28a9329c4c61
+                - 40b22a6f-b1ec-474a-8570-fe074a041f61
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162245Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260512T135517Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2747,23 +2749,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 330
+        content_length: 329
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg4ca9a48d4b5d4be79021-0067586ad5</RequestId><HostId>txg4ca9a48d4b5d4be79021-0067586ad5</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgbd6ce5853cca4d179a38-006a033145</RequestId><HostId>txgbd6ce5853cca4d179a38-006a033145</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
         headers:
             Content-Length:
-                - "330"
+                - "329"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:45 GMT
+                - Tue, 12 May 2026 13:55:17 GMT
             X-Amz-Id-2:
-                - txg4ca9a48d4b5d4be79021-0067586ad5
+                - txgbd6ce5853cca4d179a38-006a033145
             X-Amz-Request-Id:
-                - txg4ca9a48d4b5d4be79021-0067586ad5
+                - txgbd6ce5853cca4d179a38-006a033145
         status: 404 Not Found
         code: 404
-        duration: 27.32075ms
+        duration: 34.130542ms
     - id: 53
       request:
         proto: HTTP/1.1
@@ -2772,7 +2774,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2781,16 +2783,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - a06fb9dc-7269-4651-9d21-dacfef94dcfe
+                - 30839bba-f56c-4237-a493-37873f7271a3
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162245Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/
+                - 20260512T135517Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -2798,25 +2800,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 287
+        content_length: 286
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "287"
+                - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:45 GMT
+                - Tue, 12 May 2026 13:55:17 GMT
             X-Amz-Id-2:
-                - txg4e26dfe7415d4f4f997b-0067586ad5
+                - txgc2a1ee687edd40779c84-006a033145
             X-Amz-Request-Id:
-                - txg4e26dfe7415d4f4f997b-0067586ad5
+                - txgc2a1ee687edd40779c84-006a033145
         status: 200 OK
         code: 200
-        duration: 37.583292ms
+        duration: 106.002833ms
     - id: 54
       request:
         proto: HTTP/1.1
@@ -2825,7 +2827,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2834,16 +2836,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 47f3501e-8bb7-4eeb-b0a0-1a65d3211ea0
+                - 9d980ad0-02a5-402a-badf-654891022e4c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162245Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?tagging=
+                - 20260512T135517Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2851,23 +2853,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 361
+        content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg0ae5fb6f0dc7454987d1-0067586ad5</RequestId><HostId>txg0ae5fb6f0dc7454987d1-0067586ad5</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgd51cac43f22e48feb999-006a033145</RequestId><HostId>txgd51cac43f22e48feb999-006a033145</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</BucketName></Error>
         headers:
             Content-Length:
-                - "361"
+                - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:45 GMT
+                - Tue, 12 May 2026 13:55:17 GMT
             X-Amz-Id-2:
-                - txg0ae5fb6f0dc7454987d1-0067586ad5
+                - txgd51cac43f22e48feb999-006a033145
             X-Amz-Request-Id:
-                - txg0ae5fb6f0dc7454987d1-0067586ad5
+                - txgd51cac43f22e48feb999-006a033145
         status: 404 Not Found
         code: 404
-        duration: 16.494458ms
+        duration: 96.430042ms
     - id: 55
       request:
         proto: HTTP/1.1
@@ -2876,7 +2878,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2885,16 +2887,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 80d560c4-3a72-443f-9adf-744d2ffcf4c1
+                - 87a23b8f-a183-4c3d-8b86-2c33f5d6a37e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162245Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?cors=
+                - 20260512T135517Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2902,23 +2904,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 298
+        content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgbf7b5a15a91549668669-0067586ad5</RequestId><HostId>txgbf7b5a15a91549668669-0067586ad5</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg50ad68d14e054ad5a9c5-006a033145</RequestId><HostId>txg50ad68d14e054ad5a9c5-006a033145</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
         headers:
             Content-Length:
-                - "298"
+                - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:45 GMT
+                - Tue, 12 May 2026 13:55:17 GMT
             X-Amz-Id-2:
-                - txgbf7b5a15a91549668669-0067586ad5
+                - txg50ad68d14e054ad5a9c5-006a033145
             X-Amz-Request-Id:
-                - txgbf7b5a15a91549668669-0067586ad5
+                - txg50ad68d14e054ad5a9c5-006a033145
         status: 404 Not Found
         code: 404
-        duration: 14.943167ms
+        duration: 53.2495ms
     - id: 56
       request:
         proto: HTTP/1.1
@@ -2927,7 +2929,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2936,16 +2938,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ba36fae5-7ebd-479d-bbb8-9a767faecb3b
+                - cf33ac62-450a-4553-b45a-be5a2cf17508
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162245Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?versioning=
+                - 20260512T135517Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2953,25 +2955,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 155
+        content_length: 107
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Status></Status></VersioningConfiguration>
+            <VersioningConfiguration><Status></Status></VersioningConfiguration>
         headers:
             Content-Length:
-                - "155"
+                - "107"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:45 GMT
+                - Tue, 12 May 2026 13:55:17 GMT
             X-Amz-Id-2:
-                - txg539d9f68f2cc42adb589-0067586ad5
+                - txg1b69a51ca7164ef39bbe-006a033145
             X-Amz-Request-Id:
-                - txg539d9f68f2cc42adb589-0067586ad5
+                - txg1b69a51ca7164ef39bbe-006a033145
         status: 200 OK
         code: 200
-        duration: 47.819291ms
+        duration: 63.094958ms
     - id: 57
       request:
         proto: HTTP/1.1
@@ -2980,7 +2982,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2989,16 +2991,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 32bc5e2a-91ba-45c6-983a-28fdb2d1bad0
+                - 487452bf-b766-4537-ad78-c2253cf755e6
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162245Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T135517Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3006,25 +3008,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1311
+        content_length: 1105
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Days>1</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Days>1</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></LifecycleConfiguration>
+            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
-                - "1311"
+                - "1105"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:45 GMT
+                - Tue, 12 May 2026 13:55:17 GMT
             X-Amz-Id-2:
-                - txg94bce75d161f4d098a2c-0067586ad5
+                - txg23266f7d9729481db36f-006a033145
             X-Amz-Request-Id:
-                - txg94bce75d161f4d098a2c-0067586ad5
+                - txg23266f7d9729481db36f-006a033145
         status: 200 OK
         code: 200
-        duration: 26.819875ms
+        duration: 47.405542ms
     - id: 58
       request:
         proto: HTTP/1.1
@@ -3033,7 +3035,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3042,16 +3044,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ae627fd7-ce1b-40e2-bfc7-7364e97daca8
+                - 272a5ec8-7448-485e-8367-5a0b5d75a036
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162246Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/
+                - 20260512T135517Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -3066,16 +3068,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:46 GMT
+                - Tue, 12 May 2026 13:55:17 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txgdf7b6123b27e471ca5a5-0067586ad6
+                - txg1aea7b3c182a4f8e82f7-006a033145
             X-Amz-Request-Id:
-                - txgdf7b6123b27e471ca5a5-0067586ad6
+                - txg1aea7b3c182a4f8e82f7-006a033145
         status: 200 OK
         code: 200
-        duration: 28.529541ms
+        duration: 19.99825ms
     - id: 59
       request:
         proto: HTTP/1.1
@@ -3084,7 +3086,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3093,16 +3095,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 8fce136a-9c7f-40a2-b56e-c9c9b89ee2be
+                - f1b52670-1541-4897-b42a-ad3dee706717
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162246Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T135517Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3110,25 +3112,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1311
+        content_length: 1105
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Days>1</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Days>1</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></LifecycleConfiguration>
+            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
-                - "1311"
+                - "1105"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:46 GMT
+                - Tue, 12 May 2026 13:55:17 GMT
             X-Amz-Id-2:
-                - txgba910a0fbf8b4262bf4d-0067586ad6
+                - txgc8404fb3407e460dbe11-006a033145
             X-Amz-Request-Id:
-                - txgba910a0fbf8b4262bf4d-0067586ad6
+                - txgc8404fb3407e460dbe11-006a033145
         status: 200 OK
         code: 200
-        duration: 15.086542ms
+        duration: 56.21525ms
     - id: 60
       request:
         proto: HTTP/1.1
@@ -3137,7 +3139,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3146,16 +3148,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 6f7899ee-ad6e-4f73-8319-293bfefe5c78
+                - fbdb792a-d90d-4b38-9cf0-03295bd4870b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162247Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?acl=
+                - 20260512T135517Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3167,21 +3169,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
                 - "698"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:47 GMT
+                - Tue, 12 May 2026 13:55:18 GMT
             X-Amz-Id-2:
-                - txg9a9117965909419b8a86-0067586ad7
+                - txgd712bdd2ba5148ab8148-006a033146
             X-Amz-Request-Id:
-                - txg9a9117965909419b8a86-0067586ad7
+                - txgd712bdd2ba5148ab8148-006a033146
         status: 200 OK
         code: 200
-        duration: 27.961958ms
+        duration: 72.101042ms
     - id: 61
       request:
         proto: HTTP/1.1
@@ -3190,7 +3192,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3199,16 +3201,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 48c69a1d-9cc3-4d3b-b29a-ca731b627f8e
+                - 5ff8bc03-bb1c-4bfb-97c4-1fa56e7d4ba9
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162247Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260512T135518Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3216,23 +3218,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 330
+        content_length: 329
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txga4712362ddbf430f9da9-0067586ad7</RequestId><HostId>txga4712362ddbf430f9da9-0067586ad7</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg14ce471be0094e93b7e1-006a033146</RequestId><HostId>txg14ce471be0094e93b7e1-006a033146</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
         headers:
             Content-Length:
-                - "330"
+                - "329"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:47 GMT
+                - Tue, 12 May 2026 13:55:18 GMT
             X-Amz-Id-2:
-                - txga4712362ddbf430f9da9-0067586ad7
+                - txg14ce471be0094e93b7e1-006a033146
             X-Amz-Request-Id:
-                - txga4712362ddbf430f9da9-0067586ad7
+                - txg14ce471be0094e93b7e1-006a033146
         status: 404 Not Found
         code: 404
-        duration: 19.251333ms
+        duration: 104.584875ms
     - id: 62
       request:
         proto: HTTP/1.1
@@ -3241,7 +3243,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3250,16 +3252,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - bb6cc075-bd5f-46ab-80bc-9dd755bde875
+                - 1d78632d-ea37-414f-8614-eb03d2c765a0
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162247Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/
+                - 20260512T135518Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -3267,25 +3269,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 287
+        content_length: 286
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "287"
+                - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:47 GMT
+                - Tue, 12 May 2026 13:55:18 GMT
             X-Amz-Id-2:
-                - txgf192fc7fa5574419b0d6-0067586ad7
+                - txg3ae0feb5131e411783a4-006a033146
             X-Amz-Request-Id:
-                - txgf192fc7fa5574419b0d6-0067586ad7
+                - txg3ae0feb5131e411783a4-006a033146
         status: 200 OK
         code: 200
-        duration: 29.081792ms
+        duration: 34.824416ms
     - id: 63
       request:
         proto: HTTP/1.1
@@ -3294,7 +3296,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3303,16 +3305,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 80a4550b-3fd2-4d1d-814e-afc48079652b
+                - 505993bc-2a8c-46c2-a345-37b8d31bcc26
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162247Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?tagging=
+                - 20260512T135518Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3320,23 +3322,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 361
+        content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgccad67b21ce94b80947c-0067586ad7</RequestId><HostId>txgccad67b21ce94b80947c-0067586ad7</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgdd6ada5a19c34f09a253-006a033146</RequestId><HostId>txgdd6ada5a19c34f09a253-006a033146</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</BucketName></Error>
         headers:
             Content-Length:
-                - "361"
+                - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:47 GMT
+                - Tue, 12 May 2026 13:55:18 GMT
             X-Amz-Id-2:
-                - txgccad67b21ce94b80947c-0067586ad7
+                - txgdd6ada5a19c34f09a253-006a033146
             X-Amz-Request-Id:
-                - txgccad67b21ce94b80947c-0067586ad7
+                - txgdd6ada5a19c34f09a253-006a033146
         status: 404 Not Found
         code: 404
-        duration: 32.888334ms
+        duration: 35.96575ms
     - id: 64
       request:
         proto: HTTP/1.1
@@ -3345,7 +3347,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3354,16 +3356,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - cd3b3a6e-7a58-4d5f-be67-31cab10a0972
+                - f8003b54-152d-4b2a-9c03-38027e7162e9
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162247Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?cors=
+                - 20260512T135518Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3371,23 +3373,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 298
+        content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgdec734ba9fac40b7aa55-0067586ad7</RequestId><HostId>txgdec734ba9fac40b7aa55-0067586ad7</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txga61cb20c37ab448ab0cc-006a033146</RequestId><HostId>txga61cb20c37ab448ab0cc-006a033146</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
         headers:
             Content-Length:
-                - "298"
+                - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:47 GMT
+                - Tue, 12 May 2026 13:55:18 GMT
             X-Amz-Id-2:
-                - txgdec734ba9fac40b7aa55-0067586ad7
+                - txga61cb20c37ab448ab0cc-006a033146
             X-Amz-Request-Id:
-                - txgdec734ba9fac40b7aa55-0067586ad7
+                - txga61cb20c37ab448ab0cc-006a033146
         status: 404 Not Found
         code: 404
-        duration: 41.016709ms
+        duration: 26.490458ms
     - id: 65
       request:
         proto: HTTP/1.1
@@ -3396,7 +3398,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3405,16 +3407,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 3d315394-5fde-41b5-a456-f40919654944
+                - c59224a2-f54b-4dbe-a098-a56217cc5996
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162247Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?versioning=
+                - 20260512T135518Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3422,25 +3424,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 155
+        content_length: 107
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Status></Status></VersioningConfiguration>
+            <VersioningConfiguration><Status></Status></VersioningConfiguration>
         headers:
             Content-Length:
-                - "155"
+                - "107"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:47 GMT
+                - Tue, 12 May 2026 13:55:18 GMT
             X-Amz-Id-2:
-                - txg0ace367daebd4c69a92b-0067586ad7
+                - txgd07006175c234edba755-006a033146
             X-Amz-Request-Id:
-                - txg0ace367daebd4c69a92b-0067586ad7
+                - txgd07006175c234edba755-006a033146
         status: 200 OK
         code: 200
-        duration: 26.180375ms
+        duration: 19.544375ms
     - id: 66
       request:
         proto: HTTP/1.1
@@ -3449,7 +3451,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3458,16 +3460,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - a098f1db-dc58-439c-8e90-9e734c1d296b
+                - bf81a3ff-1ba8-4870-889c-648ad06337fd
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162247Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T135518Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3475,25 +3477,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1311
+        content_length: 1105
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Days>1</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Days>1</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></LifecycleConfiguration>
+            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
-                - "1311"
+                - "1105"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:47 GMT
+                - Tue, 12 May 2026 13:55:18 GMT
             X-Amz-Id-2:
-                - txgd687f9f4d63b4dd0b7cf-0067586ad7
+                - txg15596aa7cada4dada905-006a033146
             X-Amz-Request-Id:
-                - txgd687f9f4d63b4dd0b7cf-0067586ad7
+                - txg15596aa7cada4dada905-006a033146
         status: 200 OK
         code: 200
-        duration: 32.415875ms
+        duration: 22.281875ms
     - id: 67
       request:
         proto: HTTP/1.1
@@ -3502,7 +3504,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3511,16 +3513,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 501835e7-b0ac-4289-a432-2775a4e00b3d
+                - a7377838-2518-4924-a6c2-f5d06955500b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162248Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?acl=
+                - 20260512T135518Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3532,21 +3534,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
                 - "698"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:48 GMT
+                - Tue, 12 May 2026 13:55:18 GMT
             X-Amz-Id-2:
-                - txg24332e84be17417d9f2e-0067586ad8
+                - txg203ac848f15f4f788127-006a033146
             X-Amz-Request-Id:
-                - txg24332e84be17417d9f2e-0067586ad8
+                - txg203ac848f15f4f788127-006a033146
         status: 200 OK
         code: 200
-        duration: 15.72725ms
+        duration: 31.438458ms
     - id: 68
       request:
         proto: HTTP/1.1
@@ -3555,7 +3557,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3564,16 +3566,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 6f973488-e5ef-410a-af9d-699ab8a68342
+                - 100e3e1a-af68-43f8-b92a-1b6785e8d8da
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162248Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260512T135518Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3581,23 +3583,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 330
+        content_length: 329
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg02c35d7f48ce4d75a100-0067586ad8</RequestId><HostId>txg02c35d7f48ce4d75a100-0067586ad8</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgf8d1ef21f67842228fa6-006a033146</RequestId><HostId>txgf8d1ef21f67842228fa6-006a033146</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
         headers:
             Content-Length:
-                - "330"
+                - "329"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:48 GMT
+                - Tue, 12 May 2026 13:55:18 GMT
             X-Amz-Id-2:
-                - txg02c35d7f48ce4d75a100-0067586ad8
+                - txgf8d1ef21f67842228fa6-006a033146
             X-Amz-Request-Id:
-                - txg02c35d7f48ce4d75a100-0067586ad8
+                - txgf8d1ef21f67842228fa6-006a033146
         status: 404 Not Found
         code: 404
-        duration: 27.853042ms
+        duration: 20.420292ms
     - id: 69
       request:
         proto: HTTP/1.1
@@ -3606,7 +3608,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3615,16 +3617,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 19ed168a-3450-4d4b-804d-e901be1ce6b4
+                - 1fc5c2a8-ad6d-4c0a-b8e0-cfb04aadd7a1
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162248Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/
+                - 20260512T135518Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -3632,25 +3634,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 287
+        content_length: 286
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "287"
+                - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:48 GMT
+                - Tue, 12 May 2026 13:55:18 GMT
             X-Amz-Id-2:
-                - txg53f5a3cf653c4cc69cff-0067586ad8
+                - txge8baac581acf4ebeb4a0-006a033146
             X-Amz-Request-Id:
-                - txg53f5a3cf653c4cc69cff-0067586ad8
+                - txge8baac581acf4ebeb4a0-006a033146
         status: 200 OK
         code: 200
-        duration: 27.600584ms
+        duration: 49.411542ms
     - id: 70
       request:
         proto: HTTP/1.1
@@ -3659,7 +3661,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3668,16 +3670,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 20b338d3-74e3-4edc-abf4-934fcf5ee35a
+                - 7c4ba859-d434-4c1a-b2f2-fc5144e27f2a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162248Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?tagging=
+                - 20260512T135518Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3685,23 +3687,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 361
+        content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg94f310fcc1074cb1a352-0067586ad8</RequestId><HostId>txg94f310fcc1074cb1a352-0067586ad8</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgc67d9dce0f534cd3bc11-006a033146</RequestId><HostId>txgc67d9dce0f534cd3bc11-006a033146</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</BucketName></Error>
         headers:
             Content-Length:
-                - "361"
+                - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:48 GMT
+                - Tue, 12 May 2026 13:55:18 GMT
             X-Amz-Id-2:
-                - txg94f310fcc1074cb1a352-0067586ad8
+                - txgc67d9dce0f534cd3bc11-006a033146
             X-Amz-Request-Id:
-                - txg94f310fcc1074cb1a352-0067586ad8
+                - txgc67d9dce0f534cd3bc11-006a033146
         status: 404 Not Found
         code: 404
-        duration: 16.002042ms
+        duration: 49.502583ms
     - id: 71
       request:
         proto: HTTP/1.1
@@ -3710,7 +3712,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3719,16 +3721,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d6ca33cf-1a75-4c49-9818-6db2f2708f87
+                - 3880bc22-6c9a-48c1-a3c9-789603657f73
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162248Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?cors=
+                - 20260512T135518Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3736,23 +3738,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 298
+        content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg8a8d74912a664972b5c7-0067586ad8</RequestId><HostId>txg8a8d74912a664972b5c7-0067586ad8</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg3769078401ea44e38bf2-006a033146</RequestId><HostId>txg3769078401ea44e38bf2-006a033146</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
         headers:
             Content-Length:
-                - "298"
+                - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:48 GMT
+                - Tue, 12 May 2026 13:55:18 GMT
             X-Amz-Id-2:
-                - txg8a8d74912a664972b5c7-0067586ad8
+                - txg3769078401ea44e38bf2-006a033146
             X-Amz-Request-Id:
-                - txg8a8d74912a664972b5c7-0067586ad8
+                - txg3769078401ea44e38bf2-006a033146
         status: 404 Not Found
         code: 404
-        duration: 16.382ms
+        duration: 112.965334ms
     - id: 72
       request:
         proto: HTTP/1.1
@@ -3761,7 +3763,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3770,16 +3772,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 07ad8b7a-d160-4bc8-a03b-1d4b3e507bc9
+                - 1887a5f7-dfc9-4120-8e72-ca7f5487dc48
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162248Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?versioning=
+                - 20260512T135518Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3787,25 +3789,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 155
+        content_length: 107
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Status></Status></VersioningConfiguration>
+            <VersioningConfiguration><Status></Status></VersioningConfiguration>
         headers:
             Content-Length:
-                - "155"
+                - "107"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:48 GMT
+                - Tue, 12 May 2026 13:55:18 GMT
             X-Amz-Id-2:
-                - txg9ba0765c9910425bb72a-0067586ad8
+                - txgc4e99f061bd640cfba81-006a033146
             X-Amz-Request-Id:
-                - txg9ba0765c9910425bb72a-0067586ad8
+                - txgc4e99f061bd640cfba81-006a033146
         status: 200 OK
         code: 200
-        duration: 26.320208ms
+        duration: 19.993958ms
     - id: 73
       request:
         proto: HTTP/1.1
@@ -3814,7 +3816,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3823,16 +3825,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 1d037899-6dc6-4dc3-be83-e3d98c806895
+                - 64c701ce-2831-4710-964e-30859d7b9cd1
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162248Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T135518Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3840,25 +3842,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1311
+        content_length: 1105
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Days>1</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Days>1</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></LifecycleConfiguration>
+            <Configuration><Rule><Expiration><Days>365</Days></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
-                - "1311"
+                - "1105"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:48 GMT
+                - Tue, 12 May 2026 13:55:18 GMT
             X-Amz-Id-2:
-                - txg3769652be75343b29338-0067586ad8
+                - txg71377e59f53244448fff-006a033146
             X-Amz-Request-Id:
-                - txg3769652be75343b29338-0067586ad8
+                - txg71377e59f53244448fff-006a033146
         status: 200 OK
         code: 200
-        duration: 16.687083ms
+        duration: 30.984167ms
     - id: 74
       request:
         proto: HTTP/1.1
@@ -3867,7 +3869,7 @@ interactions:
         content_length: 296
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
@@ -3876,20 +3878,20 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - a638d81f-99c3-4772-9d6e-b4ee5798bb86
+                - 3269ba5d-5c2e-4dc3-b87b-817afcbfe8e7
             Amz-Sdk-Request:
                 - attempt=1; max=3
-            Content-Md5:
-                - DRiUl1CBZq31Ms3o2gUYXA==
             Content-Type:
                 - application/xml
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,Z,e
+            X-Amz-Checksum-Crc32:
+                - O87+gQ==
             X-Amz-Content-Sha256:
                 - 7756d51b786b61edff20b7957d22346417f85f71d19eeca0d6d28d6df7b15bbc
             X-Amz-Date:
-                - 20241210T162250Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T135518Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -3904,14 +3906,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 10 Dec 2024 16:22:50 GMT
+                - Tue, 12 May 2026 13:55:19 GMT
             X-Amz-Id-2:
-                - txg454adf75a33342e19904-0067586ada
+                - txg3d02ef7990b34aa5844c-006a033147
             X-Amz-Request-Id:
-                - txg454adf75a33342e19904-0067586ada
+                - txg3d02ef7990b34aa5844c-006a033147
         status: 200 OK
         code: 200
-        duration: 31.874083ms
+        duration: 20.701917ms
     - id: 75
       request:
         proto: HTTP/1.1
@@ -3920,7 +3922,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3929,16 +3931,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 8def5929-4b1a-4092-b7dc-b68676e3fd00
+                - 6df9afaf-c81b-4532-bdc8-b105e1418129
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162250Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?acl=
+                - 20260512T135519Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3950,21 +3952,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
                 - "698"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:50 GMT
+                - Tue, 12 May 2026 13:55:19 GMT
             X-Amz-Id-2:
-                - txgf97c53ab3f03413fac3f-0067586ada
+                - txg8aaa8a54860441b3bacc-006a033147
             X-Amz-Request-Id:
-                - txgf97c53ab3f03413fac3f-0067586ada
+                - txg8aaa8a54860441b3bacc-006a033147
         status: 200 OK
         code: 200
-        duration: 17.129708ms
+        duration: 19.091708ms
     - id: 76
       request:
         proto: HTTP/1.1
@@ -3973,7 +3975,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3982,16 +3984,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7197a478-cac9-4265-aa01-44fab81f99d0
+                - 35c7405f-d9ae-486d-8363-2ca2167de4f7
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162250Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260512T135519Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3999,23 +4001,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 330
+        content_length: 329
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg7a0f4144656640f896b0-0067586ada</RequestId><HostId>txg7a0f4144656640f896b0-0067586ada</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg6b3e4a5d78b54f9b8ef8-006a033147</RequestId><HostId>txg6b3e4a5d78b54f9b8ef8-006a033147</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
         headers:
             Content-Length:
-                - "330"
+                - "329"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:50 GMT
+                - Tue, 12 May 2026 13:55:19 GMT
             X-Amz-Id-2:
-                - txg7a0f4144656640f896b0-0067586ada
+                - txg6b3e4a5d78b54f9b8ef8-006a033147
             X-Amz-Request-Id:
-                - txg7a0f4144656640f896b0-0067586ada
+                - txg6b3e4a5d78b54f9b8ef8-006a033147
         status: 404 Not Found
         code: 404
-        duration: 375.124542ms
+        duration: 23.076875ms
     - id: 77
       request:
         proto: HTTP/1.1
@@ -4024,7 +4026,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4033,16 +4035,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0f659d01-0308-4a1a-a1e4-4eea3a456ff3
+                - b8102b72-3ffb-46c5-b252-0908c3b5f7cd
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162250Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/
+                - 20260512T135519Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -4050,25 +4052,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 287
+        content_length: 286
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "287"
+                - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:50 GMT
+                - Tue, 12 May 2026 13:55:19 GMT
             X-Amz-Id-2:
-                - txg8323a8970cd6497f98bf-0067586ada
+                - txg13c74295130042738510-006a033147
             X-Amz-Request-Id:
-                - txg8323a8970cd6497f98bf-0067586ada
+                - txg13c74295130042738510-006a033147
         status: 200 OK
         code: 200
-        duration: 27.676708ms
+        duration: 116.101542ms
     - id: 78
       request:
         proto: HTTP/1.1
@@ -4077,7 +4079,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4086,16 +4088,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 497e8a31-88dc-48ff-aafe-ba41517be086
+                - e001b1fe-ffb8-4590-a1b0-9d283cfd5e8d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162250Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?tagging=
+                - 20260512T135519Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4103,23 +4105,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 361
+        content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg74afc5b20f02468e99de-0067586ada</RequestId><HostId>txg74afc5b20f02468e99de-0067586ada</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg85b85817892c42f08642-006a033147</RequestId><HostId>txg85b85817892c42f08642-006a033147</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</BucketName></Error>
         headers:
             Content-Length:
-                - "361"
+                - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:50 GMT
+                - Tue, 12 May 2026 13:55:19 GMT
             X-Amz-Id-2:
-                - txg74afc5b20f02468e99de-0067586ada
+                - txg85b85817892c42f08642-006a033147
             X-Amz-Request-Id:
-                - txg74afc5b20f02468e99de-0067586ada
+                - txg85b85817892c42f08642-006a033147
         status: 404 Not Found
         code: 404
-        duration: 29.439917ms
+        duration: 19.174875ms
     - id: 79
       request:
         proto: HTTP/1.1
@@ -4128,7 +4130,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4137,16 +4139,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 639a46d0-e874-47af-9e38-8ed42aab6115
+                - 4569210f-3dce-45b0-94df-b60a8e554d6e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162250Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?cors=
+                - 20260512T135519Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4154,23 +4156,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 298
+        content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txga552d56fcd824714a6bb-0067586ada</RequestId><HostId>txga552d56fcd824714a6bb-0067586ada</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgf27ed968893e4621961a-006a033147</RequestId><HostId>txgf27ed968893e4621961a-006a033147</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
         headers:
             Content-Length:
-                - "298"
+                - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:50 GMT
+                - Tue, 12 May 2026 13:55:19 GMT
             X-Amz-Id-2:
-                - txga552d56fcd824714a6bb-0067586ada
+                - txgf27ed968893e4621961a-006a033147
             X-Amz-Request-Id:
-                - txga552d56fcd824714a6bb-0067586ada
+                - txgf27ed968893e4621961a-006a033147
         status: 404 Not Found
         code: 404
-        duration: 15.114166ms
+        duration: 19.487917ms
     - id: 80
       request:
         proto: HTTP/1.1
@@ -4179,7 +4181,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4188,16 +4190,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 597103b1-9dce-4eb4-b7b4-e47d0e5910dc
+                - 09852399-31ab-41ba-8355-931f836ff45d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162250Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?versioning=
+                - 20260512T135519Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4205,25 +4207,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 155
+        content_length: 107
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Status></Status></VersioningConfiguration>
+            <VersioningConfiguration><Status></Status></VersioningConfiguration>
         headers:
             Content-Length:
-                - "155"
+                - "107"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:50 GMT
+                - Tue, 12 May 2026 13:55:19 GMT
             X-Amz-Id-2:
-                - txga5092ddf9f674232af4d-0067586ada
+                - txg93019c29501c47649a2f-006a033147
             X-Amz-Request-Id:
-                - txga5092ddf9f674232af4d-0067586ada
+                - txg93019c29501c47649a2f-006a033147
         status: 200 OK
         code: 200
-        duration: 25.3625ms
+        duration: 18.384583ms
     - id: 81
       request:
         proto: HTTP/1.1
@@ -4232,7 +4234,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4241,16 +4243,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - a96e960a-5a3d-4d0a-8346-3ad4b67518f2
+                - faba06b7-3289-432c-a950-db70b140026b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162250Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T135519Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4258,25 +4260,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 335
+        content_length: 269
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
+            <Configuration><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status></Rule></Configuration>
         headers:
             Content-Length:
-                - "335"
+                - "269"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:50 GMT
+                - Tue, 12 May 2026 13:55:19 GMT
             X-Amz-Id-2:
-                - txg8a3cacba6a034a739bb2-0067586ada
+                - txga37b3c0a049b43bfa94b-006a033147
             X-Amz-Request-Id:
-                - txg8a3cacba6a034a739bb2-0067586ada
+                - txga37b3c0a049b43bfa94b-006a033147
         status: 200 OK
         code: 200
-        duration: 16.001ms
+        duration: 47.521333ms
     - id: 82
       request:
         proto: HTTP/1.1
@@ -4285,7 +4287,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4294,16 +4296,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 468865b6-84dc-42e3-b7c8-9882fa350f9b
+                - 04f95681-c664-4abc-b58e-8c5b188b7b88
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162251Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/
+                - 20260512T135519Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -4318,16 +4320,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:51 GMT
+                - Tue, 12 May 2026 13:55:19 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txg968a8c47b65c454484cf-0067586adb
+                - txg4c13f3c8929347e196f3-006a033147
             X-Amz-Request-Id:
-                - txg968a8c47b65c454484cf-0067586adb
+                - txg4c13f3c8929347e196f3-006a033147
         status: 200 OK
         code: 200
-        duration: 26.598875ms
+        duration: 53.389292ms
     - id: 83
       request:
         proto: HTTP/1.1
@@ -4336,7 +4338,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4345,16 +4347,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 74b723bd-c461-4827-b612-836ba0ffc515
+                - d7c07c0d-d261-4405-a09b-f917f942e391
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162251Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T135519Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4362,25 +4364,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 335
+        content_length: 269
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
+            <Configuration><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status></Rule></Configuration>
         headers:
             Content-Length:
-                - "335"
+                - "269"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:51 GMT
+                - Tue, 12 May 2026 13:55:19 GMT
             X-Amz-Id-2:
-                - txg44f5a38696904c4ca374-0067586adb
+                - txg1f0a1cb81cd24c16a92a-006a033147
             X-Amz-Request-Id:
-                - txg44f5a38696904c4ca374-0067586adb
+                - txg1f0a1cb81cd24c16a92a-006a033147
         status: 200 OK
         code: 200
-        duration: 27.69675ms
+        duration: 50.287125ms
     - id: 84
       request:
         proto: HTTP/1.1
@@ -4389,7 +4391,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4398,16 +4400,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - eefec4d7-9d09-48b0-b993-d9f5a5a46f39
+                - ba695672-50a6-445e-91e6-1c2d77f73ba8
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162252Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?acl=
+                - 20260512T135519Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4419,21 +4421,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
                 - "698"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:52 GMT
+                - Tue, 12 May 2026 13:55:19 GMT
             X-Amz-Id-2:
-                - txgec9f7e08b4ac436aaa04-0067586adc
+                - txg8762209f772e44128f0b-006a033147
             X-Amz-Request-Id:
-                - txgec9f7e08b4ac436aaa04-0067586adc
+                - txg8762209f772e44128f0b-006a033147
         status: 200 OK
         code: 200
-        duration: 26.055ms
+        duration: 37.150042ms
     - id: 85
       request:
         proto: HTTP/1.1
@@ -4442,7 +4444,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4451,16 +4453,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 99fcbe2a-9887-4203-8806-9d2d2a67b9bc
+                - b3ce8f20-da42-492d-a371-6f188d15b778
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162252Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260512T135519Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4468,23 +4470,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 330
+        content_length: 329
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg68ea2cffa3f4418b8e2a-0067586adc</RequestId><HostId>txg68ea2cffa3f4418b8e2a-0067586adc</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgffd998eb882b4976a344-006a033147</RequestId><HostId>txgffd998eb882b4976a344-006a033147</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
         headers:
             Content-Length:
-                - "330"
+                - "329"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:52 GMT
+                - Tue, 12 May 2026 13:55:19 GMT
             X-Amz-Id-2:
-                - txg68ea2cffa3f4418b8e2a-0067586adc
+                - txgffd998eb882b4976a344-006a033147
             X-Amz-Request-Id:
-                - txg68ea2cffa3f4418b8e2a-0067586adc
+                - txgffd998eb882b4976a344-006a033147
         status: 404 Not Found
         code: 404
-        duration: 25.172416ms
+        duration: 21.636291ms
     - id: 86
       request:
         proto: HTTP/1.1
@@ -4493,7 +4495,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4502,16 +4504,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 75e2cef3-a2b4-431b-be44-74f4d262015b
+                - 9d65eca6-2920-4c41-ad92-b2bda097635f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162252Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/
+                - 20260512T135519Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -4519,25 +4521,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 287
+        content_length: 286
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "287"
+                - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:52 GMT
+                - Tue, 12 May 2026 13:55:19 GMT
             X-Amz-Id-2:
-                - txgc69c0972fe884f4a922e-0067586adc
+                - txgb61dd29925c94230bd97-006a033147
             X-Amz-Request-Id:
-                - txgc69c0972fe884f4a922e-0067586adc
+                - txgb61dd29925c94230bd97-006a033147
         status: 200 OK
         code: 200
-        duration: 17.644292ms
+        duration: 53.486417ms
     - id: 87
       request:
         proto: HTTP/1.1
@@ -4546,7 +4548,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4555,16 +4557,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 2768004e-c212-4fcf-8d3e-3d634bc7cab4
+                - 9f620409-3e5f-4d63-bee6-294d7451fef0
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162252Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?tagging=
+                - 20260512T135519Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4572,23 +4574,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 361
+        content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg27274d42a4794458ac38-0067586adc</RequestId><HostId>txg27274d42a4794458ac38-0067586adc</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg3ca2f0bbf1e74ba79422-006a033147</RequestId><HostId>txg3ca2f0bbf1e74ba79422-006a033147</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</BucketName></Error>
         headers:
             Content-Length:
-                - "361"
+                - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:52 GMT
+                - Tue, 12 May 2026 13:55:19 GMT
             X-Amz-Id-2:
-                - txg27274d42a4794458ac38-0067586adc
+                - txg3ca2f0bbf1e74ba79422-006a033147
             X-Amz-Request-Id:
-                - txg27274d42a4794458ac38-0067586adc
+                - txg3ca2f0bbf1e74ba79422-006a033147
         status: 404 Not Found
         code: 404
-        duration: 15.679584ms
+        duration: 34.094541ms
     - id: 88
       request:
         proto: HTTP/1.1
@@ -4597,7 +4599,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4606,16 +4608,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - db48568d-68bd-4894-bb5b-5bdcce16ab62
+                - bea33d29-0ccd-4f94-8d59-6d1e37abcddf
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162252Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?cors=
+                - 20260512T135519Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4623,23 +4625,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 298
+        content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg55849d32448948b2838f-0067586adc</RequestId><HostId>txg55849d32448948b2838f-0067586adc</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg19616aa2a22844c59e9e-006a033147</RequestId><HostId>txg19616aa2a22844c59e9e-006a033147</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
         headers:
             Content-Length:
-                - "298"
+                - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:52 GMT
+                - Tue, 12 May 2026 13:55:19 GMT
             X-Amz-Id-2:
-                - txg55849d32448948b2838f-0067586adc
+                - txg19616aa2a22844c59e9e-006a033147
             X-Amz-Request-Id:
-                - txg55849d32448948b2838f-0067586adc
+                - txg19616aa2a22844c59e9e-006a033147
         status: 404 Not Found
         code: 404
-        duration: 16.157791ms
+        duration: 90.53025ms
     - id: 89
       request:
         proto: HTTP/1.1
@@ -4648,7 +4650,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4657,16 +4659,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ea468ac2-8c6b-46d1-a4fe-7ed68a3a84e5
+                - 807c83b0-b354-4e7f-a3e3-b07bf1dff5c3
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162252Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?versioning=
+                - 20260512T135519Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4674,25 +4676,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 155
+        content_length: 107
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Status></Status></VersioningConfiguration>
+            <VersioningConfiguration><Status></Status></VersioningConfiguration>
         headers:
             Content-Length:
-                - "155"
+                - "107"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:52 GMT
+                - Tue, 12 May 2026 13:55:20 GMT
             X-Amz-Id-2:
-                - txg708e7b1040a04f78867c-0067586adc
+                - txgd99ffc7099c9446dbf45-006a033148
             X-Amz-Request-Id:
-                - txg708e7b1040a04f78867c-0067586adc
+                - txgd99ffc7099c9446dbf45-006a033148
         status: 200 OK
         code: 200
-        duration: 17.757292ms
+        duration: 57.579542ms
     - id: 90
       request:
         proto: HTTP/1.1
@@ -4701,7 +4703,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4710,16 +4712,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - a3a4f483-4880-4c2e-907d-de3b718d8af1
+                - c2d3ed70-db0e-4502-b29e-e5b4a6f477bc
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162252Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T135520Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4727,25 +4729,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 335
+        content_length: 269
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
+            <Configuration><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status></Rule></Configuration>
         headers:
             Content-Length:
-                - "335"
+                - "269"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:52 GMT
+                - Tue, 12 May 2026 13:55:20 GMT
             X-Amz-Id-2:
-                - txgfb1410b7f8e542028e02-0067586adc
+                - txg506806035d8243a7adf9-006a033148
             X-Amz-Request-Id:
-                - txgfb1410b7f8e542028e02-0067586adc
+                - txg506806035d8243a7adf9-006a033148
         status: 200 OK
         code: 200
-        duration: 15.863791ms
+        duration: 50.597375ms
     - id: 91
       request:
         proto: HTTP/1.1
@@ -4754,7 +4756,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4763,16 +4765,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5ff5c26c-9870-43e8-af2f-7fb22c57e297
+                - 7ef21bdf-f69d-40df-b410-ea39a6c0b82d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162253Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?acl=
+                - 20260512T135520Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4784,21 +4786,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
                 - "698"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:53 GMT
+                - Tue, 12 May 2026 13:55:20 GMT
             X-Amz-Id-2:
-                - txg354030d3fc4943248dcd-0067586add
+                - txg427c28e519904129bd5f-006a033148
             X-Amz-Request-Id:
-                - txg354030d3fc4943248dcd-0067586add
+                - txg427c28e519904129bd5f-006a033148
         status: 200 OK
         code: 200
-        duration: 26.782666ms
+        duration: 42.407333ms
     - id: 92
       request:
         proto: HTTP/1.1
@@ -4807,7 +4809,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4816,16 +4818,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f2c9eb58-a1ae-42f1-a304-15f99921b689
+                - c2a2792f-65c4-4d58-8b24-4c5b41663b12
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162253Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260512T135520Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4833,23 +4835,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 330
+        content_length: 329
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg291ec8632f1a4b9098ac-0067586add</RequestId><HostId>txg291ec8632f1a4b9098ac-0067586add</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txga28555b7af4241b897c1-006a033148</RequestId><HostId>txga28555b7af4241b897c1-006a033148</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
         headers:
             Content-Length:
-                - "330"
+                - "329"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:53 GMT
+                - Tue, 12 May 2026 13:55:20 GMT
             X-Amz-Id-2:
-                - txg291ec8632f1a4b9098ac-0067586add
+                - txga28555b7af4241b897c1-006a033148
             X-Amz-Request-Id:
-                - txg291ec8632f1a4b9098ac-0067586add
+                - txga28555b7af4241b897c1-006a033148
         status: 404 Not Found
         code: 404
-        duration: 267.189333ms
+        duration: 20.022041ms
     - id: 93
       request:
         proto: HTTP/1.1
@@ -4858,7 +4860,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4867,16 +4869,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 827ed96e-80d3-4c1f-a87f-68030edf1b0a
+                - 7187a77b-3fc0-49e0-bf28-07465716df88
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162253Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/
+                - 20260512T135520Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -4884,25 +4886,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 287
+        content_length: 286
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "287"
+                - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:53 GMT
+                - Tue, 12 May 2026 13:55:20 GMT
             X-Amz-Id-2:
-                - txga450e219161843cd91ef-0067586add
+                - txg65c519a823be4395b367-006a033148
             X-Amz-Request-Id:
-                - txga450e219161843cd91ef-0067586add
+                - txg65c519a823be4395b367-006a033148
         status: 200 OK
         code: 200
-        duration: 19.04175ms
+        duration: 27.352542ms
     - id: 94
       request:
         proto: HTTP/1.1
@@ -4911,7 +4913,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4920,16 +4922,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 098073e0-ced9-482a-a2ac-6adbb7b0c4ff
+                - e370b700-9753-4999-8de6-4c821be55276
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162253Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?tagging=
+                - 20260512T135520Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4937,23 +4939,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 361
+        content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg1432bdef1be947d0aeb3-0067586add</RequestId><HostId>txg1432bdef1be947d0aeb3-0067586add</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgb5f189f21e9746cfb647-006a033148</RequestId><HostId>txgb5f189f21e9746cfb647-006a033148</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</BucketName></Error>
         headers:
             Content-Length:
-                - "361"
+                - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:53 GMT
+                - Tue, 12 May 2026 13:55:20 GMT
             X-Amz-Id-2:
-                - txg1432bdef1be947d0aeb3-0067586add
+                - txgb5f189f21e9746cfb647-006a033148
             X-Amz-Request-Id:
-                - txg1432bdef1be947d0aeb3-0067586add
+                - txgb5f189f21e9746cfb647-006a033148
         status: 404 Not Found
         code: 404
-        duration: 27.538792ms
+        duration: 35.000542ms
     - id: 95
       request:
         proto: HTTP/1.1
@@ -4962,7 +4964,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4971,16 +4973,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e061fbfc-9c8c-4c16-9987-57cc1c071338
+                - 2d9e56c6-9c20-42c0-bc40-31d9b35504ea
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162253Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?cors=
+                - 20260512T135520Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4988,23 +4990,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 298
+        content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg686adad882424d208eee-0067586add</RequestId><HostId>txg686adad882424d208eee-0067586add</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgf3600ecf465843bca10e-006a033148</RequestId><HostId>txgf3600ecf465843bca10e-006a033148</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
         headers:
             Content-Length:
-                - "298"
+                - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:53 GMT
+                - Tue, 12 May 2026 13:55:20 GMT
             X-Amz-Id-2:
-                - txg686adad882424d208eee-0067586add
+                - txgf3600ecf465843bca10e-006a033148
             X-Amz-Request-Id:
-                - txg686adad882424d208eee-0067586add
+                - txgf3600ecf465843bca10e-006a033148
         status: 404 Not Found
         code: 404
-        duration: 27.6535ms
+        duration: 70.657375ms
     - id: 96
       request:
         proto: HTTP/1.1
@@ -5013,7 +5015,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5022,16 +5024,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7bd30f7a-d5a9-4c2d-91a2-6f1aaef12c99
+                - c5fe15ea-8dd8-4573-8835-0aa68f0b9160
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162253Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?versioning=
+                - 20260512T135520Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5039,25 +5041,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 155
+        content_length: 107
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Status></Status></VersioningConfiguration>
+            <VersioningConfiguration><Status></Status></VersioningConfiguration>
         headers:
             Content-Length:
-                - "155"
+                - "107"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:53 GMT
+                - Tue, 12 May 2026 13:55:20 GMT
             X-Amz-Id-2:
-                - txg27d8f1784df64b54b855-0067586add
+                - txg01f9e7254aa5405fa534-006a033148
             X-Amz-Request-Id:
-                - txg27d8f1784df64b54b855-0067586add
+                - txg01f9e7254aa5405fa534-006a033148
         status: 200 OK
         code: 200
-        duration: 15.7855ms
+        duration: 47.946416ms
     - id: 97
       request:
         proto: HTTP/1.1
@@ -5066,7 +5068,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5075,16 +5077,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - a035a7ac-8cd6-4f25-b063-2b233192a242
+                - 51abe473-2119-4b14-8cf2-41352a033f46
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162253Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T135520Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5092,25 +5094,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 335
+        content_length: 269
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
+            <Configuration><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status></Rule></Configuration>
         headers:
             Content-Length:
-                - "335"
+                - "269"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:53 GMT
+                - Tue, 12 May 2026 13:55:20 GMT
             X-Amz-Id-2:
-                - txg45271579cd034d1dbda4-0067586add
+                - txg214e1be10b294ac188dd-006a033148
             X-Amz-Request-Id:
-                - txg45271579cd034d1dbda4-0067586add
+                - txg214e1be10b294ac188dd-006a033148
         status: 200 OK
         code: 200
-        duration: 16.09625ms
+        duration: 235.878875ms
     - id: 98
       request:
         proto: HTTP/1.1
@@ -5119,7 +5121,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5128,16 +5130,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f50f13c8-df73-4f8a-9c50-c860bb706f5e
+                - 0af3d453-3fdf-4c5f-b975-1cc188be63fc
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162254Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/
+                - 20260512T135520Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -5152,16 +5154,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:54 GMT
+                - Tue, 12 May 2026 13:55:20 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txg94f8a85925eb44f490d7-0067586ade
+                - txg5c8e3a76759d4801af90-006a033148
             X-Amz-Request-Id:
-                - txg94f8a85925eb44f490d7-0067586ade
+                - txg5c8e3a76759d4801af90-006a033148
         status: 200 OK
         code: 200
-        duration: 26.374042ms
+        duration: 91.038792ms
     - id: 99
       request:
         proto: HTTP/1.1
@@ -5170,7 +5172,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5179,16 +5181,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 695772d5-998c-42d5-be74-8e4073957521
+                - f6fdbcfa-e6c5-4406-b8ba-b2f11d899d90
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162254Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T135521Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5196,25 +5198,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 335
+        content_length: 269
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
+            <Configuration><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status></Rule></Configuration>
         headers:
             Content-Length:
-                - "335"
+                - "269"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:55 GMT
+                - Tue, 12 May 2026 13:55:21 GMT
             X-Amz-Id-2:
-                - txg9386167b9fbf4b4586fb-0067586adf
+                - txgdabf07d797e342e7b014-006a033149
             X-Amz-Request-Id:
-                - txg9386167b9fbf4b4586fb-0067586adf
+                - txgdabf07d797e342e7b014-006a033149
         status: 200 OK
         code: 200
-        duration: 15.309792ms
+        duration: 89.298ms
     - id: 100
       request:
         proto: HTTP/1.1
@@ -5223,7 +5225,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5232,16 +5234,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 26a02053-43e2-42f5-8f96-e4a12e7bf102
+                - bfcf364c-248b-442b-bc10-8de8f02b1071
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162255Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?acl=
+                - 20260512T135521Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5253,21 +5255,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
                 - "698"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:55 GMT
+                - Tue, 12 May 2026 13:55:21 GMT
             X-Amz-Id-2:
-                - txge106db75eed44f1c8290-0067586adf
+                - txg97956c39d36b41dba205-006a033149
             X-Amz-Request-Id:
-                - txge106db75eed44f1c8290-0067586adf
+                - txg97956c39d36b41dba205-006a033149
         status: 200 OK
         code: 200
-        duration: 20.1165ms
+        duration: 19.203ms
     - id: 101
       request:
         proto: HTTP/1.1
@@ -5276,7 +5278,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5285,16 +5287,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 40d1abe7-1e92-4871-9429-6d2245e57107
+                - 9485812a-32e9-4a1c-919c-ef132bd651ce
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162255Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260512T135521Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5302,23 +5304,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 330
+        content_length: 329
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg27c7bc2fb2444ac7930b-0067586adf</RequestId><HostId>txg27c7bc2fb2444ac7930b-0067586adf</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg64a31e8219e34f7b91c5-006a033149</RequestId><HostId>txg64a31e8219e34f7b91c5-006a033149</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
         headers:
             Content-Length:
-                - "330"
+                - "329"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:55 GMT
+                - Tue, 12 May 2026 13:55:21 GMT
             X-Amz-Id-2:
-                - txg27c7bc2fb2444ac7930b-0067586adf
+                - txg64a31e8219e34f7b91c5-006a033149
             X-Amz-Request-Id:
-                - txg27c7bc2fb2444ac7930b-0067586adf
+                - txg64a31e8219e34f7b91c5-006a033149
         status: 404 Not Found
         code: 404
-        duration: 34.35175ms
+        duration: 19.184833ms
     - id: 102
       request:
         proto: HTTP/1.1
@@ -5327,7 +5329,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5336,16 +5338,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 80b0412c-1aa3-4c36-8814-599b7027ccd1
+                - 0543d415-e316-4d9e-b3fb-3a63c62dd2d8
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162256Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/
+                - 20260512T135521Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -5353,25 +5355,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 287
+        content_length: 286
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "287"
+                - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:56 GMT
+                - Tue, 12 May 2026 13:55:21 GMT
             X-Amz-Id-2:
-                - txg08a3e9a1d0844e90a5ac-0067586ae0
+                - txg2c1ea0b59506439e9128-006a033149
             X-Amz-Request-Id:
-                - txg08a3e9a1d0844e90a5ac-0067586ae0
+                - txg2c1ea0b59506439e9128-006a033149
         status: 200 OK
         code: 200
-        duration: 43.28025ms
+        duration: 72.947083ms
     - id: 103
       request:
         proto: HTTP/1.1
@@ -5380,7 +5382,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5389,16 +5391,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0343a379-0347-47fd-9e98-3d177399dc09
+                - d21d0883-32a0-4336-ba2d-92123de41a7b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162256Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?tagging=
+                - 20260512T135521Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5406,23 +5408,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 361
+        content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg619b302365d84fb3b70a-0067586ae0</RequestId><HostId>txg619b302365d84fb3b70a-0067586ae0</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgc7df6a5912f748fbab39-006a033149</RequestId><HostId>txgc7df6a5912f748fbab39-006a033149</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</BucketName></Error>
         headers:
             Content-Length:
-                - "361"
+                - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:56 GMT
+                - Tue, 12 May 2026 13:55:21 GMT
             X-Amz-Id-2:
-                - txg619b302365d84fb3b70a-0067586ae0
+                - txgc7df6a5912f748fbab39-006a033149
             X-Amz-Request-Id:
-                - txg619b302365d84fb3b70a-0067586ae0
+                - txgc7df6a5912f748fbab39-006a033149
         status: 404 Not Found
         code: 404
-        duration: 15.812583ms
+        duration: 20.821792ms
     - id: 104
       request:
         proto: HTTP/1.1
@@ -5431,7 +5433,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5440,16 +5442,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 828a6a67-62ce-4881-abd2-17e57787332a
+                - 69c5ac33-d3a3-4def-9e30-f43f7adf523a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162256Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?cors=
+                - 20260512T135521Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5457,23 +5459,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 298
+        content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txga4b23556fab24147a8e2-0067586ae0</RequestId><HostId>txga4b23556fab24147a8e2-0067586ae0</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgd0014a9227d541369b65-006a033149</RequestId><HostId>txgd0014a9227d541369b65-006a033149</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
         headers:
             Content-Length:
-                - "298"
+                - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:56 GMT
+                - Tue, 12 May 2026 13:55:21 GMT
             X-Amz-Id-2:
-                - txga4b23556fab24147a8e2-0067586ae0
+                - txgd0014a9227d541369b65-006a033149
             X-Amz-Request-Id:
-                - txga4b23556fab24147a8e2-0067586ae0
+                - txgd0014a9227d541369b65-006a033149
         status: 404 Not Found
         code: 404
-        duration: 18.616875ms
+        duration: 19.522875ms
     - id: 105
       request:
         proto: HTTP/1.1
@@ -5482,7 +5484,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5491,16 +5493,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f68d1677-cc6f-49ae-abfc-f5d40819f796
+                - 4200646e-c846-4f29-b5bc-30f1e6c4030a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162256Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?versioning=
+                - 20260512T135521Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5508,25 +5510,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 155
+        content_length: 107
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Status></Status></VersioningConfiguration>
+            <VersioningConfiguration><Status></Status></VersioningConfiguration>
         headers:
             Content-Length:
-                - "155"
+                - "107"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:56 GMT
+                - Tue, 12 May 2026 13:55:21 GMT
             X-Amz-Id-2:
-                - txg1b6b3adb91d14c7197b4-0067586ae0
+                - txgb083e9ef4e2e42eca09e-006a033149
             X-Amz-Request-Id:
-                - txg1b6b3adb91d14c7197b4-0067586ae0
+                - txgb083e9ef4e2e42eca09e-006a033149
         status: 200 OK
         code: 200
-        duration: 105.239625ms
+        duration: 32.930334ms
     - id: 106
       request:
         proto: HTTP/1.1
@@ -5535,7 +5537,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5544,16 +5546,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4721d485-adac-450b-83f3-d17294a01724
+                - 1924be38-b0d4-45f2-8ce6-f9a4689149d8
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162256Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T135521Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5561,25 +5563,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 335
+        content_length: 269
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
+            <Configuration><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status></Rule></Configuration>
         headers:
             Content-Length:
-                - "335"
+                - "269"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:56 GMT
+                - Tue, 12 May 2026 13:55:21 GMT
             X-Amz-Id-2:
-                - txg7d5180f2630b4c5489a3-0067586ae0
+                - txgb4dbcac6c6424f7ca931-006a033149
             X-Amz-Request-Id:
-                - txg7d5180f2630b4c5489a3-0067586ae0
+                - txgb4dbcac6c6424f7ca931-006a033149
         status: 200 OK
         code: 200
-        duration: 24.451209ms
+        duration: 25.740208ms
     - id: 107
       request:
         proto: HTTP/1.1
@@ -5588,7 +5590,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5597,16 +5599,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0635802f-5400-4b33-98a5-ca283f0fa76f
+                - 797b2580-3c31-405d-8e3d-7d202e070b0a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162257Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?acl=
+                - 20260512T135521Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5618,21 +5620,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
                 - "698"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:57 GMT
+                - Tue, 12 May 2026 13:55:21 GMT
             X-Amz-Id-2:
-                - txg63ff59eca1114c7aa4ee-0067586ae1
+                - txg1aacc04a279244c3b038-006a033149
             X-Amz-Request-Id:
-                - txg63ff59eca1114c7aa4ee-0067586ae1
+                - txg1aacc04a279244c3b038-006a033149
         status: 200 OK
         code: 200
-        duration: 15.133458ms
+        duration: 47.894375ms
     - id: 108
       request:
         proto: HTTP/1.1
@@ -5641,7 +5643,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5650,16 +5652,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ad4931a3-7d7b-49c2-b443-a3a1ac43dbb6
+                - b8b8374b-8847-4a3a-a07f-aef7d6907698
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162257Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260512T135521Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5667,23 +5669,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 330
+        content_length: 329
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg70de52c737224729b9cb-0067586ae1</RequestId><HostId>txg70de52c737224729b9cb-0067586ae1</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgee8672df9e904543b98c-006a033149</RequestId><HostId>txgee8672df9e904543b98c-006a033149</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
         headers:
             Content-Length:
-                - "330"
+                - "329"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:57 GMT
+                - Tue, 12 May 2026 13:55:21 GMT
             X-Amz-Id-2:
-                - txg70de52c737224729b9cb-0067586ae1
+                - txgee8672df9e904543b98c-006a033149
             X-Amz-Request-Id:
-                - txg70de52c737224729b9cb-0067586ae1
+                - txgee8672df9e904543b98c-006a033149
         status: 404 Not Found
         code: 404
-        duration: 26.144709ms
+        duration: 24.569875ms
     - id: 109
       request:
         proto: HTTP/1.1
@@ -5692,7 +5694,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5701,16 +5703,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f5c994fe-db97-4b67-b8e3-8f3a3bb03844
+                - 9522d5b3-96bf-4a91-ad8d-c16307499a45
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162257Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/
+                - 20260512T135521Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -5718,25 +5720,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 287
+        content_length: 286
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "287"
+                - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:57 GMT
+                - Tue, 12 May 2026 13:55:21 GMT
             X-Amz-Id-2:
-                - txgbbd1f0767d66456a9b54-0067586ae1
+                - txga711b5ec56fb4e42b62f-006a033149
             X-Amz-Request-Id:
-                - txgbbd1f0767d66456a9b54-0067586ae1
+                - txga711b5ec56fb4e42b62f-006a033149
         status: 200 OK
         code: 200
-        duration: 33.818375ms
+        duration: 65.307083ms
     - id: 110
       request:
         proto: HTTP/1.1
@@ -5745,7 +5747,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5754,16 +5756,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0b412d97-42f1-482f-b2c4-f3c7ed74bc7a
+                - 96e32741-3c37-41fd-b953-9cdab2102b19
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162257Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?tagging=
+                - 20260512T135521Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5771,23 +5773,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 361
+        content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg0b231d3ae6224274b10a-0067586ae1</RequestId><HostId>txg0b231d3ae6224274b10a-0067586ae1</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgbc494b71c26f49e6931e-006a033149</RequestId><HostId>txgbc494b71c26f49e6931e-006a033149</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</BucketName></Error>
         headers:
             Content-Length:
-                - "361"
+                - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:57 GMT
+                - Tue, 12 May 2026 13:55:21 GMT
             X-Amz-Id-2:
-                - txg0b231d3ae6224274b10a-0067586ae1
+                - txgbc494b71c26f49e6931e-006a033149
             X-Amz-Request-Id:
-                - txg0b231d3ae6224274b10a-0067586ae1
+                - txgbc494b71c26f49e6931e-006a033149
         status: 404 Not Found
         code: 404
-        duration: 16.065708ms
+        duration: 18.642166ms
     - id: 111
       request:
         proto: HTTP/1.1
@@ -5796,7 +5798,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5805,16 +5807,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 86716378-3951-4a80-bc1d-4ed75ba0a839
+                - 7f76b794-b1a6-4d41-aadf-b06ea2444e87
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162257Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?cors=
+                - 20260512T135521Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5822,23 +5824,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 298
+        content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg47ba36226345489fbe5d-0067586ae1</RequestId><HostId>txg47ba36226345489fbe5d-0067586ae1</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg258a0b51f34445cfbb5b-006a033149</RequestId><HostId>txg258a0b51f34445cfbb5b-006a033149</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
         headers:
             Content-Length:
-                - "298"
+                - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:57 GMT
+                - Tue, 12 May 2026 13:55:21 GMT
             X-Amz-Id-2:
-                - txg47ba36226345489fbe5d-0067586ae1
+                - txg258a0b51f34445cfbb5b-006a033149
             X-Amz-Request-Id:
-                - txg47ba36226345489fbe5d-0067586ae1
+                - txg258a0b51f34445cfbb5b-006a033149
         status: 404 Not Found
         code: 404
-        duration: 25.885292ms
+        duration: 42.730167ms
     - id: 112
       request:
         proto: HTTP/1.1
@@ -5847,7 +5849,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5856,16 +5858,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0661a6b8-cc83-49aa-88ca-1fcb63434694
+                - 1a03a15f-05ec-4ff2-b744-2cf6dcaf4998
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162257Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?versioning=
+                - 20260512T135521Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5873,25 +5875,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 155
+        content_length: 107
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Status></Status></VersioningConfiguration>
+            <VersioningConfiguration><Status></Status></VersioningConfiguration>
         headers:
             Content-Length:
-                - "155"
+                - "107"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:57 GMT
+                - Tue, 12 May 2026 13:55:21 GMT
             X-Amz-Id-2:
-                - txg52e24740a6b944d7854a-0067586ae1
+                - txga8fb4998817047a1af8a-006a033149
             X-Amz-Request-Id:
-                - txg52e24740a6b944d7854a-0067586ae1
+                - txga8fb4998817047a1af8a-006a033149
         status: 200 OK
         code: 200
-        duration: 30.788458ms
+        duration: 19.405583ms
     - id: 113
       request:
         proto: HTTP/1.1
@@ -5900,7 +5902,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5909,16 +5911,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 87494297-020c-47c9-9e90-e08634296a3a
+                - dfdd75d5-cafc-4aa7-823f-d447a23ba2c2
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162257Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T135521Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5926,25 +5928,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 335
+        content_length: 269
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
+            <Configuration><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status></Rule></Configuration>
         headers:
             Content-Length:
-                - "335"
+                - "269"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:57 GMT
+                - Tue, 12 May 2026 13:55:22 GMT
             X-Amz-Id-2:
-                - txg5d8193fb674b44068d8f-0067586ae1
+                - txge5cbb8e0b5914e76908b-006a03314a
             X-Amz-Request-Id:
-                - txg5d8193fb674b44068d8f-0067586ae1
+                - txge5cbb8e0b5914e76908b-006a03314a
         status: 200 OK
         code: 200
-        duration: 15.0035ms
+        duration: 20.901583ms
     - id: 114
       request:
         proto: HTTP/1.1
@@ -5953,7 +5955,7 @@ interactions:
         content_length: 284
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path1/</Prefix><Tag><Key>deleted</Key><Value>true</Value></Tag></And></Filter><ID>id1</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
@@ -5962,20 +5964,20 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 6e28c305-71dc-45d6-ab1d-ddb2d9bb9a6f
+                - a69d15f2-ef47-4cd1-949d-6a868e4f6ab8
             Amz-Sdk-Request:
                 - attempt=1; max=3
-            Content-Md5:
-                - zqc0J7BHqrI4Fowl52m/xA==
             Content-Type:
                 - application/xml
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,Z,e
+            X-Amz-Checksum-Crc32:
+                - UfU/dQ==
             X-Amz-Content-Sha256:
                 - c66696878cc52fbe5f1b5468d871024fe4d94447494e4b1797bc44a183ccc313
             X-Amz-Date:
-                - 20241210T162258Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T135522Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -5990,14 +5992,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 10 Dec 2024 16:22:58 GMT
+                - Tue, 12 May 2026 13:55:22 GMT
             X-Amz-Id-2:
-                - txgb781243fcc964d8fa303-0067586ae2
+                - txg04509622a7694b1cac6e-006a03314a
             X-Amz-Request-Id:
-                - txgb781243fcc964d8fa303-0067586ae2
+                - txg04509622a7694b1cac6e-006a03314a
         status: 200 OK
         code: 200
-        duration: 25.388709ms
+        duration: 23.121084ms
     - id: 115
       request:
         proto: HTTP/1.1
@@ -6006,7 +6008,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6015,16 +6017,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 086a9b3b-7c5c-400e-afc6-97c0beec9262
+                - 3759e80a-6145-4768-aeea-91ec5db1b0d3
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162258Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?acl=
+                - 20260512T135522Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6036,21 +6038,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
                 - "698"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:58 GMT
+                - Tue, 12 May 2026 13:55:22 GMT
             X-Amz-Id-2:
-                - txg8867a7dfae8245638075-0067586ae2
+                - txg9c51959ebfc54ce48497-006a03314a
             X-Amz-Request-Id:
-                - txg8867a7dfae8245638075-0067586ae2
+                - txg9c51959ebfc54ce48497-006a03314a
         status: 200 OK
         code: 200
-        duration: 26.987125ms
+        duration: 19.872459ms
     - id: 116
       request:
         proto: HTTP/1.1
@@ -6059,7 +6061,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6068,16 +6070,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 6a9f8cd0-d9a0-4ad7-9fd6-d8d711bcfa25
+                - 4511da53-330a-4e68-b281-7599bee158c7
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162258Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260512T135522Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6085,23 +6087,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 330
+        content_length: 329
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgaa1696cac168402088e4-0067586ae2</RequestId><HostId>txgaa1696cac168402088e4-0067586ae2</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg00d4a0870b89473dadd6-006a03314a</RequestId><HostId>txg00d4a0870b89473dadd6-006a03314a</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
         headers:
             Content-Length:
-                - "330"
+                - "329"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:58 GMT
+                - Tue, 12 May 2026 13:55:22 GMT
             X-Amz-Id-2:
-                - txgaa1696cac168402088e4-0067586ae2
+                - txg00d4a0870b89473dadd6-006a03314a
             X-Amz-Request-Id:
-                - txgaa1696cac168402088e4-0067586ae2
+                - txg00d4a0870b89473dadd6-006a03314a
         status: 404 Not Found
         code: 404
-        duration: 26.667542ms
+        duration: 46.869041ms
     - id: 117
       request:
         proto: HTTP/1.1
@@ -6110,7 +6112,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6119,16 +6121,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 551bca1f-30fc-41f7-8346-0096b7789b39
+                - cddb18e2-7c79-4a6f-9a91-8fc1389dfd21
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162258Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/
+                - 20260512T135522Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -6136,25 +6138,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 287
+        content_length: 286
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "287"
+                - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:58 GMT
+                - Tue, 12 May 2026 13:55:22 GMT
             X-Amz-Id-2:
-                - txg55ecbf2df3be4a959577-0067586ae2
+                - txgd746a0c0967149e9a54c-006a03314a
             X-Amz-Request-Id:
-                - txg55ecbf2df3be4a959577-0067586ae2
+                - txgd746a0c0967149e9a54c-006a03314a
         status: 200 OK
         code: 200
-        duration: 15.984959ms
+        duration: 23.430833ms
     - id: 118
       request:
         proto: HTTP/1.1
@@ -6163,7 +6165,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6172,16 +6174,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 84bca257-f58a-4200-ad64-9bdd36ffc0fb
+                - 19d37562-a292-4db9-beb7-27b2541cabd5
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162258Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?tagging=
+                - 20260512T135522Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6189,23 +6191,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 361
+        content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgeabaab89a05b45098ffd-0067586ae2</RequestId><HostId>txgeabaab89a05b45098ffd-0067586ae2</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgc61ae3e4951d4b98b673-006a03314a</RequestId><HostId>txgc61ae3e4951d4b98b673-006a03314a</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</BucketName></Error>
         headers:
             Content-Length:
-                - "361"
+                - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:58 GMT
+                - Tue, 12 May 2026 13:55:22 GMT
             X-Amz-Id-2:
-                - txgeabaab89a05b45098ffd-0067586ae2
+                - txgc61ae3e4951d4b98b673-006a03314a
             X-Amz-Request-Id:
-                - txgeabaab89a05b45098ffd-0067586ae2
+                - txgc61ae3e4951d4b98b673-006a03314a
         status: 404 Not Found
         code: 404
-        duration: 26.357417ms
+        duration: 21.116792ms
     - id: 119
       request:
         proto: HTTP/1.1
@@ -6214,7 +6216,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6223,16 +6225,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 3eda7fc1-384e-4728-99b7-65ad3c0808ed
+                - 0d51bf37-90b4-4b2b-a9fb-e9bdfda7955c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162258Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?cors=
+                - 20260512T135522Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6240,23 +6242,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 298
+        content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgd2c6af0e6f434ce4a0cb-0067586ae2</RequestId><HostId>txgd2c6af0e6f434ce4a0cb-0067586ae2</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txga2e3401f86314ae9aabf-006a03314a</RequestId><HostId>txga2e3401f86314ae9aabf-006a03314a</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
         headers:
             Content-Length:
-                - "298"
+                - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:58 GMT
+                - Tue, 12 May 2026 13:55:22 GMT
             X-Amz-Id-2:
-                - txgd2c6af0e6f434ce4a0cb-0067586ae2
+                - txga2e3401f86314ae9aabf-006a03314a
             X-Amz-Request-Id:
-                - txgd2c6af0e6f434ce4a0cb-0067586ae2
+                - txga2e3401f86314ae9aabf-006a03314a
         status: 404 Not Found
         code: 404
-        duration: 28.035833ms
+        duration: 19.798791ms
     - id: 120
       request:
         proto: HTTP/1.1
@@ -6265,7 +6267,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6274,16 +6276,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d9940a56-f65d-497e-8406-26b531134257
+                - 23b897ce-7aba-4c6e-be3f-4b08df6ec168
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162258Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?versioning=
+                - 20260512T135522Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6291,25 +6293,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 155
+        content_length: 107
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Status></Status></VersioningConfiguration>
+            <VersioningConfiguration><Status></Status></VersioningConfiguration>
         headers:
             Content-Length:
-                - "155"
+                - "107"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:58 GMT
+                - Tue, 12 May 2026 13:55:22 GMT
             X-Amz-Id-2:
-                - txg7018afb991b04587abf8-0067586ae2
+                - txg871c15b8c8f14180954e-006a03314a
             X-Amz-Request-Id:
-                - txg7018afb991b04587abf8-0067586ae2
+                - txg871c15b8c8f14180954e-006a03314a
         status: 200 OK
         code: 200
-        duration: 15.441208ms
+        duration: 22.648292ms
     - id: 121
       request:
         proto: HTTP/1.1
@@ -6318,7 +6320,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6327,16 +6329,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f5a28594-64d2-429a-ad5a-af3e0be1378d
+                - c59c9091-94f0-4dd5-91b0-76af84c8a619
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162258Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T135522Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6344,25 +6346,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 323
+        content_length: 257
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path1/</Prefix><Tag><Key>deleted</Key><Value>true</Value></Tag></And></Filter><ID>id1</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
+            <Configuration><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path1/</Prefix><Tag><Key>deleted</Key><Value>true</Value></Tag></And></Filter><ID>id1</ID><Status>Enabled</Status></Rule></Configuration>
         headers:
             Content-Length:
-                - "323"
+                - "257"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:58 GMT
+                - Tue, 12 May 2026 13:55:22 GMT
             X-Amz-Id-2:
-                - txgb5ac7050028e4cd4a65f-0067586ae2
+                - txg4e62f26c94c64338b188-006a03314a
             X-Amz-Request-Id:
-                - txgb5ac7050028e4cd4a65f-0067586ae2
+                - txg4e62f26c94c64338b188-006a03314a
         status: 200 OK
         code: 200
-        duration: 16.34ms
+        duration: 25.441458ms
     - id: 122
       request:
         proto: HTTP/1.1
@@ -6371,7 +6373,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6380,16 +6382,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 74ceb556-b1b1-4831-8bcd-6a9b2a57d575
+                - 7de9a271-70cd-4ade-ac69-658e50d15451
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162258Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/
+                - 20260512T135522Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -6404,16 +6406,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:58 GMT
+                - Tue, 12 May 2026 13:55:22 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txgb7a7c539eba54e469155-0067586ae2
+                - txg693dc6d8198e4cffb307-006a03314a
             X-Amz-Request-Id:
-                - txgb7a7c539eba54e469155-0067586ae2
+                - txg693dc6d8198e4cffb307-006a03314a
         status: 200 OK
         code: 200
-        duration: 25.653708ms
+        duration: 19.140292ms
     - id: 123
       request:
         proto: HTTP/1.1
@@ -6422,7 +6424,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6431,16 +6433,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 25c99747-f49b-48d7-aa12-14ce710dd2dc
+                - 2789e92a-0d17-461f-bd32-3b584cbf187b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162258Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T135522Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6448,25 +6450,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 323
+        content_length: 257
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path1/</Prefix><Tag><Key>deleted</Key><Value>true</Value></Tag></And></Filter><ID>id1</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
+            <Configuration><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path1/</Prefix><Tag><Key>deleted</Key><Value>true</Value></Tag></And></Filter><ID>id1</ID><Status>Enabled</Status></Rule></Configuration>
         headers:
             Content-Length:
-                - "323"
+                - "257"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:58 GMT
+                - Tue, 12 May 2026 13:55:22 GMT
             X-Amz-Id-2:
-                - txg48260a5347734a60ad31-0067586ae2
+                - txg8556638fd4204762943e-006a03314a
             X-Amz-Request-Id:
-                - txg48260a5347734a60ad31-0067586ae2
+                - txg8556638fd4204762943e-006a03314a
         status: 200 OK
         code: 200
-        duration: 15.47675ms
+        duration: 21.51225ms
     - id: 124
       request:
         proto: HTTP/1.1
@@ -6475,7 +6477,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6484,16 +6486,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0e6dbd37-9690-473c-8528-c6370d9b2d7b
+                - bfa069ee-00c1-4784-8947-4fd80696b8e3
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162259Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?acl=
+                - 20260512T135522Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6505,21 +6507,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
                 - "698"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:59 GMT
+                - Tue, 12 May 2026 13:55:22 GMT
             X-Amz-Id-2:
-                - txg69995b9564f6493cb28a-0067586ae3
+                - txg5a71bdd1a8334af694a9-006a03314a
             X-Amz-Request-Id:
-                - txg69995b9564f6493cb28a-0067586ae3
+                - txg5a71bdd1a8334af694a9-006a03314a
         status: 200 OK
         code: 200
-        duration: 15.801541ms
+        duration: 29.207708ms
     - id: 125
       request:
         proto: HTTP/1.1
@@ -6528,7 +6530,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6537,16 +6539,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f66bb051-2d32-4945-a050-5fa1b6826780
+                - 72b6d799-4295-4d63-b532-0fb4637369a5
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162259Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260512T135522Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6554,23 +6556,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 330
+        content_length: 329
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg8eb2738c0925435dac5a-0067586ae3</RequestId><HostId>txg8eb2738c0925435dac5a-0067586ae3</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg505e5f766fc44d44a331-006a03314a</RequestId><HostId>txg505e5f766fc44d44a331-006a03314a</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
         headers:
             Content-Length:
-                - "330"
+                - "329"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:59 GMT
+                - Tue, 12 May 2026 13:55:22 GMT
             X-Amz-Id-2:
-                - txg8eb2738c0925435dac5a-0067586ae3
+                - txg505e5f766fc44d44a331-006a03314a
             X-Amz-Request-Id:
-                - txg8eb2738c0925435dac5a-0067586ae3
+                - txg505e5f766fc44d44a331-006a03314a
         status: 404 Not Found
         code: 404
-        duration: 25.7195ms
+        duration: 20.107125ms
     - id: 126
       request:
         proto: HTTP/1.1
@@ -6579,7 +6581,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6588,16 +6590,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ea5bc8d8-a4ee-478f-a382-58c40e58728a
+                - a81bbbb8-2ffb-4244-a492-89df7ac7231c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162259Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/
+                - 20260512T135522Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -6605,25 +6607,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 287
+        content_length: 286
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "287"
+                - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:59 GMT
+                - Tue, 12 May 2026 13:55:22 GMT
             X-Amz-Id-2:
-                - txg9c5d142852994ed983dc-0067586ae3
+                - txgd4da645a416e4d209c38-006a03314a
             X-Amz-Request-Id:
-                - txg9c5d142852994ed983dc-0067586ae3
+                - txgd4da645a416e4d209c38-006a03314a
         status: 200 OK
         code: 200
-        duration: 40.99575ms
+        duration: 348.77375ms
     - id: 127
       request:
         proto: HTTP/1.1
@@ -6632,7 +6634,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6641,16 +6643,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 05b16e03-9062-4b1c-8db2-27c42174e43e
+                - 67769d02-f605-4b07-b9d3-f262dd68d556
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162259Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?tagging=
+                - 20260512T135522Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6658,23 +6660,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 361
+        content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgd655c17db7b649e5afab-0067586ae3</RequestId><HostId>txgd655c17db7b649e5afab-0067586ae3</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txge68c19ba9a8f4d40b5af-006a03314b</RequestId><HostId>txge68c19ba9a8f4d40b5af-006a03314b</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</BucketName></Error>
         headers:
             Content-Length:
-                - "361"
+                - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:59 GMT
+                - Tue, 12 May 2026 13:55:23 GMT
             X-Amz-Id-2:
-                - txgd655c17db7b649e5afab-0067586ae3
+                - txge68c19ba9a8f4d40b5af-006a03314b
             X-Amz-Request-Id:
-                - txgd655c17db7b649e5afab-0067586ae3
+                - txge68c19ba9a8f4d40b5af-006a03314b
         status: 404 Not Found
         code: 404
-        duration: 15.493459ms
+        duration: 130.055667ms
     - id: 128
       request:
         proto: HTTP/1.1
@@ -6683,7 +6685,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6692,16 +6694,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 91d2823f-d3b1-41d0-a10e-ce0586213787
+                - 2b846205-2588-4f68-a694-7fcf56e6ec3c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162259Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?cors=
+                - 20260512T135523Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6709,23 +6711,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 298
+        content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txga0fc3c94f9e544cab987-0067586ae3</RequestId><HostId>txga0fc3c94f9e544cab987-0067586ae3</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txga6d3716993c0451a9763-006a03314b</RequestId><HostId>txga6d3716993c0451a9763-006a03314b</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
         headers:
             Content-Length:
-                - "298"
+                - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:22:59 GMT
+                - Tue, 12 May 2026 13:55:23 GMT
             X-Amz-Id-2:
-                - txga0fc3c94f9e544cab987-0067586ae3
+                - txga6d3716993c0451a9763-006a03314b
             X-Amz-Request-Id:
-                - txga0fc3c94f9e544cab987-0067586ae3
+                - txga6d3716993c0451a9763-006a03314b
         status: 404 Not Found
         code: 404
-        duration: 27.392292ms
+        duration: 19.738791ms
     - id: 129
       request:
         proto: HTTP/1.1
@@ -6734,7 +6736,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6743,16 +6745,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 21fb46b6-72b5-46c2-ae46-a17a705a4dce
+                - cb19048f-c39b-4c5f-993c-031e6e82adf3
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162259Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?versioning=
+                - 20260512T135523Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6760,25 +6762,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 155
+        content_length: 107
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Status></Status></VersioningConfiguration>
+            <VersioningConfiguration><Status></Status></VersioningConfiguration>
         headers:
             Content-Length:
-                - "155"
+                - "107"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:59 GMT
+                - Tue, 12 May 2026 13:55:23 GMT
             X-Amz-Id-2:
-                - txgfad3cfa1a4e74af49267-0067586ae3
+                - txgbc37bf33073643b08901-006a03314b
             X-Amz-Request-Id:
-                - txgfad3cfa1a4e74af49267-0067586ae3
+                - txgbc37bf33073643b08901-006a03314b
         status: 200 OK
         code: 200
-        duration: 15.932667ms
+        duration: 21.871417ms
     - id: 130
       request:
         proto: HTTP/1.1
@@ -6787,7 +6789,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6796,16 +6798,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ee0d9df2-7921-4c9e-96eb-b8b86bec7320
+                - 1a273235-6736-4c86-997b-5c066d4b3c33
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162259Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T135523Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6813,25 +6815,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 323
+        content_length: 257
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path1/</Prefix><Tag><Key>deleted</Key><Value>true</Value></Tag></And></Filter><ID>id1</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
+            <Configuration><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path1/</Prefix><Tag><Key>deleted</Key><Value>true</Value></Tag></And></Filter><ID>id1</ID><Status>Enabled</Status></Rule></Configuration>
         headers:
             Content-Length:
-                - "323"
+                - "257"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:22:59 GMT
+                - Tue, 12 May 2026 13:55:23 GMT
             X-Amz-Id-2:
-                - txg6346cb2b001a48e39dca-0067586ae3
+                - txg0c32630b6b104c6d808c-006a03314b
             X-Amz-Request-Id:
-                - txg6346cb2b001a48e39dca-0067586ae3
+                - txg0c32630b6b104c6d808c-006a03314b
         status: 200 OK
         code: 200
-        duration: 15.67875ms
+        duration: 158.039416ms
     - id: 131
       request:
         proto: HTTP/1.1
@@ -6840,7 +6842,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6849,16 +6851,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 16b79304-4e45-43c9-8224-e89cd32e2596
+                - 2ef97178-9fd7-4512-847d-a1036e8c1396
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162300Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?acl=
+                - 20260512T135523Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6870,21 +6872,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
                 - "698"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:23:00 GMT
+                - Tue, 12 May 2026 13:55:23 GMT
             X-Amz-Id-2:
-                - txgb99c1d5420d04035a918-0067586ae4
+                - txg6d021f0c19ae4d3a9a0a-006a03314b
             X-Amz-Request-Id:
-                - txgb99c1d5420d04035a918-0067586ae4
+                - txg6d021f0c19ae4d3a9a0a-006a03314b
         status: 200 OK
         code: 200
-        duration: 15.799916ms
+        duration: 21.207166ms
     - id: 132
       request:
         proto: HTTP/1.1
@@ -6893,7 +6895,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6902,16 +6904,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - db4d96d6-6679-4542-989f-32ca3578287f
+                - 972c23bf-4c6b-47bf-be36-130e404486c9
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162300Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260512T135523Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6919,23 +6921,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 330
+        content_length: 329
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg9cd33980a04c49a78291-0067586ae5</RequestId><HostId>txg9cd33980a04c49a78291-0067586ae5</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgfb880ec4f0224ab795f0-006a03314b</RequestId><HostId>txgfb880ec4f0224ab795f0-006a03314b</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
         headers:
             Content-Length:
-                - "330"
+                - "329"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:23:01 GMT
+                - Tue, 12 May 2026 13:55:23 GMT
             X-Amz-Id-2:
-                - txg9cd33980a04c49a78291-0067586ae5
+                - txgfb880ec4f0224ab795f0-006a03314b
             X-Amz-Request-Id:
-                - txg9cd33980a04c49a78291-0067586ae5
+                - txgfb880ec4f0224ab795f0-006a03314b
         status: 404 Not Found
         code: 404
-        duration: 27.704708ms
+        duration: 19.281458ms
     - id: 133
       request:
         proto: HTTP/1.1
@@ -6944,7 +6946,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6953,16 +6955,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5a9b6f8b-8557-49c5-8046-8d618982d038
+                - 14f83221-4f25-4435-9ab7-1982e1f9c7a6
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162301Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/
+                - 20260512T135523Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -6970,25 +6972,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 287
+        content_length: 286
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "287"
+                - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:23:01 GMT
+                - Tue, 12 May 2026 13:55:23 GMT
             X-Amz-Id-2:
-                - txg6dba1d3196184df698d4-0067586ae5
+                - txg7ee9b64e1aca4e1fb549-006a03314b
             X-Amz-Request-Id:
-                - txg6dba1d3196184df698d4-0067586ae5
+                - txg7ee9b64e1aca4e1fb549-006a03314b
         status: 200 OK
         code: 200
-        duration: 60.180375ms
+        duration: 34.765625ms
     - id: 134
       request:
         proto: HTTP/1.1
@@ -6997,7 +6999,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7006,16 +7008,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 25246bdb-1207-4f01-a541-d26525a076d0
+                - 0c5ed3eb-9f8a-4fee-9226-9bfca8108253
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162301Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?tagging=
+                - 20260512T135523Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7023,23 +7025,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 361
+        content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg09c06c6f7d19424da5f6-0067586ae5</RequestId><HostId>txg09c06c6f7d19424da5f6-0067586ae5</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg6cc74f233bf9420a8fef-006a03314b</RequestId><HostId>txg6cc74f233bf9420a8fef-006a03314b</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</BucketName></Error>
         headers:
             Content-Length:
-                - "361"
+                - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:23:01 GMT
+                - Tue, 12 May 2026 13:55:23 GMT
             X-Amz-Id-2:
-                - txg09c06c6f7d19424da5f6-0067586ae5
+                - txg6cc74f233bf9420a8fef-006a03314b
             X-Amz-Request-Id:
-                - txg09c06c6f7d19424da5f6-0067586ae5
+                - txg6cc74f233bf9420a8fef-006a03314b
         status: 404 Not Found
         code: 404
-        duration: 16.65975ms
+        duration: 19.917167ms
     - id: 135
       request:
         proto: HTTP/1.1
@@ -7048,7 +7050,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7057,16 +7059,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 6d9f2c0b-33e4-463a-abde-b0062a75397b
+                - 7e21f6eb-3103-4293-9099-34ac3c06ceb1
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162301Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?cors=
+                - 20260512T135523Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7074,23 +7076,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 298
+        content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg4ee68b4abdfe4a54bd68-0067586ae5</RequestId><HostId>txg4ee68b4abdfe4a54bd68-0067586ae5</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgf9ac533bc2db4b5bb89b-006a03314b</RequestId><HostId>txgf9ac533bc2db4b5bb89b-006a03314b</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
         headers:
             Content-Length:
-                - "298"
+                - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:23:01 GMT
+                - Tue, 12 May 2026 13:55:23 GMT
             X-Amz-Id-2:
-                - txg4ee68b4abdfe4a54bd68-0067586ae5
+                - txgf9ac533bc2db4b5bb89b-006a03314b
             X-Amz-Request-Id:
-                - txg4ee68b4abdfe4a54bd68-0067586ae5
+                - txgf9ac533bc2db4b5bb89b-006a03314b
         status: 404 Not Found
         code: 404
-        duration: 18.0315ms
+        duration: 27.376542ms
     - id: 136
       request:
         proto: HTTP/1.1
@@ -7099,7 +7101,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7108,16 +7110,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 804eca59-ed22-46ff-84f5-92522ab2b3e0
+                - 3bdae863-2c7e-4295-bd08-3283a90541fb
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162301Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?versioning=
+                - 20260512T135523Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7125,25 +7127,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 155
+        content_length: 107
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Status></Status></VersioningConfiguration>
+            <VersioningConfiguration><Status></Status></VersioningConfiguration>
         headers:
             Content-Length:
-                - "155"
+                - "107"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:23:01 GMT
+                - Tue, 12 May 2026 13:55:23 GMT
             X-Amz-Id-2:
-                - txg9ad50025af61460488da-0067586ae5
+                - txg2caf62660b514aa184e6-006a03314b
             X-Amz-Request-Id:
-                - txg9ad50025af61460488da-0067586ae5
+                - txg2caf62660b514aa184e6-006a03314b
         status: 200 OK
         code: 200
-        duration: 18.882333ms
+        duration: 19.205209ms
     - id: 137
       request:
         proto: HTTP/1.1
@@ -7152,7 +7154,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7161,16 +7163,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e2eb8452-ab5f-44e1-ae69-355db97c114e
+                - 559aaa7f-f8e2-40cd-928f-b86d2195d7d3
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162301Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T135523Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7178,25 +7180,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 323
+        content_length: 257
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path1/</Prefix><Tag><Key>deleted</Key><Value>true</Value></Tag></And></Filter><ID>id1</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
+            <Configuration><Rule><Expiration><Days>1</Days></Expiration><Filter><And><Prefix>path1/</Prefix><Tag><Key>deleted</Key><Value>true</Value></Tag></And></Filter><ID>id1</ID><Status>Enabled</Status></Rule></Configuration>
         headers:
             Content-Length:
-                - "323"
+                - "257"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:23:01 GMT
+                - Tue, 12 May 2026 13:55:23 GMT
             X-Amz-Id-2:
-                - txg14a4e2bcbcff42b79ce7-0067586ae5
+                - txg6b538630be8f411bb016-006a03314b
             X-Amz-Request-Id:
-                - txg14a4e2bcbcff42b79ce7-0067586ae5
+                - txg6b538630be8f411bb016-006a03314b
         status: 200 OK
         code: 200
-        duration: 15.033292ms
+        duration: 22.836ms
     - id: 138
       request:
         proto: HTTP/1.1
@@ -7205,7 +7207,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7214,16 +7216,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 545b2ae3-1b3c-4fe6-8218-0af8d4f68d08
+                - f5db8359-05e3-42ec-be9f-6e3deecff899
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162301Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/
+                - 20260512T135523Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -7236,14 +7238,14 @@ interactions:
         body: ""
         headers:
             Date:
-                - Tue, 10 Dec 2024 16:23:02 GMT
+                - Tue, 12 May 2026 13:55:24 GMT
             X-Amz-Id-2:
-                - txg555884b56fee4da2afd3-0067586ae6
+                - txg4ac589dd770c45158960-006a03314c
             X-Amz-Request-Id:
-                - txg555884b56fee4da2afd3-0067586ae6
+                - txg4ac589dd770c45158960-006a03314c
         status: 204 No Content
         code: 204
-        duration: 75.100125ms
+        duration: 182.535459ms
     - id: 139
       request:
         proto: HTTP/1.1
@@ -7252,7 +7254,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7261,18 +7263,18 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 26c4ee68-cd58-44a0-a35d-33e36ce2cb5a
+                - fbef7c38-da2d-441f-b87f-830854979f10
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Bucket-Object-Lock-Enabled:
                 - "true"
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162302Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/
+                - 20260512T135524Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
         method: PUT
       response:
         proto: HTTP/2.0
@@ -7287,16 +7289,16 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 10 Dec 2024 16:23:02 GMT
+                - Tue, 12 May 2026 13:55:24 GMT
             Location:
-                - /tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731
+                - /tf-tests-scaleway-object-bucket-lifecycle-152264452529566496
             X-Amz-Id-2:
-                - txg28358d84270e42f5b905-0067586ae6
+                - txg3ec45e7ac47f4a70be69-006a03314c
             X-Amz-Request-Id:
-                - txg28358d84270e42f5b905-0067586ae6
+                - txg3ec45e7ac47f4a70be69-006a03314c
         status: 200 OK
         code: 200
-        duration: 459.086709ms
+        duration: 6.051154875s
     - id: 140
       request:
         proto: HTTP/1.1
@@ -7305,7 +7307,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7314,18 +7316,20 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0e6ed62b-f69b-4630-abe8-f3acb31ee90c
+                - bc948de2-e0f0-4603-903f-7bdea4c3faa0
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,Z,e
             X-Amz-Acl:
                 - private
+            X-Amz-Checksum-Crc32:
+                - AAAAAA==
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162302Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?acl=
+                - 20260512T135530Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?acl=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -7340,14 +7344,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 10 Dec 2024 16:23:02 GMT
+                - Tue, 12 May 2026 13:55:30 GMT
             X-Amz-Id-2:
-                - txg81b58b3df89249aa85de-0067586ae6
+                - txg31ae4d6e90de430099cd-006a033152
             X-Amz-Request-Id:
-                - txg81b58b3df89249aa85de-0067586ae6
+                - txg31ae4d6e90de430099cd-006a033152
         status: 200 OK
         code: 200
-        duration: 105.868625ms
+        duration: 2.047572167s
     - id: 141
       request:
         proto: HTTP/1.1
@@ -7356,29 +7360,29 @@ interactions:
         content_length: 472
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
-        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>2</Days></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20241210162302662500000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20241210162302662500000002</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
+        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>2</Days></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260512135532269800000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260512135532269900000002</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
         form: {}
         headers:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 53312afd-c33a-4032-a57d-24a9b133ca8d
+                - 021efdf1-e841-4ca7-b4bf-75cf4ad7df21
             Amz-Sdk-Request:
                 - attempt=1; max=3
-            Content-Md5:
-                - keI6GWdpK52vKHsEDT1ifQ==
             Content-Type:
                 - application/xml
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,Z,e
+            X-Amz-Checksum-Crc32:
+                - rHzblg==
             X-Amz-Content-Sha256:
-                - 21ef55c84f5999672facb1c05c3099cef16234a3b315783b146377f53ea91fe0
+                - 2ce33e4e71ad18530a2b7d88880ea22baa53d973b2eac2a7bbaad68b36687b95
             X-Amz-Date:
-                - 20241210T162302Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T135530Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -7393,14 +7397,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 10 Dec 2024 16:23:02 GMT
+                - Tue, 12 May 2026 13:55:32 GMT
             X-Amz-Id-2:
-                - txg887edcd37d4d48629a7b-0067586ae6
+                - txge2d1c0ce543046608725-006a033154
             X-Amz-Request-Id:
-                - txg887edcd37d4d48629a7b-0067586ae6
+                - txge2d1c0ce543046608725-006a033154
         status: 200 OK
         code: 200
-        duration: 92.744625ms
+        duration: 1.085308542s
     - id: 142
       request:
         proto: HTTP/1.1
@@ -7409,7 +7413,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7418,16 +7422,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0157c170-2fb9-45f1-bd3a-30915ed05201
+                - cffc5d80-625a-478c-ad01-70cc8176b2b0
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162302Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?acl=
+                - 20260512T135533Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7439,21 +7443,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
                 - "698"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:23:02 GMT
+                - Tue, 12 May 2026 13:55:33 GMT
             X-Amz-Id-2:
-                - txg9002c5055eb24089a59e-0067586ae6
+                - txg2d68c15ba4ae4fd6affe-006a033155
             X-Amz-Request-Id:
-                - txg9002c5055eb24089a59e-0067586ae6
+                - txg2d68c15ba4ae4fd6affe-006a033155
         status: 200 OK
         code: 200
-        duration: 62.810375ms
+        duration: 1.061887542s
     - id: 143
       request:
         proto: HTTP/1.1
@@ -7462,7 +7466,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7471,16 +7475,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 76cf43f9-8968-45ed-85e4-3d69007c8ad1
+                - b8082991-a35e-43e9-b72c-42f984d23330
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162302Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260512T135533Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7499,14 +7503,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:23:02 GMT
+                - Tue, 12 May 2026 13:55:34 GMT
             X-Amz-Id-2:
-                - txge15c17e942d54aa5b10a-0067586ae6
+                - txgb9e546f710744ea3807a-006a033156
             X-Amz-Request-Id:
-                - txge15c17e942d54aa5b10a-0067586ae6
+                - txgb9e546f710744ea3807a-006a033156
         status: 200 OK
         code: 200
-        duration: 39.900541ms
+        duration: 1.026534541s
     - id: 144
       request:
         proto: HTTP/1.1
@@ -7515,7 +7519,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7524,16 +7528,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 36c000fa-240b-4fcd-90f0-49d0b5af5641
+                - fe13cc4e-2d46-4722-abc1-04f7ee4a504f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162302Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/
+                - 20260512T135534Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -7541,25 +7545,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 287
+        content_length: 286
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "287"
+                - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:23:02 GMT
+                - Tue, 12 May 2026 13:55:35 GMT
             X-Amz-Id-2:
-                - txg5b96e90f108e44c7bf41-0067586ae6
+                - txge008b004e47948c4ae2f-006a033157
             X-Amz-Request-Id:
-                - txg5b96e90f108e44c7bf41-0067586ae6
+                - txge008b004e47948c4ae2f-006a033157
         status: 200 OK
         code: 200
-        duration: 224.040583ms
+        duration: 1.077693042s
     - id: 145
       request:
         proto: HTTP/1.1
@@ -7568,7 +7572,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7577,16 +7581,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - a00e3713-cc11-41f9-9fc1-78ae7ae9a43f
+                - 12653d58-b5a8-465b-bc93-fb1cfab1c658
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162303Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?tagging=
+                - 20260512T135535Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7594,23 +7598,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 361
+        content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg1bfe9fa2fcef42da961b-0067586ae7</RequestId><HostId>txg1bfe9fa2fcef42da961b-0067586ae7</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgf8b918f2da7242e1a258-006a033158</RequestId><HostId>txgf8b918f2da7242e1a258-006a033158</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</BucketName></Error>
         headers:
             Content-Length:
-                - "361"
+                - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:23:03 GMT
+                - Tue, 12 May 2026 13:55:36 GMT
             X-Amz-Id-2:
-                - txg1bfe9fa2fcef42da961b-0067586ae7
+                - txgf8b918f2da7242e1a258-006a033158
             X-Amz-Request-Id:
-                - txg1bfe9fa2fcef42da961b-0067586ae7
+                - txgf8b918f2da7242e1a258-006a033158
         status: 404 Not Found
         code: 404
-        duration: 84.383958ms
+        duration: 1.022651375s
     - id: 146
       request:
         proto: HTTP/1.1
@@ -7619,7 +7623,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7628,16 +7632,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - a4a5fc57-f90e-40f4-a21d-a8de7e0cdd01
+                - 6b2f2c80-b101-41d7-9ff4-cd7dbcbe4ca3
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162303Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?cors=
+                - 20260512T135536Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7645,23 +7649,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 298
+        content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgc25e2747530b4148b853-0067586ae7</RequestId><HostId>txgc25e2747530b4148b853-0067586ae7</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgbbae0d1899ee4c159f69-006a033159</RequestId><HostId>txgbbae0d1899ee4c159f69-006a033159</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
         headers:
             Content-Length:
-                - "298"
+                - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:23:03 GMT
+                - Tue, 12 May 2026 13:55:37 GMT
             X-Amz-Id-2:
-                - txgc25e2747530b4148b853-0067586ae7
+                - txgbbae0d1899ee4c159f69-006a033159
             X-Amz-Request-Id:
-                - txgc25e2747530b4148b853-0067586ae7
+                - txgbbae0d1899ee4c159f69-006a033159
         status: 404 Not Found
         code: 404
-        duration: 63.790667ms
+        duration: 1.022517333s
     - id: 147
       request:
         proto: HTTP/1.1
@@ -7670,7 +7674,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7679,16 +7683,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 70c969a3-bde9-4624-8efe-61043b472529
+                - a76098c5-fb3b-4da1-8c43-af1447f833eb
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162303Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?versioning=
+                - 20260512T135537Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7696,25 +7700,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 114
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Status>Enabled</Status></VersioningConfiguration>
+            <VersioningConfiguration><Status>Enabled</Status></VersioningConfiguration>
         headers:
             Content-Length:
-                - "162"
+                - "114"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:23:03 GMT
+                - Tue, 12 May 2026 13:55:38 GMT
             X-Amz-Id-2:
-                - txg286c13fad7be456482c1-0067586ae7
+                - txgbd78201816664824855a-006a03315a
             X-Amz-Request-Id:
-                - txg286c13fad7be456482c1-0067586ae7
+                - txgbd78201816664824855a-006a03315a
         status: 200 OK
         code: 200
-        duration: 61.772625ms
+        duration: 33.5855ms
     - id: 148
       request:
         proto: HTTP/1.1
@@ -7723,7 +7727,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7732,16 +7736,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - db408d11-5272-4fb8-bf8f-eb2926cf0beb
+                - 692d63fe-96a7-4bcb-81f0-426b51f2a4ad
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162303Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T135538Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7749,25 +7753,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 511
+        content_length: 445
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>2</Days></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20241210162302662500000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20241210162302662500000002</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
+            <Configuration><Rule><Expiration><Days>2</Days></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260512135532269800000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260512135532269900000002</ID><Status>Enabled</Status></Rule></Configuration>
         headers:
             Content-Length:
-                - "511"
+                - "445"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:23:03 GMT
+                - Tue, 12 May 2026 13:55:38 GMT
             X-Amz-Id-2:
-                - txg7559e8389bee4ab08daa-0067586ae7
+                - txg1f069bd24b0c42049385-006a03315a
             X-Amz-Request-Id:
-                - txg7559e8389bee4ab08daa-0067586ae7
+                - txg1f069bd24b0c42049385-006a03315a
         status: 200 OK
         code: 200
-        duration: 49.9885ms
+        duration: 90.561084ms
     - id: 149
       request:
         proto: HTTP/1.1
@@ -7776,7 +7780,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7785,16 +7789,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ee8fa696-1d59-4b43-99aa-b0e039d4bf9f
+                - 3edb1b58-d5e1-48f6-a8d3-fe9a9ae8cc04
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162303Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/
+                - 20260512T135538Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -7809,16 +7813,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:23:03 GMT
+                - Tue, 12 May 2026 13:55:38 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txg54f875fc6fba46b48b67-0067586ae7
+                - txg5d616bed98fa4f85b5fb-006a03315a
             X-Amz-Request-Id:
-                - txg54f875fc6fba46b48b67-0067586ae7
+                - txg5d616bed98fa4f85b5fb-006a03315a
         status: 200 OK
         code: 200
-        duration: 42.568167ms
+        duration: 1.122937125s
     - id: 150
       request:
         proto: HTTP/1.1
@@ -7827,7 +7831,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7836,16 +7840,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - a75fe84c-0b1a-4ba7-aaa1-ca104c432748
+                - ebcf44c8-b88d-4766-b263-2d395c51ed8d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162303Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T135539Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7853,25 +7857,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 511
+        content_length: 445
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>2</Days></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20241210162302662500000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20241210162302662500000002</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
+            <Configuration><Rule><Expiration><Days>2</Days></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260512135532269800000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260512135532269900000002</ID><Status>Enabled</Status></Rule></Configuration>
         headers:
             Content-Length:
-                - "511"
+                - "445"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:23:03 GMT
+                - Tue, 12 May 2026 13:55:39 GMT
             X-Amz-Id-2:
-                - txg043ce3b57e3549e6975f-0067586ae7
+                - txgac29c82027534b3384a4-006a03315b
             X-Amz-Request-Id:
-                - txg043ce3b57e3549e6975f-0067586ae7
+                - txgac29c82027534b3384a4-006a03315b
         status: 200 OK
         code: 200
-        duration: 71.279459ms
+        duration: 1.022562542s
     - id: 151
       request:
         proto: HTTP/1.1
@@ -7880,7 +7884,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7889,16 +7893,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 65754c39-96e6-4129-a34a-073fe609501a
+                - 35c5b209-35fc-481b-8c1c-1ba7f58d0b47
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162304Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?acl=
+                - 20260512T135541Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7910,21 +7914,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
                 - "698"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:23:04 GMT
+                - Tue, 12 May 2026 13:55:41 GMT
             X-Amz-Id-2:
-                - txg28bd5a83f92f43d99e44-0067586ae8
+                - txgc21ec160a7e444c88ccd-006a03315d
             X-Amz-Request-Id:
-                - txg28bd5a83f92f43d99e44-0067586ae8
+                - txgc21ec160a7e444c88ccd-006a03315d
         status: 200 OK
         code: 200
-        duration: 75.123375ms
+        duration: 144.855209ms
     - id: 152
       request:
         proto: HTTP/1.1
@@ -7933,7 +7937,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7942,16 +7946,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e8f0e5b7-7f68-45bd-aaa8-b36e029a3988
+                - 38d33596-8b0b-4d82-8200-a534b981225f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162304Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260512T135541Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7970,14 +7974,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:23:04 GMT
+                - Tue, 12 May 2026 13:55:41 GMT
             X-Amz-Id-2:
-                - txga1c1f3679db84acb9996-0067586ae8
+                - txg9b6dd698f3ff4e069338-006a03315d
             X-Amz-Request-Id:
-                - txga1c1f3679db84acb9996-0067586ae8
+                - txg9b6dd698f3ff4e069338-006a03315d
         status: 200 OK
         code: 200
-        duration: 15.702833ms
+        duration: 1.026396208s
     - id: 153
       request:
         proto: HTTP/1.1
@@ -7986,7 +7990,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7995,16 +7999,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b99a9a44-fbcf-4c95-be73-c62f6ce3b17e
+                - e95b148f-be67-4425-b1e6-d76fc4923bdb
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162304Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/
+                - 20260512T135541Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -8012,25 +8016,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 287
+        content_length: 286
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "287"
+                - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:23:04 GMT
+                - Tue, 12 May 2026 13:55:42 GMT
             X-Amz-Id-2:
-                - txgaa049d4691da4f95ba6f-0067586ae8
+                - txg6923b43840d34e0a993e-006a03315e
             X-Amz-Request-Id:
-                - txgaa049d4691da4f95ba6f-0067586ae8
+                - txg6923b43840d34e0a993e-006a03315e
         status: 200 OK
         code: 200
-        duration: 137.071125ms
+        duration: 2.045383125s
     - id: 154
       request:
         proto: HTTP/1.1
@@ -8039,7 +8043,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8048,16 +8052,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 81de7d52-ded8-4ddc-8026-bb33166cbca2
+                - d833bebc-7248-48b3-9679-e3d23dd02432
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162304Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?tagging=
+                - 20260512T135542Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8065,23 +8069,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 361
+        content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txga6de66c108d543e5a808-0067586ae8</RequestId><HostId>txga6de66c108d543e5a808-0067586ae8</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgdff646dacd2f4084b9a4-006a033160</RequestId><HostId>txgdff646dacd2f4084b9a4-006a033160</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</BucketName></Error>
         headers:
             Content-Length:
-                - "361"
+                - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:23:04 GMT
+                - Tue, 12 May 2026 13:55:44 GMT
             X-Amz-Id-2:
-                - txga6de66c108d543e5a808-0067586ae8
+                - txgdff646dacd2f4084b9a4-006a033160
             X-Amz-Request-Id:
-                - txga6de66c108d543e5a808-0067586ae8
+                - txgdff646dacd2f4084b9a4-006a033160
         status: 404 Not Found
         code: 404
-        duration: 92.673125ms
+        duration: 1.126117708s
     - id: 155
       request:
         proto: HTTP/1.1
@@ -8090,7 +8094,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8099,16 +8103,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 2b35d8bd-733a-4989-ba27-13b551b7e175
+                - 138a0a79-6f18-4f0d-9896-710cbcac009e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162304Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?cors=
+                - 20260512T135544Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8116,23 +8120,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 298
+        content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg912f395209164c5eb5d0-0067586ae8</RequestId><HostId>txg912f395209164c5eb5d0-0067586ae8</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgd98fc014a13e4369ae00-006a033161</RequestId><HostId>txgd98fc014a13e4369ae00-006a033161</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
         headers:
             Content-Length:
-                - "298"
+                - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Dec 2024 16:23:04 GMT
+                - Tue, 12 May 2026 13:55:45 GMT
             X-Amz-Id-2:
-                - txg912f395209164c5eb5d0-0067586ae8
+                - txgd98fc014a13e4369ae00-006a033161
             X-Amz-Request-Id:
-                - txg912f395209164c5eb5d0-0067586ae8
+                - txgd98fc014a13e4369ae00-006a033161
         status: 404 Not Found
         code: 404
-        duration: 92.004959ms
+        duration: 29.80925ms
     - id: 156
       request:
         proto: HTTP/1.1
@@ -8141,7 +8145,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8150,16 +8154,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 73cb3299-a1ff-4485-a061-b5a26ebfb963
+                - 13407326-0134-47ba-9fba-d27d6c816c42
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162304Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?versioning=
+                - 20260512T135545Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8167,25 +8171,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 114
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Status>Enabled</Status></VersioningConfiguration>
+            <VersioningConfiguration><Status>Enabled</Status></VersioningConfiguration>
         headers:
             Content-Length:
-                - "162"
+                - "114"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:23:04 GMT
+                - Tue, 12 May 2026 13:55:45 GMT
             X-Amz-Id-2:
-                - txga02df68c2dde42b78fe2-0067586ae8
+                - txg6681620baceb458ab094-006a033161
             X-Amz-Request-Id:
-                - txga02df68c2dde42b78fe2-0067586ae8
+                - txg6681620baceb458ab094-006a033161
         status: 200 OK
         code: 200
-        duration: 27.866417ms
+        duration: 29.023334ms
     - id: 157
       request:
         proto: HTTP/1.1
@@ -8194,7 +8198,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8203,16 +8207,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 6416c765-29e2-4525-92c0-42132b269769
+                - dd1603a6-a997-4259-885e-e21f26f2c5f8
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162304Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260512T135545Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8220,25 +8224,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 511
+        content_length: 445
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>2</Days></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20241210162302662500000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20241210162302662500000002</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
+            <Configuration><Rule><Expiration><Days>2</Days></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260512135532269800000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260512135532269900000002</ID><Status>Enabled</Status></Rule></Configuration>
         headers:
             Content-Length:
-                - "511"
+                - "445"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Dec 2024 16:23:04 GMT
+                - Tue, 12 May 2026 13:55:45 GMT
             X-Amz-Id-2:
-                - txg2d362fb5be604974bf0c-0067586ae8
+                - txgdeb45ef2854f4277bf1a-006a033161
             X-Amz-Request-Id:
-                - txg2d362fb5be604974bf0c-0067586ae8
+                - txgdeb45ef2854f4277bf1a-006a033161
         status: 200 OK
         code: 200
-        duration: 16.589208ms
+        duration: 49.106417ms
     - id: 158
       request:
         proto: HTTP/1.1
@@ -8247,7 +8251,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8256,16 +8260,383 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 52514667-6501-488e-b7d0-d384866a00da
+                - de415bd8-7f19-43d8-a9d2-5c00beb31ee3
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - m/E aws-sdk-go-v2/1.32.3 os/macos lang/go#1.23.2 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.66.2
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20241210T162305Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-1253800434194895731.s3.nl-ams.scw.cloud/
+                - 20260512T135545Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?acl=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 698
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+        headers:
+            Content-Length:
+                - "698"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Tue, 12 May 2026 13:55:45 GMT
+            X-Amz-Id-2:
+                - txg4227fab4f74543cc90e4-006a033161
+            X-Amz-Request-Id:
+                - txg4227fab4f74543cc90e4-006a033161
+        status: 200 OK
+        code: 200
+        duration: 1.021198416s
+    - id: 159
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - a8973f43-fec9-493c-b97d-922500aa3f3d
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260512T135545Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?object-lock=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 184
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <ObjectLockConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><ObjectLockEnabled>Enabled</ObjectLockEnabled></ObjectLockConfiguration>
+        headers:
+            Content-Length:
+                - "184"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Tue, 12 May 2026 13:55:46 GMT
+            X-Amz-Id-2:
+                - txg0892d39aac174708b6bf-006a033162
+            X-Amz-Request-Id:
+                - txg0892d39aac174708b6bf-006a033162
+        status: 200 OK
+        code: 200
+        duration: 1.139039708s
+    - id: 160
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 9bbd9af4-3eac-45d1-854f-e32a4efb9371
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260512T135546Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 286
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+        headers:
+            Content-Length:
+                - "286"
+            Content-Type:
+                - application/xml
+            Date:
+                - Tue, 12 May 2026 13:55:48 GMT
+            X-Amz-Id-2:
+                - txgc495ceb9d7074b299695-006a033164
+            X-Amz-Request-Id:
+                - txgc495ceb9d7074b299695-006a033164
+        status: 200 OK
+        code: 200
+        duration: 2.042776917s
+    - id: 161
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - d32a1648-d78c-474e-8e29-fcff322408ea
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260512T135548Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?tagging=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 359
+        uncompressed: false
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg12815c0879894ec1af84-006a033166</RequestId><HostId>txg12815c0879894ec1af84-006a033166</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</BucketName></Error>
+        headers:
+            Content-Length:
+                - "359"
+            Content-Type:
+                - application/xml
+            Date:
+                - Tue, 12 May 2026 13:55:50 GMT
+            X-Amz-Id-2:
+                - txg12815c0879894ec1af84-006a033166
+            X-Amz-Request-Id:
+                - txg12815c0879894ec1af84-006a033166
+        status: 404 Not Found
+        code: 404
+        duration: 26.096583ms
+    - id: 162
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 7c66beae-e19c-4c11-a267-33381a225aec
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260512T135550Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?cors=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 297
+        uncompressed: false
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgeae4301a681145488c48-006a033166</RequestId><HostId>txgeae4301a681145488c48-006a033166</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-152264452529566496</Resource></Error>
+        headers:
+            Content-Length:
+                - "297"
+            Content-Type:
+                - application/xml
+            Date:
+                - Tue, 12 May 2026 13:55:50 GMT
+            X-Amz-Id-2:
+                - txgeae4301a681145488c48-006a033166
+            X-Amz-Request-Id:
+                - txgeae4301a681145488c48-006a033166
+        status: 404 Not Found
+        code: 404
+        duration: 1.028613458s
+    - id: 163
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 8eea8972-f14e-456b-8a31-81956b83b6c3
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260512T135550Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?versioning=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 114
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <VersioningConfiguration><Status>Enabled</Status></VersioningConfiguration>
+        headers:
+            Content-Length:
+                - "114"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Tue, 12 May 2026 13:55:51 GMT
+            X-Amz-Id-2:
+                - txg57622198f3e24074907c-006a033167
+            X-Amz-Request-Id:
+                - txg57622198f3e24074907c-006a033167
+        status: 200 OK
+        code: 200
+        duration: 1.09513725s
+    - id: 164
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 3353e076-12d9-4f77-9a26-8b10cac34e33
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260512T135551Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/?lifecycle=
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 445
+        uncompressed: false
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <Configuration><Rule><Expiration><Days>2</Days></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260512135532269800000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260512135532269900000002</ID><Status>Enabled</Status></Rule></Configuration>
+        headers:
+            Content-Length:
+                - "445"
+            Content-Type:
+                - text/xml; charset=utf-8
+            Date:
+                - Tue, 12 May 2026 13:55:52 GMT
+            X-Amz-Id-2:
+                - txg2cc907681ac04d01aee6-006a033168
+            X-Amz-Request-Id:
+                - txg2cc907681ac04d01aee6-006a033168
+        status: 200 OK
+        code: 200
+        duration: 19.459958ms
+    - id: 165
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - identity
+            Amz-Sdk-Invocation-Id:
+                - 24787126-c9e2-4492-8f7f-2f50adf2af40
+            Amz-Sdk-Request:
+                - attempt=1; max=3
+            User-Agent:
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
+            X-Amz-Content-Sha256:
+                - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+            X-Amz-Date:
+                - 20260512T135552Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-152264452529566496.s3.nl-ams.scw.cloud/
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -8278,11 +8649,11 @@ interactions:
         body: ""
         headers:
             Date:
-                - Tue, 10 Dec 2024 16:23:05 GMT
+                - Tue, 12 May 2026 13:55:52 GMT
             X-Amz-Id-2:
-                - txg1f5e342a43c4481b8c7c-0067586ae9
+                - txge663af13b07047f98684-006a033168
             X-Amz-Request-Id:
-                - txg1f5e342a43c4481b8c7c-0067586ae9
+                - txge663af13b07047f98684-006a033168
         status: 204 No Content
         code: 204
-        duration: 89.469042ms
+        duration: 221.734291ms

--- a/internal/services/object/testdata/object-bucket-lifecycle.cassette.yaml
+++ b/internal/services/object/testdata/object-bucket-lifecycle.cassette.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -18,7 +18,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4c7e7527-c2dd-452a-b810-95930308ec2a
+                - 60483fa6-82c2-4d31-a93c-656c9edd522e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -26,8 +26,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133548Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
+                - 20260518T140641Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/
         method: PUT
       response:
         proto: HTTP/2.0
@@ -42,16 +42,16 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 18 May 2026 13:35:49 GMT
+                - Mon, 18 May 2026 14:06:41 GMT
             Location:
-                - /tf-tests-scaleway-object-bucket-lifecycle-361671012043732063
+                - /tf-tests-scaleway-object-bucket-lifecycle-256272269376130782
             X-Amz-Id-2:
-                - txg95d5e938f1394555a771-006a0b15b5
+                - txg79b32b267f154257904b-006a0b1cf1
             X-Amz-Request-Id:
-                - txg95d5e938f1394555a771-006a0b15b5
+                - txg79b32b267f154257904b-006a0b1cf1
         status: 200 OK
         code: 200
-        duration: 7.733313583s
+        duration: 5.400398209s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -60,7 +60,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -69,7 +69,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 45e29889-18e8-4943-a07d-62637dd6432e
+                - c6fcf117-5bf2-4b4d-aafd-52c65c281cb0
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -81,8 +81,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133556Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T140646Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?acl=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -97,14 +97,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 18 May 2026 13:35:56 GMT
+                - Mon, 18 May 2026 14:06:46 GMT
             X-Amz-Id-2:
-                - txg3e7f2be80bf6460fb05d-006a0b15bc
+                - txg727a824cbefb4a90b82f-006a0b1cf6
             X-Amz-Request-Id:
-                - txg3e7f2be80bf6460fb05d-006a0b15bc
+                - txg727a824cbefb4a90b82f-006a0b1cf6
         status: 200 OK
         code: 200
-        duration: 78.903167ms
+        duration: 71.165625ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -113,7 +113,7 @@ interactions:
         content_length: 363
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></LifecycleConfiguration>
@@ -122,7 +122,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0d4b9e8a-def9-4332-aa76-adf3e70f9933
+                - e65156ea-96ef-4db9-a9e3-78ea6d865593
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
@@ -134,8 +134,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - 512733381e697ad60e3f974cfb76a92f1c9d2b97cb251bdf165a2579d5e88cd5
             X-Amz-Date:
-                - 20260518T133556Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T140646Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -150,14 +150,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 18 May 2026 13:35:56 GMT
+                - Mon, 18 May 2026 14:06:46 GMT
             X-Amz-Id-2:
-                - txg8223dcafbad94185a53f-006a0b15bc
+                - txgb81b9df9526848189909-006a0b1cf6
             X-Amz-Request-Id:
-                - txg8223dcafbad94185a53f-006a0b15bc
+                - txgb81b9df9526848189909-006a0b1cf6
         status: 200 OK
         code: 200
-        duration: 114.8165ms
+        duration: 114.72825ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -166,7 +166,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -175,7 +175,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0ef5a8f7-df20-4a20-9a8e-3ac25a784674
+                - c2e34ac6-06f7-4e72-8efb-af628bccaaba
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -183,8 +183,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133556Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T140646Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -203,14 +203,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:35:56 GMT
+                - Mon, 18 May 2026 14:06:46 GMT
             X-Amz-Id-2:
-                - txgba0dd215ff6f49ada4b1-006a0b15bc
+                - txg767d740ecc5944a68026-006a0b1cf6
             X-Amz-Request-Id:
-                - txgba0dd215ff6f49ada4b1-006a0b15bc
+                - txg767d740ecc5944a68026-006a0b1cf6
         status: 200 OK
         code: 200
-        duration: 59.738583ms
+        duration: 61.804666ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -219,7 +219,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -228,7 +228,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f70d2f11-4ef7-4511-add6-5bcfc9fa0aba
+                - 189e8ef3-4e41-426b-9fc7-316a9cbf24ff
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -236,8 +236,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133556Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T140646Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -247,21 +247,21 @@ interactions:
         trailer: {}
         content_length: 329
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg25385c9803f340109e77-006a0b15bd</RequestId><HostId>txg25385c9803f340109e77-006a0b15bd</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg29ccf84e7b7440da9549-006a0b1cf6</RequestId><HostId>txg29ccf84e7b7440da9549-006a0b1cf6</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource></Error>
         headers:
             Content-Length:
                 - "329"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:35:57 GMT
+                - Mon, 18 May 2026 14:06:46 GMT
             X-Amz-Id-2:
-                - txg25385c9803f340109e77-006a0b15bd
+                - txg29ccf84e7b7440da9549-006a0b1cf6
             X-Amz-Request-Id:
-                - txg25385c9803f340109e77-006a0b15bd
+                - txg29ccf84e7b7440da9549-006a0b1cf6
         status: 404 Not Found
         code: 404
-        duration: 30.0745ms
+        duration: 50.308542ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -270,7 +270,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -279,7 +279,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - cd76900b-1cca-43df-9d81-b772e6794e01
+                - 35ef077d-d083-4ae9-b0f7-658e2f2aebef
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -287,8 +287,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133557Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
+                - 20260518T140646Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -300,21 +300,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:35:57 GMT
+                - Mon, 18 May 2026 14:06:47 GMT
             X-Amz-Id-2:
-                - txg952917af00b844228635-006a0b15bd
+                - txga034ec5af5a3442c94f9-006a0b1cf7
             X-Amz-Request-Id:
-                - txg952917af00b844228635-006a0b15bd
+                - txga034ec5af5a3442c94f9-006a0b1cf7
         status: 200 OK
         code: 200
-        duration: 132.859583ms
+        duration: 306.448125ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -323,7 +323,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -332,7 +332,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5cd17394-93fb-427b-8df1-7b4e120edc5a
+                - 0be0cd9d-dff7-4bd6-927f-f8df700a54ef
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -340,8 +340,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133557Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T140647Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -351,21 +351,21 @@ interactions:
         trailer: {}
         content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg8f0f25b64aa44ab69f3c-006a0b15bd</RequestId><HostId>txg8f0f25b64aa44ab69f3c-006a0b15bd</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgaf78cfcc43fa41eb8771-006a0b1cf7</RequestId><HostId>txgaf78cfcc43fa41eb8771-006a0b1cf7</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</BucketName></Error>
         headers:
             Content-Length:
                 - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:35:57 GMT
+                - Mon, 18 May 2026 14:06:47 GMT
             X-Amz-Id-2:
-                - txg8f0f25b64aa44ab69f3c-006a0b15bd
+                - txgaf78cfcc43fa41eb8771-006a0b1cf7
             X-Amz-Request-Id:
-                - txg8f0f25b64aa44ab69f3c-006a0b15bd
+                - txgaf78cfcc43fa41eb8771-006a0b1cf7
         status: 404 Not Found
         code: 404
-        duration: 42.316667ms
+        duration: 63.638334ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -374,7 +374,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -383,7 +383,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 8b701384-cdf0-4142-b2f6-e0aba4256d70
+                - f7ea2d0d-b1c2-4427-8095-568807cd8174
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -391,8 +391,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133557Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T140647Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -402,21 +402,21 @@ interactions:
         trailer: {}
         content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg9e8f757f68754b94aaac-006a0b15bd</RequestId><HostId>txg9e8f757f68754b94aaac-006a0b15bd</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgd580c04837c2463eb71f-006a0b1cf7</RequestId><HostId>txgd580c04837c2463eb71f-006a0b1cf7</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource></Error>
         headers:
             Content-Length:
                 - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:35:57 GMT
+                - Mon, 18 May 2026 14:06:47 GMT
             X-Amz-Id-2:
-                - txg9e8f757f68754b94aaac-006a0b15bd
+                - txgd580c04837c2463eb71f-006a0b1cf7
             X-Amz-Request-Id:
-                - txg9e8f757f68754b94aaac-006a0b15bd
+                - txgd580c04837c2463eb71f-006a0b1cf7
         status: 404 Not Found
         code: 404
-        duration: 62.203042ms
+        duration: 50.225084ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -425,7 +425,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -434,7 +434,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9013d6ca-bf6c-42e0-9329-c72e32bfea0d
+                - d7196a74-fa80-425d-bd80-2ec3cd90995f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -442,8 +442,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133557Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T140647Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -462,14 +462,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:35:57 GMT
+                - Mon, 18 May 2026 14:06:47 GMT
             X-Amz-Id-2:
-                - txg99fcaade7ddf4abea9f0-006a0b15bd
+                - txgf2b70fc2d051492c82d6-006a0b1cf7
             X-Amz-Request-Id:
-                - txg99fcaade7ddf4abea9f0-006a0b15bd
+                - txgf2b70fc2d051492c82d6-006a0b1cf7
         status: 200 OK
         code: 200
-        duration: 48.296583ms
+        duration: 33.13ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -478,7 +478,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -487,7 +487,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f36767f5-7ae8-44b8-bfba-52861820f4d4
+                - c7bee156-f5a9-43f5-a71d-8c883ecf83c2
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -495,8 +495,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133557Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T140647Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -515,14 +515,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:35:57 GMT
+                - Mon, 18 May 2026 14:06:47 GMT
             X-Amz-Id-2:
-                - txgc81b4c5bc31140b2b49d-006a0b15bd
+                - txg2dc8c08e48ec4012abdc-006a0b1cf7
             X-Amz-Request-Id:
-                - txgc81b4c5bc31140b2b49d-006a0b15bd
+                - txg2dc8c08e48ec4012abdc-006a0b1cf7
         status: 200 OK
         code: 200
-        duration: 31.688833ms
+        duration: 54.752875ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -531,7 +531,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -540,7 +540,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4d8fc812-0e5d-4495-9f0d-c202fa52ae78
+                - 4efc5919-1427-4228-848a-91faca69728b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -548,8 +548,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133557Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
+                - 20260518T140647Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -564,16 +564,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:35:57 GMT
+                - Mon, 18 May 2026 14:06:47 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txg927c1a37e2c04fff8660-006a0b15bd
+                - txg71e430f0d2ad433ebf14-006a0b1cf7
             X-Amz-Request-Id:
-                - txg927c1a37e2c04fff8660-006a0b15bd
+                - txg71e430f0d2ad433ebf14-006a0b1cf7
         status: 200 OK
         code: 200
-        duration: 65.517209ms
+        duration: 30.010667ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -582,7 +582,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -591,7 +591,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5f03d4f7-fcad-405e-a9ef-8af968a22693
+                - 60d29b08-3a79-47ab-98e1-1b7d305eedfe
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -599,8 +599,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133557Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T140647Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -619,14 +619,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:35:57 GMT
+                - Mon, 18 May 2026 14:06:47 GMT
             X-Amz-Id-2:
-                - txg5a871d29c9514d1f831f-006a0b15bd
+                - txg258429bd33a849869b9e-006a0b1cf7
             X-Amz-Request-Id:
-                - txg5a871d29c9514d1f831f-006a0b15bd
+                - txg258429bd33a849869b9e-006a0b1cf7
         status: 200 OK
         code: 200
-        duration: 62.234542ms
+        duration: 64.226417ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -635,7 +635,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -644,7 +644,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7b26db91-ba1e-4d9d-bb4f-2eee2f594e82
+                - bb35d776-f91d-42ab-99c1-8dd946967f08
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -652,8 +652,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133557Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T140647Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -672,14 +672,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:35:57 GMT
+                - Mon, 18 May 2026 14:06:48 GMT
             X-Amz-Id-2:
-                - txg3b492b54f4654eaebbb9-006a0b15bd
+                - txgfd58ee86f29e47f787c6-006a0b1cf8
             X-Amz-Request-Id:
-                - txg3b492b54f4654eaebbb9-006a0b15bd
+                - txgfd58ee86f29e47f787c6-006a0b1cf8
         status: 200 OK
         code: 200
-        duration: 49.610125ms
+        duration: 115.533416ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -688,7 +688,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -697,7 +697,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 73ce7d03-e7c9-4101-a407-f302e7203edc
+                - 7837a57c-dad9-431f-a094-95a6ff2958c5
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -705,8 +705,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133557Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T140648Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -716,21 +716,21 @@ interactions:
         trailer: {}
         content_length: 329
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txga2087e1a754d4f3c9ba9-006a0b15bd</RequestId><HostId>txga2087e1a754d4f3c9ba9-006a0b15bd</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg2c607eb31bf14e11adbb-006a0b1cf8</RequestId><HostId>txg2c607eb31bf14e11adbb-006a0b1cf8</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource></Error>
         headers:
             Content-Length:
                 - "329"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:35:57 GMT
+                - Mon, 18 May 2026 14:06:48 GMT
             X-Amz-Id-2:
-                - txga2087e1a754d4f3c9ba9-006a0b15bd
+                - txg2c607eb31bf14e11adbb-006a0b1cf8
             X-Amz-Request-Id:
-                - txga2087e1a754d4f3c9ba9-006a0b15bd
+                - txg2c607eb31bf14e11adbb-006a0b1cf8
         status: 404 Not Found
         code: 404
-        duration: 63.871959ms
+        duration: 72.098584ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -739,7 +739,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -748,7 +748,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b8faaec4-da89-46bd-aac0-403d1a9d5932
+                - 68585314-f7a3-442c-9956-65ee9f3ff5b3
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -756,8 +756,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133557Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
+                - 20260518T140648Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -769,21 +769,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:35:57 GMT
+                - Mon, 18 May 2026 14:06:48 GMT
             X-Amz-Id-2:
-                - txg4252db8d38be47459a59-006a0b15bd
+                - txg129af7caa14246aca7f7-006a0b1cf8
             X-Amz-Request-Id:
-                - txg4252db8d38be47459a59-006a0b15bd
+                - txg129af7caa14246aca7f7-006a0b1cf8
         status: 200 OK
         code: 200
-        duration: 106.266792ms
+        duration: 805.442791ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -792,7 +792,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -801,7 +801,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c94e4b7b-1558-40b9-b5fd-41ec3846431f
+                - 15bd9147-b916-4a2b-bd6f-4f7d6912ef1b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -809,8 +809,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133557Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T140648Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -820,21 +820,21 @@ interactions:
         trailer: {}
         content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg566ca844e56d415f82bd-006a0b15be</RequestId><HostId>txg566ca844e56d415f82bd-006a0b15be</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg3f723d7ed8e9454d8534-006a0b1cf8</RequestId><HostId>txg3f723d7ed8e9454d8534-006a0b1cf8</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</BucketName></Error>
         headers:
             Content-Length:
                 - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:35:58 GMT
+                - Mon, 18 May 2026 14:06:48 GMT
             X-Amz-Id-2:
-                - txg566ca844e56d415f82bd-006a0b15be
+                - txg3f723d7ed8e9454d8534-006a0b1cf8
             X-Amz-Request-Id:
-                - txg566ca844e56d415f82bd-006a0b15be
+                - txg3f723d7ed8e9454d8534-006a0b1cf8
         status: 404 Not Found
         code: 404
-        duration: 21.226958ms
+        duration: 70.689917ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -843,7 +843,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -852,7 +852,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 572de172-ee4a-489b-b8cc-ab18cf2a6c40
+                - d67524db-bb68-4bd1-83f7-7ce471805ed3
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -860,8 +860,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133558Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T140648Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -871,21 +871,21 @@ interactions:
         trailer: {}
         content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgc5bf42b388064a62ae42-006a0b15be</RequestId><HostId>txgc5bf42b388064a62ae42-006a0b15be</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg20c332112d1b4504b008-006a0b1cf9</RequestId><HostId>txg20c332112d1b4504b008-006a0b1cf9</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource></Error>
         headers:
             Content-Length:
                 - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:35:58 GMT
+                - Mon, 18 May 2026 14:06:49 GMT
             X-Amz-Id-2:
-                - txgc5bf42b388064a62ae42-006a0b15be
+                - txg20c332112d1b4504b008-006a0b1cf9
             X-Amz-Request-Id:
-                - txgc5bf42b388064a62ae42-006a0b15be
+                - txg20c332112d1b4504b008-006a0b1cf9
         status: 404 Not Found
         code: 404
-        duration: 52.750917ms
+        duration: 61.59575ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -894,7 +894,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -903,7 +903,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ff43b1f1-3e67-4379-ac9b-c4aee69316d6
+                - 9e1d9721-ba06-4e08-912b-1e3e416edfee
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -911,8 +911,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133558Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T140649Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -931,14 +931,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:35:58 GMT
+                - Mon, 18 May 2026 14:06:49 GMT
             X-Amz-Id-2:
-                - txg5623adee56924833846e-006a0b15be
+                - txgd7fdcf0b727d4e188293-006a0b1cf9
             X-Amz-Request-Id:
-                - txg5623adee56924833846e-006a0b15be
+                - txgd7fdcf0b727d4e188293-006a0b1cf9
         status: 200 OK
         code: 200
-        duration: 79.133541ms
+        duration: 61.087958ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -947,7 +947,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -956,7 +956,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f0b4f58b-6512-450f-9fb4-4224c2a0a53b
+                - a153ad4e-ee34-464f-8328-f4232cabc856
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -964,8 +964,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133558Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T140649Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -984,14 +984,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:35:58 GMT
+                - Mon, 18 May 2026 14:06:49 GMT
             X-Amz-Id-2:
-                - txg49feaa0c30f4417d9a89-006a0b15be
+                - txg8931251628994e4a8ea7-006a0b1cf9
             X-Amz-Request-Id:
-                - txg49feaa0c30f4417d9a89-006a0b15be
+                - txg8931251628994e4a8ea7-006a0b1cf9
         status: 200 OK
         code: 200
-        duration: 48.709125ms
+        duration: 36.323333ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -1000,7 +1000,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1009,7 +1009,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d3451f3a-f198-47aa-a589-45c3514ec42c
+                - ffb37bcb-2456-4f82-b5ca-0961bef484ae
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1017,8 +1017,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133558Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T140649Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1037,14 +1037,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:35:58 GMT
+                - Mon, 18 May 2026 14:06:49 GMT
             X-Amz-Id-2:
-                - txgeca0adc147e34107b9b9-006a0b15be
+                - txg7b1279647b754dada07a-006a0b1cf9
             X-Amz-Request-Id:
-                - txgeca0adc147e34107b9b9-006a0b15be
+                - txg7b1279647b754dada07a-006a0b1cf9
         status: 200 OK
         code: 200
-        duration: 33.171833ms
+        duration: 61.19825ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1053,7 +1053,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1062,7 +1062,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - a1ea5dcd-8b35-4c18-b9d1-f0f20f9ec5ca
+                - 948650ee-efe2-4af9-8665-b386f92eb76e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1070,8 +1070,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133558Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T140649Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1081,21 +1081,21 @@ interactions:
         trailer: {}
         content_length: 329
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg31ddbc57ad9340d1a586-006a0b15be</RequestId><HostId>txg31ddbc57ad9340d1a586-006a0b15be</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg08fe4a47e0ba45dea717-006a0b1cf9</RequestId><HostId>txg08fe4a47e0ba45dea717-006a0b1cf9</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource></Error>
         headers:
             Content-Length:
                 - "329"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:35:58 GMT
+                - Mon, 18 May 2026 14:06:49 GMT
             X-Amz-Id-2:
-                - txg31ddbc57ad9340d1a586-006a0b15be
+                - txg08fe4a47e0ba45dea717-006a0b1cf9
             X-Amz-Request-Id:
-                - txg31ddbc57ad9340d1a586-006a0b15be
+                - txg08fe4a47e0ba45dea717-006a0b1cf9
         status: 404 Not Found
         code: 404
-        duration: 36.44275ms
+        duration: 52.718833ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1104,7 +1104,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1113,7 +1113,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 29afad61-5e6b-4dc6-ad91-719e456dd1f2
+                - 29da2c79-37c9-401e-9592-78bbd87f16cc
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1121,8 +1121,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133558Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
+                - 20260518T140649Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -1134,21 +1134,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:35:58 GMT
+                - Mon, 18 May 2026 14:06:49 GMT
             X-Amz-Id-2:
-                - txg69ccfcdc8734482e8f76-006a0b15be
+                - txgf106d0c01b2649ec9969-006a0b1cf9
             X-Amz-Request-Id:
-                - txg69ccfcdc8734482e8f76-006a0b15be
+                - txgf106d0c01b2649ec9969-006a0b1cf9
         status: 200 OK
         code: 200
-        duration: 51.824375ms
+        duration: 103.488333ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1157,7 +1157,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1166,7 +1166,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d27b5479-e421-417c-95d6-9ba303ab026a
+                - 63e1bf15-b11e-4e6d-804a-81e458658c99
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1174,8 +1174,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133558Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T140649Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1185,21 +1185,21 @@ interactions:
         trailer: {}
         content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg08e9adc0bc7e4f6c855d-006a0b15be</RequestId><HostId>txg08e9adc0bc7e4f6c855d-006a0b15be</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txge2953ebddfb64ab3b83d-006a0b1cf9</RequestId><HostId>txge2953ebddfb64ab3b83d-006a0b1cf9</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</BucketName></Error>
         headers:
             Content-Length:
                 - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:35:58 GMT
+                - Mon, 18 May 2026 14:06:49 GMT
             X-Amz-Id-2:
-                - txg08e9adc0bc7e4f6c855d-006a0b15be
+                - txge2953ebddfb64ab3b83d-006a0b1cf9
             X-Amz-Request-Id:
-                - txg08e9adc0bc7e4f6c855d-006a0b15be
+                - txge2953ebddfb64ab3b83d-006a0b1cf9
         status: 404 Not Found
         code: 404
-        duration: 35.38125ms
+        duration: 21.007959ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1208,7 +1208,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1217,7 +1217,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 92ca5056-078a-45e6-8a38-c1c534d81dea
+                - 0c2e6dfc-b469-407a-9e3b-60b5ccace079
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1225,8 +1225,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133558Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T140649Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1236,21 +1236,21 @@ interactions:
         trailer: {}
         content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg4be503d61c684cefaf95-006a0b15be</RequestId><HostId>txg4be503d61c684cefaf95-006a0b15be</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgf32df9b844c14767a45f-006a0b1cf9</RequestId><HostId>txgf32df9b844c14767a45f-006a0b1cf9</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource></Error>
         headers:
             Content-Length:
                 - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:35:58 GMT
+                - Mon, 18 May 2026 14:06:49 GMT
             X-Amz-Id-2:
-                - txg4be503d61c684cefaf95-006a0b15be
+                - txgf32df9b844c14767a45f-006a0b1cf9
             X-Amz-Request-Id:
-                - txg4be503d61c684cefaf95-006a0b15be
+                - txgf32df9b844c14767a45f-006a0b1cf9
         status: 404 Not Found
         code: 404
-        duration: 57.986834ms
+        duration: 35.079417ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1259,7 +1259,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1268,7 +1268,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f7bfdd56-d79d-4fa1-9cd7-5838a7fe855d
+                - 1ab67350-bf02-4e8c-929b-5c2afc90c928
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1276,8 +1276,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133558Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T140649Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1296,14 +1296,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:35:58 GMT
+                - Mon, 18 May 2026 14:06:49 GMT
             X-Amz-Id-2:
-                - txg116573d3e3a44c39841f-006a0b15be
+                - txg0702d790e6a041788af5-006a0b1cf9
             X-Amz-Request-Id:
-                - txg116573d3e3a44c39841f-006a0b15be
+                - txg0702d790e6a041788af5-006a0b1cf9
         status: 200 OK
         code: 200
-        duration: 19.425083ms
+        duration: 64.434084ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1312,7 +1312,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1321,7 +1321,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f219c0a8-0556-478e-b857-3eda4db47bd8
+                - 711ca1cb-46dc-4439-b6a8-15e1d4ab46c3
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1329,8 +1329,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133558Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T140649Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1349,14 +1349,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:35:58 GMT
+                - Mon, 18 May 2026 14:06:49 GMT
             X-Amz-Id-2:
-                - txgdfed9b4b1090448c9923-006a0b15be
+                - txg3eef50913b1f416db8de-006a0b1cf9
             X-Amz-Request-Id:
-                - txgdfed9b4b1090448c9923-006a0b15be
+                - txg3eef50913b1f416db8de-006a0b1cf9
         status: 200 OK
         code: 200
-        duration: 74.490875ms
+        duration: 52.633625ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1365,7 +1365,7 @@ interactions:
         content_length: 366
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition></Rule></LifecycleConfiguration>
@@ -1374,7 +1374,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 2f4e8e40-7f08-495d-b9a4-4769aed5ca0f
+                - fd50d7aa-ef5e-4662-87b4-6c10c0c973bf
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
@@ -1386,8 +1386,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - 1695287f0c18bfb8c0d3d10989fec9b3e430afbc2914de7c50f434a75491894c
             X-Amz-Date:
-                - 20260518T133558Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T140649Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -1402,14 +1402,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 18 May 2026 13:35:58 GMT
+                - Mon, 18 May 2026 14:06:50 GMT
             X-Amz-Id-2:
-                - txg85abb7ed93224b44b486-006a0b15be
+                - txgf822029e5bc64b45bd0c-006a0b1cfa
             X-Amz-Request-Id:
-                - txg85abb7ed93224b44b486-006a0b15be
+                - txgf822029e5bc64b45bd0c-006a0b1cfa
         status: 200 OK
         code: 200
-        duration: 63.122333ms
+        duration: 2.125861666s
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1418,7 +1418,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1427,7 +1427,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c6b4a30b-9210-4346-adfd-47773f1005e1
+                - 530fd781-0caa-4e72-beff-c5051c9c3efb
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1435,8 +1435,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133559Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T140652Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1455,14 +1455,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:35:59 GMT
+                - Mon, 18 May 2026 14:06:52 GMT
             X-Amz-Id-2:
-                - txg2d2bc01238794a5799b9-006a0b15bf
+                - txgc0c3f13989b845bc8e9a-006a0b1cfc
             X-Amz-Request-Id:
-                - txg2d2bc01238794a5799b9-006a0b15bf
+                - txgc0c3f13989b845bc8e9a-006a0b1cfc
         status: 200 OK
         code: 200
-        duration: 31.601833ms
+        duration: 20.473791ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1471,7 +1471,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1480,7 +1480,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c5e2597a-86d7-427b-9bb8-ef87eed2d6fb
+                - 3efc1fee-f700-43cc-934b-ba66e56a1d0e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1488,8 +1488,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133559Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T140652Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1499,21 +1499,21 @@ interactions:
         trailer: {}
         content_length: 329
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg7ff6b92af4244057ad3c-006a0b15bf</RequestId><HostId>txg7ff6b92af4244057ad3c-006a0b15bf</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg3c6ab70f612d47779a8e-006a0b1cfc</RequestId><HostId>txg3c6ab70f612d47779a8e-006a0b1cfc</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource></Error>
         headers:
             Content-Length:
                 - "329"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:35:59 GMT
+                - Mon, 18 May 2026 14:06:52 GMT
             X-Amz-Id-2:
-                - txg7ff6b92af4244057ad3c-006a0b15bf
+                - txg3c6ab70f612d47779a8e-006a0b1cfc
             X-Amz-Request-Id:
-                - txg7ff6b92af4244057ad3c-006a0b15bf
+                - txg3c6ab70f612d47779a8e-006a0b1cfc
         status: 404 Not Found
         code: 404
-        duration: 31.844333ms
+        duration: 22.176333ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1522,7 +1522,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1531,7 +1531,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 114d0593-d98a-438b-bc1b-e19cfd3a93b3
+                - ecf7ec60-c34b-474a-ae5c-63e6a4c2e913
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1539,8 +1539,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133559Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
+                - 20260518T140652Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -1552,21 +1552,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:35:59 GMT
+                - Mon, 18 May 2026 14:06:52 GMT
             X-Amz-Id-2:
-                - txgd46ce7ebb4a54e328597-006a0b15bf
+                - txg1090015da9d24c188a27-006a0b1cfc
             X-Amz-Request-Id:
-                - txgd46ce7ebb4a54e328597-006a0b15bf
+                - txg1090015da9d24c188a27-006a0b1cfc
         status: 200 OK
         code: 200
-        duration: 29.2935ms
+        duration: 100.920542ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1575,7 +1575,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1584,7 +1584,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 505f5f4f-8c70-4206-bbe9-c23c1726a1d7
+                - fb637656-1f7f-479a-974c-70c2309e2ff0
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1592,8 +1592,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133559Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T140652Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1603,21 +1603,21 @@ interactions:
         trailer: {}
         content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg4cfd89bdfcfc451dab80-006a0b15bf</RequestId><HostId>txg4cfd89bdfcfc451dab80-006a0b15bf</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgdb16e3c41cff41b897d4-006a0b1cfc</RequestId><HostId>txgdb16e3c41cff41b897d4-006a0b1cfc</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</BucketName></Error>
         headers:
             Content-Length:
                 - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:35:59 GMT
+                - Mon, 18 May 2026 14:06:52 GMT
             X-Amz-Id-2:
-                - txg4cfd89bdfcfc451dab80-006a0b15bf
+                - txgdb16e3c41cff41b897d4-006a0b1cfc
             X-Amz-Request-Id:
-                - txg4cfd89bdfcfc451dab80-006a0b15bf
+                - txgdb16e3c41cff41b897d4-006a0b1cfc
         status: 404 Not Found
         code: 404
-        duration: 18.752ms
+        duration: 35.098792ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1626,7 +1626,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1635,7 +1635,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c8b73fe2-a3ef-4279-8d00-122f26ec5587
+                - d16ebbc3-2ae9-489f-badb-237b0c298460
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1643,8 +1643,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133559Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T140652Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1654,21 +1654,21 @@ interactions:
         trailer: {}
         content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg6312263a8ad648b49799-006a0b15bf</RequestId><HostId>txg6312263a8ad648b49799-006a0b15bf</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg9eb3ad16176d4e6e892e-006a0b1cfc</RequestId><HostId>txg9eb3ad16176d4e6e892e-006a0b1cfc</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource></Error>
         headers:
             Content-Length:
                 - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:35:59 GMT
+                - Mon, 18 May 2026 14:06:52 GMT
             X-Amz-Id-2:
-                - txg6312263a8ad648b49799-006a0b15bf
+                - txg9eb3ad16176d4e6e892e-006a0b1cfc
             X-Amz-Request-Id:
-                - txg6312263a8ad648b49799-006a0b15bf
+                - txg9eb3ad16176d4e6e892e-006a0b1cfc
         status: 404 Not Found
         code: 404
-        duration: 61.025042ms
+        duration: 61.649209ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1677,7 +1677,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1686,7 +1686,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 45b66c7a-190a-4864-b244-4baa31dcfdbd
+                - 5991d9a6-8f18-427d-80d7-575951693b41
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1694,8 +1694,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133559Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T140652Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1714,14 +1714,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:35:59 GMT
+                - Mon, 18 May 2026 14:06:52 GMT
             X-Amz-Id-2:
-                - txgaa9733d8453c495b87fd-006a0b15bf
+                - txg870af97b2a5046aeb5cf-006a0b1cfc
             X-Amz-Request-Id:
-                - txgaa9733d8453c495b87fd-006a0b15bf
+                - txg870af97b2a5046aeb5cf-006a0b1cfc
         status: 200 OK
         code: 200
-        duration: 33.189584ms
+        duration: 193.636292ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1730,7 +1730,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1739,7 +1739,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - dfcd926d-75d7-47fc-888f-2042e5a600d5
+                - 4168d9c4-6837-433b-8a3c-06fef4b5bb3e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1747,8 +1747,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133559Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T140652Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1767,14 +1767,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:35:59 GMT
+                - Mon, 18 May 2026 14:06:52 GMT
             X-Amz-Id-2:
-                - txg84a78b112aa64dc2876b-006a0b15bf
+                - txgcd039a1e61bf44b2a026-006a0b1cfc
             X-Amz-Request-Id:
-                - txg84a78b112aa64dc2876b-006a0b15bf
+                - txgcd039a1e61bf44b2a026-006a0b1cfc
         status: 200 OK
         code: 200
-        duration: 47.729042ms
+        duration: 56.497292ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1783,7 +1783,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1792,7 +1792,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 292561fd-fc9c-46e3-8b33-4a819dc582ec
+                - d0fcffa4-e338-4460-b63b-1b0a1831e230
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1800,8 +1800,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133559Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
+                - 20260518T140652Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -1816,16 +1816,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:35:59 GMT
+                - Mon, 18 May 2026 14:06:52 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txg45bdff0158264a82b917-006a0b15bf
+                - txga30ad39f6d6c4f309fd1-006a0b1cfc
             X-Amz-Request-Id:
-                - txg45bdff0158264a82b917-006a0b15bf
+                - txga30ad39f6d6c4f309fd1-006a0b1cfc
         status: 200 OK
         code: 200
-        duration: 35.383333ms
+        duration: 61.942208ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1834,7 +1834,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1843,7 +1843,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 31509049-43d9-40f3-b189-2c13cb83acb5
+                - 6e100dc6-a75e-450b-8130-7f73fb7dafc6
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1851,8 +1851,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133559Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T140652Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1871,14 +1871,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:35:59 GMT
+                - Mon, 18 May 2026 14:06:52 GMT
             X-Amz-Id-2:
-                - txgbc07c46e7ee14e9bbcf1-006a0b15bf
+                - txg0e135f74d35741469776-006a0b1cfc
             X-Amz-Request-Id:
-                - txgbc07c46e7ee14e9bbcf1-006a0b15bf
+                - txg0e135f74d35741469776-006a0b1cfc
         status: 200 OK
         code: 200
-        duration: 58.54025ms
+        duration: 64.132834ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1887,7 +1887,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1896,7 +1896,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f35f7d5a-0d72-41aa-9fa0-4783ea1de93d
+                - b8237153-9a43-41dd-967d-21064dac28d9
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1904,8 +1904,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133559Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T140653Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1924,14 +1924,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:35:59 GMT
+                - Mon, 18 May 2026 14:06:53 GMT
             X-Amz-Id-2:
-                - txg420d3b14b68745b09b2b-006a0b15bf
+                - txgbf920b0d53b04021ba71-006a0b1cfd
             X-Amz-Request-Id:
-                - txg420d3b14b68745b09b2b-006a0b15bf
+                - txgbf920b0d53b04021ba71-006a0b1cfd
         status: 200 OK
         code: 200
-        duration: 64.338959ms
+        duration: 97.44275ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1940,7 +1940,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1949,7 +1949,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4bb3b75e-a085-4e26-9476-cca6ecb2ddef
+                - 093d6326-05a5-4a6f-8cfd-48dcbc3d49f9
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -1957,8 +1957,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133559Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T140653Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1968,21 +1968,21 @@ interactions:
         trailer: {}
         content_length: 329
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg920c84f45816478ab67b-006a0b15bf</RequestId><HostId>txg920c84f45816478ab67b-006a0b15bf</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg5996cf6673544bcd9cfe-006a0b1cfd</RequestId><HostId>txg5996cf6673544bcd9cfe-006a0b1cfd</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource></Error>
         headers:
             Content-Length:
                 - "329"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:35:59 GMT
+                - Mon, 18 May 2026 14:06:53 GMT
             X-Amz-Id-2:
-                - txg920c84f45816478ab67b-006a0b15bf
+                - txg5996cf6673544bcd9cfe-006a0b1cfd
             X-Amz-Request-Id:
-                - txg920c84f45816478ab67b-006a0b15bf
+                - txg5996cf6673544bcd9cfe-006a0b1cfd
         status: 404 Not Found
         code: 404
-        duration: 50.502167ms
+        duration: 20.876125ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1991,7 +1991,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2000,7 +2000,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5ea7f7f4-1817-4992-91eb-962a2e8cb4e2
+                - 40c6227a-3824-45ca-8566-c5342c94f66d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2008,8 +2008,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133559Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
+                - 20260518T140653Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -2021,21 +2021,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:35:59 GMT
+                - Mon, 18 May 2026 14:06:53 GMT
             X-Amz-Id-2:
-                - txgbe4360aa6085456498b3-006a0b15bf
+                - txgaa4d1a153a7e4028bc61-006a0b1cfd
             X-Amz-Request-Id:
-                - txgbe4360aa6085456498b3-006a0b15bf
+                - txgaa4d1a153a7e4028bc61-006a0b1cfd
         status: 200 OK
         code: 200
-        duration: 20.805292ms
+        duration: 221.086125ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -2044,7 +2044,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2053,7 +2053,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 653e829d-e5c6-4b8b-996b-3cfb50cd46e2
+                - a95da9b7-7816-4367-b819-996dff6ca866
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2061,8 +2061,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133559Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T140653Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2072,21 +2072,21 @@ interactions:
         trailer: {}
         content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg678514fed7614fc89b1c-006a0b15bf</RequestId><HostId>txg678514fed7614fc89b1c-006a0b15bf</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg2a347384bcad4db0ba2d-006a0b1cfd</RequestId><HostId>txg2a347384bcad4db0ba2d-006a0b1cfd</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</BucketName></Error>
         headers:
             Content-Length:
                 - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:35:59 GMT
+                - Mon, 18 May 2026 14:06:53 GMT
             X-Amz-Id-2:
-                - txg678514fed7614fc89b1c-006a0b15bf
+                - txg2a347384bcad4db0ba2d-006a0b1cfd
             X-Amz-Request-Id:
-                - txg678514fed7614fc89b1c-006a0b15bf
+                - txg2a347384bcad4db0ba2d-006a0b1cfd
         status: 404 Not Found
         code: 404
-        duration: 61.166417ms
+        duration: 36.822042ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -2095,7 +2095,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2104,7 +2104,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7377f5fb-db48-47ec-a8a3-d50e8f7121e3
+                - 21314421-4632-482d-ae2c-a1f99837fa9d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2112,8 +2112,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133559Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T140653Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2123,21 +2123,21 @@ interactions:
         trailer: {}
         content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txge0a3ea1e2cb44294af00-006a0b15bf</RequestId><HostId>txge0a3ea1e2cb44294af00-006a0b15bf</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg40f437b3d26d4e389666-006a0b1cfd</RequestId><HostId>txg40f437b3d26d4e389666-006a0b1cfd</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource></Error>
         headers:
             Content-Length:
                 - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:35:59 GMT
+                - Mon, 18 May 2026 14:06:53 GMT
             X-Amz-Id-2:
-                - txge0a3ea1e2cb44294af00-006a0b15bf
+                - txg40f437b3d26d4e389666-006a0b1cfd
             X-Amz-Request-Id:
-                - txge0a3ea1e2cb44294af00-006a0b15bf
+                - txg40f437b3d26d4e389666-006a0b1cfd
         status: 404 Not Found
         code: 404
-        duration: 20.850709ms
+        duration: 61.420792ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -2146,7 +2146,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2155,7 +2155,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 3325555a-1257-4f71-bd8d-591e417fb017
+                - dd520620-1452-48c5-b946-d838bd667b5c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2163,8 +2163,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133559Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T140653Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2183,14 +2183,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:35:59 GMT
+                - Mon, 18 May 2026 14:06:53 GMT
             X-Amz-Id-2:
-                - txg8e510b8c57844e1fa687-006a0b15bf
+                - txg7d95992dc7d249cf9c10-006a0b1cfd
             X-Amz-Request-Id:
-                - txg8e510b8c57844e1fa687-006a0b15bf
+                - txg7d95992dc7d249cf9c10-006a0b1cfd
         status: 200 OK
         code: 200
-        duration: 60.918708ms
+        duration: 57.281291ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -2199,7 +2199,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2208,7 +2208,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7d6c617d-7e97-4f07-936a-cdd8cfe1aeab
+                - 57d8e85a-d5b9-4765-9ae4-e153d6699f2e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2216,8 +2216,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133559Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T140653Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2236,14 +2236,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:36:00 GMT
+                - Mon, 18 May 2026 14:06:53 GMT
             X-Amz-Id-2:
-                - txgba9a2c461b114ff79b1e-006a0b15c0
+                - txg4eb342e9844e4a7ea2c1-006a0b1cfd
             X-Amz-Request-Id:
-                - txgba9a2c461b114ff79b1e-006a0b15c0
+                - txg4eb342e9844e4a7ea2c1-006a0b1cfd
         status: 200 OK
         code: 200
-        duration: 20.514875ms
+        duration: 52.607333ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -2252,7 +2252,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2261,7 +2261,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7b899472-7724-412a-a65a-4374da4ddf63
+                - 0d14af72-2a57-4a47-8518-d3be14eb233d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2269,8 +2269,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133600Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T140653Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2289,14 +2289,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:36:00 GMT
+                - Mon, 18 May 2026 14:06:53 GMT
             X-Amz-Id-2:
-                - txg1fce40260d5e46d6a268-006a0b15c0
+                - txgd51ee1f90e72472f9f77-006a0b1cfd
             X-Amz-Request-Id:
-                - txg1fce40260d5e46d6a268-006a0b15c0
+                - txgd51ee1f90e72472f9f77-006a0b1cfd
         status: 200 OK
         code: 200
-        duration: 20.321583ms
+        duration: 36.01975ms
     - id: 44
       request:
         proto: HTTP/1.1
@@ -2305,7 +2305,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2314,7 +2314,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 85a9b849-f45b-42a5-a473-92c1b4597a00
+                - bdd58b5a-4aca-4917-bd58-bce44d0dd63f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2322,8 +2322,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133600Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T140653Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2333,21 +2333,21 @@ interactions:
         trailer: {}
         content_length: 329
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg97b4a35719df4769b7b3-006a0b15c0</RequestId><HostId>txg97b4a35719df4769b7b3-006a0b15c0</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg20fc3368d04248f8acc7-006a0b1cfd</RequestId><HostId>txg20fc3368d04248f8acc7-006a0b1cfd</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource></Error>
         headers:
             Content-Length:
                 - "329"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:00 GMT
+                - Mon, 18 May 2026 14:06:53 GMT
             X-Amz-Id-2:
-                - txg97b4a35719df4769b7b3-006a0b15c0
+                - txg20fc3368d04248f8acc7-006a0b1cfd
             X-Amz-Request-Id:
-                - txg97b4a35719df4769b7b3-006a0b15c0
+                - txg20fc3368d04248f8acc7-006a0b1cfd
         status: 404 Not Found
         code: 404
-        duration: 82.519083ms
+        duration: 58.664667ms
     - id: 45
       request:
         proto: HTTP/1.1
@@ -2356,7 +2356,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2365,7 +2365,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f98a83ad-9269-4392-a65b-f35134515edb
+                - b078ad51-a565-4153-bb2b-2f4a786e04f2
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2373,8 +2373,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133600Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
+                - 20260518T140653Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -2386,21 +2386,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:00 GMT
+                - Mon, 18 May 2026 14:06:53 GMT
             X-Amz-Id-2:
-                - txg8426e91605314618bb2c-006a0b15c0
+                - txge5bbae0425304d2d848e-006a0b1cfd
             X-Amz-Request-Id:
-                - txg8426e91605314618bb2c-006a0b15c0
+                - txge5bbae0425304d2d848e-006a0b1cfd
         status: 200 OK
         code: 200
-        duration: 95.0265ms
+        duration: 246.54125ms
     - id: 46
       request:
         proto: HTTP/1.1
@@ -2409,7 +2409,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2418,7 +2418,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b10285a3-e2e7-4996-aff7-0a6c1ebb44c7
+                - 9d8be370-dbd3-41dd-864b-2cbc13f27ddc
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2426,8 +2426,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133600Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T140653Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2437,21 +2437,21 @@ interactions:
         trailer: {}
         content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg375e22b29c59463c9ba6-006a0b15c0</RequestId><HostId>txg375e22b29c59463c9ba6-006a0b15c0</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg137c05b8cb404017909b-006a0b1cfe</RequestId><HostId>txg137c05b8cb404017909b-006a0b1cfe</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</BucketName></Error>
         headers:
             Content-Length:
                 - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:00 GMT
+                - Mon, 18 May 2026 14:06:54 GMT
             X-Amz-Id-2:
-                - txg375e22b29c59463c9ba6-006a0b15c0
+                - txg137c05b8cb404017909b-006a0b1cfe
             X-Amz-Request-Id:
-                - txg375e22b29c59463c9ba6-006a0b15c0
+                - txg137c05b8cb404017909b-006a0b1cfe
         status: 404 Not Found
         code: 404
-        duration: 30.652167ms
+        duration: 62.285083ms
     - id: 47
       request:
         proto: HTTP/1.1
@@ -2460,7 +2460,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2469,7 +2469,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0bab10c3-a3fe-4f22-9529-a67b4231b697
+                - 5ce1fd2d-367a-4dbf-b6b6-17d12c630d01
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2477,8 +2477,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133600Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T140654Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2488,21 +2488,21 @@ interactions:
         trailer: {}
         content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txge908319b63a74f81861d-006a0b15c0</RequestId><HostId>txge908319b63a74f81861d-006a0b15c0</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg630c8ad86cb7442980a5-006a0b1cfe</RequestId><HostId>txg630c8ad86cb7442980a5-006a0b1cfe</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource></Error>
         headers:
             Content-Length:
                 - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:00 GMT
+                - Mon, 18 May 2026 14:06:54 GMT
             X-Amz-Id-2:
-                - txge908319b63a74f81861d-006a0b15c0
+                - txg630c8ad86cb7442980a5-006a0b1cfe
             X-Amz-Request-Id:
-                - txge908319b63a74f81861d-006a0b15c0
+                - txg630c8ad86cb7442980a5-006a0b1cfe
         status: 404 Not Found
         code: 404
-        duration: 50.60525ms
+        duration: 35.857875ms
     - id: 48
       request:
         proto: HTTP/1.1
@@ -2511,7 +2511,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2520,7 +2520,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 604f8f45-45e1-44e0-a0a9-88562608de72
+                - b1ee129c-877c-4a13-ae53-64ca01d8a7c2
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2528,8 +2528,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133600Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T140654Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2548,14 +2548,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:36:00 GMT
+                - Mon, 18 May 2026 14:06:54 GMT
             X-Amz-Id-2:
-                - txgcc7f8ca0c4e04b0aa841-006a0b15c0
+                - txgd9fb890c489e45d3bbdf-006a0b1cfe
             X-Amz-Request-Id:
-                - txgcc7f8ca0c4e04b0aa841-006a0b15c0
+                - txgd9fb890c489e45d3bbdf-006a0b1cfe
         status: 200 OK
         code: 200
-        duration: 39.1305ms
+        duration: 54.146958ms
     - id: 49
       request:
         proto: HTTP/1.1
@@ -2564,7 +2564,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2573,7 +2573,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 17356a66-ce84-46ae-b024-92cb6ca59994
+                - f56baf28-dc7e-453a-b964-56f4c793e786
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2581,8 +2581,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133600Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T140654Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2601,14 +2601,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:36:00 GMT
+                - Mon, 18 May 2026 14:06:54 GMT
             X-Amz-Id-2:
-                - txg7c7634e5725e40bc9292-006a0b15c0
+                - txg6fddb5f194824c16a93d-006a0b1cfe
             X-Amz-Request-Id:
-                - txg7c7634e5725e40bc9292-006a0b15c0
+                - txg6fddb5f194824c16a93d-006a0b1cfe
         status: 200 OK
         code: 200
-        duration: 36.392708ms
+        duration: 20.449667ms
     - id: 50
       request:
         proto: HTTP/1.1
@@ -2617,16 +2617,16 @@ interactions:
         content_length: 1312
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
-        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></LifecycleConfiguration>
+        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></LifecycleConfiguration>
         form: {}
         headers:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9f64d105-8a87-4260-97d7-b698b84a03af
+                - 85d0b8b2-e213-44a3-a481-c4c50d955e75
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
@@ -2634,12 +2634,12 @@ interactions:
             User-Agent:
                 - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,Z,e
             X-Amz-Checksum-Crc32:
-                - uMAwFg==
+                - pPLx6g==
             X-Amz-Content-Sha256:
-                - 45868aab6daf1016fee02a51a4a72191a7d55026e146191922aab1a4acb0706f
+                - 470295ace4b044f717c552c2027846524dad4509d1af1ee0e1d1439541cbacd6
             X-Amz-Date:
-                - 20260518T133600Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T140654Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -2654,14 +2654,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 18 May 2026 13:36:00 GMT
+                - Mon, 18 May 2026 14:06:54 GMT
             X-Amz-Id-2:
-                - txg7abd36328efd423880a1-006a0b15c0
+                - txg02bbd7b4d401432fae43-006a0b1cfe
             X-Amz-Request-Id:
-                - txg7abd36328efd423880a1-006a0b15c0
+                - txg02bbd7b4d401432fae43-006a0b1cfe
         status: 200 OK
         code: 200
-        duration: 39.960042ms
+        duration: 975.671708ms
     - id: 51
       request:
         proto: HTTP/1.1
@@ -2670,7 +2670,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2679,7 +2679,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - caa90fa4-efb1-43bc-a414-fee20565dc70
+                - d8eb14ae-2952-4c24-9185-1577cee94ccb
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2687,8 +2687,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133600Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T140655Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2707,14 +2707,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:36:00 GMT
+                - Mon, 18 May 2026 14:06:55 GMT
             X-Amz-Id-2:
-                - txgc89d7cf8d5154be49de4-006a0b15c0
+                - txg375a6c44db164fde8c5e-006a0b1cff
             X-Amz-Request-Id:
-                - txgc89d7cf8d5154be49de4-006a0b15c0
+                - txg375a6c44db164fde8c5e-006a0b1cff
         status: 200 OK
         code: 200
-        duration: 23.012583ms
+        duration: 20.629541ms
     - id: 52
       request:
         proto: HTTP/1.1
@@ -2723,7 +2723,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2732,7 +2732,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - bc8811ab-2ce1-4b64-8de1-aa3f8954d82a
+                - ca209757-a600-4309-9412-fcc08227a3a1
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2740,8 +2740,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133600Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T140655Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2751,21 +2751,21 @@ interactions:
         trailer: {}
         content_length: 329
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg107e42c0680a4ceaa019-006a0b15c0</RequestId><HostId>txg107e42c0680a4ceaa019-006a0b15c0</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg9f0dad54c3164bc08277-006a0b1cff</RequestId><HostId>txg9f0dad54c3164bc08277-006a0b1cff</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource></Error>
         headers:
             Content-Length:
                 - "329"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:00 GMT
+                - Mon, 18 May 2026 14:06:55 GMT
             X-Amz-Id-2:
-                - txg107e42c0680a4ceaa019-006a0b15c0
+                - txg9f0dad54c3164bc08277-006a0b1cff
             X-Amz-Request-Id:
-                - txg107e42c0680a4ceaa019-006a0b15c0
+                - txg9f0dad54c3164bc08277-006a0b1cff
         status: 404 Not Found
         code: 404
-        duration: 36.825416ms
+        duration: 20.925875ms
     - id: 53
       request:
         proto: HTTP/1.1
@@ -2774,7 +2774,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2783,7 +2783,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 705ee487-3caa-4655-9c40-b8ca9734e74d
+                - 9af38de0-50d1-46b1-be62-a6104a0574c1
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2791,8 +2791,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133600Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
+                - 20260518T140655Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -2804,21 +2804,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:00 GMT
+                - Mon, 18 May 2026 14:06:55 GMT
             X-Amz-Id-2:
-                - txgd718c5303e8f4fe7a262-006a0b15c0
+                - txge6859b07ca2444269b2b-006a0b1cff
             X-Amz-Request-Id:
-                - txgd718c5303e8f4fe7a262-006a0b15c0
+                - txge6859b07ca2444269b2b-006a0b1cff
         status: 200 OK
         code: 200
-        duration: 91.468541ms
+        duration: 63.662ms
     - id: 54
       request:
         proto: HTTP/1.1
@@ -2827,7 +2827,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2836,7 +2836,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 00b86f0d-0f98-40b6-bb57-329b422df0b6
+                - 6dc5d211-14ef-44de-aeeb-72ec9f258fdc
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2844,8 +2844,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133600Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T140655Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2855,21 +2855,21 @@ interactions:
         trailer: {}
         content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txge6333df19adf48e7a2db-006a0b15c0</RequestId><HostId>txge6333df19adf48e7a2db-006a0b15c0</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg3ef321004f1a45bc91bf-006a0b1cff</RequestId><HostId>txg3ef321004f1a45bc91bf-006a0b1cff</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</BucketName></Error>
         headers:
             Content-Length:
                 - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:00 GMT
+                - Mon, 18 May 2026 14:06:55 GMT
             X-Amz-Id-2:
-                - txge6333df19adf48e7a2db-006a0b15c0
+                - txg3ef321004f1a45bc91bf-006a0b1cff
             X-Amz-Request-Id:
-                - txge6333df19adf48e7a2db-006a0b15c0
+                - txg3ef321004f1a45bc91bf-006a0b1cff
         status: 404 Not Found
         code: 404
-        duration: 21.006791ms
+        duration: 51.409458ms
     - id: 55
       request:
         proto: HTTP/1.1
@@ -2878,7 +2878,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2887,7 +2887,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7d764301-af1b-4c01-978e-5af924c1c3ee
+                - f8976aa6-9d28-4adc-88e8-186b601b2f81
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2895,8 +2895,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133600Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T140655Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2906,21 +2906,21 @@ interactions:
         trailer: {}
         content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txga1a7dbf1527045f7ab74-006a0b15c0</RequestId><HostId>txga1a7dbf1527045f7ab74-006a0b15c0</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg0962df8904f64a0f9a4a-006a0b1cff</RequestId><HostId>txg0962df8904f64a0f9a4a-006a0b1cff</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource></Error>
         headers:
             Content-Length:
                 - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:00 GMT
+                - Mon, 18 May 2026 14:06:55 GMT
             X-Amz-Id-2:
-                - txga1a7dbf1527045f7ab74-006a0b15c0
+                - txg0962df8904f64a0f9a4a-006a0b1cff
             X-Amz-Request-Id:
-                - txga1a7dbf1527045f7ab74-006a0b15c0
+                - txg0962df8904f64a0f9a4a-006a0b1cff
         status: 404 Not Found
         code: 404
-        duration: 61.679125ms
+        duration: 65.087792ms
     - id: 56
       request:
         proto: HTTP/1.1
@@ -2929,7 +2929,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2938,7 +2938,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b988adb3-219f-4254-b7cc-5bbf07d0b307
+                - c32ab384-8e35-4f16-9037-c8fc98e85965
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2946,8 +2946,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133600Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T140655Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -2966,14 +2966,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:36:01 GMT
+                - Mon, 18 May 2026 14:06:55 GMT
             X-Amz-Id-2:
-                - txge3af76b19a0242af8f4a-006a0b15c1
+                - txga37da9e6a0d14f27ad00-006a0b1cff
             X-Amz-Request-Id:
-                - txge3af76b19a0242af8f4a-006a0b15c1
+                - txga37da9e6a0d14f27ad00-006a0b1cff
         status: 200 OK
         code: 200
-        duration: 19.865541ms
+        duration: 21.74125ms
     - id: 57
       request:
         proto: HTTP/1.1
@@ -2982,7 +2982,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -2991,7 +2991,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 91a39df0-7a5c-412c-a8db-74c58e85675f
+                - 690accc5-5470-4e84-ad13-473ad72416cc
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -2999,8 +2999,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133601Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T140655Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3012,21 +3012,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
                 - "1285"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:36:01 GMT
+                - Mon, 18 May 2026 14:06:55 GMT
             X-Amz-Id-2:
-                - txg80d5c65bd850455bb84c-006a0b15c1
+                - txgdac114104e3e429cb5c4-006a0b1cff
             X-Amz-Request-Id:
-                - txg80d5c65bd850455bb84c-006a0b15c1
+                - txgdac114104e3e429cb5c4-006a0b1cff
         status: 200 OK
         code: 200
-        duration: 18.810208ms
+        duration: 20.462625ms
     - id: 58
       request:
         proto: HTTP/1.1
@@ -3035,7 +3035,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3044,7 +3044,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e818d9a6-8793-4676-8bf8-a498fcd74547
+                - 17df36a3-3421-435f-ab93-43ec1c41a065
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3052,8 +3052,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133601Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
+                - 20260518T140655Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -3068,16 +3068,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:01 GMT
+                - Mon, 18 May 2026 14:06:55 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txg7f3412ba12c441ce866b-006a0b15c1
+                - txg997f3a423f3942c290eb-006a0b1cff
             X-Amz-Request-Id:
-                - txg7f3412ba12c441ce866b-006a0b15c1
+                - txg997f3a423f3942c290eb-006a0b1cff
         status: 200 OK
         code: 200
-        duration: 34.768541ms
+        duration: 36.19275ms
     - id: 59
       request:
         proto: HTTP/1.1
@@ -3086,7 +3086,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3095,7 +3095,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 483155e2-624b-4da5-b512-e1c0d0a29045
+                - 6fda988e-a84a-41f0-8e88-5b5d1b798f40
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3103,8 +3103,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133601Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T140655Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3116,21 +3116,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
                 - "1285"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:36:01 GMT
+                - Mon, 18 May 2026 14:06:55 GMT
             X-Amz-Id-2:
-                - txg9b9bd5a4e307421bac2f-006a0b15c1
+                - txg71c33cfcc31d4c3baace-006a0b1cff
             X-Amz-Request-Id:
-                - txg9b9bd5a4e307421bac2f-006a0b15c1
+                - txg71c33cfcc31d4c3baace-006a0b1cff
         status: 200 OK
         code: 200
-        duration: 34.856291ms
+        duration: 20.782333ms
     - id: 60
       request:
         proto: HTTP/1.1
@@ -3139,7 +3139,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3148,7 +3148,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0901da06-f3f8-4d65-875f-29a75c2b5fb4
+                - 9edd1cdb-4ead-4e9a-b77d-701349ee8d4c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3156,8 +3156,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133601Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T140656Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3176,14 +3176,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:36:01 GMT
+                - Mon, 18 May 2026 14:06:56 GMT
             X-Amz-Id-2:
-                - txge61a7b68c13b40bdbbc1-006a0b15c1
+                - txg3711087ad4bc4cac9a44-006a0b1d00
             X-Amz-Request-Id:
-                - txge61a7b68c13b40bdbbc1-006a0b15c1
+                - txg3711087ad4bc4cac9a44-006a0b1d00
         status: 200 OK
         code: 200
-        duration: 33.21475ms
+        duration: 34.741708ms
     - id: 61
       request:
         proto: HTTP/1.1
@@ -3192,7 +3192,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3201,7 +3201,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - dd3068f0-c28c-4c40-b4c4-8c1d9fbb1006
+                - 543a2de9-cf00-42b0-b78b-0189e671496e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3209,8 +3209,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133601Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T140656Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3220,21 +3220,21 @@ interactions:
         trailer: {}
         content_length: 329
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg8358bed674364cf7b78f-006a0b15c1</RequestId><HostId>txg8358bed674364cf7b78f-006a0b15c1</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg79e98cc5cd8345e6ad54-006a0b1d00</RequestId><HostId>txg79e98cc5cd8345e6ad54-006a0b1d00</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource></Error>
         headers:
             Content-Length:
                 - "329"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:01 GMT
+                - Mon, 18 May 2026 14:06:56 GMT
             X-Amz-Id-2:
-                - txg8358bed674364cf7b78f-006a0b15c1
+                - txg79e98cc5cd8345e6ad54-006a0b1d00
             X-Amz-Request-Id:
-                - txg8358bed674364cf7b78f-006a0b15c1
+                - txg79e98cc5cd8345e6ad54-006a0b1d00
         status: 404 Not Found
         code: 404
-        duration: 37.71325ms
+        duration: 27.642792ms
     - id: 62
       request:
         proto: HTTP/1.1
@@ -3243,7 +3243,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3252,7 +3252,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f9860c8c-9f3e-4fa0-b618-343bbd27ab8f
+                - dc700bf8-6192-4e46-a64e-8ee0f8edcf2a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3260,8 +3260,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133601Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
+                - 20260518T140656Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -3273,21 +3273,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:01 GMT
+                - Mon, 18 May 2026 14:06:56 GMT
             X-Amz-Id-2:
-                - txg67613cdd10cc443a84cb-006a0b15c1
+                - txgf92b482410ae46498090-006a0b1d00
             X-Amz-Request-Id:
-                - txg67613cdd10cc443a84cb-006a0b15c1
+                - txgf92b482410ae46498090-006a0b1d00
         status: 200 OK
         code: 200
-        duration: 30.323708ms
+        duration: 130.492375ms
     - id: 63
       request:
         proto: HTTP/1.1
@@ -3296,7 +3296,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3305,7 +3305,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - a9dbe0bd-7181-4f52-8658-c07a995f2c15
+                - d6e390d3-b0f0-428f-a8bf-b0c559d460f6
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3313,8 +3313,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133601Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T140656Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3324,21 +3324,21 @@ interactions:
         trailer: {}
         content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgc3d9aa03942d4eccafdc-006a0b15c1</RequestId><HostId>txgc3d9aa03942d4eccafdc-006a0b15c1</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgf41b554318c949438691-006a0b1d00</RequestId><HostId>txgf41b554318c949438691-006a0b1d00</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</BucketName></Error>
         headers:
             Content-Length:
                 - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:01 GMT
+                - Mon, 18 May 2026 14:06:56 GMT
             X-Amz-Id-2:
-                - txgc3d9aa03942d4eccafdc-006a0b15c1
+                - txgf41b554318c949438691-006a0b1d00
             X-Amz-Request-Id:
-                - txgc3d9aa03942d4eccafdc-006a0b15c1
+                - txgf41b554318c949438691-006a0b1d00
         status: 404 Not Found
         code: 404
-        duration: 19.769916ms
+        duration: 60.312125ms
     - id: 64
       request:
         proto: HTTP/1.1
@@ -3347,7 +3347,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3356,7 +3356,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 8175fe4d-a694-49b8-b391-b6a020ced508
+                - 76335350-dc5a-428c-8ddb-77d7f1225be1
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3364,8 +3364,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133601Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T140656Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3375,21 +3375,21 @@ interactions:
         trailer: {}
         content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txga138f5ddc8a44fa29b34-006a0b15c1</RequestId><HostId>txga138f5ddc8a44fa29b34-006a0b15c1</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg950560fbdbaf42118373-006a0b1d00</RequestId><HostId>txg950560fbdbaf42118373-006a0b1d00</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource></Error>
         headers:
             Content-Length:
                 - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:01 GMT
+                - Mon, 18 May 2026 14:06:56 GMT
             X-Amz-Id-2:
-                - txga138f5ddc8a44fa29b34-006a0b15c1
+                - txg950560fbdbaf42118373-006a0b1d00
             X-Amz-Request-Id:
-                - txga138f5ddc8a44fa29b34-006a0b15c1
+                - txg950560fbdbaf42118373-006a0b1d00
         status: 404 Not Found
         code: 404
-        duration: 107.336042ms
+        duration: 26.995375ms
     - id: 65
       request:
         proto: HTTP/1.1
@@ -3398,7 +3398,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3407,7 +3407,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 47c9553d-aa58-490c-ab8b-c0db415d570e
+                - 405a456f-9fab-4f7a-bfcb-1bfb41020bde
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3415,8 +3415,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133601Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T140656Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3435,14 +3435,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:36:01 GMT
+                - Mon, 18 May 2026 14:06:56 GMT
             X-Amz-Id-2:
-                - txg096dc48c8bb2479999de-006a0b15c1
+                - txg14839e208beb45499f19-006a0b1d00
             X-Amz-Request-Id:
-                - txg096dc48c8bb2479999de-006a0b15c1
+                - txg14839e208beb45499f19-006a0b1d00
         status: 200 OK
         code: 200
-        duration: 59.704ms
+        duration: 59.654083ms
     - id: 66
       request:
         proto: HTTP/1.1
@@ -3451,7 +3451,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3460,7 +3460,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b9870707-ed32-4629-8292-5bccb825e7ac
+                - e1def66d-df57-4bae-83e5-f422fc1681c3
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3468,8 +3468,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133601Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T140656Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3481,21 +3481,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
                 - "1285"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:36:01 GMT
+                - Mon, 18 May 2026 14:06:56 GMT
             X-Amz-Id-2:
-                - txg401c8deae34e4638a463-006a0b15c1
+                - txg9b97c546888841e9a4b3-006a0b1d00
             X-Amz-Request-Id:
-                - txg401c8deae34e4638a463-006a0b15c1
+                - txg9b97c546888841e9a4b3-006a0b1d00
         status: 200 OK
         code: 200
-        duration: 34.210125ms
+        duration: 52.747375ms
     - id: 67
       request:
         proto: HTTP/1.1
@@ -3504,7 +3504,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3513,7 +3513,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e3e213ac-311d-4e4a-8acd-f2b69acecc81
+                - 5c3a66e5-5c88-44e4-a0b4-51040af0a27b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3521,8 +3521,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133601Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T140656Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3541,14 +3541,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:36:02 GMT
+                - Mon, 18 May 2026 14:06:56 GMT
             X-Amz-Id-2:
-                - txgb38778d22b3e48eabe5d-006a0b15c2
+                - txgaad6d851500d46db9d36-006a0b1d00
             X-Amz-Request-Id:
-                - txgb38778d22b3e48eabe5d-006a0b15c2
+                - txgaad6d851500d46db9d36-006a0b1d00
         status: 200 OK
         code: 200
-        duration: 18.305291ms
+        duration: 19.932416ms
     - id: 68
       request:
         proto: HTTP/1.1
@@ -3557,7 +3557,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3566,7 +3566,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d84fbf70-d8f4-44da-b060-2e3fa8f14cc4
+                - 96b4d44d-060b-4d25-abfb-eb04407dd698
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3574,8 +3574,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133602Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T140656Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3585,21 +3585,21 @@ interactions:
         trailer: {}
         content_length: 329
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg9bd094d885824d5183a0-006a0b15c2</RequestId><HostId>txg9bd094d885824d5183a0-006a0b15c2</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg94ae148fb92c41b9bde7-006a0b1d00</RequestId><HostId>txg94ae148fb92c41b9bde7-006a0b1d00</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource></Error>
         headers:
             Content-Length:
                 - "329"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:02 GMT
+                - Mon, 18 May 2026 14:06:56 GMT
             X-Amz-Id-2:
-                - txg9bd094d885824d5183a0-006a0b15c2
+                - txg94ae148fb92c41b9bde7-006a0b1d00
             X-Amz-Request-Id:
-                - txg9bd094d885824d5183a0-006a0b15c2
+                - txg94ae148fb92c41b9bde7-006a0b1d00
         status: 404 Not Found
         code: 404
-        duration: 52.663916ms
+        duration: 64.976542ms
     - id: 69
       request:
         proto: HTTP/1.1
@@ -3608,7 +3608,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3617,7 +3617,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b428458b-e670-48db-af0e-cc34c4060a6e
+                - 7dd22606-533d-4636-a9f9-7246c5ac5711
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3625,8 +3625,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133602Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
+                - 20260518T140656Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -3638,21 +3638,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:02 GMT
+                - Mon, 18 May 2026 14:06:56 GMT
             X-Amz-Id-2:
-                - txg1258b35d1a6447ec8784-006a0b15c2
+                - txge70a530a00534c3aa1aa-006a0b1d00
             X-Amz-Request-Id:
-                - txg1258b35d1a6447ec8784-006a0b15c2
+                - txge70a530a00534c3aa1aa-006a0b1d00
         status: 200 OK
         code: 200
-        duration: 21.28475ms
+        duration: 83.269416ms
     - id: 70
       request:
         proto: HTTP/1.1
@@ -3661,7 +3661,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3670,7 +3670,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 8dd63355-4141-483a-8ae5-670031cbf33d
+                - f024cedb-5a90-409f-b852-5098f47838a8
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3678,8 +3678,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133602Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T140656Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3689,21 +3689,21 @@ interactions:
         trailer: {}
         content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg460252d27eaa4fde8581-006a0b15c2</RequestId><HostId>txg460252d27eaa4fde8581-006a0b15c2</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg5301a00afd3b479b8c6a-006a0b1d00</RequestId><HostId>txg5301a00afd3b479b8c6a-006a0b1d00</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</BucketName></Error>
         headers:
             Content-Length:
                 - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:02 GMT
+                - Mon, 18 May 2026 14:06:56 GMT
             X-Amz-Id-2:
-                - txg460252d27eaa4fde8581-006a0b15c2
+                - txg5301a00afd3b479b8c6a-006a0b1d00
             X-Amz-Request-Id:
-                - txg460252d27eaa4fde8581-006a0b15c2
+                - txg5301a00afd3b479b8c6a-006a0b1d00
         status: 404 Not Found
         code: 404
-        duration: 84.369083ms
+        duration: 21.288709ms
     - id: 71
       request:
         proto: HTTP/1.1
@@ -3712,7 +3712,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3721,7 +3721,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ef2ce59c-efdc-42cd-8312-4edd9a712b38
+                - 306feabf-a10d-46f8-befd-1bab561be512
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3729,8 +3729,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133602Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T140656Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3740,21 +3740,21 @@ interactions:
         trailer: {}
         content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgd9478a46620c48edadd3-006a0b15c2</RequestId><HostId>txgd9478a46620c48edadd3-006a0b15c2</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg3d3885f9be024958af6d-006a0b1d00</RequestId><HostId>txg3d3885f9be024958af6d-006a0b1d00</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource></Error>
         headers:
             Content-Length:
                 - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:02 GMT
+                - Mon, 18 May 2026 14:06:56 GMT
             X-Amz-Id-2:
-                - txgd9478a46620c48edadd3-006a0b15c2
+                - txg3d3885f9be024958af6d-006a0b1d00
             X-Amz-Request-Id:
-                - txgd9478a46620c48edadd3-006a0b15c2
+                - txg3d3885f9be024958af6d-006a0b1d00
         status: 404 Not Found
         code: 404
-        duration: 58.836958ms
+        duration: 21.810167ms
     - id: 72
       request:
         proto: HTTP/1.1
@@ -3763,7 +3763,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3772,7 +3772,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 539de228-a52e-4429-ab31-d2e2d5463fb4
+                - 16ee42aa-feea-4deb-86ae-b35bb53d1e43
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3780,8 +3780,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133602Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T140656Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3800,14 +3800,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:36:02 GMT
+                - Mon, 18 May 2026 14:06:57 GMT
             X-Amz-Id-2:
-                - txg1f442b018f7f44789f0d-006a0b15c2
+                - txg472f49d3e2054e03b8a1-006a0b1d01
             X-Amz-Request-Id:
-                - txg1f442b018f7f44789f0d-006a0b15c2
+                - txg472f49d3e2054e03b8a1-006a0b1d01
         status: 200 OK
         code: 200
-        duration: 171.952958ms
+        duration: 57.418375ms
     - id: 73
       request:
         proto: HTTP/1.1
@@ -3816,7 +3816,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3825,7 +3825,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ff1cedb6-a57a-4354-b4d7-c0bc9fd8f071
+                - 6b6436e0-2521-4fbd-9dad-234216a46764
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3833,8 +3833,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133602Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T140657Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3846,21 +3846,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Days>50</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path3/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id3</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status><Transition><Days>101</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>102</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
                 - "1285"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:36:02 GMT
+                - Mon, 18 May 2026 14:06:57 GMT
             X-Amz-Id-2:
-                - txgeaf8387d98ac4f78b029-006a0b15c2
+                - txg2bd93b7354314c1fa428-006a0b1d01
             X-Amz-Request-Id:
-                - txgeaf8387d98ac4f78b029-006a0b15c2
+                - txg2bd93b7354314c1fa428-006a0b1d01
         status: 200 OK
         code: 200
-        duration: 20.733208ms
+        duration: 93.332542ms
     - id: 74
       request:
         proto: HTTP/1.1
@@ -3869,7 +3869,7 @@ interactions:
         content_length: 296
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
@@ -3878,7 +3878,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 6c0a83da-899e-4e5f-ba7f-93174106a992
+                - f63f06c0-c956-4af9-89a9-e3ee5431ce88
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
@@ -3890,8 +3890,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - 7756d51b786b61edff20b7957d22346417f85f71d19eeca0d6d28d6df7b15bbc
             X-Amz-Date:
-                - 20260518T133602Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T140657Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -3906,14 +3906,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 18 May 2026 13:36:02 GMT
+                - Mon, 18 May 2026 14:06:57 GMT
             X-Amz-Id-2:
-                - txgc3fe67db41944847a326-006a0b15c2
+                - txg945508e9a4394a73ab7f-006a0b1d01
             X-Amz-Request-Id:
-                - txgc3fe67db41944847a326-006a0b15c2
+                - txg945508e9a4394a73ab7f-006a0b1d01
         status: 200 OK
         code: 200
-        duration: 22.204042ms
+        duration: 178.492541ms
     - id: 75
       request:
         proto: HTTP/1.1
@@ -3922,7 +3922,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3931,7 +3931,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b0262691-186a-4dda-87ee-c257263da6a8
+                - fb1498ae-9b6f-44b7-9a09-ebb7c75629fe
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3939,8 +3939,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133602Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T140657Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -3959,14 +3959,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:36:02 GMT
+                - Mon, 18 May 2026 14:06:57 GMT
             X-Amz-Id-2:
-                - txg5ed619075ac64062a89e-006a0b15c2
+                - txgcfeea0c8420c4253b5cf-006a0b1d01
             X-Amz-Request-Id:
-                - txg5ed619075ac64062a89e-006a0b15c2
+                - txgcfeea0c8420c4253b5cf-006a0b1d01
         status: 200 OK
         code: 200
-        duration: 22.008875ms
+        duration: 35.704667ms
     - id: 76
       request:
         proto: HTTP/1.1
@@ -3975,7 +3975,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3984,7 +3984,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - af3210b9-f6df-47d6-9baa-60e573b3d34e
+                - 952f84f7-05d1-41e0-b477-35bf076fcb58
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -3992,8 +3992,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133602Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T140657Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4003,21 +4003,21 @@ interactions:
         trailer: {}
         content_length: 329
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg8c0cd459f62f43b68041-006a0b15c2</RequestId><HostId>txg8c0cd459f62f43b68041-006a0b15c2</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg7cde83b27af246bcad71-006a0b1d01</RequestId><HostId>txg7cde83b27af246bcad71-006a0b1d01</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource></Error>
         headers:
             Content-Length:
                 - "329"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:02 GMT
+                - Mon, 18 May 2026 14:06:57 GMT
             X-Amz-Id-2:
-                - txg8c0cd459f62f43b68041-006a0b15c2
+                - txg7cde83b27af246bcad71-006a0b1d01
             X-Amz-Request-Id:
-                - txg8c0cd459f62f43b68041-006a0b15c2
+                - txg7cde83b27af246bcad71-006a0b1d01
         status: 404 Not Found
         code: 404
-        duration: 59.14125ms
+        duration: 19.951583ms
     - id: 77
       request:
         proto: HTTP/1.1
@@ -4026,7 +4026,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4035,7 +4035,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 821d5e5b-12d5-4694-89f8-aa9faa67a3c5
+                - 7400b5b3-82ec-4eb2-9b53-d63c149b9925
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4043,8 +4043,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133602Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
+                - 20260518T140657Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -4056,21 +4056,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:02 GMT
+                - Mon, 18 May 2026 14:06:57 GMT
             X-Amz-Id-2:
-                - txga759d844c6354cddb6ce-006a0b15c2
+                - txg23a3e263a74d4f96bc3c-006a0b1d01
             X-Amz-Request-Id:
-                - txga759d844c6354cddb6ce-006a0b15c2
+                - txg23a3e263a74d4f96bc3c-006a0b1d01
         status: 200 OK
         code: 200
-        duration: 19.257291ms
+        duration: 23.9065ms
     - id: 78
       request:
         proto: HTTP/1.1
@@ -4079,7 +4079,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4088,7 +4088,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4caf6fe3-c107-454c-b8c3-676f2c01436e
+                - 4478cbdd-f72e-4ab2-ac73-526c567bc2e3
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4096,8 +4096,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133602Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T140657Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4107,21 +4107,21 @@ interactions:
         trailer: {}
         content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgcc36082bea9e4fd399be-006a0b15c2</RequestId><HostId>txgcc36082bea9e4fd399be-006a0b15c2</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg750d421ab861475e87d8-006a0b1d01</RequestId><HostId>txg750d421ab861475e87d8-006a0b1d01</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</BucketName></Error>
         headers:
             Content-Length:
                 - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:02 GMT
+                - Mon, 18 May 2026 14:06:57 GMT
             X-Amz-Id-2:
-                - txgcc36082bea9e4fd399be-006a0b15c2
+                - txg750d421ab861475e87d8-006a0b1d01
             X-Amz-Request-Id:
-                - txgcc36082bea9e4fd399be-006a0b15c2
+                - txg750d421ab861475e87d8-006a0b1d01
         status: 404 Not Found
         code: 404
-        duration: 58.403334ms
+        duration: 65.531167ms
     - id: 79
       request:
         proto: HTTP/1.1
@@ -4130,7 +4130,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4139,7 +4139,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - bce0ec15-e790-436b-bc3b-07c668306c79
+                - 183e5878-18db-4c3b-bd28-624f347de337
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4147,8 +4147,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133602Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T140657Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4158,21 +4158,21 @@ interactions:
         trailer: {}
         content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg6fc7045ddcbf4c6a92b2-006a0b15c2</RequestId><HostId>txg6fc7045ddcbf4c6a92b2-006a0b15c2</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg14886ae45c1c4c83988b-006a0b1d01</RequestId><HostId>txg14886ae45c1c4c83988b-006a0b1d01</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource></Error>
         headers:
             Content-Length:
                 - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:02 GMT
+                - Mon, 18 May 2026 14:06:57 GMT
             X-Amz-Id-2:
-                - txg6fc7045ddcbf4c6a92b2-006a0b15c2
+                - txg14886ae45c1c4c83988b-006a0b1d01
             X-Amz-Request-Id:
-                - txg6fc7045ddcbf4c6a92b2-006a0b15c2
+                - txg14886ae45c1c4c83988b-006a0b1d01
         status: 404 Not Found
         code: 404
-        duration: 18.891583ms
+        duration: 50.413542ms
     - id: 80
       request:
         proto: HTTP/1.1
@@ -4181,7 +4181,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4190,7 +4190,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f8f28038-346c-4ee2-bd0c-feea98ef53fe
+                - 9d3ac4a1-8f09-4505-a947-83dc4fa9acfb
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4198,8 +4198,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133602Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T140657Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4218,14 +4218,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:36:02 GMT
+                - Mon, 18 May 2026 14:06:57 GMT
             X-Amz-Id-2:
-                - txg2e06b36763644c6d899b-006a0b15c2
+                - txg3340834947e1469a96ef-006a0b1d01
             X-Amz-Request-Id:
-                - txg2e06b36763644c6d899b-006a0b15c2
+                - txg3340834947e1469a96ef-006a0b1d01
         status: 200 OK
         code: 200
-        duration: 51.0555ms
+        duration: 35.917417ms
     - id: 81
       request:
         proto: HTTP/1.1
@@ -4234,7 +4234,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4243,7 +4243,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 97b96b6e-e330-474b-a1ed-75a122178f0d
+                - 8533788c-893a-4164-b1f4-3e51e10464b3
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4251,8 +4251,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133602Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T140657Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4271,14 +4271,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:36:02 GMT
+                - Mon, 18 May 2026 14:06:57 GMT
             X-Amz-Id-2:
-                - txg1503fa18959b462882f7-006a0b15c2
+                - txg55965b20b31d48d8aa66-006a0b1d01
             X-Amz-Request-Id:
-                - txg1503fa18959b462882f7-006a0b15c2
+                - txg55965b20b31d48d8aa66-006a0b1d01
         status: 200 OK
         code: 200
-        duration: 18.257583ms
+        duration: 22.296458ms
     - id: 82
       request:
         proto: HTTP/1.1
@@ -4287,7 +4287,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4296,7 +4296,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 2dfd2a8b-02d7-4993-9a6a-0f68a8a1c4a1
+                - 0ffa06e2-51dc-405e-8078-15bbbed1d901
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4304,8 +4304,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133603Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
+                - 20260518T140657Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -4320,16 +4320,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:03 GMT
+                - Mon, 18 May 2026 14:06:57 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txg4eeddda8c36940e48bec-006a0b15c3
+                - txgec9e79225efb4e2785fe-006a0b1d01
             X-Amz-Request-Id:
-                - txg4eeddda8c36940e48bec-006a0b15c3
+                - txgec9e79225efb4e2785fe-006a0b1d01
         status: 200 OK
         code: 200
-        duration: 18.62775ms
+        duration: 53.675042ms
     - id: 83
       request:
         proto: HTTP/1.1
@@ -4338,7 +4338,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4347,7 +4347,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4f99be3c-9371-4462-a1e8-3521b4dc3407
+                - 2e2c3fc3-a236-4b65-904c-f8e4ac91381e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4355,8 +4355,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133603Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T140657Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4375,14 +4375,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:36:03 GMT
+                - Mon, 18 May 2026 14:06:57 GMT
             X-Amz-Id-2:
-                - txg5b870d2e84c2461893f4-006a0b15c3
+                - txgb3e3b18f3a7b4d0097a5-006a0b1d01
             X-Amz-Request-Id:
-                - txg5b870d2e84c2461893f4-006a0b15c3
+                - txgb3e3b18f3a7b4d0097a5-006a0b1d01
         status: 200 OK
         code: 200
-        duration: 19.295084ms
+        duration: 61.483375ms
     - id: 84
       request:
         proto: HTTP/1.1
@@ -4391,7 +4391,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4400,7 +4400,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - eec8879c-f01b-4630-8a57-25e847dbdc01
+                - 9c58afa9-416f-4179-8abc-c0f3c97b9dc8
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4408,8 +4408,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133603Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T140658Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4428,14 +4428,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:36:03 GMT
+                - Mon, 18 May 2026 14:06:58 GMT
             X-Amz-Id-2:
-                - txgc6c23d56c9c74712b9b5-006a0b15c3
+                - txg4db71c2b40f946489d8d-006a0b1d02
             X-Amz-Request-Id:
-                - txgc6c23d56c9c74712b9b5-006a0b15c3
+                - txg4db71c2b40f946489d8d-006a0b1d02
         status: 200 OK
         code: 200
-        duration: 59.989041ms
+        duration: 112.49525ms
     - id: 85
       request:
         proto: HTTP/1.1
@@ -4444,7 +4444,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4453,7 +4453,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - fc39d1eb-cfa8-4bb8-8134-eedd2a2f96b4
+                - 9b085bd4-8cba-4ddd-8222-64f0bad29aae
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4461,8 +4461,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133603Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T140658Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4472,21 +4472,21 @@ interactions:
         trailer: {}
         content_length: 329
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg246540cd03d44d36bf62-006a0b15c3</RequestId><HostId>txg246540cd03d44d36bf62-006a0b15c3</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg194e634f6d36496895ff-006a0b1d02</RequestId><HostId>txg194e634f6d36496895ff-006a0b1d02</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource></Error>
         headers:
             Content-Length:
                 - "329"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:03 GMT
+                - Mon, 18 May 2026 14:06:58 GMT
             X-Amz-Id-2:
-                - txg246540cd03d44d36bf62-006a0b15c3
+                - txg194e634f6d36496895ff-006a0b1d02
             X-Amz-Request-Id:
-                - txg246540cd03d44d36bf62-006a0b15c3
+                - txg194e634f6d36496895ff-006a0b1d02
         status: 404 Not Found
         code: 404
-        duration: 19.477167ms
+        duration: 23.051416ms
     - id: 86
       request:
         proto: HTTP/1.1
@@ -4495,7 +4495,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4504,7 +4504,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - fe00fd94-5a22-43fa-a771-c6a3e72a838e
+                - bc70f345-9aa1-434e-8f50-b225adf85364
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4512,8 +4512,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133603Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
+                - 20260518T140658Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -4525,21 +4525,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:03 GMT
+                - Mon, 18 May 2026 14:06:58 GMT
             X-Amz-Id-2:
-                - txgbf67fa987cdc4f0684aa-006a0b15c3
+                - txg36e5094ae0504079b37a-006a0b1d02
             X-Amz-Request-Id:
-                - txgbf67fa987cdc4f0684aa-006a0b15c3
+                - txg36e5094ae0504079b37a-006a0b1d02
         status: 200 OK
         code: 200
-        duration: 49.012041ms
+        duration: 66.612584ms
     - id: 87
       request:
         proto: HTTP/1.1
@@ -4548,7 +4548,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4557,7 +4557,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 810759ac-5c9c-436c-8c0e-ac9665a08f98
+                - a91f170b-380f-4565-a208-8cc86f8985a1
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4565,8 +4565,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133603Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T140658Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4576,21 +4576,21 @@ interactions:
         trailer: {}
         content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg1e9d7570da3d46d69f75-006a0b15c3</RequestId><HostId>txg1e9d7570da3d46d69f75-006a0b15c3</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg924acd66d5364861bf80-006a0b1d02</RequestId><HostId>txg924acd66d5364861bf80-006a0b1d02</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</BucketName></Error>
         headers:
             Content-Length:
                 - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:03 GMT
+                - Mon, 18 May 2026 14:06:58 GMT
             X-Amz-Id-2:
-                - txg1e9d7570da3d46d69f75-006a0b15c3
+                - txg924acd66d5364861bf80-006a0b1d02
             X-Amz-Request-Id:
-                - txg1e9d7570da3d46d69f75-006a0b15c3
+                - txg924acd66d5364861bf80-006a0b1d02
         status: 404 Not Found
         code: 404
-        duration: 60.656709ms
+        duration: 20.626417ms
     - id: 88
       request:
         proto: HTTP/1.1
@@ -4599,7 +4599,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4608,7 +4608,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f7b82545-6a6f-4de5-91cd-2085abb8525a
+                - 3d474eb8-6be6-4864-a15e-661f6dadc4b8
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4616,8 +4616,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133603Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T140658Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4627,21 +4627,21 @@ interactions:
         trailer: {}
         content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg7cd0962096274628b762-006a0b15c3</RequestId><HostId>txg7cd0962096274628b762-006a0b15c3</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg41bcce9c392c4d0698f5-006a0b1d02</RequestId><HostId>txg41bcce9c392c4d0698f5-006a0b1d02</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource></Error>
         headers:
             Content-Length:
                 - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:03 GMT
+                - Mon, 18 May 2026 14:06:58 GMT
             X-Amz-Id-2:
-                - txg7cd0962096274628b762-006a0b15c3
+                - txg41bcce9c392c4d0698f5-006a0b1d02
             X-Amz-Request-Id:
-                - txg7cd0962096274628b762-006a0b15c3
+                - txg41bcce9c392c4d0698f5-006a0b1d02
         status: 404 Not Found
         code: 404
-        duration: 18.084916ms
+        duration: 20.944916ms
     - id: 89
       request:
         proto: HTTP/1.1
@@ -4650,7 +4650,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4659,7 +4659,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 571131ea-862b-4538-a272-5ef381ea3262
+                - f819ede8-f229-4442-9b98-177cbec381f5
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4667,8 +4667,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133603Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T140658Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4687,14 +4687,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:36:03 GMT
+                - Mon, 18 May 2026 14:06:58 GMT
             X-Amz-Id-2:
-                - txg532d759c6fa64c17be92-006a0b15c3
+                - txg877318e38b334c9aa470-006a0b1d02
             X-Amz-Request-Id:
-                - txg532d759c6fa64c17be92-006a0b15c3
+                - txg877318e38b334c9aa470-006a0b1d02
         status: 200 OK
         code: 200
-        duration: 18.627291ms
+        duration: 21.141459ms
     - id: 90
       request:
         proto: HTTP/1.1
@@ -4703,7 +4703,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4712,7 +4712,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7d5f1c83-dfc2-4628-bd4f-dd59395ff187
+                - bce5b343-896f-4325-8537-8534d8a1c9a4
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4720,8 +4720,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133603Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T140658Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4740,14 +4740,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:36:03 GMT
+                - Mon, 18 May 2026 14:06:58 GMT
             X-Amz-Id-2:
-                - txg3b44a5324e994920a3b4-006a0b15c3
+                - txg3f250a28ac1f46ff9869-006a0b1d02
             X-Amz-Request-Id:
-                - txg3b44a5324e994920a3b4-006a0b15c3
+                - txg3f250a28ac1f46ff9869-006a0b1d02
         status: 200 OK
         code: 200
-        duration: 19.56ms
+        duration: 63.9355ms
     - id: 91
       request:
         proto: HTTP/1.1
@@ -4756,7 +4756,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4765,7 +4765,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 42185baf-312c-4fd5-9bec-c982e5700a7f
+                - 1cf0774e-bfb7-4570-afd4-497d7d426e03
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4773,8 +4773,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133603Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T140658Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4793,14 +4793,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:36:03 GMT
+                - Mon, 18 May 2026 14:06:58 GMT
             X-Amz-Id-2:
-                - txg0c9242daf3bd49a2908d-006a0b15c3
+                - txg8ef96c4e50464585b18b-006a0b1d02
             X-Amz-Request-Id:
-                - txg0c9242daf3bd49a2908d-006a0b15c3
+                - txg8ef96c4e50464585b18b-006a0b1d02
         status: 200 OK
         code: 200
-        duration: 19.343166ms
+        duration: 21.226167ms
     - id: 92
       request:
         proto: HTTP/1.1
@@ -4809,7 +4809,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4818,7 +4818,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e0aaa70d-9160-4ae4-a7f3-3e9ee9dbf3e2
+                - 8c9705d2-57be-49f0-b073-e20c67d9bb6d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4826,8 +4826,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133603Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T140658Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4837,21 +4837,21 @@ interactions:
         trailer: {}
         content_length: 329
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg1ec5b71219224a558b71-006a0b15c3</RequestId><HostId>txg1ec5b71219224a558b71-006a0b15c3</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg7a27bee9ddd54adbac3d-006a0b1d02</RequestId><HostId>txg7a27bee9ddd54adbac3d-006a0b1d02</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource></Error>
         headers:
             Content-Length:
                 - "329"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:03 GMT
+                - Mon, 18 May 2026 14:06:58 GMT
             X-Amz-Id-2:
-                - txg1ec5b71219224a558b71-006a0b15c3
+                - txg7a27bee9ddd54adbac3d-006a0b1d02
             X-Amz-Request-Id:
-                - txg1ec5b71219224a558b71-006a0b15c3
+                - txg7a27bee9ddd54adbac3d-006a0b1d02
         status: 404 Not Found
         code: 404
-        duration: 20.155416ms
+        duration: 21.845958ms
     - id: 93
       request:
         proto: HTTP/1.1
@@ -4860,7 +4860,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4869,7 +4869,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 6bc4ffce-9a28-4c2e-92e4-b1b36c32419b
+                - 7ad5cae2-a11a-4e77-a0a0-15730e911433
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4877,8 +4877,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133603Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
+                - 20260518T140658Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -4890,21 +4890,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:03 GMT
+                - Mon, 18 May 2026 14:06:58 GMT
             X-Amz-Id-2:
-                - txgdd622b9fa50d4fe08d17-006a0b15c3
+                - txge6513c81594a4ae8a669-006a0b1d02
             X-Amz-Request-Id:
-                - txgdd622b9fa50d4fe08d17-006a0b15c3
+                - txge6513c81594a4ae8a669-006a0b1d02
         status: 200 OK
         code: 200
-        duration: 31.426083ms
+        duration: 67.897625ms
     - id: 94
       request:
         proto: HTTP/1.1
@@ -4913,7 +4913,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4922,7 +4922,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 563dc347-3bf6-4e64-ae91-a2cba76ca0fa
+                - 7c5dac8c-6107-4c27-82f7-11f3b051b429
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4930,8 +4930,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133603Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T140658Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4941,21 +4941,21 @@ interactions:
         trailer: {}
         content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txge4e82ad4ea85417dbe88-006a0b15c3</RequestId><HostId>txge4e82ad4ea85417dbe88-006a0b15c3</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg23ccfd6730c34a6a8dd2-006a0b1d02</RequestId><HostId>txg23ccfd6730c34a6a8dd2-006a0b1d02</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</BucketName></Error>
         headers:
             Content-Length:
                 - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:03 GMT
+                - Mon, 18 May 2026 14:06:58 GMT
             X-Amz-Id-2:
-                - txge4e82ad4ea85417dbe88-006a0b15c3
+                - txg23ccfd6730c34a6a8dd2-006a0b1d02
             X-Amz-Request-Id:
-                - txge4e82ad4ea85417dbe88-006a0b15c3
+                - txg23ccfd6730c34a6a8dd2-006a0b1d02
         status: 404 Not Found
         code: 404
-        duration: 59.015416ms
+        duration: 22.330042ms
     - id: 95
       request:
         proto: HTTP/1.1
@@ -4964,7 +4964,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -4973,7 +4973,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b955b179-90e5-4ce7-9898-68d358d20b39
+                - 4116ff58-c9ef-477d-9d32-2223ceafd425
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -4981,8 +4981,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133603Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T140658Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -4992,21 +4992,21 @@ interactions:
         trailer: {}
         content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgc584a0d5be7b45cc843a-006a0b15c3</RequestId><HostId>txgc584a0d5be7b45cc843a-006a0b15c3</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg771ea4fe620d427b87f5-006a0b1d02</RequestId><HostId>txg771ea4fe620d427b87f5-006a0b1d02</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource></Error>
         headers:
             Content-Length:
                 - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:03 GMT
+                - Mon, 18 May 2026 14:06:58 GMT
             X-Amz-Id-2:
-                - txgc584a0d5be7b45cc843a-006a0b15c3
+                - txg771ea4fe620d427b87f5-006a0b1d02
             X-Amz-Request-Id:
-                - txgc584a0d5be7b45cc843a-006a0b15c3
+                - txg771ea4fe620d427b87f5-006a0b1d02
         status: 404 Not Found
         code: 404
-        duration: 19.094792ms
+        duration: 20.49475ms
     - id: 96
       request:
         proto: HTTP/1.1
@@ -5015,7 +5015,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5024,7 +5024,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f5321642-8077-456c-bdd3-b9d69ffdda3b
+                - f9e684a0-3dcc-469d-aa01-90dff0274b3c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5032,8 +5032,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133603Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T140658Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5052,14 +5052,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:36:03 GMT
+                - Mon, 18 May 2026 14:06:58 GMT
             X-Amz-Id-2:
-                - txg4f8d2a8540bc41e8aa75-006a0b15c3
+                - txg513d4d2580d14d878491-006a0b1d02
             X-Amz-Request-Id:
-                - txg4f8d2a8540bc41e8aa75-006a0b15c3
+                - txg513d4d2580d14d878491-006a0b1d02
         status: 200 OK
         code: 200
-        duration: 30.262875ms
+        duration: 22.264917ms
     - id: 97
       request:
         proto: HTTP/1.1
@@ -5068,7 +5068,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5077,7 +5077,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - cb8ca374-bc60-4a9a-8e80-53d5b747c897
+                - 7f9a6bb6-7142-42c9-aa18-6b9cec2e9d49
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5085,8 +5085,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133603Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T140658Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5105,14 +5105,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:36:03 GMT
+                - Mon, 18 May 2026 14:06:58 GMT
             X-Amz-Id-2:
-                - txg8f556bb2ebd34de9a817-006a0b15c3
+                - txgfcdb75bf7d3448a6843b-006a0b1d02
             X-Amz-Request-Id:
-                - txg8f556bb2ebd34de9a817-006a0b15c3
+                - txgfcdb75bf7d3448a6843b-006a0b1d02
         status: 200 OK
         code: 200
-        duration: 18.5705ms
+        duration: 62.66725ms
     - id: 98
       request:
         proto: HTTP/1.1
@@ -5121,7 +5121,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5130,7 +5130,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 29b6328d-d227-4377-955a-173f623756b9
+                - 682d4c44-82fd-4df5-8678-ca9494367758
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5138,8 +5138,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133604Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
+                - 20260518T140659Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -5154,16 +5154,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:04 GMT
+                - Mon, 18 May 2026 14:06:59 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txgefd1174a9dd24e5e8588-006a0b15c4
+                - txga4818374fca34af19d27-006a0b1d03
             X-Amz-Request-Id:
-                - txgefd1174a9dd24e5e8588-006a0b15c4
+                - txga4818374fca34af19d27-006a0b1d03
         status: 200 OK
         code: 200
-        duration: 678.278667ms
+        duration: 63.462166ms
     - id: 99
       request:
         proto: HTTP/1.1
@@ -5172,7 +5172,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5181,7 +5181,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c1d8d61c-9ca3-439b-a8f0-25001e9753f4
+                - b084155e-ddc4-4b91-a4c8-c79f8e6c7f8e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5189,8 +5189,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133604Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T140659Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5209,14 +5209,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:36:04 GMT
+                - Mon, 18 May 2026 14:06:59 GMT
             X-Amz-Id-2:
-                - txgc22a386516ea47048d48-006a0b15c4
+                - txgef02541205f04186a19b-006a0b1d03
             X-Amz-Request-Id:
-                - txgc22a386516ea47048d48-006a0b15c4
+                - txgef02541205f04186a19b-006a0b1d03
         status: 200 OK
         code: 200
-        duration: 56.451917ms
+        duration: 22.476042ms
     - id: 100
       request:
         proto: HTTP/1.1
@@ -5225,7 +5225,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5234,7 +5234,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 94f39d9c-da5f-4148-8837-74782d6bbaaa
+                - 93c67b04-9a39-4945-988e-a91b119a5314
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5242,8 +5242,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133605Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T140659Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5262,14 +5262,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:36:05 GMT
+                - Mon, 18 May 2026 14:06:59 GMT
             X-Amz-Id-2:
-                - txg2de748b3b6c0428c803f-006a0b15c5
+                - txg739db120adac4abe9d8d-006a0b1d03
             X-Amz-Request-Id:
-                - txg2de748b3b6c0428c803f-006a0b15c5
+                - txg739db120adac4abe9d8d-006a0b1d03
         status: 200 OK
         code: 200
-        duration: 19.418167ms
+        duration: 55.247958ms
     - id: 101
       request:
         proto: HTTP/1.1
@@ -5278,7 +5278,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5287,7 +5287,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e74cadd9-a2e9-491e-ab86-ad668fb186a4
+                - af7b75ce-2c2c-481b-ade9-1dfc29689bb1
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5295,8 +5295,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133605Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T140659Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5306,21 +5306,21 @@ interactions:
         trailer: {}
         content_length: 329
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgd752d331f67f406fad58-006a0b15c5</RequestId><HostId>txgd752d331f67f406fad58-006a0b15c5</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgdaddb83adc624b17a997-006a0b1d03</RequestId><HostId>txgdaddb83adc624b17a997-006a0b1d03</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource></Error>
         headers:
             Content-Length:
                 - "329"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:05 GMT
+                - Mon, 18 May 2026 14:06:59 GMT
             X-Amz-Id-2:
-                - txgd752d331f67f406fad58-006a0b15c5
+                - txgdaddb83adc624b17a997-006a0b1d03
             X-Amz-Request-Id:
-                - txgd752d331f67f406fad58-006a0b15c5
+                - txgdaddb83adc624b17a997-006a0b1d03
         status: 404 Not Found
         code: 404
-        duration: 21.582458ms
+        duration: 60.763ms
     - id: 102
       request:
         proto: HTTP/1.1
@@ -5329,7 +5329,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5338,7 +5338,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5607591a-d5d4-40e4-81a1-fc0ecd4968b1
+                - 3c6747ee-9ef1-48b2-83df-a92b9cee7def
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5346,8 +5346,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133605Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
+                - 20260518T140659Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -5359,21 +5359,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:05 GMT
+                - Mon, 18 May 2026 14:06:59 GMT
             X-Amz-Id-2:
-                - txg3268bbac9edd41a29920-006a0b15c5
+                - txgc73a98b927514f3292cd-006a0b1d03
             X-Amz-Request-Id:
-                - txg3268bbac9edd41a29920-006a0b15c5
+                - txgc73a98b927514f3292cd-006a0b1d03
         status: 200 OK
         code: 200
-        duration: 20.680875ms
+        duration: 52.3295ms
     - id: 103
       request:
         proto: HTTP/1.1
@@ -5382,7 +5382,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5391,7 +5391,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 85fd0406-775f-4134-acd3-14dd7e6404c0
+                - d90e4a2e-86e9-4274-941c-32c0c4f0faed
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5399,8 +5399,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133605Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T140659Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5410,21 +5410,21 @@ interactions:
         trailer: {}
         content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txge3eb600e2232468399a7-006a0b15c5</RequestId><HostId>txge3eb600e2232468399a7-006a0b15c5</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg0e67a986714f4c15a49d-006a0b1d03</RequestId><HostId>txg0e67a986714f4c15a49d-006a0b1d03</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</BucketName></Error>
         headers:
             Content-Length:
                 - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:05 GMT
+                - Mon, 18 May 2026 14:06:59 GMT
             X-Amz-Id-2:
-                - txge3eb600e2232468399a7-006a0b15c5
+                - txg0e67a986714f4c15a49d-006a0b1d03
             X-Amz-Request-Id:
-                - txge3eb600e2232468399a7-006a0b15c5
+                - txg0e67a986714f4c15a49d-006a0b1d03
         status: 404 Not Found
         code: 404
-        duration: 18.6755ms
+        duration: 54.751375ms
     - id: 104
       request:
         proto: HTTP/1.1
@@ -5433,7 +5433,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5442,7 +5442,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 92914863-9943-4966-aaa7-7454743242ce
+                - 575b62d3-6ff5-4f2a-9ec4-a72eb4466608
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5450,8 +5450,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133605Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T140659Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5461,21 +5461,21 @@ interactions:
         trailer: {}
         content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg58eccead3de74c02974d-006a0b15c5</RequestId><HostId>txg58eccead3de74c02974d-006a0b15c5</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg77f44651a11240638982-006a0b1d03</RequestId><HostId>txg77f44651a11240638982-006a0b1d03</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource></Error>
         headers:
             Content-Length:
                 - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:05 GMT
+                - Mon, 18 May 2026 14:06:59 GMT
             X-Amz-Id-2:
-                - txg58eccead3de74c02974d-006a0b15c5
+                - txg77f44651a11240638982-006a0b1d03
             X-Amz-Request-Id:
-                - txg58eccead3de74c02974d-006a0b15c5
+                - txg77f44651a11240638982-006a0b1d03
         status: 404 Not Found
         code: 404
-        duration: 20.254542ms
+        duration: 21.402459ms
     - id: 105
       request:
         proto: HTTP/1.1
@@ -5484,7 +5484,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5493,7 +5493,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 33fdc835-260e-45cc-adfd-284990cdfd29
+                - fb7aa332-0eda-4f15-82b5-436ef0f44809
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5501,8 +5501,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133605Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T140659Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5521,14 +5521,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:36:05 GMT
+                - Mon, 18 May 2026 14:06:59 GMT
             X-Amz-Id-2:
-                - txgdaeb24d03a74436f826d-006a0b15c5
+                - txge386ad18001d45a2941b-006a0b1d03
             X-Amz-Request-Id:
-                - txgdaeb24d03a74436f826d-006a0b15c5
+                - txge386ad18001d45a2941b-006a0b1d03
         status: 200 OK
         code: 200
-        duration: 20.798459ms
+        duration: 20.965292ms
     - id: 106
       request:
         proto: HTTP/1.1
@@ -5537,7 +5537,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5546,7 +5546,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - cbe0ca0c-cf01-4723-919f-fa0fb67c60d6
+                - 6e73809a-c9b7-4643-b013-bfe0f2817109
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5554,8 +5554,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133605Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T140659Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5574,14 +5574,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:36:05 GMT
+                - Mon, 18 May 2026 14:06:59 GMT
             X-Amz-Id-2:
-                - txg1f83fe80f1464b61b129-006a0b15c5
+                - txge7c738b7f547437086c2-006a0b1d03
             X-Amz-Request-Id:
-                - txg1f83fe80f1464b61b129-006a0b15c5
+                - txge7c738b7f547437086c2-006a0b1d03
         status: 200 OK
         code: 200
-        duration: 49.231333ms
+        duration: 60.935ms
     - id: 107
       request:
         proto: HTTP/1.1
@@ -5590,7 +5590,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5599,7 +5599,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 00225984-fee9-4284-b208-552c6ec322bf
+                - 74d9c0cf-82d7-4a2b-8104-c8cf5561f13f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5607,8 +5607,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133605Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T140659Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5627,14 +5627,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:36:05 GMT
+                - Mon, 18 May 2026 14:07:00 GMT
             X-Amz-Id-2:
-                - txg608761dbce3d472e93f7-006a0b15c5
+                - txgb9ae6a27cc0b40a2b365-006a0b1d04
             X-Amz-Request-Id:
-                - txg608761dbce3d472e93f7-006a0b15c5
+                - txgb9ae6a27cc0b40a2b365-006a0b1d04
         status: 200 OK
         code: 200
-        duration: 20.496959ms
+        duration: 51.327ms
     - id: 108
       request:
         proto: HTTP/1.1
@@ -5643,7 +5643,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5652,7 +5652,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 1ad8bc58-cb94-404b-8d8a-e2fc0fc85354
+                - e85b9fdd-2665-4580-a33d-3397ed433d65
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5660,8 +5660,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133605Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T140700Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5671,21 +5671,21 @@ interactions:
         trailer: {}
         content_length: 329
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg3ce8f6caa7ec456ea3b3-006a0b15c5</RequestId><HostId>txg3ce8f6caa7ec456ea3b3-006a0b15c5</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgc4cc65ba57874e7fa446-006a0b1d04</RequestId><HostId>txgc4cc65ba57874e7fa446-006a0b1d04</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource></Error>
         headers:
             Content-Length:
                 - "329"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:05 GMT
+                - Mon, 18 May 2026 14:07:00 GMT
             X-Amz-Id-2:
-                - txg3ce8f6caa7ec456ea3b3-006a0b15c5
+                - txgc4cc65ba57874e7fa446-006a0b1d04
             X-Amz-Request-Id:
-                - txg3ce8f6caa7ec456ea3b3-006a0b15c5
+                - txgc4cc65ba57874e7fa446-006a0b1d04
         status: 404 Not Found
         code: 404
-        duration: 20.549917ms
+        duration: 51.180458ms
     - id: 109
       request:
         proto: HTTP/1.1
@@ -5694,7 +5694,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5703,7 +5703,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 59693bf9-190d-42ce-a636-6ac4bb06c01a
+                - e324a7e2-5058-4146-afe6-c61117fd7eaf
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5711,8 +5711,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133605Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
+                - 20260518T140700Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -5724,21 +5724,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:05 GMT
+                - Mon, 18 May 2026 14:07:00 GMT
             X-Amz-Id-2:
-                - txg2804ea820a0b4d9c8fcb-006a0b15c5
+                - txgf38a78aed75643b7b63e-006a0b1d04
             X-Amz-Request-Id:
-                - txg2804ea820a0b4d9c8fcb-006a0b15c5
+                - txgf38a78aed75643b7b63e-006a0b1d04
         status: 200 OK
         code: 200
-        duration: 57.276084ms
+        duration: 56.075334ms
     - id: 110
       request:
         proto: HTTP/1.1
@@ -5747,7 +5747,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5756,7 +5756,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - a44f0651-de4b-4d10-bddb-dfdbf59d6120
+                - 479a5792-ae0c-4d37-b6e0-5a8a02170ecd
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5764,8 +5764,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133605Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T140700Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5775,21 +5775,21 @@ interactions:
         trailer: {}
         content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg42fccefa95d74163a1d7-006a0b15c5</RequestId><HostId>txg42fccefa95d74163a1d7-006a0b15c5</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgea792770dc014247ac4c-006a0b1d04</RequestId><HostId>txgea792770dc014247ac4c-006a0b1d04</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</BucketName></Error>
         headers:
             Content-Length:
                 - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:05 GMT
+                - Mon, 18 May 2026 14:07:00 GMT
             X-Amz-Id-2:
-                - txg42fccefa95d74163a1d7-006a0b15c5
+                - txgea792770dc014247ac4c-006a0b1d04
             X-Amz-Request-Id:
-                - txg42fccefa95d74163a1d7-006a0b15c5
+                - txgea792770dc014247ac4c-006a0b1d04
         status: 404 Not Found
         code: 404
-        duration: 19.278792ms
+        duration: 82.106166ms
     - id: 111
       request:
         proto: HTTP/1.1
@@ -5798,7 +5798,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5807,7 +5807,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ebc5b244-b70a-4cfb-ad87-883fa03aa01b
+                - 3caee62c-1678-498a-97fa-9f2812a87720
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5815,8 +5815,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133605Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T140700Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5826,21 +5826,21 @@ interactions:
         trailer: {}
         content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txged7b380cd04244bca52f-006a0b15c5</RequestId><HostId>txged7b380cd04244bca52f-006a0b15c5</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgf10268397cb44f7aba98-006a0b1d04</RequestId><HostId>txgf10268397cb44f7aba98-006a0b1d04</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource></Error>
         headers:
             Content-Length:
                 - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:05 GMT
+                - Mon, 18 May 2026 14:07:00 GMT
             X-Amz-Id-2:
-                - txged7b380cd04244bca52f-006a0b15c5
+                - txgf10268397cb44f7aba98-006a0b1d04
             X-Amz-Request-Id:
-                - txged7b380cd04244bca52f-006a0b15c5
+                - txgf10268397cb44f7aba98-006a0b1d04
         status: 404 Not Found
         code: 404
-        duration: 19.9545ms
+        duration: 62.162583ms
     - id: 112
       request:
         proto: HTTP/1.1
@@ -5849,7 +5849,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5858,7 +5858,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d380e281-b231-48db-8c3b-dfcde25b9139
+                - 204d5756-9997-45f9-833f-2d56640fb5f3
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5866,8 +5866,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133605Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T140700Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5886,14 +5886,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:36:05 GMT
+                - Mon, 18 May 2026 14:07:00 GMT
             X-Amz-Id-2:
-                - txgdf1cd6803e3e4fd3a0fd-006a0b15c5
+                - txga8cce380b68d446b8185-006a0b1d04
             X-Amz-Request-Id:
-                - txgdf1cd6803e3e4fd3a0fd-006a0b15c5
+                - txga8cce380b68d446b8185-006a0b1d04
         status: 200 OK
         code: 200
-        duration: 20.145958ms
+        duration: 20.467833ms
     - id: 113
       request:
         proto: HTTP/1.1
@@ -5902,7 +5902,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -5911,7 +5911,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 961cc332-8ea8-4089-a1fe-6443ac683c41
+                - a0b9e949-7da4-4b55-a635-0b8d5958bf6f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -5919,8 +5919,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133605Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T140700Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -5939,14 +5939,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:36:05 GMT
+                - Mon, 18 May 2026 14:07:00 GMT
             X-Amz-Id-2:
-                - txg8508f0c96ebf44e78b4a-006a0b15c5
+                - txg3ff3d20f3488453fbb15-006a0b1d04
             X-Amz-Request-Id:
-                - txg8508f0c96ebf44e78b4a-006a0b15c5
+                - txg3ff3d20f3488453fbb15-006a0b1d04
         status: 200 OK
         code: 200
-        duration: 19.486917ms
+        duration: 20.535958ms
     - id: 114
       request:
         proto: HTTP/1.1
@@ -5955,7 +5955,7 @@ interactions:
         content_length: 344
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>1</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path1/</Prefix><Tag><Key>deleted</Key><Value>true</Value></Tag></And></Filter><ID>id1</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
@@ -5964,7 +5964,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - a3e10bde-0b31-4c07-9b7c-c7afc323eda7
+                - 1428c3c0-28d1-485c-a41b-c53ceff5ad67
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
@@ -5976,8 +5976,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - b0de451c31309fbdd3611c566f2f38ddccf0dd237feb3e8d186422993ecf7a1f
             X-Amz-Date:
-                - 20260518T133605Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T140700Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -5992,14 +5992,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 18 May 2026 13:36:05 GMT
+                - Mon, 18 May 2026 14:07:00 GMT
             X-Amz-Id-2:
-                - txg6b7e2edcf3bf423db8a8-006a0b15c5
+                - txgc0c527d6519b4887811f-006a0b1d04
             X-Amz-Request-Id:
-                - txg6b7e2edcf3bf423db8a8-006a0b15c5
+                - txgc0c527d6519b4887811f-006a0b1d04
         status: 200 OK
         code: 200
-        duration: 20.614292ms
+        duration: 64.805ms
     - id: 115
       request:
         proto: HTTP/1.1
@@ -6008,7 +6008,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6017,7 +6017,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 01b31146-0eb7-4bd4-a8a4-d9dddbd5a33e
+                - dae65679-92d0-424f-b730-07b7e095e7e9
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6025,8 +6025,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133605Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T140700Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6045,14 +6045,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:36:05 GMT
+                - Mon, 18 May 2026 14:07:00 GMT
             X-Amz-Id-2:
-                - txg61c5c3f978214818a368-006a0b15c5
+                - txgcee3f0f8c2f24cb09396-006a0b1d04
             X-Amz-Request-Id:
-                - txg61c5c3f978214818a368-006a0b15c5
+                - txgcee3f0f8c2f24cb09396-006a0b1d04
         status: 200 OK
         code: 200
-        duration: 34.886542ms
+        duration: 23.760833ms
     - id: 116
       request:
         proto: HTTP/1.1
@@ -6061,7 +6061,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6070,7 +6070,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 1749c4ea-7445-4292-88f6-c641dc5e9ad2
+                - 9f56bb0f-4e80-4472-97cf-8695fc86090b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6078,8 +6078,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133605Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T140700Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6089,21 +6089,21 @@ interactions:
         trailer: {}
         content_length: 329
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg579079461cd741be8636-006a0b15c5</RequestId><HostId>txg579079461cd741be8636-006a0b15c5</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txge80aeaaefb494554862b-006a0b1d04</RequestId><HostId>txge80aeaaefb494554862b-006a0b1d04</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource></Error>
         headers:
             Content-Length:
                 - "329"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:05 GMT
+                - Mon, 18 May 2026 14:07:00 GMT
             X-Amz-Id-2:
-                - txg579079461cd741be8636-006a0b15c5
+                - txge80aeaaefb494554862b-006a0b1d04
             X-Amz-Request-Id:
-                - txg579079461cd741be8636-006a0b15c5
+                - txge80aeaaefb494554862b-006a0b1d04
         status: 404 Not Found
         code: 404
-        duration: 20.192291ms
+        duration: 20.791541ms
     - id: 117
       request:
         proto: HTTP/1.1
@@ -6112,7 +6112,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6121,7 +6121,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 927088f7-c11b-48f3-90f7-8eb68bcd53d4
+                - f9c40fc4-a312-409e-b61c-f8dddb8c4a2c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6129,8 +6129,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133605Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
+                - 20260518T140700Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -6142,21 +6142,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:05 GMT
+                - Mon, 18 May 2026 14:07:00 GMT
             X-Amz-Id-2:
-                - txgb2d4e87e9a59433795d9-006a0b15c5
+                - txg1359314c896540cd9ec0-006a0b1d04
             X-Amz-Request-Id:
-                - txgb2d4e87e9a59433795d9-006a0b15c5
+                - txg1359314c896540cd9ec0-006a0b1d04
         status: 200 OK
         code: 200
-        duration: 135.229958ms
+        duration: 22.361625ms
     - id: 118
       request:
         proto: HTTP/1.1
@@ -6165,7 +6165,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6174,7 +6174,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 68adbcd7-c6be-4c6d-ba53-c2856009a832
+                - 2b69e45b-b960-4519-8d85-8c914acf3cac
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6182,8 +6182,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133605Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T140700Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6193,21 +6193,21 @@ interactions:
         trailer: {}
         content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgdd92c63746b240b0b2f7-006a0b15c6</RequestId><HostId>txgdd92c63746b240b0b2f7-006a0b15c6</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgd7a8facc072b491f823b-006a0b1d04</RequestId><HostId>txgd7a8facc072b491f823b-006a0b1d04</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</BucketName></Error>
         headers:
             Content-Length:
                 - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:06 GMT
+                - Mon, 18 May 2026 14:07:00 GMT
             X-Amz-Id-2:
-                - txgdd92c63746b240b0b2f7-006a0b15c6
+                - txgd7a8facc072b491f823b-006a0b1d04
             X-Amz-Request-Id:
-                - txgdd92c63746b240b0b2f7-006a0b15c6
+                - txgd7a8facc072b491f823b-006a0b1d04
         status: 404 Not Found
         code: 404
-        duration: 34.880292ms
+        duration: 20.658042ms
     - id: 119
       request:
         proto: HTTP/1.1
@@ -6216,7 +6216,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6225,7 +6225,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4bec1fa2-b835-4b44-b865-41471e00ba55
+                - d21438eb-51f7-4efd-89a0-285b6b1053b4
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6233,8 +6233,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133606Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T140700Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6244,21 +6244,21 @@ interactions:
         trailer: {}
         content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg9733cb7730b8464cbd60-006a0b15c6</RequestId><HostId>txg9733cb7730b8464cbd60-006a0b15c6</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg9f356b3235fa4b6ca2cf-006a0b1d04</RequestId><HostId>txg9f356b3235fa4b6ca2cf-006a0b1d04</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource></Error>
         headers:
             Content-Length:
                 - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:06 GMT
+                - Mon, 18 May 2026 14:07:00 GMT
             X-Amz-Id-2:
-                - txg9733cb7730b8464cbd60-006a0b15c6
+                - txg9f356b3235fa4b6ca2cf-006a0b1d04
             X-Amz-Request-Id:
-                - txg9733cb7730b8464cbd60-006a0b15c6
+                - txg9f356b3235fa4b6ca2cf-006a0b1d04
         status: 404 Not Found
         code: 404
-        duration: 19.534375ms
+        duration: 53.237791ms
     - id: 120
       request:
         proto: HTTP/1.1
@@ -6267,7 +6267,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6276,7 +6276,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 55cc270d-8710-4452-a1d2-1ebb629f8114
+                - 1b2c3143-0219-401f-bcd0-dab9084e16cf
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6284,8 +6284,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133606Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T140700Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6304,14 +6304,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:36:06 GMT
+                - Mon, 18 May 2026 14:07:00 GMT
             X-Amz-Id-2:
-                - txgcc8d061ee07e462ab467-006a0b15c6
+                - txg29697ab2b9bd4afc88ba-006a0b1d04
             X-Amz-Request-Id:
-                - txgcc8d061ee07e462ab467-006a0b15c6
+                - txg29697ab2b9bd4afc88ba-006a0b1d04
         status: 200 OK
         code: 200
-        duration: 51.285125ms
+        duration: 20.027583ms
     - id: 121
       request:
         proto: HTTP/1.1
@@ -6320,7 +6320,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6329,7 +6329,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 73030ee8-bf34-4ac3-8d6d-c80a175bf77c
+                - 080d3a02-9d8d-4e23-aed4-b2d5f84e2fd4
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6337,8 +6337,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133606Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T140700Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6357,14 +6357,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:36:06 GMT
+                - Mon, 18 May 2026 14:07:00 GMT
             X-Amz-Id-2:
-                - txg4a63c826cff643a6ad4d-006a0b15c6
+                - txgc6d5a77cb5e24defaacf-006a0b1d04
             X-Amz-Request-Id:
-                - txg4a63c826cff643a6ad4d-006a0b15c6
+                - txgc6d5a77cb5e24defaacf-006a0b1d04
         status: 200 OK
         code: 200
-        duration: 19.366042ms
+        duration: 20.849ms
     - id: 122
       request:
         proto: HTTP/1.1
@@ -6373,7 +6373,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6382,7 +6382,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 61c48d5f-5088-4596-8649-4200c51f7286
+                - c7f0584a-2835-4bdf-be34-6750341256d5
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6390,8 +6390,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133606Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
+                - 20260518T140700Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -6406,16 +6406,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:06 GMT
+                - Mon, 18 May 2026 14:07:01 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txg38b0717f16ef4eaba188-006a0b15c6
+                - txg8b1f08f7ecaf4ead8490-006a0b1d05
             X-Amz-Request-Id:
-                - txg38b0717f16ef4eaba188-006a0b15c6
+                - txg8b1f08f7ecaf4ead8490-006a0b1d05
         status: 200 OK
         code: 200
-        duration: 29.100417ms
+        duration: 166.460458ms
     - id: 123
       request:
         proto: HTTP/1.1
@@ -6424,7 +6424,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6433,7 +6433,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e9a32af2-0685-417f-941a-3a3488953105
+                - 2b6dd99c-3bbd-41f5-ae36-f991a52eb9bc
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6441,8 +6441,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133606Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T140701Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6461,14 +6461,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:36:06 GMT
+                - Mon, 18 May 2026 14:07:01 GMT
             X-Amz-Id-2:
-                - txg0484cbb56001449eaecf-006a0b15c6
+                - txg500791416ec942bd889b-006a0b1d05
             X-Amz-Request-Id:
-                - txg0484cbb56001449eaecf-006a0b15c6
+                - txg500791416ec942bd889b-006a0b1d05
         status: 200 OK
         code: 200
-        duration: 22.066792ms
+        duration: 21.087917ms
     - id: 124
       request:
         proto: HTTP/1.1
@@ -6477,7 +6477,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6486,7 +6486,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - affe0440-10d1-4d2f-905a-7dbd3a56f698
+                - 5af86b02-b404-42d8-8114-25c2c49ca9b8
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6494,8 +6494,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133606Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T140701Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6514,14 +6514,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:36:06 GMT
+                - Mon, 18 May 2026 14:07:01 GMT
             X-Amz-Id-2:
-                - txge0e1fdc14e764d998a3e-006a0b15c6
+                - txgddfdf5f4cc304fa88756-006a0b1d05
             X-Amz-Request-Id:
-                - txge0e1fdc14e764d998a3e-006a0b15c6
+                - txgddfdf5f4cc304fa88756-006a0b1d05
         status: 200 OK
         code: 200
-        duration: 32.23075ms
+        duration: 29.249333ms
     - id: 125
       request:
         proto: HTTP/1.1
@@ -6530,7 +6530,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6539,7 +6539,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 63cfda8d-7639-4da4-83c1-d1c5c330a9e0
+                - fe35f502-b195-4201-87e7-fcfa5d0566dd
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6547,8 +6547,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133606Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T140701Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6558,21 +6558,21 @@ interactions:
         trailer: {}
         content_length: 329
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg2ec4bfe5cfa44f03bed5-006a0b15c6</RequestId><HostId>txg2ec4bfe5cfa44f03bed5-006a0b15c6</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txga9374f1cdbd94fb9bac4-006a0b1d05</RequestId><HostId>txga9374f1cdbd94fb9bac4-006a0b1d05</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource></Error>
         headers:
             Content-Length:
                 - "329"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:06 GMT
+                - Mon, 18 May 2026 14:07:01 GMT
             X-Amz-Id-2:
-                - txg2ec4bfe5cfa44f03bed5-006a0b15c6
+                - txga9374f1cdbd94fb9bac4-006a0b1d05
             X-Amz-Request-Id:
-                - txg2ec4bfe5cfa44f03bed5-006a0b15c6
+                - txga9374f1cdbd94fb9bac4-006a0b1d05
         status: 404 Not Found
         code: 404
-        duration: 19.91925ms
+        duration: 19.412792ms
     - id: 126
       request:
         proto: HTTP/1.1
@@ -6581,7 +6581,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6590,7 +6590,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 1105aa3b-3dea-48d0-906a-c07661875c54
+                - 6d20eed4-6a9e-4f2d-9aaf-a3c05faacd5f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6598,8 +6598,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133606Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
+                - 20260518T140701Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -6611,21 +6611,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:06 GMT
+                - Mon, 18 May 2026 14:07:01 GMT
             X-Amz-Id-2:
-                - txg81c1614609b1444eb0a1-006a0b15c6
+                - txg24c1b4655e1e454ab3fb-006a0b1d05
             X-Amz-Request-Id:
-                - txg81c1614609b1444eb0a1-006a0b15c6
+                - txg24c1b4655e1e454ab3fb-006a0b1d05
         status: 200 OK
         code: 200
-        duration: 33.842833ms
+        duration: 223.341167ms
     - id: 127
       request:
         proto: HTTP/1.1
@@ -6634,7 +6634,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6643,7 +6643,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ad66677d-bb5e-4f52-8bb9-b97308d6d71a
+                - 24f7a006-552c-46be-8149-c8961a8fffd4
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6651,8 +6651,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133606Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T140701Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6662,21 +6662,21 @@ interactions:
         trailer: {}
         content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgc1985b358cca4d7f87af-006a0b15c6</RequestId><HostId>txgc1985b358cca4d7f87af-006a0b15c6</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgb1c0d6d3b8634db59aca-006a0b1d05</RequestId><HostId>txgb1c0d6d3b8634db59aca-006a0b1d05</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</BucketName></Error>
         headers:
             Content-Length:
                 - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:06 GMT
+                - Mon, 18 May 2026 14:07:01 GMT
             X-Amz-Id-2:
-                - txgc1985b358cca4d7f87af-006a0b15c6
+                - txgb1c0d6d3b8634db59aca-006a0b1d05
             X-Amz-Request-Id:
-                - txgc1985b358cca4d7f87af-006a0b15c6
+                - txgb1c0d6d3b8634db59aca-006a0b1d05
         status: 404 Not Found
         code: 404
-        duration: 24.712583ms
+        duration: 21.741083ms
     - id: 128
       request:
         proto: HTTP/1.1
@@ -6685,7 +6685,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6694,7 +6694,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 87f99006-8f33-462a-8579-68930998e62d
+                - 5b71b25e-c353-45f2-bad7-ba5fc6a69985
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6702,8 +6702,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133606Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T140701Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6713,21 +6713,21 @@ interactions:
         trailer: {}
         content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg3e3ba8e564204019affd-006a0b15c6</RequestId><HostId>txg3e3ba8e564204019affd-006a0b15c6</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg85485edcbe57435980a7-006a0b1d05</RequestId><HostId>txg85485edcbe57435980a7-006a0b1d05</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource></Error>
         headers:
             Content-Length:
                 - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:06 GMT
+                - Mon, 18 May 2026 14:07:01 GMT
             X-Amz-Id-2:
-                - txg3e3ba8e564204019affd-006a0b15c6
+                - txg85485edcbe57435980a7-006a0b1d05
             X-Amz-Request-Id:
-                - txg3e3ba8e564204019affd-006a0b15c6
+                - txg85485edcbe57435980a7-006a0b1d05
         status: 404 Not Found
         code: 404
-        duration: 34.034458ms
+        duration: 32.598792ms
     - id: 129
       request:
         proto: HTTP/1.1
@@ -6736,7 +6736,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6745,7 +6745,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 68409dd3-8714-4fcc-aba0-a00139ca245f
+                - 9fd736bc-bc8c-4747-8f5e-a5ac14b45730
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6753,8 +6753,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133606Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T140701Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6773,14 +6773,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:36:06 GMT
+                - Mon, 18 May 2026 14:07:01 GMT
             X-Amz-Id-2:
-                - txg277895b04c434bc7a414-006a0b15c6
+                - txgfd6abe31eba041c7b67c-006a0b1d05
             X-Amz-Request-Id:
-                - txg277895b04c434bc7a414-006a0b15c6
+                - txgfd6abe31eba041c7b67c-006a0b1d05
         status: 200 OK
         code: 200
-        duration: 20.435125ms
+        duration: 19.410916ms
     - id: 130
       request:
         proto: HTTP/1.1
@@ -6789,7 +6789,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6798,7 +6798,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - eeb217f9-fe74-4ef7-a7cd-2f5d6e11c937
+                - 7d69b526-22e5-4a49-88b8-97de1d26d7b1
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6806,8 +6806,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133606Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T140701Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6826,14 +6826,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:36:06 GMT
+                - Mon, 18 May 2026 14:07:01 GMT
             X-Amz-Id-2:
-                - txg5ca1a5f37a454f5982b4-006a0b15c6
+                - txg0fdc5bf2ed724508bb59-006a0b1d05
             X-Amz-Request-Id:
-                - txg5ca1a5f37a454f5982b4-006a0b15c6
+                - txg0fdc5bf2ed724508bb59-006a0b1d05
         status: 200 OK
         code: 200
-        duration: 34.457708ms
+        duration: 20.197292ms
     - id: 131
       request:
         proto: HTTP/1.1
@@ -6842,7 +6842,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6851,7 +6851,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5d9c9ff9-1033-4369-b396-28566f06109f
+                - 159185e4-a359-41c6-8919-ea6b2806eafc
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6859,8 +6859,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133606Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T140701Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6879,14 +6879,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:36:06 GMT
+                - Mon, 18 May 2026 14:07:01 GMT
             X-Amz-Id-2:
-                - txg588f548f05e4494198f2-006a0b15c6
+                - txg31b571856fee4af7b9f9-006a0b1d05
             X-Amz-Request-Id:
-                - txg588f548f05e4494198f2-006a0b15c6
+                - txg31b571856fee4af7b9f9-006a0b1d05
         status: 200 OK
         code: 200
-        duration: 21.376833ms
+        duration: 60.391208ms
     - id: 132
       request:
         proto: HTTP/1.1
@@ -6895,7 +6895,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6904,7 +6904,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d0bb9c47-f8f3-4949-9d0b-a1804ba1f86f
+                - 12ea77d4-b2ed-4eaa-9547-425dc5383e73
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6912,8 +6912,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133606Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T140701Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -6923,21 +6923,21 @@ interactions:
         trailer: {}
         content_length: 329
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgbba9f64554694ccaa6bf-006a0b15c6</RequestId><HostId>txgbba9f64554694ccaa6bf-006a0b15c6</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg04c35e0f75804551adf1-006a0b1d06</RequestId><HostId>txg04c35e0f75804551adf1-006a0b1d06</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource></Error>
         headers:
             Content-Length:
                 - "329"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:06 GMT
+                - Mon, 18 May 2026 14:07:02 GMT
             X-Amz-Id-2:
-                - txgbba9f64554694ccaa6bf-006a0b15c6
+                - txg04c35e0f75804551adf1-006a0b1d06
             X-Amz-Request-Id:
-                - txgbba9f64554694ccaa6bf-006a0b15c6
+                - txg04c35e0f75804551adf1-006a0b1d06
         status: 404 Not Found
         code: 404
-        duration: 19.581875ms
+        duration: 64.258875ms
     - id: 133
       request:
         proto: HTTP/1.1
@@ -6946,7 +6946,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -6955,7 +6955,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 671f6392-00bb-48e2-b773-c1ebc17b7868
+                - 0a3717b5-9b56-4cf1-8c9e-43d7f647a220
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -6963,8 +6963,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133606Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
+                - 20260518T140702Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -6976,21 +6976,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:06 GMT
+                - Mon, 18 May 2026 14:07:02 GMT
             X-Amz-Id-2:
-                - txg23cc5af37f8a42b5bd20-006a0b15c6
+                - txg43d6b2aaf53c475c84ff-006a0b1d06
             X-Amz-Request-Id:
-                - txg23cc5af37f8a42b5bd20-006a0b15c6
+                - txg43d6b2aaf53c475c84ff-006a0b1d06
         status: 200 OK
         code: 200
-        duration: 20.355375ms
+        duration: 52.057083ms
     - id: 134
       request:
         proto: HTTP/1.1
@@ -6999,7 +6999,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7008,7 +7008,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 178009fc-04b4-4392-b197-d69ba35b98f7
+                - a73356ed-145e-4b0c-b36a-1122d1cba06d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7016,8 +7016,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133606Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T140702Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7027,21 +7027,21 @@ interactions:
         trailer: {}
         content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg680523882c2641d6b4fc-006a0b15c6</RequestId><HostId>txg680523882c2641d6b4fc-006a0b15c6</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgacbc5233049b44239f40-006a0b1d06</RequestId><HostId>txgacbc5233049b44239f40-006a0b1d06</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</BucketName></Error>
         headers:
             Content-Length:
                 - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:06 GMT
+                - Mon, 18 May 2026 14:07:02 GMT
             X-Amz-Id-2:
-                - txg680523882c2641d6b4fc-006a0b15c6
+                - txgacbc5233049b44239f40-006a0b1d06
             X-Amz-Request-Id:
-                - txg680523882c2641d6b4fc-006a0b15c6
+                - txgacbc5233049b44239f40-006a0b1d06
         status: 404 Not Found
         code: 404
-        duration: 35.253917ms
+        duration: 62.153208ms
     - id: 135
       request:
         proto: HTTP/1.1
@@ -7050,7 +7050,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7059,7 +7059,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f7678680-e3fb-4d97-a748-25675f4cb15b
+                - 5fa33b75-2d3d-4ce1-beea-346600e9c82d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7067,8 +7067,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133606Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T140702Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7078,21 +7078,21 @@ interactions:
         trailer: {}
         content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txga83bd6330daf4c37953a-006a0b15c7</RequestId><HostId>txga83bd6330daf4c37953a-006a0b15c7</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgbc91876e4dbe422e9e8f-006a0b1d06</RequestId><HostId>txgbc91876e4dbe422e9e8f-006a0b1d06</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource></Error>
         headers:
             Content-Length:
                 - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:07 GMT
+                - Mon, 18 May 2026 14:07:02 GMT
             X-Amz-Id-2:
-                - txga83bd6330daf4c37953a-006a0b15c7
+                - txgbc91876e4dbe422e9e8f-006a0b1d06
             X-Amz-Request-Id:
-                - txga83bd6330daf4c37953a-006a0b15c7
+                - txgbc91876e4dbe422e9e8f-006a0b1d06
         status: 404 Not Found
         code: 404
-        duration: 19.747834ms
+        duration: 61.783167ms
     - id: 136
       request:
         proto: HTTP/1.1
@@ -7101,7 +7101,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7110,7 +7110,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 8c48f5b7-fad7-49aa-937e-3b1f875f36fe
+                - 242f4622-dde5-4464-bea3-8f3cc058b502
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7118,8 +7118,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133607Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T140702Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7138,14 +7138,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:36:07 GMT
+                - Mon, 18 May 2026 14:07:02 GMT
             X-Amz-Id-2:
-                - txg88043fddf1ea4736a06e-006a0b15c7
+                - txg7d44713e3a1546b2a963-006a0b1d06
             X-Amz-Request-Id:
-                - txg88043fddf1ea4736a06e-006a0b15c7
+                - txg7d44713e3a1546b2a963-006a0b1d06
         status: 200 OK
         code: 200
-        duration: 19.924292ms
+        duration: 33.112125ms
     - id: 137
       request:
         proto: HTTP/1.1
@@ -7154,7 +7154,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7163,7 +7163,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - da0c122d-56f9-4d1b-8a28-5aaf8b99edfa
+                - dd6beb30-1599-48f5-bd37-978c4a9e0765
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7171,8 +7171,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133607Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T140702Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7191,14 +7191,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:36:07 GMT
+                - Mon, 18 May 2026 14:07:02 GMT
             X-Amz-Id-2:
-                - txg47a562c937eb44eda718-006a0b15c7
+                - txg2d64facc2d5945cc90f7-006a0b1d06
             X-Amz-Request-Id:
-                - txg47a562c937eb44eda718-006a0b15c7
+                - txg2d64facc2d5945cc90f7-006a0b1d06
         status: 200 OK
         code: 200
-        duration: 22.189541ms
+        duration: 61.487084ms
     - id: 138
       request:
         proto: HTTP/1.1
@@ -7207,7 +7207,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7216,7 +7216,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 83373199-0722-4eee-b923-09a5596f5711
+                - 4cb1a4c1-8f6c-45b9-be1d-2c3d3badd39c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7224,8 +7224,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133607Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
+                - 20260518T140702Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -7238,14 +7238,14 @@ interactions:
         body: ""
         headers:
             Date:
-                - Mon, 18 May 2026 13:36:07 GMT
+                - Mon, 18 May 2026 14:07:02 GMT
             X-Amz-Id-2:
-                - txgaa2d6132d2f64dababff-006a0b15c7
+                - txg0b4abd58adb342da98a7-006a0b1d06
             X-Amz-Request-Id:
-                - txgaa2d6132d2f64dababff-006a0b15c7
+                - txg0b4abd58adb342da98a7-006a0b1d06
         status: 204 No Content
         code: 204
-        duration: 172.2125ms
+        duration: 1.971245625s
     - id: 139
       request:
         proto: HTTP/1.1
@@ -7254,7 +7254,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7263,7 +7263,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 82e754ae-22c9-44d8-babc-8a970e59463f
+                - 44513793-6bdc-4681-91c1-e97605a57fe2
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7273,8 +7273,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133607Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
+                - 20260518T140704Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/
         method: PUT
       response:
         proto: HTTP/2.0
@@ -7289,16 +7289,16 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 18 May 2026 13:36:07 GMT
+                - Mon, 18 May 2026 14:07:04 GMT
             Location:
-                - /tf-tests-scaleway-object-bucket-lifecycle-361671012043732063
+                - /tf-tests-scaleway-object-bucket-lifecycle-256272269376130782
             X-Amz-Id-2:
-                - txg00b3096cabcb4df98b10-006a0b15c7
+                - txg9d59ec7daa824e079430-006a0b1d08
             X-Amz-Request-Id:
-                - txg00b3096cabcb4df98b10-006a0b15c7
+                - txg9d59ec7daa824e079430-006a0b1d08
         status: 200 OK
         code: 200
-        duration: 4.614000417s
+        duration: 7.356263917s
     - id: 140
       request:
         proto: HTTP/1.1
@@ -7307,7 +7307,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7316,7 +7316,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 00fb1f57-3b60-46bb-8b36-1345f7b4e835
+                - 01e0212c-3d55-41ac-83a0-8f846f267791
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7328,8 +7328,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133612Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T140711Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?acl=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -7344,14 +7344,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 18 May 2026 13:36:12 GMT
+                - Mon, 18 May 2026 14:07:11 GMT
             X-Amz-Id-2:
-                - txg73455e353882410dae15-006a0b15cc
+                - txg4163cd67549c4960af38-006a0b1d0f
             X-Amz-Request-Id:
-                - txg73455e353882410dae15-006a0b15cc
+                - txg4163cd67549c4960af38-006a0b1d0f
         status: 200 OK
         code: 200
-        duration: 1.164811459s
+        duration: 2.02938525s
     - id: 141
       request:
         proto: HTTP/1.1
@@ -7360,16 +7360,16 @@ interactions:
         content_length: 532
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
-        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>2</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260518133613185900000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260518133613186000000002</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
+        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>2</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260518140713854100000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260518140713854200000002</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>
         form: {}
         headers:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 453b8cd5-7bd8-414f-b7f6-aba97a126bc9
+                - 18818271-43f4-4b00-87e9-85c11d17e9de
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
@@ -7377,12 +7377,12 @@ interactions:
             User-Agent:
                 - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,Z,e
             X-Amz-Checksum-Crc32:
-                - 9y+UsA==
+                - cqA7ng==
             X-Amz-Content-Sha256:
-                - d8c2af333845b17443ca15939e6571c2f7b75a8be7c50d49b01359dafbd939b0
+                - 3b7ec0bedb6ca42f60aa4ab6a8d1e764f72bd4bd2a255a02e6a5e02b05243059
             X-Amz-Date:
-                - 20260518T133612Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T140711Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -7397,14 +7397,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 18 May 2026 13:36:13 GMT
+                - Mon, 18 May 2026 14:07:13 GMT
             X-Amz-Id-2:
-                - txg38ad9e04960f45a0b015-006a0b15cd
+                - txga3a42a3d0b774ae3aa34-006a0b1d11
             X-Amz-Request-Id:
-                - txg38ad9e04960f45a0b015-006a0b15cd
+                - txga3a42a3d0b774ae3aa34-006a0b1d11
         status: 200 OK
         code: 200
-        duration: 2.82618975s
+        duration: 2.894463833s
     - id: 142
       request:
         proto: HTTP/1.1
@@ -7413,7 +7413,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7422,7 +7422,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 26962e3b-c559-460c-8bf8-041d7ba52548
+                - c4c4bfba-267c-4e4b-a0ac-61d3d7c02223
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7430,8 +7430,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133616Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T140716Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7450,14 +7450,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:36:16 GMT
+                - Mon, 18 May 2026 14:07:16 GMT
             X-Amz-Id-2:
-                - txg15cfa35478ce4741a9f3-006a0b15d0
+                - txg4fa48c695f764c79afe4-006a0b1d14
             X-Amz-Request-Id:
-                - txg15cfa35478ce4741a9f3-006a0b15d0
+                - txg4fa48c695f764c79afe4-006a0b1d14
         status: 200 OK
         code: 200
-        duration: 1.721237208s
+        duration: 62.151792ms
     - id: 143
       request:
         proto: HTTP/1.1
@@ -7466,7 +7466,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7475,7 +7475,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 845b1933-71e1-4ca6-a82e-e96bd412c6de
+                - 69b1846f-8eb0-4637-84e8-b41284e3a753
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7483,8 +7483,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133616Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T140716Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7503,14 +7503,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:36:17 GMT
+                - Mon, 18 May 2026 14:07:16 GMT
             X-Amz-Id-2:
-                - txge7fd2044e6804ed780cf-006a0b15d1
+                - txg42375f98dfcc4ea4885c-006a0b1d14
             X-Amz-Request-Id:
-                - txge7fd2044e6804ed780cf-006a0b15d1
+                - txg42375f98dfcc4ea4885c-006a0b1d14
         status: 200 OK
         code: 200
-        duration: 1.224746792s
+        duration: 213.653625ms
     - id: 144
       request:
         proto: HTTP/1.1
@@ -7519,7 +7519,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7528,7 +7528,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9c978479-b4c3-40c1-89b9-da9f83ecd3f2
+                - d3d90bf2-dd89-4fbe-be53-824bf797b61f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7536,8 +7536,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133617Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
+                - 20260518T140716Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -7549,21 +7549,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:19 GMT
+                - Mon, 18 May 2026 14:07:17 GMT
             X-Amz-Id-2:
-                - txga84e5cabce7a4a07b19c-006a0b15d3
+                - txg3cef8fce58b04f36ba59-006a0b1d15
             X-Amz-Request-Id:
-                - txga84e5cabce7a4a07b19c-006a0b15d3
+                - txg3cef8fce58b04f36ba59-006a0b1d15
         status: 200 OK
         code: 200
-        duration: 2.14837875s
+        duration: 4.677905042s
     - id: 145
       request:
         proto: HTTP/1.1
@@ -7572,7 +7572,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7581,7 +7581,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b288b763-41c3-405d-8743-5d7a24b555ea
+                - 52c5e2d8-edcc-454f-8294-500e63723156
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7589,8 +7589,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133619Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T140717Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7600,21 +7600,21 @@ interactions:
         trailer: {}
         content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg187fd8f4103a4adaa6c0-006a0b15d5</RequestId><HostId>txg187fd8f4103a4adaa6c0-006a0b15d5</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg74010db5eb1c4f6cb93e-006a0b1d19</RequestId><HostId>txg74010db5eb1c4f6cb93e-006a0b1d19</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</BucketName></Error>
         headers:
             Content-Length:
                 - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:21 GMT
+                - Mon, 18 May 2026 14:07:21 GMT
             X-Amz-Id-2:
-                - txg187fd8f4103a4adaa6c0-006a0b15d5
+                - txg74010db5eb1c4f6cb93e-006a0b1d19
             X-Amz-Request-Id:
-                - txg187fd8f4103a4adaa6c0-006a0b15d5
+                - txg74010db5eb1c4f6cb93e-006a0b1d19
         status: 404 Not Found
         code: 404
-        duration: 1.021799709s
+        duration: 1.026974417s
     - id: 146
       request:
         proto: HTTP/1.1
@@ -7623,7 +7623,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7632,7 +7632,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ec66e44d-beb0-4499-b899-1e20df3e1358
+                - 070b00ec-4567-4373-ae14-59b5ae315166
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7640,8 +7640,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133621Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T140721Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7651,21 +7651,21 @@ interactions:
         trailer: {}
         content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg37a6591647024ab3a4e1-006a0b15d6</RequestId><HostId>txg37a6591647024ab3a4e1-006a0b15d6</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg95f343f71f45441796c5-006a0b1d1a</RequestId><HostId>txg95f343f71f45441796c5-006a0b1d1a</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource></Error>
         headers:
             Content-Length:
                 - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:22 GMT
+                - Mon, 18 May 2026 14:07:22 GMT
             X-Amz-Id-2:
-                - txg37a6591647024ab3a4e1-006a0b15d6
+                - txg95f343f71f45441796c5-006a0b1d1a
             X-Amz-Request-Id:
-                - txg37a6591647024ab3a4e1-006a0b15d6
+                - txg95f343f71f45441796c5-006a0b1d1a
         status: 404 Not Found
         code: 404
-        duration: 126.612084ms
+        duration: 52.161667ms
     - id: 147
       request:
         proto: HTTP/1.1
@@ -7674,7 +7674,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7683,7 +7683,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 365a515f-30ef-43de-9714-fbcbc5afddc9
+                - b466e8ba-9b56-49db-b35e-86fa15e1c511
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7691,8 +7691,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133622Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T140722Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7711,14 +7711,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:36:22 GMT
+                - Mon, 18 May 2026 14:07:22 GMT
             X-Amz-Id-2:
-                - txg54e30f2d7954445fb9d1-006a0b15d6
+                - txgc8131a69dbf243f6a76d-006a0b1d1a
             X-Amz-Request-Id:
-                - txg54e30f2d7954445fb9d1-006a0b15d6
+                - txgc8131a69dbf243f6a76d-006a0b1d1a
         status: 200 OK
         code: 200
-        duration: 1.246878125s
+        duration: 2.921265208s
     - id: 148
       request:
         proto: HTTP/1.1
@@ -7727,7 +7727,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7736,7 +7736,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 347115f4-64e8-481e-b845-f7831cd1f83c
+                - 0155a7b9-29a0-4fee-bb70-548ccfe19588
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7744,8 +7744,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133622Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T140722Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7757,21 +7757,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>2</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260518133613185900000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260518133613186000000002</ID><Status>Enabled</Status></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>2</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260518140713854100000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260518140713854200000002</ID><Status>Enabled</Status></Rule></Configuration>
         headers:
             Content-Length:
                 - "505"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:36:23 GMT
+                - Mon, 18 May 2026 14:07:25 GMT
             X-Amz-Id-2:
-                - txgc69e5595ea564ee0892d-006a0b15d7
+                - txge202dded71274ae4bde3-006a0b1d1d
             X-Amz-Request-Id:
-                - txgc69e5595ea564ee0892d-006a0b15d7
+                - txge202dded71274ae4bde3-006a0b1d1d
         status: 200 OK
         code: 200
-        duration: 121.593833ms
+        duration: 1.04081275s
     - id: 149
       request:
         proto: HTTP/1.1
@@ -7780,7 +7780,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7789,7 +7789,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 00692af2-9e20-4ae0-a7d7-ed0b93d33b4d
+                - 0008f050-4d38-469a-8e25-a427658adbe9
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7797,8 +7797,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133623Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
+                - 20260518T140726Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -7813,16 +7813,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:23 GMT
+                - Mon, 18 May 2026 14:07:26 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txg2e807df5c57a4b85bfc8-006a0b15d7
+                - txg2a4b94d1bf7548a9a845-006a0b1d1e
             X-Amz-Request-Id:
-                - txg2e807df5c57a4b85bfc8-006a0b15d7
+                - txg2a4b94d1bf7548a9a845-006a0b1d1e
         status: 200 OK
         code: 200
-        duration: 19.981708ms
+        duration: 52.29725ms
     - id: 150
       request:
         proto: HTTP/1.1
@@ -7831,7 +7831,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7840,7 +7840,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0d15dec2-bf99-4d84-aa0c-cb6f44a1a5ae
+                - 9dc3d152-b17a-436d-bd9e-e57dd515aa3a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7848,8 +7848,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133623Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T140726Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7861,21 +7861,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>2</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260518133613185900000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260518133613186000000002</ID><Status>Enabled</Status></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>2</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260518140713854100000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260518140713854200000002</ID><Status>Enabled</Status></Rule></Configuration>
         headers:
             Content-Length:
                 - "505"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:36:23 GMT
+                - Mon, 18 May 2026 14:07:26 GMT
             X-Amz-Id-2:
-                - txg24b00641544f48c8a01b-006a0b15d7
+                - txg8bb6ecf0a86c4c0bb616-006a0b1d1e
             X-Amz-Request-Id:
-                - txg24b00641544f48c8a01b-006a0b15d7
+                - txg8bb6ecf0a86c4c0bb616-006a0b1d1e
         status: 200 OK
         code: 200
-        duration: 1.044525375s
+        duration: 2.529350875s
     - id: 151
       request:
         proto: HTTP/1.1
@@ -7884,7 +7884,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7893,7 +7893,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 3b330b6b-9611-47b1-9835-9b5e16e5462e
+                - 5a161e62-98dd-41b1-997f-6a500ff0e975
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7901,8 +7901,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133625Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T140729Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7921,14 +7921,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:36:25 GMT
+                - Mon, 18 May 2026 14:07:29 GMT
             X-Amz-Id-2:
-                - txg3feea4b005104b649ec6-006a0b15d9
+                - txg1d8512984d4b4106b634-006a0b1d21
             X-Amz-Request-Id:
-                - txg3feea4b005104b649ec6-006a0b15d9
+                - txg1d8512984d4b4106b634-006a0b1d21
         status: 200 OK
         code: 200
-        duration: 2.626895875s
+        duration: 2.04900525s
     - id: 152
       request:
         proto: HTTP/1.1
@@ -7937,7 +7937,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7946,7 +7946,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9c5eb019-8372-4e32-b777-6ccb24aaf5ac
+                - 07201366-8acd-4370-b312-5590610fcc33
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -7954,8 +7954,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133625Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T140729Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -7974,14 +7974,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:36:27 GMT
+                - Mon, 18 May 2026 14:07:31 GMT
             X-Amz-Id-2:
-                - txgc4622629c3df46f195f7-006a0b15db
+                - txgbe25b1cf11ae417eb38c-006a0b1d23
             X-Amz-Request-Id:
-                - txgc4622629c3df46f195f7-006a0b15db
+                - txgbe25b1cf11ae417eb38c-006a0b1d23
         status: 200 OK
         code: 200
-        duration: 1.026374s
+        duration: 62.565584ms
     - id: 153
       request:
         proto: HTTP/1.1
@@ -7990,7 +7990,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -7999,7 +7999,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 41627670-0ed6-41ff-bbe6-6fef04b20c91
+                - 58be4e1f-7cb3-4a20-b7aa-b5ac14939c95
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8007,8 +8007,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133627Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
+                - 20260518T140731Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -8020,21 +8020,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:28 GMT
+                - Mon, 18 May 2026 14:07:31 GMT
             X-Amz-Id-2:
-                - txg1b6e70c7b8d9412b8729-006a0b15dc
+                - txg63b9412cc1a74c40bdd3-006a0b1d23
             X-Amz-Request-Id:
-                - txg1b6e70c7b8d9412b8729-006a0b15dc
+                - txg63b9412cc1a74c40bdd3-006a0b1d23
         status: 200 OK
         code: 200
-        duration: 3.898730125s
+        duration: 3.945015708s
     - id: 154
       request:
         proto: HTTP/1.1
@@ -8043,7 +8043,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8052,7 +8052,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4191e922-8850-49c3-9880-e7010642969a
+                - bd1d54dc-7a49-4872-9408-7497c8c7c6e1
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8060,8 +8060,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133628Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T140731Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8071,21 +8071,21 @@ interactions:
         trailer: {}
         content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgc292dbe82b7b441fb3a4-006a0b15e0</RequestId><HostId>txgc292dbe82b7b441fb3a4-006a0b15e0</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg984020f534ff4b7c9989-006a0b1d27</RequestId><HostId>txg984020f534ff4b7c9989-006a0b1d27</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</BucketName></Error>
         headers:
             Content-Length:
                 - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:32 GMT
+                - Mon, 18 May 2026 14:07:35 GMT
             X-Amz-Id-2:
-                - txgc292dbe82b7b441fb3a4-006a0b15e0
+                - txg984020f534ff4b7c9989-006a0b1d27
             X-Amz-Request-Id:
-                - txgc292dbe82b7b441fb3a4-006a0b15e0
+                - txg984020f534ff4b7c9989-006a0b1d27
         status: 404 Not Found
         code: 404
-        duration: 2.074946833s
+        duration: 1.128192792s
     - id: 155
       request:
         proto: HTTP/1.1
@@ -8094,7 +8094,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8103,7 +8103,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 97b1b641-3dab-41f7-9170-0ee2c0736c31
+                - f21686c0-ad0b-4b56-a597-3b5ff37da06d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8111,8 +8111,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133632Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T140735Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8122,21 +8122,21 @@ interactions:
         trailer: {}
         content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg89c70743b3f44f59b094-006a0b15e2</RequestId><HostId>txg89c70743b3f44f59b094-006a0b15e2</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txge4da77b6ef934a4a8aed-006a0b1d28</RequestId><HostId>txge4da77b6ef934a4a8aed-006a0b1d28</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource></Error>
         headers:
             Content-Length:
                 - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:34 GMT
+                - Mon, 18 May 2026 14:07:36 GMT
             X-Amz-Id-2:
-                - txg89c70743b3f44f59b094-006a0b15e2
+                - txge4da77b6ef934a4a8aed-006a0b1d28
             X-Amz-Request-Id:
-                - txg89c70743b3f44f59b094-006a0b15e2
+                - txge4da77b6ef934a4a8aed-006a0b1d28
         status: 404 Not Found
         code: 404
-        duration: 1.06716775s
+        duration: 1.027920459s
     - id: 156
       request:
         proto: HTTP/1.1
@@ -8145,7 +8145,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8154,7 +8154,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7f783e30-0214-46c7-b03c-abf64f595d81
+                - 9763ae8b-4544-4161-8fa0-028c68b22e1a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8162,8 +8162,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133634Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T140736Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8182,14 +8182,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:36:35 GMT
+                - Mon, 18 May 2026 14:07:37 GMT
             X-Amz-Id-2:
-                - txg7c5a3b70206746a18903-006a0b15e3
+                - txg7979bf6c1de349039b52-006a0b1d29
             X-Amz-Request-Id:
-                - txg7c5a3b70206746a18903-006a0b15e3
+                - txg7979bf6c1de349039b52-006a0b1d29
         status: 200 OK
         code: 200
-        duration: 1.02447225s
+        duration: 58.677125ms
     - id: 157
       request:
         proto: HTTP/1.1
@@ -8198,7 +8198,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8207,7 +8207,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4980715e-506e-4c6e-aa63-551ac52f5a0a
+                - d91d183e-0d5b-42de-a049-fab0058dc0fd
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8215,8 +8215,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133635Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T140737Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8228,21 +8228,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>2</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260518133613185900000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260518133613186000000002</ID><Status>Enabled</Status></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>2</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260518140713854100000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260518140713854200000002</ID><Status>Enabled</Status></Rule></Configuration>
         headers:
             Content-Length:
                 - "505"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:36:36 GMT
+                - Mon, 18 May 2026 14:07:38 GMT
             X-Amz-Id-2:
-                - txge1ca7e12e742464f9df4-006a0b15e4
+                - txgf09f5a4cbaa644848386-006a0b1d2a
             X-Amz-Request-Id:
-                - txge1ca7e12e742464f9df4-006a0b15e4
+                - txgf09f5a4cbaa644848386-006a0b1d2a
         status: 200 OK
         code: 200
-        duration: 19.926833ms
+        duration: 1.032941792s
     - id: 158
       request:
         proto: HTTP/1.1
@@ -8251,7 +8251,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8260,7 +8260,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 14454924-53f7-44ea-8095-211c9cc5172d
+                - 997735c4-18f8-4c16-95c0-028cd16950e9
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8268,8 +8268,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133636Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T140739Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8288,14 +8288,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:36:37 GMT
+                - Mon, 18 May 2026 14:07:39 GMT
             X-Amz-Id-2:
-                - txg311e2daa16d341c98757-006a0b15e5
+                - txgea55a18ac9c8472db940-006a0b1d2b
             X-Amz-Request-Id:
-                - txg311e2daa16d341c98757-006a0b15e5
+                - txgea55a18ac9c8472db940-006a0b1d2b
         status: 200 OK
         code: 200
-        duration: 19.793375ms
+        duration: 1.350557167s
     - id: 159
       request:
         proto: HTTP/1.1
@@ -8304,7 +8304,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8313,7 +8313,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 55be1f5d-8bae-4f45-b6f1-6618368a9f8f
+                - 122319d6-f5bc-40d1-959f-321edb132bc5
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8321,8 +8321,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133637Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T140739Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8341,14 +8341,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:36:37 GMT
+                - Mon, 18 May 2026 14:07:40 GMT
             X-Amz-Id-2:
-                - txgd2eb2c6102844ab39c75-006a0b15e5
+                - txg101cbafacae247489577-006a0b1d2c
             X-Amz-Request-Id:
-                - txgd2eb2c6102844ab39c75-006a0b15e5
+                - txg101cbafacae247489577-006a0b1d2c
         status: 200 OK
         code: 200
-        duration: 51.1095ms
+        duration: 1.311361209s
     - id: 160
       request:
         proto: HTTP/1.1
@@ -8357,7 +8357,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8366,7 +8366,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0fb81303-b500-4e39-828a-6816f57ef147
+                - b9e6e14e-2bb5-480e-9971-82fd39104621
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8374,8 +8374,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133637Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
+                - 20260518T140740Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -8387,21 +8387,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:37 GMT
+                - Mon, 18 May 2026 14:07:41 GMT
             X-Amz-Id-2:
-                - txg12e1489453a845889488-006a0b15e5
+                - txgc1da375ed4c845a596dd-006a0b1d2d
             X-Amz-Request-Id:
-                - txg12e1489453a845889488-006a0b15e5
+                - txgc1da375ed4c845a596dd-006a0b1d2d
         status: 200 OK
         code: 200
-        duration: 1.546570667s
+        duration: 1.513310583s
     - id: 161
       request:
         proto: HTTP/1.1
@@ -8410,7 +8410,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8419,7 +8419,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b646ee0e-0a26-4a35-acbd-c5f0f9860eeb
+                - eaa84ffb-41cb-47bb-a299-02614331b0cc
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8427,8 +8427,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133637Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T140741Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8438,21 +8438,21 @@ interactions:
         trailer: {}
         content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgef11b52df2ea410cad15-006a0b15e6</RequestId><HostId>txgef11b52df2ea410cad15-006a0b15e6</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txga73208eeadd54a4faf27-006a0b1d2f</RequestId><HostId>txga73208eeadd54a4faf27-006a0b1d2f</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</BucketName></Error>
         headers:
             Content-Length:
                 - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:38 GMT
+                - Mon, 18 May 2026 14:07:43 GMT
             X-Amz-Id-2:
-                - txgef11b52df2ea410cad15-006a0b15e6
+                - txga73208eeadd54a4faf27-006a0b1d2f
             X-Amz-Request-Id:
-                - txgef11b52df2ea410cad15-006a0b15e6
+                - txga73208eeadd54a4faf27-006a0b1d2f
         status: 404 Not Found
         code: 404
-        duration: 20.574417ms
+        duration: 35.710042ms
     - id: 162
       request:
         proto: HTTP/1.1
@@ -8461,7 +8461,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8470,7 +8470,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ecd10f29-e68c-4714-967d-d7c435114308
+                - 685ade18-8ff6-49f2-bfbb-b035690249f5
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8478,8 +8478,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133638Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T140743Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8489,21 +8489,21 @@ interactions:
         trailer: {}
         content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg40230d9e6eb440989826-006a0b15e6</RequestId><HostId>txg40230d9e6eb440989826-006a0b15e6</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg59e6f2fd3ca24f74b587-006a0b1d2f</RequestId><HostId>txg59e6f2fd3ca24f74b587-006a0b1d2f</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource></Error>
         headers:
             Content-Length:
                 - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:38 GMT
+                - Mon, 18 May 2026 14:07:43 GMT
             X-Amz-Id-2:
-                - txg40230d9e6eb440989826-006a0b15e6
+                - txg59e6f2fd3ca24f74b587-006a0b1d2f
             X-Amz-Request-Id:
-                - txg40230d9e6eb440989826-006a0b15e6
+                - txg59e6f2fd3ca24f74b587-006a0b1d2f
         status: 404 Not Found
         code: 404
-        duration: 18.98525ms
+        duration: 20.299458ms
     - id: 163
       request:
         proto: HTTP/1.1
@@ -8512,7 +8512,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8521,7 +8521,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 6ed1fc9e-96c1-4c4f-aeb6-3274bff17ef0
+                - af4cc9be-27b3-4626-88f6-6c54d28e3aa9
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8529,8 +8529,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133638Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T140743Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8549,14 +8549,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:36:38 GMT
+                - Mon, 18 May 2026 14:07:43 GMT
             X-Amz-Id-2:
-                - txg583dd89ca4334830930c-006a0b15e6
+                - txg0ea25185fcd447059bdb-006a0b1d2f
             X-Amz-Request-Id:
-                - txg583dd89ca4334830930c-006a0b15e6
+                - txg0ea25185fcd447059bdb-006a0b1d2f
         status: 200 OK
         code: 200
-        duration: 19.562333ms
+        duration: 20.448875ms
     - id: 164
       request:
         proto: HTTP/1.1
@@ -8565,7 +8565,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8574,7 +8574,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5097609e-d0c7-40b7-b47d-4ff7d2decf59
+                - d7bc2e2c-e34f-495c-a457-1c2dfa7f4e85
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8582,8 +8582,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133638Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T140743Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8595,21 +8595,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>2</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260518133613185900000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260518133613186000000002</ID><Status>Enabled</Status></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>2</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260518140713854100000001</ID><Status>Enabled</Status></Rule><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>30</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter></Filter><ID>tf-scw-bucket-lifecycle-20260518140713854200000002</ID><Status>Enabled</Status></Rule></Configuration>
         headers:
             Content-Length:
                 - "505"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:36:38 GMT
+                - Mon, 18 May 2026 14:07:43 GMT
             X-Amz-Id-2:
-                - txg05e6fb394e9c4377b0cc-006a0b15e6
+                - txgd4821c57329744828254-006a0b1d2f
             X-Amz-Request-Id:
-                - txg05e6fb394e9c4377b0cc-006a0b15e6
+                - txgd4821c57329744828254-006a0b1d2f
         status: 200 OK
         code: 200
-        duration: 1.803375458s
+        duration: 52.680209ms
     - id: 165
       request:
         proto: HTTP/1.1
@@ -8618,7 +8618,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8627,7 +8627,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9ce3acf4-fbe4-49b4-a0dd-383ab160744a
+                - 04610538-eb99-40c0-abb0-9b6d7687f3bf
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8635,8 +8635,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133640Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
+                - 20260518T140743Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -8649,14 +8649,14 @@ interactions:
         body: ""
         headers:
             Date:
-                - Mon, 18 May 2026 13:36:40 GMT
+                - Mon, 18 May 2026 14:07:43 GMT
             X-Amz-Id-2:
-                - txg77aedfae1b934475a48c-006a0b15e8
+                - txg27814691c7504705aa76-006a0b1d2f
             X-Amz-Request-Id:
-                - txg77aedfae1b934475a48c-006a0b15e8
+                - txg27814691c7504705aa76-006a0b1d2f
         status: 204 No Content
         code: 204
-        duration: 1.571270708s
+        duration: 2.114568625s
     - id: 166
       request:
         proto: HTTP/1.1
@@ -8665,7 +8665,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8674,7 +8674,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 41d1b5cc-a158-4b72-9755-8d00582e65b9
+                - f4fa13ea-8819-453c-b03a-17c7fd88d323
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8682,8 +8682,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133642Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
+                - 20260518T140745Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/
         method: PUT
       response:
         proto: HTTP/2.0
@@ -8698,16 +8698,16 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 18 May 2026 13:36:42 GMT
+                - Mon, 18 May 2026 14:07:45 GMT
             Location:
-                - /tf-tests-scaleway-object-bucket-lifecycle-361671012043732063
+                - /tf-tests-scaleway-object-bucket-lifecycle-256272269376130782
             X-Amz-Id-2:
-                - txg14e2aa10e91f49e5892c-006a0b15ea
+                - txg2c16cace17f043b78e6c-006a0b1d31
             X-Amz-Request-Id:
-                - txg14e2aa10e91f49e5892c-006a0b15ea
+                - txg2c16cace17f043b78e6c-006a0b1d31
         status: 200 OK
         code: 200
-        duration: 4.811523042s
+        duration: 5.923374292s
     - id: 167
       request:
         proto: HTTP/1.1
@@ -8716,7 +8716,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8725,7 +8725,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 67c5a3a7-0f16-4bf5-bc2b-b11e709f9e4a
+                - b5db1ca1-76c1-4261-8fcf-5dc79654ed8a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8737,8 +8737,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133647Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T140751Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?acl=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -8753,14 +8753,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 18 May 2026 13:36:47 GMT
+                - Mon, 18 May 2026 14:07:51 GMT
             X-Amz-Id-2:
-                - txgf4e824ffa9f2445fa09e-006a0b15ef
+                - txg163bcea93bd74c1ab16d-006a0b1d37
             X-Amz-Request-Id:
-                - txgf4e824ffa9f2445fa09e-006a0b15ef
+                - txg163bcea93bd74c1ab16d-006a0b1d37
         status: 200 OK
         code: 200
-        duration: 3.131689584s
+        duration: 2.316361375s
     - id: 168
       request:
         proto: HTTP/1.1
@@ -8769,16 +8769,16 @@ interactions:
         content_length: 1829
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
-        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>30</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition><Transition><Days>210</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>95</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Date>2016-01-12T00:00:00Z</Date><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Filter><Prefix>path3/</Prefix></Filter><ID>id3</ID><Status>Enabled</Status><Transition><Days>130</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Date>2016-01-12T00:00:00Z</Date><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path4/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>155</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id6</ID><Status>Enabled</Status><Transition><Days>156</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></LifecycleConfiguration>
+        body: <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>30</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition><Transition><Days>210</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>95</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Date>2016-01-12T00:00:00Z</Date><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Filter><Prefix>path3/</Prefix></Filter><ID>id3</ID><Status>Enabled</Status><Transition><Days>130</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Date>2016-01-12T00:00:00Z</Date><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path4/</Prefix><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>155</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id6</ID><Status>Enabled</Status><Transition><Days>156</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></LifecycleConfiguration>
         form: {}
         headers:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 31754445-af5c-4eb3-92fe-2e09a38d2fb8
+                - 97592fbd-c071-4fc5-8d07-a964fb7fb0f8
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
@@ -8786,12 +8786,12 @@ interactions:
             User-Agent:
                 - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,Z,e
             X-Amz-Checksum-Crc32:
-                - N+yQ4g==
+                - K95RHg==
             X-Amz-Content-Sha256:
-                - 38b14e9de843e5a2c2fe4ff0e368fdc7fa7ad53552471a7082320b8f609ab675
+                - e8ad0a665d4b49c819e7ca5b44b920cf11ff47b2647c6df77d468c637b6b1394
             X-Amz-Date:
-                - 20260518T133647Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T140751Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?lifecycle=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -8806,14 +8806,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 18 May 2026 13:36:50 GMT
+                - Mon, 18 May 2026 14:07:54 GMT
             X-Amz-Id-2:
-                - txgf6b1c333217e45a088db-006a0b15f2
+                - txg610e6f2117a547cb9f55-006a0b1d3a
             X-Amz-Request-Id:
-                - txgf6b1c333217e45a088db-006a0b15f2
+                - txg610e6f2117a547cb9f55-006a0b1d3a
         status: 200 OK
         code: 200
-        duration: 2.448533917s
+        duration: 1.082531333s
     - id: 169
       request:
         proto: HTTP/1.1
@@ -8822,7 +8822,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8831,7 +8831,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7734b22d-13aa-4037-a643-4829b7b2acc3
+                - 542ee031-a7df-426e-8703-6d4b399e58da
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8839,8 +8839,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133652Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T140755Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8859,14 +8859,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:36:52 GMT
+                - Mon, 18 May 2026 14:07:55 GMT
             X-Amz-Id-2:
-                - txgd78e7c92cebd4dfa8171-006a0b15f4
+                - txga62f657c2027449ca198-006a0b1d3b
             X-Amz-Request-Id:
-                - txgd78e7c92cebd4dfa8171-006a0b15f4
+                - txga62f657c2027449ca198-006a0b1d3b
         status: 200 OK
         code: 200
-        duration: 3.192811708s
+        duration: 1.023550417s
     - id: 170
       request:
         proto: HTTP/1.1
@@ -8875,7 +8875,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8884,7 +8884,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d24f487d-0cd9-4a62-a649-65f8ff74d4a9
+                - 557fe976-ede7-48e4-b138-1a6ad6b5d014
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8892,8 +8892,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133652Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T140755Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -8903,21 +8903,21 @@ interactions:
         trailer: {}
         content_length: 329
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txga935992339ba438fa6e9-006a0b15f7</RequestId><HostId>txga935992339ba438fa6e9-006a0b15f7</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg58def3c0e82141c8b2d8-006a0b1d3c</RequestId><HostId>txg58def3c0e82141c8b2d8-006a0b1d3c</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource></Error>
         headers:
             Content-Length:
                 - "329"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:55 GMT
+                - Mon, 18 May 2026 14:07:56 GMT
             X-Amz-Id-2:
-                - txga935992339ba438fa6e9-006a0b15f7
+                - txg58def3c0e82141c8b2d8-006a0b1d3c
             X-Amz-Request-Id:
-                - txga935992339ba438fa6e9-006a0b15f7
+                - txg58def3c0e82141c8b2d8-006a0b1d3c
         status: 404 Not Found
         code: 404
-        duration: 1.025827083s
+        duration: 1.023350208s
     - id: 171
       request:
         proto: HTTP/1.1
@@ -8926,7 +8926,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8935,7 +8935,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 17ba028f-8088-4b17-b8c5-d3808c4bfedc
+                - 5e69cbc9-5a4e-4c87-88e0-e3d613eed688
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8943,8 +8943,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133655Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
+                - 20260518T140756Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -8956,21 +8956,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:56 GMT
+                - Mon, 18 May 2026 14:07:57 GMT
             X-Amz-Id-2:
-                - txg9dcddb49f12349e6a2be-006a0b15f8
+                - txgdc8feb517d6a4733968a-006a0b1d3d
             X-Amz-Request-Id:
-                - txg9dcddb49f12349e6a2be-006a0b15f8
+                - txgdc8feb517d6a4733968a-006a0b1d3d
         status: 200 OK
         code: 200
-        duration: 1.061964125s
+        duration: 2.233688s
     - id: 172
       request:
         proto: HTTP/1.1
@@ -8979,7 +8979,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -8988,7 +8988,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0ca9be72-6d04-4d99-9e66-aab11c5b5cfd
+                - 4180341d-4921-4521-822b-815e5c96347a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -8996,8 +8996,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133656Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T140757Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -9007,21 +9007,21 @@ interactions:
         trailer: {}
         content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg3f0e7093e75c410ea20f-006a0b15f9</RequestId><HostId>txg3f0e7093e75c410ea20f-006a0b15f9</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg476c2d39cc6048d09206-006a0b1d3f</RequestId><HostId>txg476c2d39cc6048d09206-006a0b1d3f</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</BucketName></Error>
         headers:
             Content-Length:
                 - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:57 GMT
+                - Mon, 18 May 2026 14:07:59 GMT
             X-Amz-Id-2:
-                - txg3f0e7093e75c410ea20f-006a0b15f9
+                - txg476c2d39cc6048d09206-006a0b1d3f
             X-Amz-Request-Id:
-                - txg3f0e7093e75c410ea20f-006a0b15f9
+                - txg476c2d39cc6048d09206-006a0b1d3f
         status: 404 Not Found
         code: 404
-        duration: 30.869958ms
+        duration: 1.286254083s
     - id: 173
       request:
         proto: HTTP/1.1
@@ -9030,7 +9030,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -9039,7 +9039,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - a75cacd1-3a96-4199-b1f4-c32acef84d2a
+                - e13933f2-fad4-4022-8280-fbafdf326b43
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -9047,8 +9047,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133657Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T140759Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -9058,21 +9058,21 @@ interactions:
         trailer: {}
         content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg9d3cf982ed9447ad8b4a-006a0b15f9</RequestId><HostId>txg9d3cf982ed9447ad8b4a-006a0b15f9</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgf0594a274efc4b18a65b-006a0b1d40</RequestId><HostId>txgf0594a274efc4b18a65b-006a0b1d40</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource></Error>
         headers:
             Content-Length:
                 - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:36:57 GMT
+                - Mon, 18 May 2026 14:08:00 GMT
             X-Amz-Id-2:
-                - txg9d3cf982ed9447ad8b4a-006a0b15f9
+                - txgf0594a274efc4b18a65b-006a0b1d40
             X-Amz-Request-Id:
-                - txg9d3cf982ed9447ad8b4a-006a0b15f9
+                - txgf0594a274efc4b18a65b-006a0b1d40
         status: 404 Not Found
         code: 404
-        duration: 31.321625ms
+        duration: 1.025261583s
     - id: 174
       request:
         proto: HTTP/1.1
@@ -9081,7 +9081,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -9090,7 +9090,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0204795d-2ab5-4a5c-80ac-cd8bdcbb8d1d
+                - ef061932-6248-4fb5-bc91-21ba72b6d1e7
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -9098,8 +9098,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133657Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T140800Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -9118,14 +9118,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:36:58 GMT
+                - Mon, 18 May 2026 14:08:01 GMT
             X-Amz-Id-2:
-                - txg2e8ab82588f740408b5a-006a0b15fa
+                - txg9a700271185e42e1b6dd-006a0b1d41
             X-Amz-Request-Id:
-                - txg2e8ab82588f740408b5a-006a0b15fa
+                - txg9a700271185e42e1b6dd-006a0b1d41
         status: 200 OK
         code: 200
-        duration: 1.036417541s
+        duration: 1.028215583s
     - id: 175
       request:
         proto: HTTP/1.1
@@ -9134,7 +9134,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -9143,7 +9143,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 201ffaf5-5cea-473e-817b-b5a5bc746df8
+                - a7d4dad7-71de-49ed-a992-4a0258aac14b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -9151,8 +9151,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133658Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T140801Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -9164,21 +9164,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>30</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition><Transition><Days>210</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>95</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Date>2016-01-12T00:00:00Z</Date><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Filter><Prefix>path3/</Prefix></Filter><ID>id3</ID><Status>Enabled</Status><Transition><Days>130</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Date>2016-01-12T00:00:00Z</Date><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path4/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>155</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id6</ID><Status>Enabled</Status><Transition><Days>156</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>30</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition><Transition><Days>210</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>95</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Date>2016-01-12T00:00:00Z</Date><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Filter><Prefix>path3/</Prefix></Filter><ID>id3</ID><Status>Enabled</Status><Transition><Days>130</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Date>2016-01-12T00:00:00Z</Date><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path4/</Prefix><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>155</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id6</ID><Status>Enabled</Status><Transition><Days>156</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
                 - "1802"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:36:59 GMT
+                - Mon, 18 May 2026 14:08:02 GMT
             X-Amz-Id-2:
-                - txg075a69d53aa64d87b7f6-006a0b15fb
+                - txg94af2c3574e147099e0a-006a0b1d42
             X-Amz-Request-Id:
-                - txg075a69d53aa64d87b7f6-006a0b15fb
+                - txg94af2c3574e147099e0a-006a0b1d42
         status: 200 OK
         code: 200
-        duration: 1.711657875s
+        duration: 51.902916ms
     - id: 176
       request:
         proto: HTTP/1.1
@@ -9187,7 +9187,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -9196,7 +9196,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c2527145-a967-4195-9de0-81891854d6d9
+                - 750cbcc1-f3e4-467d-b71e-ffd59d4ae04a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -9204,8 +9204,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133700Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
+                - 20260518T140802Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/
         method: HEAD
       response:
         proto: HTTP/2.0
@@ -9220,16 +9220,16 @@ interactions:
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:37:00 GMT
+                - Mon, 18 May 2026 14:08:03 GMT
             X-Amz-Bucket-Region:
                 - nl-ams
             X-Amz-Id-2:
-                - txgd6de7f7894584946ba9e-006a0b15fc
+                - txgdd3f90b6128841ef9a72-006a0b1d43
             X-Amz-Request-Id:
-                - txgd6de7f7894584946ba9e-006a0b15fc
+                - txgdd3f90b6128841ef9a72-006a0b1d43
         status: 200 OK
         code: 200
-        duration: 21.484375ms
+        duration: 53.22825ms
     - id: 177
       request:
         proto: HTTP/1.1
@@ -9238,7 +9238,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -9247,7 +9247,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - b225a73e-52bc-44ad-bc68-26dc0f7e0860
+                - e616ebbb-05c5-406a-be48-d5a6ea095a8d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -9255,8 +9255,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133701Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?acl=
+                - 20260518T140803Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -9275,14 +9275,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:37:01 GMT
+                - Mon, 18 May 2026 14:08:03 GMT
             X-Amz-Id-2:
-                - txg569ef4b9091840119b2f-006a0b15fd
+                - txg9376b7d9c74749f583bc-006a0b1d43
             X-Amz-Request-Id:
-                - txg569ef4b9091840119b2f-006a0b15fd
+                - txg9376b7d9c74749f583bc-006a0b1d43
         status: 200 OK
         code: 200
-        duration: 19.377542ms
+        duration: 1.44473125s
     - id: 178
       request:
         proto: HTTP/1.1
@@ -9291,7 +9291,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -9300,7 +9300,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d43978c5-12f1-4cbe-b98a-7830d0f27e42
+                - a1b55134-ef34-4b74-89ec-5550cd59ee46
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -9308,8 +9308,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133701Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?object-lock=
+                - 20260518T140803Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -9319,21 +9319,21 @@ interactions:
         trailer: {}
         content_length: 329
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg5e9921f6fb9f4d1eadc8-006a0b15fd</RequestId><HostId>txg5e9921f6fb9f4d1eadc8-006a0b15fd</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg5de37344e3be47a9834d-006a0b1d44</RequestId><HostId>txg5de37344e3be47a9834d-006a0b1d44</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource></Error>
         headers:
             Content-Length:
                 - "329"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:37:01 GMT
+                - Mon, 18 May 2026 14:08:04 GMT
             X-Amz-Id-2:
-                - txg5e9921f6fb9f4d1eadc8-006a0b15fd
+                - txg5de37344e3be47a9834d-006a0b1d44
             X-Amz-Request-Id:
-                - txg5e9921f6fb9f4d1eadc8-006a0b15fd
+                - txg5de37344e3be47a9834d-006a0b1d44
         status: 404 Not Found
         code: 404
-        duration: 1.094344666s
+        duration: 27.416917ms
     - id: 179
       request:
         proto: HTTP/1.1
@@ -9342,7 +9342,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -9351,7 +9351,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 034f8429-eb6d-4acb-930f-3cab54315019
+                - 45c9b368-2e5c-4f23-9129-2d81834930ee
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -9359,8 +9359,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133701Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
+                - 20260518T140804Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -9372,21 +9372,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "286"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:37:02 GMT
+                - Mon, 18 May 2026 14:08:04 GMT
             X-Amz-Id-2:
-                - txg47d88f65fbe04d1d90bf-006a0b15fe
+                - txg358046030a844f308cae-006a0b1d44
             X-Amz-Request-Id:
-                - txg47d88f65fbe04d1d90bf-006a0b15fe
+                - txg358046030a844f308cae-006a0b1d44
         status: 200 OK
         code: 200
-        duration: 2.737119209s
+        duration: 1.178272s
     - id: 180
       request:
         proto: HTTP/1.1
@@ -9395,7 +9395,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -9404,7 +9404,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ece0197b-d4a4-486e-ba1f-f6490e69414c
+                - 7bd53a6b-4bf9-4bcb-9a10-ddf0f95ac15d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -9412,8 +9412,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133702Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?tagging=
+                - 20260518T140804Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -9423,21 +9423,21 @@ interactions:
         trailer: {}
         content_length: 359
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgd5b7fcd7bc9f4b0998cd-006a0b1600</RequestId><HostId>txgd5b7fcd7bc9f4b0998cd-006a0b1600</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg4678ffd9784641e5aad1-006a0b1d45</RequestId><HostId>txg4678ffd9784641e5aad1-006a0b1d45</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource><BucketName>tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</BucketName></Error>
         headers:
             Content-Length:
                 - "359"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:37:04 GMT
+                - Mon, 18 May 2026 14:08:05 GMT
             X-Amz-Id-2:
-                - txgd5b7fcd7bc9f4b0998cd-006a0b1600
+                - txg4678ffd9784641e5aad1-006a0b1d45
             X-Amz-Request-Id:
-                - txgd5b7fcd7bc9f4b0998cd-006a0b1600
+                - txg4678ffd9784641e5aad1-006a0b1d45
         status: 404 Not Found
         code: 404
-        duration: 1.208632167s
+        duration: 40.203709ms
     - id: 181
       request:
         proto: HTTP/1.1
@@ -9446,7 +9446,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -9455,7 +9455,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 07b9e7c2-b370-4ec4-a828-727b92a7a1c8
+                - 3f463dcf-458f-4ec3-9cbc-d18705020139
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -9463,8 +9463,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133704Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?cors=
+                - 20260518T140805Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -9474,21 +9474,21 @@ interactions:
         trailer: {}
         content_length: 297
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg986ca7e70dba4092ae70-006a0b1602</RequestId><HostId>txg986ca7e70dba4092ae70-006a0b1602</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-361671012043732063</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg60533cfae60245ce84e8-006a0b1d46</RequestId><HostId>txg60533cfae60245ce84e8-006a0b1d46</HostId><Resource>/tf-tests-scaleway-object-bucket-lifecycle-256272269376130782</Resource></Error>
         headers:
             Content-Length:
                 - "297"
             Content-Type:
                 - application/xml
             Date:
-                - Mon, 18 May 2026 13:37:06 GMT
+                - Mon, 18 May 2026 14:08:06 GMT
             X-Amz-Id-2:
-                - txg986ca7e70dba4092ae70-006a0b1602
+                - txg60533cfae60245ce84e8-006a0b1d46
             X-Amz-Request-Id:
-                - txg986ca7e70dba4092ae70-006a0b1602
+                - txg60533cfae60245ce84e8-006a0b1d46
         status: 404 Not Found
         code: 404
-        duration: 20.982166ms
+        duration: 55.77825ms
     - id: 182
       request:
         proto: HTTP/1.1
@@ -9497,7 +9497,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -9506,7 +9506,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d9789034-97fc-44b9-a867-a7480b8fb027
+                - 3f2f0ff8-c42b-49c4-add7-1c702d663905
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -9514,8 +9514,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133706Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?versioning=
+                - 20260518T140806Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -9534,14 +9534,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:37:06 GMT
+                - Mon, 18 May 2026 14:08:06 GMT
             X-Amz-Id-2:
-                - txge417bb90497b474ea907-006a0b1602
+                - txgc781c55dc08342a1a28d-006a0b1d46
             X-Amz-Request-Id:
-                - txge417bb90497b474ea907-006a0b1602
+                - txgc781c55dc08342a1a28d-006a0b1d46
         status: 200 OK
         code: 200
-        duration: 21.192958ms
+        duration: 53.906708ms
     - id: 183
       request:
         proto: HTTP/1.1
@@ -9550,7 +9550,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -9559,7 +9559,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - fb90a67f-d197-4d18-9d14-5f72ae7cfe4a
+                - f2eb17de-ad9b-4a0c-92fc-8ddb6820e18a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -9567,8 +9567,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133706Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/?lifecycle=
+                - 20260518T140806Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -9580,21 +9580,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>30</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition><Transition><Days>210</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>95</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Date>2016-01-12T00:00:00Z</Date><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Filter><Prefix>path3/</Prefix></Filter><ID>id3</ID><Status>Enabled</Status><Transition><Days>130</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Date>2016-01-12T00:00:00Z</Date><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path4/</Prefix><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>155</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id6</ID><Status>Enabled</Status><Transition><Days>156</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
+            <Configuration><Rule><Expiration><Days>365</Days><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path1/</Prefix></Filter><ID>id1</ID><Status>Enabled</Status><Transition><Days>30</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>90</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>120</Days><StorageClass>GLACIER</StorageClass></Transition><Transition><Days>210</Days><StorageClass>ONEZONE_IA</StorageClass></Transition><Transition><Days>95</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Date>2016-01-12T00:00:00Z</Date><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>path2/</Prefix></Filter><ID>id2</ID><Status>Enabled</Status></Rule><Rule><Filter><Prefix>path3/</Prefix></Filter><ID>id3</ID><Status>Enabled</Status><Transition><Days>130</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Expiration><Date>2016-01-12T00:00:00Z</Date><ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker></Expiration><Filter><And><Prefix>path4/</Prefix><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id4</ID><Status>Enabled</Status></Rule><Rule><Filter><And><Tag><Key>terraform</Key><Value>hashicorp</Value></Tag><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></And></Filter><ID>id5</ID><Status>Enabled</Status><Transition><Days>155</Days><StorageClass>GLACIER</StorageClass></Transition></Rule><Rule><Filter><Tag><Key>tagKey</Key><Value>tagValue</Value></Tag></Filter><ID>id6</ID><Status>Enabled</Status><Transition><Days>156</Days><StorageClass>GLACIER</StorageClass></Transition></Rule></Configuration>
         headers:
             Content-Length:
                 - "1802"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Mon, 18 May 2026 13:37:06 GMT
+                - Mon, 18 May 2026 14:08:06 GMT
             X-Amz-Id-2:
-                - txgd18aa3ede71d4538821f-006a0b1602
+                - txg6516b6894a574c57aab9-006a0b1d46
             X-Amz-Request-Id:
-                - txgd18aa3ede71d4538821f-006a0b1602
+                - txg6516b6894a574c57aab9-006a0b1d46
         status: 200 OK
         code: 200
-        duration: 1.021161042s
+        duration: 1.028657042s
     - id: 184
       request:
         proto: HTTP/1.1
@@ -9603,7 +9603,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud
+        host: tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -9612,7 +9612,7 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c2613daf-923e-4d9a-9c49-55c1ceac4639
+                - a280d72b-fbd8-464e-a9ca-a8ed1b771aaf
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
@@ -9620,8 +9620,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260518T133707Z
-        url: https://tf-tests-scaleway-object-bucket-lifecycle-361671012043732063.s3.nl-ams.scw.cloud/
+                - 20260518T140807Z
+        url: https://tf-tests-scaleway-object-bucket-lifecycle-256272269376130782.s3.nl-ams.scw.cloud/
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -9634,11 +9634,11 @@ interactions:
         body: ""
         headers:
             Date:
-                - Mon, 18 May 2026 13:37:07 GMT
+                - Mon, 18 May 2026 14:08:07 GMT
             X-Amz-Id-2:
-                - txgeda50dc90aab4c6eb3c7-006a0b1603
+                - txg576a9613cff741afac0f-006a0b1d47
             X-Amz-Request-Id:
-                - txgeda50dc90aab4c6eb3c7-006a0b1603
+                - txg576a9613cff741afac0f-006a0b1d47
         status: 204 No Content
         code: 204
-        duration: 180.393125ms
+        duration: 1.434019083s


### PR DESCRIPTION
Add support for `noncurrent_version_transition` and `noncurrent_version_expiration` blocks, both part of the `lifecycle_rule` block.