### PR TITLE
fix(object): add support for bucket encryption region

### DIFF
--- a/internal/services/object/bucket_server_side_encryption_configuration.go
+++ b/internal/services/object/bucket_server_side_encryption_configuration.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/identity"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/locality/regional"
 )
 
 func ResourceBucketServerSideEncryptionConfiguration() *schema.Resource {
@@ -37,6 +38,7 @@ func bucketServerSideEncryptionConfigurationSchema() map[string]*schema.Schema {
 			ForceNew:    true,
 			Description: "The bucket's name or regional ID.",
 		},
+		"region": regional.Schema(),
 		"rule": {
 			Type:        schema.TypeSet,
 			Required:    true,
@@ -124,6 +126,7 @@ func resourceBucketServerSideEncryptionConfigurationRead(ctx context.Context, d 
 	}
 
 	_ = d.Set("bucket", bucketName)
+	_ = d.Set("region", region)
 	if err := d.Set("rule", flattenServerSideEncryptionRules(sse.Rules)); err != nil {
 		return diag.FromErr(err)
 	}

--- a/internal/services/object/bucket_server_side_encryption_configuration.go
+++ b/internal/services/object/bucket_server_side_encryption_configuration.go
@@ -127,6 +127,7 @@ func resourceBucketServerSideEncryptionConfigurationRead(ctx context.Context, d 
 
 	_ = d.Set("bucket", bucketName)
 	_ = d.Set("region", region)
+
 	if err := d.Set("rule", flattenServerSideEncryptionRules(sse.Rules)); err != nil {
 		return diag.FromErr(err)
 	}

--- a/internal/services/object/bucket_server_side_encryption_configuration_test.go
+++ b/internal/services/object/bucket_server_side_encryption_configuration_test.go
@@ -132,10 +132,12 @@ func testAccBucketServerSideEncryptionConfigurationConfig_basic(rName string) st
 	return fmt.Sprintf(`
 resource "scaleway_object_bucket" "test" {
   name = %[1]q
+  region = "%[2]s"
 }
 
 resource "scaleway_object_bucket_server_side_encryption_configuration" "test" {
   bucket = scaleway_object_bucket.test.name
+  region = "%[2]s"
 
   rule {
     apply_server_side_encryption_by_default {
@@ -143,17 +145,19 @@ resource "scaleway_object_bucket_server_side_encryption_configuration" "test" {
     }
   }
 }
-`, rName)
+`, rName, objectTestsMainRegion)
 }
 
 func testAccBucketServerSideEncryptionConfigurationConfig_applySSEByDefaultSSEAlgorithm(rName, sseAlgorithm string) string {
 	return fmt.Sprintf(`
 resource "scaleway_object_bucket" "test" {
   name = %[1]q
+  region = "%[3]s"
 }
 
 resource "scaleway_object_bucket_server_side_encryption_configuration" "test" {
   bucket = scaleway_object_bucket.test.name
+  region = "%[3]s"
 
   rule {
     apply_server_side_encryption_by_default {
@@ -161,5 +165,5 @@ resource "scaleway_object_bucket_server_side_encryption_configuration" "test" {
     }
   }
 }
-`, rName, sseAlgorithm)
+`, rName, sseAlgorithm, objectTestsMainRegion)
 }

--- a/internal/services/object/testdata/s3-bucket-server-side-encryption-configuration-apply-see-by-default-aes256.cassette.yaml
+++ b/internal/services/object/testdata/s3-bucket-server-side-encryption-configuration-apply-see-by-default-aes256.cassette.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-acc-test-4993750738523549756.s3.fr-par.scw.cloud
+        host: tf-acc-test-6529491692301554750.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -18,16 +18,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 6a7d3db1-3e30-4d22-a560-40c4f12d3252
+                - 959bfd95-4fcd-4e33-89ab-378919988f92
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.1 ua/2.1 os/macos lang/go#1.26.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.93.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260310T153100Z
-        url: https://tf-acc-test-4993750738523549756.s3.fr-par.scw.cloud/
+                - 20260513T140936Z
+        url: https://tf-acc-test-6529491692301554750.s3.nl-ams.scw.cloud/
         method: PUT
       response:
         proto: HTTP/2.0
@@ -42,16 +42,16 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 10 Mar 2026 15:31:00 GMT
+                - Wed, 13 May 2026 14:09:36 GMT
             Location:
-                - /tf-acc-test-4993750738523549756
+                - /tf-acc-test-6529491692301554750
             X-Amz-Id-2:
-                - txg41fe92f06e814cfc997d-0069b03934
+                - txgb2df85aff42041718299-006a048620
             X-Amz-Request-Id:
-                - txg41fe92f06e814cfc997d-0069b03934
+                - txgb2df85aff42041718299-006a048620
         status: 200 OK
         code: 200
-        duration: 790.422958ms
+        duration: 4.684749417s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -60,7 +60,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-acc-test-4993750738523549756.s3.fr-par.scw.cloud
+        host: tf-acc-test-6529491692301554750.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -69,11 +69,11 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5220d978-2ec1-434b-bec1-10bca80c3209
+                - a2dc4ca8-a518-4c82-95d3-c407a3f15b58
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.1 ua/2.1 os/macos lang/go#1.26.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.93.0 terraform-provider-scaleway/develop m/E,Z,e
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,Z,e
             X-Amz-Acl:
                 - private
             X-Amz-Checksum-Crc32:
@@ -81,8 +81,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260310T153101Z
-        url: https://tf-acc-test-4993750738523549756.s3.fr-par.scw.cloud/?acl=
+                - 20260513T140940Z
+        url: https://tf-acc-test-6529491692301554750.s3.nl-ams.scw.cloud/?acl=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -97,14 +97,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 10 Mar 2026 15:31:01 GMT
+                - Wed, 13 May 2026 14:09:40 GMT
             X-Amz-Id-2:
-                - txgb1c6bdde6dc44b3fa2c3-0069b03935
+                - txgc39c9e39e1f6483b8a01-006a048624
             X-Amz-Request-Id:
-                - txgb1c6bdde6dc44b3fa2c3-0069b03935
+                - txgc39c9e39e1f6483b8a01-006a048624
         status: 200 OK
         code: 200
-        duration: 233.575417ms
+        duration: 50.045208ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -113,7 +113,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-acc-test-4993750738523549756.s3.fr-par.scw.cloud
+        host: tf-acc-test-6529491692301554750.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -122,16 +122,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e952b1fe-214d-452d-905b-872206b43f0b
+                - 979ee668-3322-401b-9533-bde09861bd22
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.1 ua/2.1 os/macos lang/go#1.26.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.93.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260310T153101Z
-        url: https://tf-acc-test-4993750738523549756.s3.fr-par.scw.cloud/?acl=
+                - 20260513T140941Z
+        url: https://tf-acc-test-6529491692301554750.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -143,21 +143,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
                 - "698"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Mar 2026 15:31:01 GMT
+                - Wed, 13 May 2026 14:09:41 GMT
             X-Amz-Id-2:
-                - txg1cd402cb32ef4224adf3-0069b03935
+                - txg26ff8651887a4bdab1cb-006a048625
             X-Amz-Request-Id:
-                - txg1cd402cb32ef4224adf3-0069b03935
+                - txg26ff8651887a4bdab1cb-006a048625
         status: 200 OK
         code: 200
-        duration: 121.844334ms
+        duration: 86.871375ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -166,7 +166,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-acc-test-4993750738523549756.s3.fr-par.scw.cloud
+        host: tf-acc-test-6529491692301554750.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -175,16 +175,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 078361f9-1807-42a6-b3fb-ff6e9e888e03
+                - 1665657e-2204-499c-8c05-2f4b426a5e74
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.1 ua/2.1 os/macos lang/go#1.26.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.93.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260310T153101Z
-        url: https://tf-acc-test-4993750738523549756.s3.fr-par.scw.cloud/?object-lock=
+                - 20260513T140941Z
+        url: https://tf-acc-test-6529491692301554750.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -194,21 +194,21 @@ interactions:
         trailer: {}
         content_length: 300
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txgbb3c3b32ba4644548825-0069b03935</RequestId><HostId>txgbb3c3b32ba4644548825-0069b03935</HostId><Resource>/tf-acc-test-4993750738523549756</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg6cc0755743d14fed9d3f-006a048625</RequestId><HostId>txg6cc0755743d14fed9d3f-006a048625</HostId><Resource>/tf-acc-test-6529491692301554750</Resource></Error>
         headers:
             Content-Length:
                 - "300"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Mar 2026 15:31:01 GMT
+                - Wed, 13 May 2026 14:09:41 GMT
             X-Amz-Id-2:
-                - txgbb3c3b32ba4644548825-0069b03935
+                - txg6cc0755743d14fed9d3f-006a048625
             X-Amz-Request-Id:
-                - txgbb3c3b32ba4644548825-0069b03935
+                - txg6cc0755743d14fed9d3f-006a048625
         status: 404 Not Found
         code: 404
-        duration: 149.660583ms
+        duration: 180.71625ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -217,7 +217,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-acc-test-4993750738523549756.s3.fr-par.scw.cloud
+        host: tf-acc-test-6529491692301554750.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -226,16 +226,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 7544264d-94b2-47f3-a113-c6df54ae9df8
+                - 3087c803-b7f8-4c17-9335-bceaab14974a
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.1 ua/2.1 os/macos lang/go#1.26.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.93.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260310T153101Z
-        url: https://tf-acc-test-4993750738523549756.s3.fr-par.scw.cloud/
+                - 20260513T140941Z
+        url: https://tf-acc-test-6529491692301554750.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -247,21 +247,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-acc-test-4993750738523549756</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-acc-test-6529491692301554750</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "257"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Mar 2026 15:31:01 GMT
+                - Wed, 13 May 2026 14:09:41 GMT
             X-Amz-Id-2:
-                - txg3f0c71e497bb4f3e9609-0069b03935
+                - txg247ddab1f30a40afb741-006a048625
             X-Amz-Request-Id:
-                - txg3f0c71e497bb4f3e9609-0069b03935
+                - txg247ddab1f30a40afb741-006a048625
         status: 200 OK
         code: 200
-        duration: 90.516417ms
+        duration: 291.125125ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -270,7 +270,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-acc-test-4993750738523549756.s3.fr-par.scw.cloud
+        host: tf-acc-test-6529491692301554750.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -279,16 +279,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 87237dda-1b0f-4393-926b-f54cfdf58bc7
+                - d2ce2859-b8df-49aa-8b30-77c612b46f1b
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.1 ua/2.1 os/macos lang/go#1.26.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.93.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260310T153101Z
-        url: https://tf-acc-test-4993750738523549756.s3.fr-par.scw.cloud/?tagging=
+                - 20260513T140941Z
+        url: https://tf-acc-test-6529491692301554750.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -298,21 +298,21 @@ interactions:
         trailer: {}
         content_length: 301
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgf1d1d9adeffd4f75a24d-0069b03935</RequestId><HostId>txgf1d1d9adeffd4f75a24d-0069b03935</HostId><Resource>/tf-acc-test-4993750738523549756</Resource><BucketName>tf-acc-test-4993750738523549756</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgc68dab399e9b4c14a472-006a048625</RequestId><HostId>txgc68dab399e9b4c14a472-006a048625</HostId><Resource>/tf-acc-test-6529491692301554750</Resource><BucketName>tf-acc-test-6529491692301554750</BucketName></Error>
         headers:
             Content-Length:
                 - "301"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Mar 2026 15:31:01 GMT
+                - Wed, 13 May 2026 14:09:41 GMT
             X-Amz-Id-2:
-                - txgf1d1d9adeffd4f75a24d-0069b03935
+                - txgc68dab399e9b4c14a472-006a048625
             X-Amz-Request-Id:
-                - txgf1d1d9adeffd4f75a24d-0069b03935
+                - txgc68dab399e9b4c14a472-006a048625
         status: 404 Not Found
         code: 404
-        duration: 50.483125ms
+        duration: 246.4695ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -321,7 +321,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-acc-test-4993750738523549756.s3.fr-par.scw.cloud
+        host: tf-acc-test-6529491692301554750.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -330,16 +330,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 14631e2c-0a4e-402e-8c8c-c77e03079e84
+                - b6fddff1-55e0-4ce1-98be-db8ac3a91f33
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.1 ua/2.1 os/macos lang/go#1.26.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.93.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260310T153101Z
-        url: https://tf-acc-test-4993750738523549756.s3.fr-par.scw.cloud/?cors=
+                - 20260513T140941Z
+        url: https://tf-acc-test-6529491692301554750.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -349,21 +349,21 @@ interactions:
         trailer: {}
         content_length: 268
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg0f6fbeb6bb9d40ceb4ed-0069b03935</RequestId><HostId>txg0f6fbeb6bb9d40ceb4ed-0069b03935</HostId><Resource>/tf-acc-test-4993750738523549756</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg778830ad616a46b098aa-006a048625</RequestId><HostId>txg778830ad616a46b098aa-006a048625</HostId><Resource>/tf-acc-test-6529491692301554750</Resource></Error>
         headers:
             Content-Length:
                 - "268"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Mar 2026 15:31:01 GMT
+                - Wed, 13 May 2026 14:09:41 GMT
             X-Amz-Id-2:
-                - txg0f6fbeb6bb9d40ceb4ed-0069b03935
+                - txg778830ad616a46b098aa-006a048625
             X-Amz-Request-Id:
-                - txg0f6fbeb6bb9d40ceb4ed-0069b03935
+                - txg778830ad616a46b098aa-006a048625
         status: 404 Not Found
         code: 404
-        duration: 11.475625ms
+        duration: 136.176417ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -372,7 +372,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-acc-test-4993750738523549756.s3.fr-par.scw.cloud
+        host: tf-acc-test-6529491692301554750.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -381,16 +381,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4180f404-0636-42c4-8bc3-a7a8e824c04f
+                - b146a074-0a65-4194-8845-5e47e6653b18
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.1 ua/2.1 os/macos lang/go#1.26.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.93.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260310T153101Z
-        url: https://tf-acc-test-4993750738523549756.s3.fr-par.scw.cloud/?versioning=
+                - 20260513T140941Z
+        url: https://tf-acc-test-6529491692301554750.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -409,14 +409,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Mar 2026 15:31:01 GMT
+                - Wed, 13 May 2026 14:09:41 GMT
             X-Amz-Id-2:
-                - txg4fd894ec3ba84a5f9a16-0069b03935
+                - txg1918393a2c63414ebeba-006a048625
             X-Amz-Request-Id:
-                - txg4fd894ec3ba84a5f9a16-0069b03935
+                - txg1918393a2c63414ebeba-006a048625
         status: 200 OK
         code: 200
-        duration: 7.059666ms
+        duration: 53.211042ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -425,7 +425,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-acc-test-4993750738523549756.s3.fr-par.scw.cloud
+        host: tf-acc-test-6529491692301554750.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -434,16 +434,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 6074ff0c-bd29-412d-ab99-1c480309c935
+                - eba8c606-572f-46dd-be81-9235c23bf8cd
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.1 ua/2.1 os/macos lang/go#1.26.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.93.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260310T153101Z
-        url: https://tf-acc-test-4993750738523549756.s3.fr-par.scw.cloud/?lifecycle=
+                - 20260513T140941Z
+        url: https://tf-acc-test-6529491692301554750.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -453,52 +453,52 @@ interactions:
         trailer: {}
         content_length: 334
         uncompressed: false
-        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txg4900037c80df4268b199-0069b03935</RequestId><HostId>txg4900037c80df4268b199-0069b03935</HostId><Resource>/tf-acc-test-4993750738523549756</Resource><BucketName>tf-acc-test-4993750738523549756</BucketName></Error>
+        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txg8e789d049c1c4eceac28-006a048626</RequestId><HostId>txg8e789d049c1c4eceac28-006a048626</HostId><Resource>/tf-acc-test-6529491692301554750</Resource><BucketName>tf-acc-test-6529491692301554750</BucketName></Error>
         headers:
             Content-Length:
                 - "334"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Mar 2026 15:31:01 GMT
+                - Wed, 13 May 2026 14:09:42 GMT
             X-Amz-Id-2:
-                - txg4900037c80df4268b199-0069b03935
+                - txg8e789d049c1c4eceac28-006a048626
             X-Amz-Request-Id:
-                - txg4900037c80df4268b199-0069b03935
+                - txg8e789d049c1c4eceac28-006a048626
         status: 404 Not Found
         code: 404
-        duration: 191.256375ms
+        duration: 177.18375ms
     - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 282
+        content_length: 240
         transfer_encoding: []
         trailer: {}
-        host: tf-acc-test-4993750738523549756.s3.fr-par.scw.cloud
+        host: tf-acc-test-6529491692301554750.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
-        body: <ServerSideEncryptionConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><ApplyServerSideEncryptionByDefault><SSEAlgorithm>AES256</SSEAlgorithm></ApplyServerSideEncryptionByDefault><BucketKeyEnabled>false</BucketKeyEnabled></Rule></ServerSideEncryptionConfiguration>
+        body: <ServerSideEncryptionConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><ApplyServerSideEncryptionByDefault><SSEAlgorithm>AES256</SSEAlgorithm></ApplyServerSideEncryptionByDefault></Rule></ServerSideEncryptionConfiguration>
         form: {}
         headers:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c6421b00-9dfd-408a-aa89-67016aa2627c
+                - 6e93bbde-ce58-4d9a-9485-334d7cf287ce
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
                 - application/xml
             User-Agent:
-                - aws-sdk-go-v2/1.41.1 ua/2.1 os/macos lang/go#1.26.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.93.0 terraform-provider-scaleway/develop m/E,Z,e
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,Z,e
             X-Amz-Checksum-Crc32:
-                - uqUmTQ==
+                - 2516AQ==
             X-Amz-Content-Sha256:
-                - cc498bd1cc58d45ab57f56e82647e126e3d4f80a5a0c6a081db1860f7ff14d54
+                - df4e3e6cf7a0b4af67ba58f41eaa596d54579eea2ed2f993da09600f59413711
             X-Amz-Date:
-                - 20260310T153101Z
-        url: https://tf-acc-test-4993750738523549756.s3.fr-par.scw.cloud/?encryption=
+                - 20260513T140942Z
+        url: https://tf-acc-test-6529491692301554750.s3.nl-ams.scw.cloud/?encryption=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -513,14 +513,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 10 Mar 2026 15:31:01 GMT
+                - Wed, 13 May 2026 14:09:42 GMT
             X-Amz-Id-2:
-                - txge3e753a1569448a1991e-0069b03935
+                - txgfaf03b7f84774e98b0bc-006a048626
             X-Amz-Request-Id:
-                - txge3e753a1569448a1991e-0069b03935
+                - txgfaf03b7f84774e98b0bc-006a048626
         status: 200 OK
         code: 200
-        duration: 257.762459ms
+        duration: 148.428209ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -529,7 +529,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-acc-test-4993750738523549756.s3.fr-par.scw.cloud
+        host: tf-acc-test-6529491692301554750.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -538,16 +538,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d00f59f4-7bc1-41b1-83d7-49afc9df827f
+                - 0192b4ac-a3da-41e3-8529-b7cc88450add
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.1 ua/2.1 os/macos lang/go#1.26.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.93.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260310T153102Z
-        url: https://tf-acc-test-4993750738523549756.s3.fr-par.scw.cloud/?encryption=
+                - 20260513T140942Z
+        url: https://tf-acc-test-6529491692301554750.s3.nl-ams.scw.cloud/?encryption=
         method: GET
       response:
         proto: HTTP/2.0
@@ -566,14 +566,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Mar 2026 15:31:02 GMT
+                - Wed, 13 May 2026 14:09:42 GMT
             X-Amz-Id-2:
-                - txg4f545a46e4a94ef7b50b-0069b03936
+                - txg0f620e5abb3c4636ba41-006a048626
             X-Amz-Request-Id:
-                - txg4f545a46e4a94ef7b50b-0069b03936
+                - txg0f620e5abb3c4636ba41-006a048626
         status: 200 OK
         code: 200
-        duration: 155.495583ms
+        duration: 64.443417ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -582,7 +582,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-acc-test-4993750738523549756.s3.fr-par.scw.cloud
+        host: tf-acc-test-6529491692301554750.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -591,16 +591,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 1392b109-9be1-4951-a015-24728416c1b9
+                - aa18a7e6-0132-4635-9f49-e9b1a25dc52c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.1 ua/2.1 os/macos lang/go#1.26.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.93.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260310T153102Z
-        url: https://tf-acc-test-4993750738523549756.s3.fr-par.scw.cloud/?encryption=
+                - 20260513T140942Z
+        url: https://tf-acc-test-6529491692301554750.s3.nl-ams.scw.cloud/?encryption=
         method: GET
       response:
         proto: HTTP/2.0
@@ -619,14 +619,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Mar 2026 15:31:02 GMT
+                - Wed, 13 May 2026 14:09:42 GMT
             X-Amz-Id-2:
-                - txg9a80fa0f8a2e440585d9-0069b03936
+                - txg28c88afb5c0a448c9169-006a048626
             X-Amz-Request-Id:
-                - txg9a80fa0f8a2e440585d9-0069b03936
+                - txg28c88afb5c0a448c9169-006a048626
         status: 200 OK
         code: 200
-        duration: 11.503541ms
+        duration: 50.14225ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -635,7 +635,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-acc-test-4993750738523549756.s3.fr-par.scw.cloud
+        host: tf-acc-test-6529491692301554750.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -644,16 +644,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e9606e6d-030b-485f-86d9-a09ce4e53924
+                - 8fa65c3c-9605-4ffb-a129-ad5ed57138cb
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.1 ua/2.1 os/macos lang/go#1.26.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.93.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260310T153102Z
-        url: https://tf-acc-test-4993750738523549756.s3.fr-par.scw.cloud/?encryption=
+                - 20260513T140942Z
+        url: https://tf-acc-test-6529491692301554750.s3.nl-ams.scw.cloud/?encryption=
         method: GET
       response:
         proto: HTTP/2.0
@@ -672,14 +672,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Mar 2026 15:31:02 GMT
+                - Wed, 13 May 2026 14:09:42 GMT
             X-Amz-Id-2:
-                - txg27a37aecb64c4d1faddc-0069b03936
+                - txg726cecebd6f94496801b-006a048626
             X-Amz-Request-Id:
-                - txg27a37aecb64c4d1faddc-0069b03936
+                - txg726cecebd6f94496801b-006a048626
         status: 200 OK
         code: 200
-        duration: 146.902ms
+        duration: 52.299583ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -688,7 +688,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-acc-test-4993750738523549756.s3.fr-par.scw.cloud
+        host: tf-acc-test-6529491692301554750.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -697,16 +697,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - bfb613f0-6142-4407-9ed8-6156148ab8c3
+                - 331d16d8-d16d-4254-b388-836f4828ea9f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.1 ua/2.1 os/macos lang/go#1.26.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.93.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260310T153102Z
-        url: https://tf-acc-test-4993750738523549756.s3.fr-par.scw.cloud/?acl=
+                - 20260513T140942Z
+        url: https://tf-acc-test-6529491692301554750.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -718,21 +718,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
                 - "698"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Mar 2026 15:31:02 GMT
+                - Wed, 13 May 2026 14:09:42 GMT
             X-Amz-Id-2:
-                - txgc5baddd38d65445eb68c-0069b03936
+                - txga0122c20f27348fc9a51-006a048626
             X-Amz-Request-Id:
-                - txgc5baddd38d65445eb68c-0069b03936
+                - txga0122c20f27348fc9a51-006a048626
         status: 200 OK
         code: 200
-        duration: 151.902084ms
+        duration: 74.813958ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -741,7 +741,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-acc-test-4993750738523549756.s3.fr-par.scw.cloud
+        host: tf-acc-test-6529491692301554750.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -750,16 +750,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 730aaf3c-3074-4f5e-9b08-147340984631
+                - 5f056bec-7a4b-40e4-b143-5ec67690a5eb
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.1 ua/2.1 os/macos lang/go#1.26.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.93.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260310T153103Z
-        url: https://tf-acc-test-4993750738523549756.s3.fr-par.scw.cloud/?object-lock=
+                - 20260513T140942Z
+        url: https://tf-acc-test-6529491692301554750.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -769,21 +769,21 @@ interactions:
         trailer: {}
         content_length: 300
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg8abb413aa8bf4f27930e-0069b03937</RequestId><HostId>txg8abb413aa8bf4f27930e-0069b03937</HostId><Resource>/tf-acc-test-4993750738523549756</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg0428f219b13a49f797ec-006a048626</RequestId><HostId>txg0428f219b13a49f797ec-006a048626</HostId><Resource>/tf-acc-test-6529491692301554750</Resource></Error>
         headers:
             Content-Length:
                 - "300"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Mar 2026 15:31:03 GMT
+                - Wed, 13 May 2026 14:09:42 GMT
             X-Amz-Id-2:
-                - txg8abb413aa8bf4f27930e-0069b03937
+                - txg0428f219b13a49f797ec-006a048626
             X-Amz-Request-Id:
-                - txg8abb413aa8bf4f27930e-0069b03937
+                - txg0428f219b13a49f797ec-006a048626
         status: 404 Not Found
         code: 404
-        duration: 22.472541ms
+        duration: 62.884875ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -792,7 +792,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-acc-test-4993750738523549756.s3.fr-par.scw.cloud
+        host: tf-acc-test-6529491692301554750.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -801,16 +801,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5dc65816-9800-474a-a219-7b4f79ad8fc8
+                - 5cdb7956-cec3-4b03-880c-5f1d5d4f4b63
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.1 ua/2.1 os/macos lang/go#1.26.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.93.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260310T153103Z
-        url: https://tf-acc-test-4993750738523549756.s3.fr-par.scw.cloud/
+                - 20260513T140942Z
+        url: https://tf-acc-test-6529491692301554750.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -822,21 +822,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-acc-test-4993750738523549756</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>tf-acc-test-6529491692301554750</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
                 - "257"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Mar 2026 15:31:03 GMT
+                - Wed, 13 May 2026 14:09:43 GMT
             X-Amz-Id-2:
-                - txg0133f502d5674b9facbd-0069b03937
+                - txg8325c11a0f824545ad89-006a048627
             X-Amz-Request-Id:
-                - txg0133f502d5674b9facbd-0069b03937
+                - txg8325c11a0f824545ad89-006a048627
         status: 200 OK
         code: 200
-        duration: 51.22175ms
+        duration: 246.467416ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -845,7 +845,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-acc-test-4993750738523549756.s3.fr-par.scw.cloud
+        host: tf-acc-test-6529491692301554750.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -854,16 +854,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 442be626-7eeb-4fc9-bb9c-04a375c0db61
+                - 47c7b136-ee9f-46f9-839a-fe29ffd8c30e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.1 ua/2.1 os/macos lang/go#1.26.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.93.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260310T153103Z
-        url: https://tf-acc-test-4993750738523549756.s3.fr-par.scw.cloud/?tagging=
+                - 20260513T140943Z
+        url: https://tf-acc-test-6529491692301554750.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -873,21 +873,21 @@ interactions:
         trailer: {}
         content_length: 301
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg60e54bac34b2445baa86-0069b03937</RequestId><HostId>txg60e54bac34b2445baa86-0069b03937</HostId><Resource>/tf-acc-test-4993750738523549756</Resource><BucketName>tf-acc-test-4993750738523549756</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgc5f1e08fb10e4b1ab83a-006a048627</RequestId><HostId>txgc5f1e08fb10e4b1ab83a-006a048627</HostId><Resource>/tf-acc-test-6529491692301554750</Resource><BucketName>tf-acc-test-6529491692301554750</BucketName></Error>
         headers:
             Content-Length:
                 - "301"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Mar 2026 15:31:03 GMT
+                - Wed, 13 May 2026 14:09:43 GMT
             X-Amz-Id-2:
-                - txg60e54bac34b2445baa86-0069b03937
+                - txgc5f1e08fb10e4b1ab83a-006a048627
             X-Amz-Request-Id:
-                - txg60e54bac34b2445baa86-0069b03937
+                - txgc5f1e08fb10e4b1ab83a-006a048627
         status: 404 Not Found
         code: 404
-        duration: 55.080833ms
+        duration: 154.707417ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -896,7 +896,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-acc-test-4993750738523549756.s3.fr-par.scw.cloud
+        host: tf-acc-test-6529491692301554750.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -905,16 +905,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 57c9bddb-ff22-4ad5-967d-5e50fb294703
+                - cf8a073d-e509-445b-b58d-ee6e6e976eda
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.1 ua/2.1 os/macos lang/go#1.26.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.93.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260310T153103Z
-        url: https://tf-acc-test-4993750738523549756.s3.fr-par.scw.cloud/?cors=
+                - 20260513T140943Z
+        url: https://tf-acc-test-6529491692301554750.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -924,21 +924,21 @@ interactions:
         trailer: {}
         content_length: 268
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg9dab5d3a14e248a2b0ca-0069b03937</RequestId><HostId>txg9dab5d3a14e248a2b0ca-0069b03937</HostId><Resource>/tf-acc-test-4993750738523549756</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgfb57866fdccb4e38bda9-006a048627</RequestId><HostId>txgfb57866fdccb4e38bda9-006a048627</HostId><Resource>/tf-acc-test-6529491692301554750</Resource></Error>
         headers:
             Content-Length:
                 - "268"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Mar 2026 15:31:03 GMT
+                - Wed, 13 May 2026 14:09:43 GMT
             X-Amz-Id-2:
-                - txg9dab5d3a14e248a2b0ca-0069b03937
+                - txgfb57866fdccb4e38bda9-006a048627
             X-Amz-Request-Id:
-                - txg9dab5d3a14e248a2b0ca-0069b03937
+                - txgfb57866fdccb4e38bda9-006a048627
         status: 404 Not Found
         code: 404
-        duration: 51.119333ms
+        duration: 52.653667ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -947,7 +947,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-acc-test-4993750738523549756.s3.fr-par.scw.cloud
+        host: tf-acc-test-6529491692301554750.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -956,16 +956,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 62a85760-9e76-4571-8143-2adc23967f0b
+                - b82c18d6-a636-470c-a6e7-e7904809e53c
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.1 ua/2.1 os/macos lang/go#1.26.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.93.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260310T153103Z
-        url: https://tf-acc-test-4993750738523549756.s3.fr-par.scw.cloud/?versioning=
+                - 20260513T140943Z
+        url: https://tf-acc-test-6529491692301554750.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -984,14 +984,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Mar 2026 15:31:03 GMT
+                - Wed, 13 May 2026 14:09:43 GMT
             X-Amz-Id-2:
-                - txg83877927be9a42f49672-0069b03937
+                - txg0ca7a165d28348a5a2b0-006a048627
             X-Amz-Request-Id:
-                - txg83877927be9a42f49672-0069b03937
+                - txg0ca7a165d28348a5a2b0-006a048627
         status: 200 OK
         code: 200
-        duration: 13.290666ms
+        duration: 37.1895ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -1000,7 +1000,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-acc-test-4993750738523549756.s3.fr-par.scw.cloud
+        host: tf-acc-test-6529491692301554750.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1009,16 +1009,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f0509140-bb65-4eb9-8d58-e374d5f456a0
+                - 01b5a739-3e9e-4cfc-91f2-a0639be160ce
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.1 ua/2.1 os/macos lang/go#1.26.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.93.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260310T153103Z
-        url: https://tf-acc-test-4993750738523549756.s3.fr-par.scw.cloud/?lifecycle=
+                - 20260513T140943Z
+        url: https://tf-acc-test-6529491692301554750.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1028,21 +1028,21 @@ interactions:
         trailer: {}
         content_length: 334
         uncompressed: false
-        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txg5e7b7381921b46fc9c04-0069b03937</RequestId><HostId>txg5e7b7381921b46fc9c04-0069b03937</HostId><Resource>/tf-acc-test-4993750738523549756</Resource><BucketName>tf-acc-test-4993750738523549756</BucketName></Error>
+        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txg582eaaa481d3481dbf34-006a048627</RequestId><HostId>txg582eaaa481d3481dbf34-006a048627</HostId><Resource>/tf-acc-test-6529491692301554750</Resource><BucketName>tf-acc-test-6529491692301554750</BucketName></Error>
         headers:
             Content-Length:
                 - "334"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Mar 2026 15:31:03 GMT
+                - Wed, 13 May 2026 14:09:43 GMT
             X-Amz-Id-2:
-                - txg5e7b7381921b46fc9c04-0069b03937
+                - txg582eaaa481d3481dbf34-006a048627
             X-Amz-Request-Id:
-                - txg5e7b7381921b46fc9c04-0069b03937
+                - txg582eaaa481d3481dbf34-006a048627
         status: 404 Not Found
         code: 404
-        duration: 61.109833ms
+        duration: 167.563333ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1051,7 +1051,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-acc-test-4993750738523549756.s3.fr-par.scw.cloud
+        host: tf-acc-test-6529491692301554750.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1060,16 +1060,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 2c271112-695e-4961-a46e-b455b5cfc9d5
+                - 9bdfa592-7fc7-4fcc-a727-10cc1a18b6cb
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.1 ua/2.1 os/macos lang/go#1.26.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.93.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260310T153103Z
-        url: https://tf-acc-test-4993750738523549756.s3.fr-par.scw.cloud/?encryption=
+                - 20260513T140943Z
+        url: https://tf-acc-test-6529491692301554750.s3.nl-ams.scw.cloud/?encryption=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1088,14 +1088,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Mar 2026 15:31:03 GMT
+                - Wed, 13 May 2026 14:09:43 GMT
             X-Amz-Id-2:
-                - txg875b9f9acb624a63ac38-0069b03937
+                - txgadcfebfc4d1c462292b8-006a048627
             X-Amz-Request-Id:
-                - txg875b9f9acb624a63ac38-0069b03937
+                - txgadcfebfc4d1c462292b8-006a048627
         status: 200 OK
         code: 200
-        duration: 77.963541ms
+        duration: 222.884041ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1104,7 +1104,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-acc-test-4993750738523549756.s3.fr-par.scw.cloud
+        host: tf-acc-test-6529491692301554750.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1113,16 +1113,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 81d88375-5abf-4f47-8dc5-4948086a32b9
+                - 4ae29efc-062d-4175-990f-e96e471615d6
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.1 ua/2.1 os/macos lang/go#1.26.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.93.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260310T153103Z
-        url: https://tf-acc-test-4993750738523549756.s3.fr-par.scw.cloud/?encryption=
+                - 20260513T140944Z
+        url: https://tf-acc-test-6529491692301554750.s3.nl-ams.scw.cloud/?encryption=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1141,14 +1141,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Mar 2026 15:31:03 GMT
+                - Wed, 13 May 2026 14:09:44 GMT
             X-Amz-Id-2:
-                - txg604564647aa641fc8a5f-0069b03937
+                - txg6e3037a9e55a459db37c-006a048628
             X-Amz-Request-Id:
-                - txg604564647aa641fc8a5f-0069b03937
+                - txg6e3037a9e55a459db37c-006a048628
         status: 200 OK
         code: 200
-        duration: 99.390917ms
+        duration: 277.236708ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1157,7 +1157,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-acc-test-4993750738523549756.s3.fr-par.scw.cloud
+        host: tf-acc-test-6529491692301554750.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1166,16 +1166,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 0fc90719-06e3-4f4a-b327-2bdbd0662601
+                - 1fd3fbac-89f6-4388-a2b6-356cfac640e6
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.1 ua/2.1 os/macos lang/go#1.26.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.93.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260310T153104Z
-        url: https://tf-acc-test-4993750738523549756.s3.fr-par.scw.cloud/?encryption=
+                - 20260513T140944Z
+        url: https://tf-acc-test-6529491692301554750.s3.nl-ams.scw.cloud/?encryption=
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1188,14 +1188,14 @@ interactions:
         body: ""
         headers:
             Date:
-                - Tue, 10 Mar 2026 15:31:04 GMT
+                - Wed, 13 May 2026 14:09:44 GMT
             X-Amz-Id-2:
-                - txgafc543daf35a4f3ea126-0069b03938
+                - txg6e1fef74d890442ebd9a-006a048628
             X-Amz-Request-Id:
-                - txgafc543daf35a4f3ea126-0069b03938
+                - txg6e1fef74d890442ebd9a-006a048628
         status: 204 No Content
         code: 204
-        duration: 119.613416ms
+        duration: 64.789958ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1204,7 +1204,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: tf-acc-test-4993750738523549756.s3.fr-par.scw.cloud
+        host: tf-acc-test-6529491692301554750.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1213,16 +1213,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9e362b7c-5e97-452b-9a2f-184cc6807577
+                - a4381b1d-72cc-4cec-ae90-4140f7449284
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.1 ua/2.1 os/macos lang/go#1.26.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.93.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260310T153104Z
-        url: https://tf-acc-test-4993750738523549756.s3.fr-par.scw.cloud/
+                - 20260513T140944Z
+        url: https://tf-acc-test-6529491692301554750.s3.nl-ams.scw.cloud/
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1235,11 +1235,11 @@ interactions:
         body: ""
         headers:
             Date:
-                - Tue, 10 Mar 2026 15:31:04 GMT
+                - Wed, 13 May 2026 14:09:44 GMT
             X-Amz-Id-2:
-                - txgb2a2fddd15814d038a48-0069b03938
+                - txg181b8ef0b1764353be3a-006a048628
             X-Amz-Request-Id:
-                - txgb2a2fddd15814d038a48-0069b03938
+                - txg181b8ef0b1764353be3a-006a048628
         status: 204 No Content
         code: 204
-        duration: 186.126083ms
+        duration: 541.895125ms

--- a/internal/services/object/testdata/s3-bucket-server-side-encryption-configuration-basic.cassette.yaml
+++ b/internal/services/object/testdata/s3-bucket-server-side-encryption-configuration-basic.cassette.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: sse-config-basic-5305686071073161344.s3.fr-par.scw.cloud
+        host: sse-config-basic-737899739397838738.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -18,16 +18,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 5873d466-a1ae-45b0-8562-1ef08079ebad
+                - 11f00edd-f5e1-4599-8da1-f09c136fe855
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.1 ua/2.1 os/macos lang/go#1.26.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.93.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260310T153035Z
-        url: https://sse-config-basic-5305686071073161344.s3.fr-par.scw.cloud/
+                - 20260513T140803Z
+        url: https://sse-config-basic-737899739397838738.s3.nl-ams.scw.cloud/
         method: PUT
       response:
         proto: HTTP/2.0
@@ -42,16 +42,16 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 10 Mar 2026 15:30:35 GMT
+                - Wed, 13 May 2026 14:08:03 GMT
             Location:
-                - /sse-config-basic-5305686071073161344
+                - /sse-config-basic-737899739397838738
             X-Amz-Id-2:
-                - txgd9aa385fc34343d69d1a-0069b0391b
+                - txg6a60a1f2798f4455a0d2-006a0485c3
             X-Amz-Request-Id:
-                - txgd9aa385fc34343d69d1a-0069b0391b
+                - txg6a60a1f2798f4455a0d2-006a0485c3
         status: 200 OK
         code: 200
-        duration: 4.881416458s
+        duration: 4.379962417s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -60,7 +60,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: sse-config-basic-5305686071073161344.s3.fr-par.scw.cloud
+        host: sse-config-basic-737899739397838738.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -69,11 +69,11 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 33a5d5c9-f7e6-4d5d-8196-4cd5e5e5141b
+                - 40d900f6-1355-4f81-ab3b-4c5eea9a3c86
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.1 ua/2.1 os/macos lang/go#1.26.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.93.0 terraform-provider-scaleway/develop m/E,Z,e
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,Z,e
             X-Amz-Acl:
                 - private
             X-Amz-Checksum-Crc32:
@@ -81,8 +81,8 @@ interactions:
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260310T153040Z
-        url: https://sse-config-basic-5305686071073161344.s3.fr-par.scw.cloud/?acl=
+                - 20260513T140807Z
+        url: https://sse-config-basic-737899739397838738.s3.nl-ams.scw.cloud/?acl=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -97,14 +97,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 10 Mar 2026 15:30:40 GMT
+                - Wed, 13 May 2026 14:08:07 GMT
             X-Amz-Id-2:
-                - txge3b7d59f4b384e1e8bdd-0069b03920
+                - txgc944fa244d654a9d95dc-006a0485c7
             X-Amz-Request-Id:
-                - txge3b7d59f4b384e1e8bdd-0069b03920
+                - txgc944fa244d654a9d95dc-006a0485c7
         status: 200 OK
         code: 200
-        duration: 204.021667ms
+        duration: 55.870625ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -113,7 +113,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: sse-config-basic-5305686071073161344.s3.fr-par.scw.cloud
+        host: sse-config-basic-737899739397838738.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -122,16 +122,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - d8d33435-a70f-4b18-a834-350db7a7f42c
+                - 0617637a-d690-44b8-89c6-3293f6438eae
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.1 ua/2.1 os/macos lang/go#1.26.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.93.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260310T153040Z
-        url: https://sse-config-basic-5305686071073161344.s3.fr-par.scw.cloud/?acl=
+                - 20260513T140807Z
+        url: https://sse-config-basic-737899739397838738.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -143,21 +143,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
                 - "698"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Mar 2026 15:30:40 GMT
+                - Wed, 13 May 2026 14:08:07 GMT
             X-Amz-Id-2:
-                - txg559f2c301d3f4f70a43a-0069b03920
+                - txg39ea3460e4ba4814a389-006a0485c7
             X-Amz-Request-Id:
-                - txg559f2c301d3f4f70a43a-0069b03920
+                - txg39ea3460e4ba4814a389-006a0485c7
         status: 200 OK
         code: 200
-        duration: 161.839792ms
+        duration: 94.543833ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -166,7 +166,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: sse-config-basic-5305686071073161344.s3.fr-par.scw.cloud
+        host: sse-config-basic-737899739397838738.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -175,16 +175,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ce1ccd54-04c9-4132-a086-2e64739733db
+                - c2f53762-02a1-426d-9437-3f5f53dc5e17
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.1 ua/2.1 os/macos lang/go#1.26.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.93.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260310T153040Z
-        url: https://sse-config-basic-5305686071073161344.s3.fr-par.scw.cloud/?object-lock=
+                - 20260513T140807Z
+        url: https://sse-config-basic-737899739397838738.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -192,23 +192,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 305
+        content_length: 304
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg014bb20ad12142ab984c-0069b03920</RequestId><HostId>txg014bb20ad12142ab984c-0069b03920</HostId><Resource>/sse-config-basic-5305686071073161344</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txge96f8e7ce8364da1a01d-006a0485c7</RequestId><HostId>txge96f8e7ce8364da1a01d-006a0485c7</HostId><Resource>/sse-config-basic-737899739397838738</Resource></Error>
         headers:
             Content-Length:
-                - "305"
+                - "304"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Mar 2026 15:30:40 GMT
+                - Wed, 13 May 2026 14:08:07 GMT
             X-Amz-Id-2:
-                - txg014bb20ad12142ab984c-0069b03920
+                - txge96f8e7ce8364da1a01d-006a0485c7
             X-Amz-Request-Id:
-                - txg014bb20ad12142ab984c-0069b03920
+                - txge96f8e7ce8364da1a01d-006a0485c7
         status: 404 Not Found
         code: 404
-        duration: 103.415667ms
+        duration: 80.961666ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -217,7 +217,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: sse-config-basic-5305686071073161344.s3.fr-par.scw.cloud
+        host: sse-config-basic-737899739397838738.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -226,16 +226,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 436b84b6-f263-4b0f-9efc-0b3e93b33017
+                - b7b35e0e-4a0a-4e41-adaf-799c0c091e3f
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.1 ua/2.1 os/macos lang/go#1.26.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.93.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260310T153041Z
-        url: https://sse-config-basic-5305686071073161344.s3.fr-par.scw.cloud/
+                - 20260513T140807Z
+        url: https://sse-config-basic-737899739397838738.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -243,25 +243,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 262
+        content_length: 261
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>sse-config-basic-5305686071073161344</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>sse-config-basic-737899739397838738</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "262"
+                - "261"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Mar 2026 15:30:41 GMT
+                - Wed, 13 May 2026 14:08:07 GMT
             X-Amz-Id-2:
-                - txg218f04161ac1402d8707-0069b03921
+                - txgaa1d08eef99a47798070-006a0485c7
             X-Amz-Request-Id:
-                - txg218f04161ac1402d8707-0069b03921
+                - txgaa1d08eef99a47798070-006a0485c7
         status: 200 OK
         code: 200
-        duration: 349.881959ms
+        duration: 91.409083ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -270,7 +270,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: sse-config-basic-5305686071073161344.s3.fr-par.scw.cloud
+        host: sse-config-basic-737899739397838738.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -279,16 +279,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - db612b71-f8bf-45b0-b0e0-84dcd2e06f3b
+                - 83bf0eb5-19eb-4cc8-9bc2-9fc1bd953a5d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.1 ua/2.1 os/macos lang/go#1.26.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.93.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260310T153041Z
-        url: https://sse-config-basic-5305686071073161344.s3.fr-par.scw.cloud/?tagging=
+                - 20260513T140807Z
+        url: https://sse-config-basic-737899739397838738.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -296,23 +296,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 311
+        content_length: 309
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txgc86c05a7c81f416492e5-0069b03921</RequestId><HostId>txgc86c05a7c81f416492e5-0069b03921</HostId><Resource>/sse-config-basic-5305686071073161344</Resource><BucketName>sse-config-basic-5305686071073161344</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg2c93c0ecce1c4e92bf80-006a0485c7</RequestId><HostId>txg2c93c0ecce1c4e92bf80-006a0485c7</HostId><Resource>/sse-config-basic-737899739397838738</Resource><BucketName>sse-config-basic-737899739397838738</BucketName></Error>
         headers:
             Content-Length:
-                - "311"
+                - "309"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Mar 2026 15:30:41 GMT
+                - Wed, 13 May 2026 14:08:07 GMT
             X-Amz-Id-2:
-                - txgc86c05a7c81f416492e5-0069b03921
+                - txg2c93c0ecce1c4e92bf80-006a0485c7
             X-Amz-Request-Id:
-                - txgc86c05a7c81f416492e5-0069b03921
+                - txg2c93c0ecce1c4e92bf80-006a0485c7
         status: 404 Not Found
         code: 404
-        duration: 6.071917ms
+        duration: 48.16375ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -321,7 +321,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: sse-config-basic-5305686071073161344.s3.fr-par.scw.cloud
+        host: sse-config-basic-737899739397838738.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -330,16 +330,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 4c4f4e21-bbcb-4498-8b8e-9dff6854ea08
+                - c8430a6a-4e27-4647-a5ff-a8bc0b377293
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.1 ua/2.1 os/macos lang/go#1.26.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.93.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260310T153041Z
-        url: https://sse-config-basic-5305686071073161344.s3.fr-par.scw.cloud/?cors=
+                - 20260513T140807Z
+        url: https://sse-config-basic-737899739397838738.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -347,23 +347,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 273
+        content_length: 272
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txgb073575139d949308103-0069b03921</RequestId><HostId>txgb073575139d949308103-0069b03921</HostId><Resource>/sse-config-basic-5305686071073161344</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg93bbd3365eda4855ace2-006a0485c7</RequestId><HostId>txg93bbd3365eda4855ace2-006a0485c7</HostId><Resource>/sse-config-basic-737899739397838738</Resource></Error>
         headers:
             Content-Length:
-                - "273"
+                - "272"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Mar 2026 15:30:41 GMT
+                - Wed, 13 May 2026 14:08:07 GMT
             X-Amz-Id-2:
-                - txgb073575139d949308103-0069b03921
+                - txg93bbd3365eda4855ace2-006a0485c7
             X-Amz-Request-Id:
-                - txgb073575139d949308103-0069b03921
+                - txg93bbd3365eda4855ace2-006a0485c7
         status: 404 Not Found
         code: 404
-        duration: 105.6245ms
+        duration: 130.336167ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -372,7 +372,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: sse-config-basic-5305686071073161344.s3.fr-par.scw.cloud
+        host: sse-config-basic-737899739397838738.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -381,16 +381,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - f8925a2c-be7c-4084-97be-166bd4fbf563
+                - e18fd8c5-c5d0-475e-bc2e-80351ea3f97e
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.1 ua/2.1 os/macos lang/go#1.26.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.93.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260310T153041Z
-        url: https://sse-config-basic-5305686071073161344.s3.fr-par.scw.cloud/?versioning=
+                - 20260513T140807Z
+        url: https://sse-config-basic-737899739397838738.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -409,14 +409,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Mar 2026 15:30:41 GMT
+                - Wed, 13 May 2026 14:08:08 GMT
             X-Amz-Id-2:
-                - txga940984b0d0d4d28a908-0069b03921
+                - txgc990eb04a7a845c8a54f-006a0485c8
             X-Amz-Request-Id:
-                - txga940984b0d0d4d28a908-0069b03921
+                - txgc990eb04a7a845c8a54f-006a0485c8
         status: 200 OK
         code: 200
-        duration: 92.346917ms
+        duration: 48.64025ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -425,7 +425,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: sse-config-basic-5305686071073161344.s3.fr-par.scw.cloud
+        host: sse-config-basic-737899739397838738.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -434,16 +434,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 9508c4aa-540a-465c-8b99-f195c6a002d8
+                - d47c9b90-71ca-46fc-be7a-f957ba916a58
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.1 ua/2.1 os/macos lang/go#1.26.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.93.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260310T153041Z
-        url: https://sse-config-basic-5305686071073161344.s3.fr-par.scw.cloud/?lifecycle=
+                - 20260513T140808Z
+        url: https://sse-config-basic-737899739397838738.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -451,54 +451,54 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 344
+        content_length: 342
         uncompressed: false
-        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txg6cd2f5cf13fa4db6ad14-0069b03921</RequestId><HostId>txg6cd2f5cf13fa4db6ad14-0069b03921</HostId><Resource>/sse-config-basic-5305686071073161344</Resource><BucketName>sse-config-basic-5305686071073161344</BucketName></Error>
+        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txga74931cf661548e3b8f6-006a0485c8</RequestId><HostId>txga74931cf661548e3b8f6-006a0485c8</HostId><Resource>/sse-config-basic-737899739397838738</Resource><BucketName>sse-config-basic-737899739397838738</BucketName></Error>
         headers:
             Content-Length:
-                - "344"
+                - "342"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Mar 2026 15:30:41 GMT
+                - Wed, 13 May 2026 14:08:08 GMT
             X-Amz-Id-2:
-                - txg6cd2f5cf13fa4db6ad14-0069b03921
+                - txga74931cf661548e3b8f6-006a0485c8
             X-Amz-Request-Id:
-                - txg6cd2f5cf13fa4db6ad14-0069b03921
+                - txga74931cf661548e3b8f6-006a0485c8
         status: 404 Not Found
         code: 404
-        duration: 160.653375ms
+        duration: 82.635667ms
     - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 282
+        content_length: 240
         transfer_encoding: []
         trailer: {}
-        host: sse-config-basic-5305686071073161344.s3.fr-par.scw.cloud
+        host: sse-config-basic-737899739397838738.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
-        body: <ServerSideEncryptionConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><ApplyServerSideEncryptionByDefault><SSEAlgorithm>AES256</SSEAlgorithm></ApplyServerSideEncryptionByDefault><BucketKeyEnabled>false</BucketKeyEnabled></Rule></ServerSideEncryptionConfiguration>
+        body: <ServerSideEncryptionConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><ApplyServerSideEncryptionByDefault><SSEAlgorithm>AES256</SSEAlgorithm></ApplyServerSideEncryptionByDefault></Rule></ServerSideEncryptionConfiguration>
         form: {}
         headers:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - c95cacf5-1d79-4cb9-8bcc-25749fea9446
+                - 8a1f72ed-fe39-44e4-96da-8d9f13c440f2
             Amz-Sdk-Request:
                 - attempt=1; max=3
             Content-Type:
                 - application/xml
             User-Agent:
-                - aws-sdk-go-v2/1.41.1 ua/2.1 os/macos lang/go#1.26.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.93.0 terraform-provider-scaleway/develop m/E,Z,e
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,Z,e
             X-Amz-Checksum-Crc32:
-                - uqUmTQ==
+                - 2516AQ==
             X-Amz-Content-Sha256:
-                - cc498bd1cc58d45ab57f56e82647e126e3d4f80a5a0c6a081db1860f7ff14d54
+                - df4e3e6cf7a0b4af67ba58f41eaa596d54579eea2ed2f993da09600f59413711
             X-Amz-Date:
-                - 20260310T153041Z
-        url: https://sse-config-basic-5305686071073161344.s3.fr-par.scw.cloud/?encryption=
+                - 20260513T140808Z
+        url: https://sse-config-basic-737899739397838738.s3.nl-ams.scw.cloud/?encryption=
         method: PUT
       response:
         proto: HTTP/2.0
@@ -513,14 +513,14 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 10 Mar 2026 15:30:41 GMT
+                - Wed, 13 May 2026 14:08:08 GMT
             X-Amz-Id-2:
-                - txg4011aefdf27a4c0c9a32-0069b03921
+                - txgd3814ee46b9e4dca96eb-006a0485c8
             X-Amz-Request-Id:
-                - txg4011aefdf27a4c0c9a32-0069b03921
+                - txgd3814ee46b9e4dca96eb-006a0485c8
         status: 200 OK
         code: 200
-        duration: 122.72625ms
+        duration: 176.915416ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -529,7 +529,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: sse-config-basic-5305686071073161344.s3.fr-par.scw.cloud
+        host: sse-config-basic-737899739397838738.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -538,16 +538,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e4cfa0a5-df09-448e-ac83-392829a020f8
+                - 116bf3b0-6cd5-4257-ad2f-f42a945befce
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.1 ua/2.1 os/macos lang/go#1.26.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.93.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260310T153041Z
-        url: https://sse-config-basic-5305686071073161344.s3.fr-par.scw.cloud/?encryption=
+                - 20260513T140808Z
+        url: https://sse-config-basic-737899739397838738.s3.nl-ams.scw.cloud/?encryption=
         method: GET
       response:
         proto: HTTP/2.0
@@ -566,14 +566,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Mar 2026 15:30:41 GMT
+                - Wed, 13 May 2026 14:08:08 GMT
             X-Amz-Id-2:
-                - txg00ff8ceaf81043ec86a6-0069b03921
+                - txgaa3ecc5d7cc14bccaa83-006a0485c8
             X-Amz-Request-Id:
-                - txg00ff8ceaf81043ec86a6-0069b03921
+                - txgaa3ecc5d7cc14bccaa83-006a0485c8
         status: 200 OK
         code: 200
-        duration: 82.316584ms
+        duration: 172.874417ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -582,7 +582,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: sse-config-basic-5305686071073161344.s3.fr-par.scw.cloud
+        host: sse-config-basic-737899739397838738.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -591,16 +591,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 2f750332-cb19-46fa-8353-cd59fc267ab5
+                - 1b22a767-4bdd-473b-b42f-8d611286a7ed
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.1 ua/2.1 os/macos lang/go#1.26.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.93.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260310T153041Z
-        url: https://sse-config-basic-5305686071073161344.s3.fr-par.scw.cloud/?encryption=
+                - 20260513T140808Z
+        url: https://sse-config-basic-737899739397838738.s3.nl-ams.scw.cloud/?encryption=
         method: GET
       response:
         proto: HTTP/2.0
@@ -619,14 +619,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Mar 2026 15:30:41 GMT
+                - Wed, 13 May 2026 14:08:08 GMT
             X-Amz-Id-2:
-                - txg6e5d328123d5478aac28-0069b03921
+                - txg3b25d59b4c3640948d22-006a0485c8
             X-Amz-Request-Id:
-                - txg6e5d328123d5478aac28-0069b03921
+                - txg3b25d59b4c3640948d22-006a0485c8
         status: 200 OK
         code: 200
-        duration: 46.604292ms
+        duration: 109.080084ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -635,7 +635,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: sse-config-basic-5305686071073161344.s3.fr-par.scw.cloud
+        host: sse-config-basic-737899739397838738.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -644,16 +644,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 493343c3-8871-43db-9b56-d8f9e08ef1fe
+                - c89f7cfd-5a9f-412d-a034-a2b3d8733ddd
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.1 ua/2.1 os/macos lang/go#1.26.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.93.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260310T153042Z
-        url: https://sse-config-basic-5305686071073161344.s3.fr-par.scw.cloud/?encryption=
+                - 20260513T140808Z
+        url: https://sse-config-basic-737899739397838738.s3.nl-ams.scw.cloud/?encryption=
         method: GET
       response:
         proto: HTTP/2.0
@@ -672,14 +672,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Mar 2026 15:30:42 GMT
+                - Wed, 13 May 2026 14:08:08 GMT
             X-Amz-Id-2:
-                - txga413c60564ba4f7394f7-0069b03922
+                - txgddc32e2107df4cd7bc3c-006a0485c8
             X-Amz-Request-Id:
-                - txga413c60564ba4f7394f7-0069b03922
+                - txgddc32e2107df4cd7bc3c-006a0485c8
         status: 200 OK
         code: 200
-        duration: 7.819959ms
+        duration: 52.949541ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -688,7 +688,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: sse-config-basic-5305686071073161344.s3.fr-par.scw.cloud
+        host: sse-config-basic-737899739397838738.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -697,16 +697,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - cbc8ed5e-bf18-4d48-b0e5-32789c676e8f
+                - 9c01ee30-48aa-485f-8e07-d0474511dd97
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.1 ua/2.1 os/macos lang/go#1.26.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.93.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260310T153042Z
-        url: https://sse-config-basic-5305686071073161344.s3.fr-par.scw.cloud/?acl=
+                - 20260513T140809Z
+        url: https://sse-config-basic-737899739397838738.s3.nl-ams.scw.cloud/?acl=
         method: GET
       response:
         proto: HTTP/2.0
@@ -718,21 +718,21 @@ interactions:
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</ID><DisplayName>105bdce1-64c0-48ab-899d-868455867ecf:105bdce1-64c0-48ab-899d-868455867ecf</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+            <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</ID><DisplayName>4d333544-41be-4b0b-8907-0b9036859747:4d333544-41be-4b0b-8907-0b9036859747</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
         headers:
             Content-Length:
                 - "698"
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Mar 2026 15:30:42 GMT
+                - Wed, 13 May 2026 14:08:09 GMT
             X-Amz-Id-2:
-                - txgf96fc5ff380c40b1b418-0069b03922
+                - txg75e1fb7d45c2469294d4-006a0485c9
             X-Amz-Request-Id:
-                - txgf96fc5ff380c40b1b418-0069b03922
+                - txg75e1fb7d45c2469294d4-006a0485c9
         status: 200 OK
         code: 200
-        duration: 8.966166ms
+        duration: 67.358333ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -741,7 +741,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: sse-config-basic-5305686071073161344.s3.fr-par.scw.cloud
+        host: sse-config-basic-737899739397838738.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -750,16 +750,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - ef102a9d-cea3-4513-a6ef-611b0aaf29f9
+                - c3c4d514-4d22-4d37-b2d5-c691d486d3a8
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.1 ua/2.1 os/macos lang/go#1.26.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.93.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260310T153042Z
-        url: https://sse-config-basic-5305686071073161344.s3.fr-par.scw.cloud/?object-lock=
+                - 20260513T140809Z
+        url: https://sse-config-basic-737899739397838738.s3.nl-ams.scw.cloud/?object-lock=
         method: GET
       response:
         proto: HTTP/2.0
@@ -767,23 +767,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 305
+        content_length: 304
         uncompressed: false
-        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg431661d289d04b9cba8b-0069b03922</RequestId><HostId>txg431661d289d04b9cba8b-0069b03922</HostId><Resource>/sse-config-basic-5305686071073161344</Resource></Error>
+        body: <Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>Object Lock configuration does not exist for this bucket</Message><RequestId>txg998530f291654627ac7a-006a0485c9</RequestId><HostId>txg998530f291654627ac7a-006a0485c9</HostId><Resource>/sse-config-basic-737899739397838738</Resource></Error>
         headers:
             Content-Length:
-                - "305"
+                - "304"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Mar 2026 15:30:42 GMT
+                - Wed, 13 May 2026 14:08:09 GMT
             X-Amz-Id-2:
-                - txg431661d289d04b9cba8b-0069b03922
+                - txg998530f291654627ac7a-006a0485c9
             X-Amz-Request-Id:
-                - txg431661d289d04b9cba8b-0069b03922
+                - txg998530f291654627ac7a-006a0485c9
         status: 404 Not Found
         code: 404
-        duration: 69.554959ms
+        duration: 24.114292ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -792,7 +792,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: sse-config-basic-5305686071073161344.s3.fr-par.scw.cloud
+        host: sse-config-basic-737899739397838738.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -801,16 +801,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 17733903-42fa-4d06-b924-4cd5c3428f87
+                - dc130ec0-5d38-4954-a029-ba435cfa0efa
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.1 ua/2.1 os/macos lang/go#1.26.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.93.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260310T153042Z
-        url: https://sse-config-basic-5305686071073161344.s3.fr-par.scw.cloud/
+                - 20260513T140809Z
+        url: https://sse-config-basic-737899739397838738.s3.nl-ams.scw.cloud/
         method: GET
       response:
         proto: HTTP/2.0
@@ -818,25 +818,25 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 262
+        content_length: 261
         uncompressed: false
         body: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>sse-config-basic-5305686071073161344</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>sse-config-basic-737899739397838738</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
         headers:
             Content-Length:
-                - "262"
+                - "261"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Mar 2026 15:30:42 GMT
+                - Wed, 13 May 2026 14:08:09 GMT
             X-Amz-Id-2:
-                - txgd043dca82fbf407eba64-0069b03922
+                - txg4ac35054a0c9469cbf7e-006a0485c9
             X-Amz-Request-Id:
-                - txgd043dca82fbf407eba64-0069b03922
+                - txg4ac35054a0c9469cbf7e-006a0485c9
         status: 200 OK
         code: 200
-        duration: 199.614791ms
+        duration: 202.45375ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -845,7 +845,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: sse-config-basic-5305686071073161344.s3.fr-par.scw.cloud
+        host: sse-config-basic-737899739397838738.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -854,16 +854,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 687ffc16-e899-4a03-bfe3-1bb7eeb6aa61
+                - f9500c18-e9d3-4718-ac43-1670220f6e24
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.1 ua/2.1 os/macos lang/go#1.26.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.93.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260310T153042Z
-        url: https://sse-config-basic-5305686071073161344.s3.fr-par.scw.cloud/?tagging=
+                - 20260513T140809Z
+        url: https://sse-config-basic-737899739397838738.s3.nl-ams.scw.cloud/?tagging=
         method: GET
       response:
         proto: HTTP/2.0
@@ -871,23 +871,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 311
+        content_length: 309
         uncompressed: false
-        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg4971d11d51f9453cb2dc-0069b03922</RequestId><HostId>txg4971d11d51f9453cb2dc-0069b03922</HostId><Resource>/sse-config-basic-5305686071073161344</Resource><BucketName>sse-config-basic-5305686071073161344</BucketName></Error>
+        body: <Error><Code>NoSuchTagSet</Code><Message>The TagSet does not exist</Message><RequestId>txg5987bce59a284dca9298-006a0485c9</RequestId><HostId>txg5987bce59a284dca9298-006a0485c9</HostId><Resource>/sse-config-basic-737899739397838738</Resource><BucketName>sse-config-basic-737899739397838738</BucketName></Error>
         headers:
             Content-Length:
-                - "311"
+                - "309"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Mar 2026 15:30:42 GMT
+                - Wed, 13 May 2026 14:08:09 GMT
             X-Amz-Id-2:
-                - txg4971d11d51f9453cb2dc-0069b03922
+                - txg5987bce59a284dca9298-006a0485c9
             X-Amz-Request-Id:
-                - txg4971d11d51f9453cb2dc-0069b03922
+                - txg5987bce59a284dca9298-006a0485c9
         status: 404 Not Found
         code: 404
-        duration: 79.09225ms
+        duration: 249.742875ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -896,7 +896,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: sse-config-basic-5305686071073161344.s3.fr-par.scw.cloud
+        host: sse-config-basic-737899739397838738.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -905,16 +905,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 01625f34-fa19-4b16-b888-ef008cfdac55
+                - 9006af79-15df-4fd7-87d8-5d1e0ed1c7ab
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.1 ua/2.1 os/macos lang/go#1.26.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.93.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260310T153042Z
-        url: https://sse-config-basic-5305686071073161344.s3.fr-par.scw.cloud/?cors=
+                - 20260513T140809Z
+        url: https://sse-config-basic-737899739397838738.s3.nl-ams.scw.cloud/?cors=
         method: GET
       response:
         proto: HTTP/2.0
@@ -922,23 +922,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 273
+        content_length: 272
         uncompressed: false
-        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg5da8a5795ec64e63ab07-0069b03922</RequestId><HostId>txg5da8a5795ec64e63ab07-0069b03922</HostId><Resource>/sse-config-basic-5305686071073161344</Resource></Error>
+        body: <Error><Code>NoSuchCORSConfiguration</Code><Message>The CORS configuration does not exist</Message><RequestId>txg01077cd0b7d246a58d28-006a0485c9</RequestId><HostId>txg01077cd0b7d246a58d28-006a0485c9</HostId><Resource>/sse-config-basic-737899739397838738</Resource></Error>
         headers:
             Content-Length:
-                - "273"
+                - "272"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Mar 2026 15:30:42 GMT
+                - Wed, 13 May 2026 14:08:09 GMT
             X-Amz-Id-2:
-                - txg5da8a5795ec64e63ab07-0069b03922
+                - txg01077cd0b7d246a58d28-006a0485c9
             X-Amz-Request-Id:
-                - txg5da8a5795ec64e63ab07-0069b03922
+                - txg01077cd0b7d246a58d28-006a0485c9
         status: 404 Not Found
         code: 404
-        duration: 44.184333ms
+        duration: 36.157875ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -947,7 +947,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: sse-config-basic-5305686071073161344.s3.fr-par.scw.cloud
+        host: sse-config-basic-737899739397838738.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -956,16 +956,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - a87c62c4-ec4a-4300-9ebe-c823aa30f654
+                - 84a9f655-eb2e-4e84-aaab-a8a4cf4cbcbd
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.1 ua/2.1 os/macos lang/go#1.26.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.93.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260310T153042Z
-        url: https://sse-config-basic-5305686071073161344.s3.fr-par.scw.cloud/?versioning=
+                - 20260513T140809Z
+        url: https://sse-config-basic-737899739397838738.s3.nl-ams.scw.cloud/?versioning=
         method: GET
       response:
         proto: HTTP/2.0
@@ -984,14 +984,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Mar 2026 15:30:42 GMT
+                - Wed, 13 May 2026 14:08:09 GMT
             X-Amz-Id-2:
-                - txg8e470d62d30d4acabe14-0069b03922
+                - txgee48ac976a734cd29147-006a0485c9
             X-Amz-Request-Id:
-                - txg8e470d62d30d4acabe14-0069b03922
+                - txgee48ac976a734cd29147-006a0485c9
         status: 200 OK
         code: 200
-        duration: 46.472708ms
+        duration: 163.122125ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -1000,7 +1000,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: sse-config-basic-5305686071073161344.s3.fr-par.scw.cloud
+        host: sse-config-basic-737899739397838738.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1009,16 +1009,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 20ba6d26-2251-4d48-9e4c-9d2e773598e0
+                - 4c242381-10ed-4b25-8d84-4b8c2e6dbbd8
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.1 ua/2.1 os/macos lang/go#1.26.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.93.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260310T153042Z
-        url: https://sse-config-basic-5305686071073161344.s3.fr-par.scw.cloud/?lifecycle=
+                - 20260513T140809Z
+        url: https://sse-config-basic-737899739397838738.s3.nl-ams.scw.cloud/?lifecycle=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1026,23 +1026,23 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 344
+        content_length: 342
         uncompressed: false
-        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txg990d4f83e2e7407fb1f1-0069b03922</RequestId><HostId>txg990d4f83e2e7407fb1f1-0069b03922</HostId><Resource>/sse-config-basic-5305686071073161344</Resource><BucketName>sse-config-basic-5305686071073161344</BucketName></Error>
+        body: <Error><Code>NoSuchLifecycleConfiguration</Code><Message>The lifecycle configuration does not exist</Message><RequestId>txg1e1263bb8c0b47e7b1dd-006a0485c9</RequestId><HostId>txg1e1263bb8c0b47e7b1dd-006a0485c9</HostId><Resource>/sse-config-basic-737899739397838738</Resource><BucketName>sse-config-basic-737899739397838738</BucketName></Error>
         headers:
             Content-Length:
-                - "344"
+                - "342"
             Content-Type:
                 - application/xml
             Date:
-                - Tue, 10 Mar 2026 15:30:42 GMT
+                - Wed, 13 May 2026 14:08:09 GMT
             X-Amz-Id-2:
-                - txg990d4f83e2e7407fb1f1-0069b03922
+                - txg1e1263bb8c0b47e7b1dd-006a0485c9
             X-Amz-Request-Id:
-                - txg990d4f83e2e7407fb1f1-0069b03922
+                - txg1e1263bb8c0b47e7b1dd-006a0485c9
         status: 404 Not Found
         code: 404
-        duration: 145.841625ms
+        duration: 42.006458ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1051,7 +1051,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: sse-config-basic-5305686071073161344.s3.fr-par.scw.cloud
+        host: sse-config-basic-737899739397838738.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1060,16 +1060,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - e0869d8d-f752-4f37-90a9-6a1e7f740ec4
+                - a646874a-4c35-467a-9ee5-27f5a4750cdd
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.1 ua/2.1 os/macos lang/go#1.26.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.93.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260310T153043Z
-        url: https://sse-config-basic-5305686071073161344.s3.fr-par.scw.cloud/?encryption=
+                - 20260513T140809Z
+        url: https://sse-config-basic-737899739397838738.s3.nl-ams.scw.cloud/?encryption=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1088,14 +1088,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Mar 2026 15:30:43 GMT
+                - Wed, 13 May 2026 14:08:09 GMT
             X-Amz-Id-2:
-                - txg3947c0f8cbff40529e20-0069b03923
+                - txg51d0c7647c51429a8335-006a0485c9
             X-Amz-Request-Id:
-                - txg3947c0f8cbff40529e20-0069b03923
+                - txg51d0c7647c51429a8335-006a0485c9
         status: 200 OK
         code: 200
-        duration: 56.836208ms
+        duration: 36.125208ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1104,7 +1104,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: sse-config-basic-5305686071073161344.s3.fr-par.scw.cloud
+        host: sse-config-basic-737899739397838738.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1113,16 +1113,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 14f3615a-eb93-4e51-a024-caa34611c9d4
+                - ceb13721-9084-4f41-933c-a97536795e45
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.1 ua/2.1 os/macos lang/go#1.26.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.93.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260310T153043Z
-        url: https://sse-config-basic-5305686071073161344.s3.fr-par.scw.cloud/?encryption=
+                - 20260513T140810Z
+        url: https://sse-config-basic-737899739397838738.s3.nl-ams.scw.cloud/?encryption=
         method: GET
       response:
         proto: HTTP/2.0
@@ -1141,14 +1141,14 @@ interactions:
             Content-Type:
                 - text/xml; charset=utf-8
             Date:
-                - Tue, 10 Mar 2026 15:30:43 GMT
+                - Wed, 13 May 2026 14:08:10 GMT
             X-Amz-Id-2:
-                - txg94e3d84e10584149b0a0-0069b03923
+                - txg2b9f6e484f32470b84bf-006a0485ca
             X-Amz-Request-Id:
-                - txg94e3d84e10584149b0a0-0069b03923
+                - txg2b9f6e484f32470b84bf-006a0485ca
         status: 200 OK
         code: 200
-        duration: 102.509666ms
+        duration: 64.207875ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1157,7 +1157,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: sse-config-basic-5305686071073161344.s3.fr-par.scw.cloud
+        host: sse-config-basic-737899739397838738.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1166,16 +1166,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - bd2dcbcf-a419-453e-8670-ad9872a7538e
+                - a5cdd871-e01a-4fbf-a4c6-00a88790255d
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.1 ua/2.1 os/macos lang/go#1.26.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.93.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260310T153043Z
-        url: https://sse-config-basic-5305686071073161344.s3.fr-par.scw.cloud/?encryption=
+                - 20260513T140810Z
+        url: https://sse-config-basic-737899739397838738.s3.nl-ams.scw.cloud/?encryption=
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1188,14 +1188,14 @@ interactions:
         body: ""
         headers:
             Date:
-                - Tue, 10 Mar 2026 15:30:43 GMT
+                - Wed, 13 May 2026 14:08:10 GMT
             X-Amz-Id-2:
-                - txga1f5b4b55247443a8876-0069b03923
+                - txgd9861721dde543e4becd-006a0485ca
             X-Amz-Request-Id:
-                - txga1f5b4b55247443a8876-0069b03923
+                - txgd9861721dde543e4becd-006a0485ca
         status: 204 No Content
         code: 204
-        duration: 284.384083ms
+        duration: 148.790708ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1204,7 +1204,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: sse-config-basic-5305686071073161344.s3.fr-par.scw.cloud
+        host: sse-config-basic-737899739397838738.s3.nl-ams.scw.cloud
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -1213,16 +1213,16 @@ interactions:
             Accept-Encoding:
                 - identity
             Amz-Sdk-Invocation-Id:
-                - 8ce5f20d-e046-4a7b-89c8-cded5092ce2f
+                - 06c0a382-7358-483b-ac6b-6c25dca3aec2
             Amz-Sdk-Request:
                 - attempt=1; max=3
             User-Agent:
-                - aws-sdk-go-v2/1.41.1 ua/2.1 os/macos lang/go#1.26.1 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.93.0 terraform-provider-scaleway/develop m/E,e
+                - aws-sdk-go-v2/1.41.7 ua/2.1 os/macos lang/go#1.26.3 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.97.3 terraform-provider-scaleway/develop m/E,e
             X-Amz-Content-Sha256:
                 - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
             X-Amz-Date:
-                - 20260310T153044Z
-        url: https://sse-config-basic-5305686071073161344.s3.fr-par.scw.cloud/
+                - 20260513T140810Z
+        url: https://sse-config-basic-737899739397838738.s3.nl-ams.scw.cloud/
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1235,11 +1235,11 @@ interactions:
         body: ""
         headers:
             Date:
-                - Tue, 10 Mar 2026 15:30:44 GMT
+                - Wed, 13 May 2026 14:08:10 GMT
             X-Amz-Id-2:
-                - txgc2dd7f6ea2884deebcef-0069b03924
+                - txg851fce9488fb40a0b33d-006a0485ca
             X-Amz-Request-Id:
-                - txgc2dd7f6ea2884deebcef-0069b03924
+                - txg851fce9488fb40a0b33d-006a0485ca
         status: 204 No Content
         code: 204
-        duration: 295.591542ms
+        duration: 317.85775ms


### PR DESCRIPTION
Add optional field `region` to the `scaleway_object_bucket_server_side_encryption_configuration` resource.