### PR TITLE
feat(container): display a warning when container status is not ready

### DIFF
--- a/docs/resources/container.md
+++ b/docs/resources/container.md
@@ -272,7 +272,7 @@ The following arguments are supported:
 
 - `command` - (Optional) Command executed when the container starts. This overrides the default command defined in the container image. This is usually the main executable, or entry point script to run.
 
-- `args` - (Optional) Arguments passed to the command specified in the "command" field. These override the default arguments from the container image, and behave like command-line parameters.
+- `args` - (Optional) Arguments passed to the command specified in the `command` field. These override the default arguments from the container image, and behave like command-line parameters.
 
 - `private_network_id` (Optional) The ID of the Private Network the container is connected to.
 
@@ -288,9 +288,7 @@ The `scaleway_container` resource exports certain attributes once the Container 
 
 - `region` - (Defaults to [provider](../index.md#arguments-reference) `region`) The [region](../guides/regions_and_zones.md#regions) in which the container was created.
 
-- `status` - The container status.
-
-- `cron_status` - The cron status of the container.
+- `status` - The container status. In case the status is different from `ready`, a warning will be displayed when Terraform reads the resource.
 
 - `error_message` - The error message of the container.
 

--- a/internal/services/container/container.go
+++ b/internal/services/container/container.go
@@ -2,8 +2,10 @@ package container
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -341,6 +343,7 @@ func containerSchema() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Description: "The cron status",
 			Computed:    true,
+			Deprecated:  "Please refer to the scaleway_container_trigger resource instead.",
 		},
 		"error_message": {
 			Type:        schema.TypeString,
@@ -460,7 +463,6 @@ func ResourceContainerRead(ctx context.Context, d *schema.ResourceData, m any) d
 	_ = d.Set("public_endpoint", co.PublicEndpoint)
 	_ = d.Set("domain_name", strings.TrimPrefix(co.PublicEndpoint, "https://"))
 	_ = d.Set("protocol", co.Protocol.String())
-	_ = d.Set("cron_status", co.Status.String())
 	_ = d.Set("port", int(co.Port))
 	_ = d.Set("https_connections_only", co.HTTPSConnectionsOnly)
 
@@ -487,6 +489,20 @@ func ResourceContainerRead(ctx context.Context, d *schema.ResourceData, m any) d
 		_ = d.Set("private_network_id", regional.NewID(region, types.FlattenStringPtr(co.PrivateNetworkID).(string)).String())
 	} else {
 		_ = d.Set("private_network_id", nil)
+	}
+
+	if co.Status != container.ContainerStatusReady {
+		statusWarning := diag.Diagnostic{
+			Severity:      diag.Warning,
+			Summary:       fmt.Sprintf("Container is not ready, but has status %q", co.Status.String()),
+			AttributePath: cty.GetAttrPath("status"),
+		}
+
+		if co.ErrorMessage != nil {
+			statusWarning.Detail = fmt.Sprintf("Container error message: %q", *co.ErrorMessage)
+		}
+
+		return diag.Diagnostics{statusWarning}
 	}
 
 	return nil

--- a/templates/resources/container.md.tmpl
+++ b/templates/resources/container.md.tmpl
@@ -130,7 +130,7 @@ The following arguments are supported:
 
 - `command` - (Optional) Command executed when the container starts. This overrides the default command defined in the container image. This is usually the main executable, or entry point script to run.
 
-- `args` - (Optional) Arguments passed to the command specified in the "command" field. These override the default arguments from the container image, and behave like command-line parameters.
+- `args` - (Optional) Arguments passed to the command specified in the `command` field. These override the default arguments from the container image, and behave like command-line parameters.
 
 - `private_network_id` (Optional) The ID of the Private Network the container is connected to.
 
@@ -146,9 +146,7 @@ The `scaleway_container` resource exports certain attributes once the Container 
 
 - `region` - (Defaults to [provider](../index.md#arguments-reference) `region`) The [region](../guides/regions_and_zones.md#regions) in which the container was created.
 
-- `status` - The container status.
-
-- `cron_status` - The cron status of the container.
+- `status` - The container status. In case the status is different from `ready`, a warning will be displayed when Terraform reads the resource.
 
 - `error_message` - The error message of the container.
 


### PR DESCRIPTION
This PR adds a warning when Terraform reads the container resource and its status is not `ready`.

This operation is quite frequent, so we've figured a warning would be more appropriate, as to not disturb existing workflows too much.

It also removes the `cron_status` attribute from the doc and the Read as it is not present in the container resource anymore.

Closes #3838 