### PR TITLE
chore(iam): rename test applications to prevent conflict

### DIFF
--- a/internal/services/iam/api_key_data_source_test.go
+++ b/internal/services/iam/api_key_data_source_test.go
@@ -20,7 +20,7 @@ func TestAccDataSourceApiKey_Basic(t *testing.T) {
 			{
 				Config: `
 						resource "scaleway_iam_application" "main" {
-							name = "tf_tests_app_key_basic"
+							name = "tf_tests_app_key_ds_basic"
 						}
 
 						resource "scaleway_iam_api_key" "main" {

--- a/internal/services/iam/api_key_list_test.go
+++ b/internal/services/iam/api_key_list_test.go
@@ -26,7 +26,7 @@ func TestAccListIAMAPIKeys_Basic(t *testing.T) {
 			{
 				Config: `
 					resource "scaleway_iam_application" "main" {
-						name = "tf_tests_app_key_basic"
+						name = "tf_tests_app_key_list_basic"
 					}
 
 					resource "scaleway_iam_api_key" "key1" {
@@ -38,7 +38,7 @@ func TestAccListIAMAPIKeys_Basic(t *testing.T) {
 			{
 				Config: `
 					resource "scaleway_iam_application" "main" {
-						name = "tf_tests_app_key_basic"
+						name = "tf_tests_app_key_list_basic"
 					}
 
 					resource "scaleway_iam_api_key" "key1" {

--- a/internal/services/iam/testdata/data-source-api-key-basic.cassette.yaml
+++ b/internal/services/iam/testdata/data-source-api-key-basic.cassette.yaml
@@ -6,9 +6,9 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 117
+        content_length: 120
         host: api.scaleway.com
-        body: '{"name":"tf_tests_app_key_basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","description":"","tags":[]}'
+        body: '{"name":"tf_tests_app_key_ds_basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","description":"","tags":[]}'
         headers:
             Content-Type:
                 - application/json
@@ -20,22 +20,22 @@ interactions:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 322
-        body: '{"id":"86e7fce9-f78a-497a-b063-403486feec17", "name":"tf_tests_app_key_basic", "description":"", "created_at":"2026-06-10T16:09:50.635787Z", "updated_at":"2026-06-10T16:09:50.635787Z", "organization_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "nb_api_keys":0, "tags":[]}'
+        content_length: 325
+        body: '{"id":"43a211a4-5ffb-4c01-896b-e28cc8a8ce09", "name":"tf_tests_app_key_ds_basic", "description":"", "created_at":"2026-06-16T09:31:50.085429Z", "updated_at":"2026-06-16T09:31:50.085429Z", "organization_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "nb_api_keys":0, "tags":[]}'
         headers:
             Content-Length:
-                - "322"
+                - "325"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 10 Jun 2026 16:09:50 GMT
+                - Tue, 16 Jun 2026 09:31:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 51886dee-0dd4-432d-b543-79ca7a68dd75
+                - e2737af4-3941-4a68-bf8c-e1de2efabb29
         status: 200 OK
         code: 200
-        duration: 386.267645ms
+        duration: 276.14927ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -46,28 +46,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/iam/v1alpha1/applications/86e7fce9-f78a-497a-b063-403486feec17
+        url: https://api.scaleway.com/iam/v1alpha1/applications/43a211a4-5ffb-4c01-896b-e28cc8a8ce09
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 322
-        body: '{"id":"86e7fce9-f78a-497a-b063-403486feec17", "name":"tf_tests_app_key_basic", "description":"", "created_at":"2026-06-10T16:09:50.635787Z", "updated_at":"2026-06-10T16:09:50.635787Z", "organization_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "nb_api_keys":0, "tags":[]}'
+        content_length: 325
+        body: '{"id":"43a211a4-5ffb-4c01-896b-e28cc8a8ce09", "name":"tf_tests_app_key_ds_basic", "description":"", "created_at":"2026-06-16T09:31:50.085429Z", "updated_at":"2026-06-16T09:31:50.085429Z", "organization_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "nb_api_keys":0, "tags":[]}'
         headers:
             Content-Length:
-                - "322"
+                - "325"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 10 Jun 2026 16:09:52 GMT
+                - Tue, 16 Jun 2026 09:31:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 19e0697e-973d-420e-a835-2c2a21d8c084
+                - 6a4fddb3-4d9d-491d-aa3c-c0d4ae16ed36
         status: 200 OK
         code: 200
-        duration: 1.477913168s
+        duration: 142.453456ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -75,7 +75,7 @@ interactions:
         proto_minor: 1
         content_length: 99
         host: api.scaleway.com
-        body: '{"application_id":"86e7fce9-f78a-497a-b063-403486feec17","description":"tf_tests_with_application"}'
+        body: '{"application_id":"43a211a4-5ffb-4c01-896b-e28cc8a8ce09","description":"tf_tests_with_application"}'
         headers:
             Content-Type:
                 - application/json
@@ -87,22 +87,22 @@ interactions:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 442
-        body: '{"access_key":"SCW8BR3W44EADPT17BPR", "secret_key":"11111111-1111-1111-1111-111111111111", "description":"tf_tests_with_application", "created_at":"2026-06-10T16:09:52.378175Z", "updated_at":"2026-06-10T16:09:52.378175Z", "expires_at":null, "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"88.189.216.157", "application_id":"86e7fce9-f78a-497a-b063-403486feec17"}'
+        content_length: 441
+        body: '{"access_key":"SCWBD8PX72VTEVB5AMQE", "secret_key":"11111111-1111-1111-1111-111111111111", "description":"tf_tests_with_application", "created_at":"2026-06-16T09:31:50.577650Z", "updated_at":"2026-06-16T09:31:50.577650Z", "expires_at":null, "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"51.159.46.153", "application_id":"43a211a4-5ffb-4c01-896b-e28cc8a8ce09"}'
         headers:
             Content-Length:
-                - "442"
+                - "441"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 10 Jun 2026 16:09:52 GMT
+                - Tue, 16 Jun 2026 09:31:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - f8be84d3-9d2d-4ec8-9fdd-e19c769c2340
+                - 7f90bb1d-1778-46a8-a505-4a96b28036a3
         status: 200 OK
         code: 200
-        duration: 252.165096ms
+        duration: 406.704751ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -119,22 +119,22 @@ interactions:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 408
-        body: '{"access_key":"SCW8BR3W44EADPT17BPR", "secret_key":null, "description":"tf_tests_with_application", "created_at":"2026-06-10T16:09:52.378175Z", "updated_at":"2026-06-10T16:09:52.378175Z", "expires_at":null, "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"88.189.216.157", "application_id":"86e7fce9-f78a-497a-b063-403486feec17"}'
+        content_length: 407
+        body: '{"access_key":"SCWBD8PX72VTEVB5AMQE", "secret_key":null, "description":"tf_tests_with_application", "created_at":"2026-06-16T09:31:50.577650Z", "updated_at":"2026-06-16T09:31:50.577650Z", "expires_at":null, "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"51.159.46.153", "application_id":"43a211a4-5ffb-4c01-896b-e28cc8a8ce09"}'
         headers:
             Content-Length:
-                - "408"
+                - "407"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 10 Jun 2026 16:09:52 GMT
+                - Tue, 16 Jun 2026 09:31:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 9a0c166c-9fde-4ddf-80e0-dad212f90740
+                - d4c1d06d-d2c2-4ef0-97cd-19a459780b49
         status: 200 OK
         code: 200
-        duration: 213.901362ms
+        duration: 263.836093ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -151,22 +151,22 @@ interactions:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 408
-        body: '{"access_key":"SCW8BR3W44EADPT17BPR", "secret_key":null, "description":"tf_tests_with_application", "created_at":"2026-06-10T16:09:52.378175Z", "updated_at":"2026-06-10T16:09:52.378175Z", "expires_at":null, "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"88.189.216.157", "application_id":"86e7fce9-f78a-497a-b063-403486feec17"}'
+        content_length: 407
+        body: '{"access_key":"SCWBD8PX72VTEVB5AMQE", "secret_key":null, "description":"tf_tests_with_application", "created_at":"2026-06-16T09:31:50.577650Z", "updated_at":"2026-06-16T09:31:50.577650Z", "expires_at":null, "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"51.159.46.153", "application_id":"43a211a4-5ffb-4c01-896b-e28cc8a8ce09"}'
         headers:
             Content-Length:
-                - "408"
+                - "407"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 10 Jun 2026 16:09:52 GMT
+                - Tue, 16 Jun 2026 09:31:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 7c01ffad-eb8b-44f3-806f-a4a8204fca2f
+                - d5208f14-ccc2-4cba-91cc-ca25e27d0896
         status: 200 OK
         code: 200
-        duration: 202.301865ms
+        duration: 199.920618ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -183,22 +183,22 @@ interactions:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 408
-        body: '{"access_key":"SCW8BR3W44EADPT17BPR", "secret_key":null, "description":"tf_tests_with_application", "created_at":"2026-06-10T16:09:52.378175Z", "updated_at":"2026-06-10T16:09:52.378175Z", "expires_at":null, "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"88.189.216.157", "application_id":"86e7fce9-f78a-497a-b063-403486feec17"}'
+        content_length: 407
+        body: '{"access_key":"SCWBD8PX72VTEVB5AMQE", "secret_key":null, "description":"tf_tests_with_application", "created_at":"2026-06-16T09:31:50.577650Z", "updated_at":"2026-06-16T09:31:50.577650Z", "expires_at":null, "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"51.159.46.153", "application_id":"43a211a4-5ffb-4c01-896b-e28cc8a8ce09"}'
         headers:
             Content-Length:
-                - "408"
+                - "407"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 10 Jun 2026 16:09:53 GMT
+                - Tue, 16 Jun 2026 09:31:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - d0a47db7-f635-4ddb-a4f9-d052452b1021
+                - 85ff0b45-cd15-49b7-b845-98e0d42bcbdc
         status: 200 OK
         code: 200
-        duration: 190.888007ms
+        duration: 294.565739ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -215,22 +215,22 @@ interactions:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 408
-        body: '{"access_key":"SCW8BR3W44EADPT17BPR", "secret_key":null, "description":"tf_tests_with_application", "created_at":"2026-06-10T16:09:52.378175Z", "updated_at":"2026-06-10T16:09:52.378175Z", "expires_at":null, "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"88.189.216.157", "application_id":"86e7fce9-f78a-497a-b063-403486feec17"}'
+        content_length: 407
+        body: '{"access_key":"SCWBD8PX72VTEVB5AMQE", "secret_key":null, "description":"tf_tests_with_application", "created_at":"2026-06-16T09:31:50.577650Z", "updated_at":"2026-06-16T09:31:50.577650Z", "expires_at":null, "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"51.159.46.153", "application_id":"43a211a4-5ffb-4c01-896b-e28cc8a8ce09"}'
         headers:
             Content-Length:
-                - "408"
+                - "407"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 10 Jun 2026 16:09:53 GMT
+                - Tue, 16 Jun 2026 09:31:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - bbaf6308-5bcb-46c7-8445-7d929ee551cc
+                - 1569f5b8-e51e-4160-aae8-dcbeeb44ee97
         status: 200 OK
         code: 200
-        duration: 52.887915ms
+        duration: 284.376842ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -241,28 +241,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/iam/v1alpha1/applications/86e7fce9-f78a-497a-b063-403486feec17
+        url: https://api.scaleway.com/iam/v1alpha1/applications/43a211a4-5ffb-4c01-896b-e28cc8a8ce09
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 322
-        body: '{"id":"86e7fce9-f78a-497a-b063-403486feec17", "name":"tf_tests_app_key_basic", "description":"", "created_at":"2026-06-10T16:09:50.635787Z", "updated_at":"2026-06-10T16:09:50.635787Z", "organization_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "nb_api_keys":1, "tags":[]}'
+        content_length: 325
+        body: '{"id":"43a211a4-5ffb-4c01-896b-e28cc8a8ce09", "name":"tf_tests_app_key_ds_basic", "description":"", "created_at":"2026-06-16T09:31:50.085429Z", "updated_at":"2026-06-16T09:31:50.085429Z", "organization_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "nb_api_keys":1, "tags":[]}'
         headers:
             Content-Length:
-                - "322"
+                - "325"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 10 Jun 2026 16:09:53 GMT
+                - Tue, 16 Jun 2026 09:31:52 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 179061de-cd9c-4e2f-83a1-bbb7ded2462d
+                - 25f27d58-4b1d-4001-83a6-5e4f638594ee
         status: 200 OK
         code: 200
-        duration: 44.940916ms
+        duration: 154.892549ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -279,22 +279,22 @@ interactions:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 408
-        body: '{"access_key":"SCW8BR3W44EADPT17BPR", "secret_key":null, "description":"tf_tests_with_application", "created_at":"2026-06-10T16:09:52.378175Z", "updated_at":"2026-06-10T16:09:52.378175Z", "expires_at":null, "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"88.189.216.157", "application_id":"86e7fce9-f78a-497a-b063-403486feec17"}'
+        content_length: 407
+        body: '{"access_key":"SCWBD8PX72VTEVB5AMQE", "secret_key":null, "description":"tf_tests_with_application", "created_at":"2026-06-16T09:31:50.577650Z", "updated_at":"2026-06-16T09:31:50.577650Z", "expires_at":null, "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"51.159.46.153", "application_id":"43a211a4-5ffb-4c01-896b-e28cc8a8ce09"}'
         headers:
             Content-Length:
-                - "408"
+                - "407"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 10 Jun 2026 16:09:53 GMT
+                - Tue, 16 Jun 2026 09:31:52 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - f0718c96-f2dc-4d0c-868b-7b33652ba770
+                - c9b3dc14-2088-4794-9f6a-8278cb05c67b
         status: 200 OK
         code: 200
-        duration: 175.558376ms
+        duration: 229.651492ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -311,22 +311,22 @@ interactions:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 408
-        body: '{"access_key":"SCW8BR3W44EADPT17BPR", "secret_key":null, "description":"tf_tests_with_application", "created_at":"2026-06-10T16:09:52.378175Z", "updated_at":"2026-06-10T16:09:52.378175Z", "expires_at":null, "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"88.189.216.157", "application_id":"86e7fce9-f78a-497a-b063-403486feec17"}'
+        content_length: 407
+        body: '{"access_key":"SCWBD8PX72VTEVB5AMQE", "secret_key":null, "description":"tf_tests_with_application", "created_at":"2026-06-16T09:31:50.577650Z", "updated_at":"2026-06-16T09:31:50.577650Z", "expires_at":null, "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"51.159.46.153", "application_id":"43a211a4-5ffb-4c01-896b-e28cc8a8ce09"}'
         headers:
             Content-Length:
-                - "408"
+                - "407"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 10 Jun 2026 16:09:53 GMT
+                - Tue, 16 Jun 2026 09:31:52 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 0c1ac2c9-135f-4b11-9a32-1317f14387f7
+                - 3edb85eb-7dd9-4a17-bf7e-7be4e2a6c51f
         status: 200 OK
         code: 200
-        duration: 46.943794ms
+        duration: 204.232658ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -349,14 +349,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 10 Jun 2026 16:09:54 GMT
+                - Tue, 16 Jun 2026 09:31:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - c6ea6cdb-6ad2-45c9-bf66-12083ccb6bac
+                - fae143b4-4047-43aa-950a-80f43b790bda
         status: 204 No Content
         code: 204
-        duration: 206.358552ms
+        duration: 198.740914ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -367,7 +367,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/iam/v1alpha1/applications/86e7fce9-f78a-497a-b063-403486feec17
+        url: https://api.scaleway.com/iam/v1alpha1/applications/43a211a4-5ffb-4c01-896b-e28cc8a8ce09
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -379,14 +379,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 10 Jun 2026 16:09:54 GMT
+                - Tue, 16 Jun 2026 09:31:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - 2b3042e1-d97e-4c01-8c3e-7a25d496a1ce
+                - 14c6723d-74a7-4f2a-8d4d-a4110821422f
         status: 204 No Content
         code: 204
-        duration: 176.06978ms
+        duration: 104.551946ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -404,21 +404,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 115
-        body: '{"message":"resource is not found","resource":"access_key","resource_id":"SCW8BR3W44EADPT17BPR","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"access_key","resource_id":"SCWBD8PX72VTEVB5AMQE","type":"not_found"}'
         headers:
             Content-Length:
                 - "115"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 10 Jun 2026 16:09:54 GMT
+                - Tue, 16 Jun 2026 09:31:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - f874c350-c3eb-4747-b57d-276de242fc6e
+                - 08975d90-a083-4eaf-92e0-f87f41cea2eb
         status: 404 Not Found
         code: 404
-        duration: 37.788798ms
+        duration: 36.15393ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -436,18 +436,18 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 115
-        body: '{"message":"resource is not found","resource":"access_key","resource_id":"SCW8BR3W44EADPT17BPR","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"access_key","resource_id":"SCWBD8PX72VTEVB5AMQE","type":"not_found"}'
         headers:
             Content-Length:
                 - "115"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 10 Jun 2026 16:09:54 GMT
+                - Tue, 16 Jun 2026 09:31:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             X-Request-Id:
-                - bfab70ef-fa9e-4dc4-a0a1-9ba591808597
+                - 1afacd43-61a8-4014-85be-a770cd1912e2
         status: 404 Not Found
         code: 404
-        duration: 34.494114ms
+        duration: 37.241607ms

--- a/internal/services/iam/testdata/list-iamapi-keys-basic.cassette.yaml
+++ b/internal/services/iam/testdata/list-iamapi-keys-basic.cassette.yaml
@@ -6,9 +6,9 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 117
+        content_length: 122
         host: api.scaleway.com
-        body: '{"name":"tf_tests_app_key_basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","description":"","tags":[]}'
+        body: '{"name":"tf_tests_app_key_list_basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","description":"","tags":[]}'
         headers:
             Content-Type:
                 - application/json
@@ -20,22 +20,22 @@ interactions:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 322
-        body: '{"id":"a437515e-8295-4fcd-8fa0-f379d9400e35", "name":"tf_tests_app_key_basic", "description":"", "created_at":"2026-06-11T14:12:30.220938Z", "updated_at":"2026-06-11T14:12:30.220938Z", "organization_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "nb_api_keys":0, "tags":[]}'
+        content_length: 327
+        body: '{"id":"a94c31ce-e268-4f19-a5d5-5f5075c46d9b", "name":"tf_tests_app_key_list_basic", "description":"", "created_at":"2026-06-16T09:32:00.768480Z", "updated_at":"2026-06-16T09:32:00.768480Z", "organization_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "nb_api_keys":0, "tags":[]}'
         headers:
             Content-Length:
-                - "322"
+                - "327"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 11 Jun 2026 14:12:30 GMT
+                - Tue, 16 Jun 2026 09:32:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             X-Request-Id:
-                - 6ac2f14c-2d08-4c1f-8a04-ec5ed99f7e0c
+                - c66f02d7-1e12-4ebc-98ce-3fe4f82e6ae7
         status: 200 OK
         code: 200
-        duration: 233.166973ms
+        duration: 241.501442ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -46,28 +46,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/iam/v1alpha1/applications/a437515e-8295-4fcd-8fa0-f379d9400e35
+        url: https://api.scaleway.com/iam/v1alpha1/applications/a94c31ce-e268-4f19-a5d5-5f5075c46d9b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 322
-        body: '{"id":"a437515e-8295-4fcd-8fa0-f379d9400e35", "name":"tf_tests_app_key_basic", "description":"", "created_at":"2026-06-11T14:12:30.220938Z", "updated_at":"2026-06-11T14:12:30.220938Z", "organization_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "nb_api_keys":0, "tags":[]}'
+        content_length: 327
+        body: '{"id":"a94c31ce-e268-4f19-a5d5-5f5075c46d9b", "name":"tf_tests_app_key_list_basic", "description":"", "created_at":"2026-06-16T09:32:00.768480Z", "updated_at":"2026-06-16T09:32:00.768480Z", "organization_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "nb_api_keys":0, "tags":[]}'
         headers:
             Content-Length:
-                - "322"
+                - "327"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 11 Jun 2026 14:12:30 GMT
+                - Tue, 16 Jun 2026 09:32:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             X-Request-Id:
-                - 16e4e193-5a5d-4cec-a917-a20dbf59e024
+                - 8605fd86-4814-4795-b119-110dccd2b761
         status: 200 OK
         code: 200
-        duration: 137.907502ms
+        duration: 43.738692ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -75,7 +75,7 @@ interactions:
         proto_minor: 1
         content_length: 93
         host: api.scaleway.com
-        body: '{"application_id":"a437515e-8295-4fcd-8fa0-f379d9400e35","description":"test-api-key-list-1"}'
+        body: '{"application_id":"a94c31ce-e268-4f19-a5d5-5f5075c46d9b","description":"test-api-key-list-1"}'
         headers:
             Content-Type:
                 - application/json
@@ -87,22 +87,22 @@ interactions:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 436
-        body: '{"access_key":"SCWM89BTFYCN0YDNQRJV", "secret_key":"11111111-1111-1111-1111-111111111111", "description":"test-api-key-list-1", "created_at":"2026-06-11T14:12:30.719319Z", "updated_at":"2026-06-11T14:12:30.719319Z", "expires_at":null, "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"88.189.216.157", "application_id":"a437515e-8295-4fcd-8fa0-f379d9400e35"}'
+        content_length: 435
+        body: '{"access_key":"SCWBN9HR9AA2PZHPSSNV", "secret_key":"11111111-1111-1111-1111-111111111111", "description":"test-api-key-list-1", "created_at":"2026-06-16T09:32:01.136614Z", "updated_at":"2026-06-16T09:32:01.136614Z", "expires_at":null, "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"51.159.46.153", "application_id":"a94c31ce-e268-4f19-a5d5-5f5075c46d9b"}'
         headers:
             Content-Length:
-                - "436"
+                - "435"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 11 Jun 2026 14:12:30 GMT
+                - Tue, 16 Jun 2026 09:32:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             X-Request-Id:
-                - ec6d4b43-62b8-43b9-bd41-99016dc4285f
+                - be7c8193-0fcb-469b-8339-54c5f0be2357
         status: 200 OK
         code: 200
-        duration: 358.230952ms
+        duration: 313.168424ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -119,22 +119,22 @@ interactions:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 402
-        body: '{"access_key":"SCWM89BTFYCN0YDNQRJV", "secret_key":null, "description":"test-api-key-list-1", "created_at":"2026-06-11T14:12:30.719319Z", "updated_at":"2026-06-11T14:12:30.719319Z", "expires_at":null, "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"88.189.216.157", "application_id":"a437515e-8295-4fcd-8fa0-f379d9400e35"}'
+        content_length: 401
+        body: '{"access_key":"SCWBN9HR9AA2PZHPSSNV", "secret_key":null, "description":"test-api-key-list-1", "created_at":"2026-06-16T09:32:01.136614Z", "updated_at":"2026-06-16T09:32:01.136614Z", "expires_at":null, "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"51.159.46.153", "application_id":"a94c31ce-e268-4f19-a5d5-5f5075c46d9b"}'
         headers:
             Content-Length:
-                - "402"
+                - "401"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 11 Jun 2026 14:12:30 GMT
+                - Tue, 16 Jun 2026 09:32:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             X-Request-Id:
-                - 9bfbf1d2-420e-4fb5-8b9f-4348dc1d500b
+                - 4c4015ad-dd90-4290-b631-19943df8ce98
         status: 200 OK
         code: 200
-        duration: 202.329847ms
+        duration: 321.29185ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -145,28 +145,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/iam/v1alpha1/applications/a437515e-8295-4fcd-8fa0-f379d9400e35
+        url: https://api.scaleway.com/iam/v1alpha1/applications/a94c31ce-e268-4f19-a5d5-5f5075c46d9b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 322
-        body: '{"id":"a437515e-8295-4fcd-8fa0-f379d9400e35", "name":"tf_tests_app_key_basic", "description":"", "created_at":"2026-06-11T14:12:30.220938Z", "updated_at":"2026-06-11T14:12:30.220938Z", "organization_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "nb_api_keys":1, "tags":[]}'
+        content_length: 327
+        body: '{"id":"a94c31ce-e268-4f19-a5d5-5f5075c46d9b", "name":"tf_tests_app_key_list_basic", "description":"", "created_at":"2026-06-16T09:32:00.768480Z", "updated_at":"2026-06-16T09:32:00.768480Z", "organization_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "nb_api_keys":1, "tags":[]}'
         headers:
             Content-Length:
-                - "322"
+                - "327"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 11 Jun 2026 14:12:31 GMT
+                - Tue, 16 Jun 2026 09:32:01 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             X-Request-Id:
-                - 59b8ceb0-931d-4e8e-b199-d7437835a9fb
+                - d714b5ae-c456-4e01-a66e-3bf19c7d95ec
         status: 200 OK
         code: 200
-        duration: 105.979149ms
+        duration: 123.362384ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -183,22 +183,22 @@ interactions:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 402
-        body: '{"access_key":"SCWM89BTFYCN0YDNQRJV", "secret_key":null, "description":"test-api-key-list-1", "created_at":"2026-06-11T14:12:30.719319Z", "updated_at":"2026-06-11T14:12:30.719319Z", "expires_at":null, "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"88.189.216.157", "application_id":"a437515e-8295-4fcd-8fa0-f379d9400e35"}'
+        content_length: 401
+        body: '{"access_key":"SCWBN9HR9AA2PZHPSSNV", "secret_key":null, "description":"test-api-key-list-1", "created_at":"2026-06-16T09:32:01.136614Z", "updated_at":"2026-06-16T09:32:01.136614Z", "expires_at":null, "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"51.159.46.153", "application_id":"a94c31ce-e268-4f19-a5d5-5f5075c46d9b"}'
         headers:
             Content-Length:
-                - "402"
+                - "401"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 11 Jun 2026 14:12:31 GMT
+                - Tue, 16 Jun 2026 09:32:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             X-Request-Id:
-                - fd505fe7-d957-4658-a13e-b396c98a74b4
+                - d2c26098-59bc-442c-bea2-c71d37de0074
         status: 200 OK
         code: 200
-        duration: 203.088413ms
+        duration: 225.595691ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -209,28 +209,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/iam/v1alpha1/applications/a437515e-8295-4fcd-8fa0-f379d9400e35
+        url: https://api.scaleway.com/iam/v1alpha1/applications/a94c31ce-e268-4f19-a5d5-5f5075c46d9b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 322
-        body: '{"id":"a437515e-8295-4fcd-8fa0-f379d9400e35", "name":"tf_tests_app_key_basic", "description":"", "created_at":"2026-06-11T14:12:30.220938Z", "updated_at":"2026-06-11T14:12:30.220938Z", "organization_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "nb_api_keys":1, "tags":[]}'
+        content_length: 327
+        body: '{"id":"a94c31ce-e268-4f19-a5d5-5f5075c46d9b", "name":"tf_tests_app_key_list_basic", "description":"", "created_at":"2026-06-16T09:32:00.768480Z", "updated_at":"2026-06-16T09:32:00.768480Z", "organization_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "nb_api_keys":1, "tags":[]}'
         headers:
             Content-Length:
-                - "322"
+                - "327"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 11 Jun 2026 14:12:31 GMT
+                - Tue, 16 Jun 2026 09:32:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             X-Request-Id:
-                - 86a2c459-97b9-466b-9292-e3257e559703
+                - 43e08232-b029-4f37-9cbe-bf9e91d83442
         status: 200 OK
         code: 200
-        duration: 117.847181ms
+        duration: 83.917058ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -247,22 +247,22 @@ interactions:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 402
-        body: '{"access_key":"SCWM89BTFYCN0YDNQRJV", "secret_key":null, "description":"test-api-key-list-1", "created_at":"2026-06-11T14:12:30.719319Z", "updated_at":"2026-06-11T14:12:30.719319Z", "expires_at":null, "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"88.189.216.157", "application_id":"a437515e-8295-4fcd-8fa0-f379d9400e35"}'
+        content_length: 401
+        body: '{"access_key":"SCWBN9HR9AA2PZHPSSNV", "secret_key":null, "description":"test-api-key-list-1", "created_at":"2026-06-16T09:32:01.136614Z", "updated_at":"2026-06-16T09:32:01.136614Z", "expires_at":null, "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"51.159.46.153", "application_id":"a94c31ce-e268-4f19-a5d5-5f5075c46d9b"}'
         headers:
             Content-Length:
-                - "402"
+                - "401"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 11 Jun 2026 14:12:32 GMT
+                - Tue, 16 Jun 2026 09:32:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             X-Request-Id:
-                - 14a6c2c3-a7c6-49e6-b6dc-100bc174b12d
+                - d70a17c3-dd89-46ed-a3a4-48c3ac24f739
         status: 200 OK
         code: 200
-        duration: 231.404939ms
+        duration: 60.023475ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -273,28 +273,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/iam/v1alpha1/applications/a437515e-8295-4fcd-8fa0-f379d9400e35
+        url: https://api.scaleway.com/iam/v1alpha1/applications/a94c31ce-e268-4f19-a5d5-5f5075c46d9b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 322
-        body: '{"id":"a437515e-8295-4fcd-8fa0-f379d9400e35", "name":"tf_tests_app_key_basic", "description":"", "created_at":"2026-06-11T14:12:30.220938Z", "updated_at":"2026-06-11T14:12:30.220938Z", "organization_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "nb_api_keys":1, "tags":[]}'
+        content_length: 327
+        body: '{"id":"a94c31ce-e268-4f19-a5d5-5f5075c46d9b", "name":"tf_tests_app_key_list_basic", "description":"", "created_at":"2026-06-16T09:32:00.768480Z", "updated_at":"2026-06-16T09:32:00.768480Z", "organization_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "nb_api_keys":1, "tags":[]}'
         headers:
             Content-Length:
-                - "322"
+                - "327"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 11 Jun 2026 14:12:32 GMT
+                - Tue, 16 Jun 2026 09:32:02 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             X-Request-Id:
-                - c060a544-846d-400a-82e4-dae74efc80be
+                - 45754e4f-faf1-4e37-82ce-a2da69c011a6
         status: 200 OK
         code: 200
-        duration: 103.071479ms
+        duration: 60.494953ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -311,22 +311,22 @@ interactions:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 402
-        body: '{"access_key":"SCWM89BTFYCN0YDNQRJV", "secret_key":null, "description":"test-api-key-list-1", "created_at":"2026-06-11T14:12:30.719319Z", "updated_at":"2026-06-11T14:12:30.719319Z", "expires_at":null, "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"88.189.216.157", "application_id":"a437515e-8295-4fcd-8fa0-f379d9400e35"}'
+        content_length: 401
+        body: '{"access_key":"SCWBN9HR9AA2PZHPSSNV", "secret_key":null, "description":"test-api-key-list-1", "created_at":"2026-06-16T09:32:01.136614Z", "updated_at":"2026-06-16T09:32:01.136614Z", "expires_at":null, "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"51.159.46.153", "application_id":"a94c31ce-e268-4f19-a5d5-5f5075c46d9b"}'
         headers:
             Content-Length:
-                - "402"
+                - "401"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 11 Jun 2026 14:12:32 GMT
+                - Tue, 16 Jun 2026 09:32:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             X-Request-Id:
-                - b449666e-7e8a-4f2e-b75d-6b60dbb91809
+                - cf798487-eca3-48a3-bc79-a024966e973e
         status: 200 OK
         code: 200
-        duration: 209.75199ms
+        duration: 240.249666ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -352,22 +352,22 @@ interactions:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 2790
-        body: '{"api_keys":[{"access_key":"SCWY48KAJYQE3EHTVAG6", "secret_key":null, "description":"esoulard", "created_at":"2026-03-24T15:10:41.081963Z", "updated_at":"2026-03-24T15:10:41.081963Z", "expires_at":"2027-03-24T15:10:40.879Z", "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"51.159.73.9", "user_id":"0b8cc93b-dfd2-4427-b674-8d27affb0334"}, {"access_key":"SCWP7Z6GF21G5C6AHW8A", "secret_key":null, "description":"jremy", "created_at":"2026-03-26T14:38:12.000609Z", "updated_at":"2026-03-26T14:38:12.000609Z", "expires_at":null, "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"51.159.73.145", "user_id":"ee474852-1f90-4cc1-bad0-4a17998c51e7"}, {"access_key":"SCW9S2TRP4KTKS44DZWP", "secret_key":null, "description":"", "created_at":"2026-03-27T14:09:05.244013Z", "updated_at":"2026-03-27T14:09:05.244013Z", "expires_at":null, "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"51.159.46.153", "user_id":"ef29ce05-3f2b-4fa0-a259-d76110850d57"}, {"access_key":"SCW8QZ96TGKZNJ9Y5QBB", "secret_key":null, "description":"lmarabese", "created_at":"2026-04-20T13:06:45.099977Z", "updated_at":"2026-04-20T13:06:45.099977Z", "expires_at":"2027-04-20T13:06:44.943Z", "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"51.159.46.153", "user_id":"29c74dc1-87e7-4c49-91a1-0ad5540ecdd7"}, {"access_key":"SCWC7544PWQDZYCKFXR7", "secret_key":null, "description":"", "created_at":"2026-06-04T16:22:27.164337Z", "updated_at":"2026-06-04T16:22:27.164337Z", "expires_at":null, "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"51.159.73.145", "user_id":"88b4dde1-f3d4-478a-a281-784d53399a30"}, {"access_key":"SCWQJVJ5BWW1BN9G4VBM", "secret_key":null, "description":"Generated by the Scaleway CLI", "created_at":"2026-06-10T15:22:12.947124Z", "updated_at":"2026-06-10T15:22:12.947124Z", "expires_at":null, "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"88.189.216.157", "user_id":"0b8cc93b-dfd2-4427-b674-8d27affb0334"}, {"access_key":"SCWM89BTFYCN0YDNQRJV", "secret_key":null, "description":"test-api-key-list-1", "created_at":"2026-06-11T14:12:30.719319Z", "updated_at":"2026-06-11T14:12:30.719319Z", "expires_at":null, "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"88.189.216.157", "application_id":"a437515e-8295-4fcd-8fa0-f379d9400e35"}], "total_count":7}'
+        content_length: 3201
+        body: '{"api_keys":[{"access_key":"SCWY48KAJYQE3EHTVAG6", "secret_key":null, "description":"esoulard", "created_at":"2026-03-24T15:10:41.081963Z", "updated_at":"2026-03-24T15:10:41.081963Z", "expires_at":"2027-03-24T15:10:40.879Z", "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"51.159.73.9", "user_id":"0b8cc93b-dfd2-4427-b674-8d27affb0334"}, {"access_key":"SCWP7Z6GF21G5C6AHW8A", "secret_key":null, "description":"jremy", "created_at":"2026-03-26T14:38:12.000609Z", "updated_at":"2026-03-26T14:38:12.000609Z", "expires_at":null, "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"51.159.73.145", "user_id":"ee474852-1f90-4cc1-bad0-4a17998c51e7"}, {"access_key":"SCW9S2TRP4KTKS44DZWP", "secret_key":null, "description":"", "created_at":"2026-03-27T14:09:05.244013Z", "updated_at":"2026-03-27T14:09:05.244013Z", "expires_at":null, "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"51.159.46.153", "user_id":"ef29ce05-3f2b-4fa0-a259-d76110850d57"}, {"access_key":"SCW8QZ96TGKZNJ9Y5QBB", "secret_key":null, "description":"lmarabese", "created_at":"2026-04-20T13:06:45.099977Z", "updated_at":"2026-04-20T13:06:45.099977Z", "expires_at":"2027-04-20T13:06:44.943Z", "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"51.159.46.153", "user_id":"29c74dc1-87e7-4c49-91a1-0ad5540ecdd7"}, {"access_key":"SCWC7544PWQDZYCKFXR7", "secret_key":null, "description":"", "created_at":"2026-06-04T16:22:27.164337Z", "updated_at":"2026-06-04T16:22:27.164337Z", "expires_at":null, "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"51.159.73.145", "user_id":"88b4dde1-f3d4-478a-a281-784d53399a30"}, {"access_key":"SCWQJVJ5BWW1BN9G4VBM", "secret_key":null, "description":"Generated by the Scaleway CLI", "created_at":"2026-06-10T15:22:12.947124Z", "updated_at":"2026-06-10T15:22:12.947124Z", "expires_at":null, "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"88.189.216.157", "user_id":"0b8cc93b-dfd2-4427-b674-8d27affb0334"}, {"access_key":"SCW3DN63FVR6JT6W4H7X", "secret_key":null, "description":"API key for packer e2e testing", "created_at":"2026-06-15T16:03:37.273077Z", "updated_at":"2026-06-15T16:03:37.273077Z", "expires_at":null, "default_project_id":"60c2a82f-3d0c-45bf-8c69-62627e5abe4d", "editable":true, "deletable":true, "managed":false, "creation_ip":"51.159.73.9", "application_id":"166d33e7-63d7-48a0-96ec-f372a1c7f766"}, {"access_key":"SCWBN9HR9AA2PZHPSSNV", "secret_key":null, "description":"test-api-key-list-1", "created_at":"2026-06-16T09:32:01.136614Z", "updated_at":"2026-06-16T09:32:01.136614Z", "expires_at":null, "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"51.159.46.153", "application_id":"a94c31ce-e268-4f19-a5d5-5f5075c46d9b"}], "total_count":8}'
         headers:
             Content-Length:
-                - "2790"
+                - "3201"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 11 Jun 2026 14:12:33 GMT
+                - Tue, 16 Jun 2026 09:32:03 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             X-Request-Id:
-                - 7d507086-ad82-4201-aafc-71a46e34249d
+                - 700d13b6-2a2d-42ed-874b-59851cd0f19a
         status: 200 OK
         code: 200
-        duration: 376.029542ms
+        duration: 402.359792ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -395,22 +395,22 @@ interactions:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 434
-        body: '{"api_keys":[{"access_key":"SCWM89BTFYCN0YDNQRJV", "secret_key":null, "description":"test-api-key-list-1", "created_at":"2026-06-11T14:12:30.719319Z", "updated_at":"2026-06-11T14:12:30.719319Z", "expires_at":null, "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"88.189.216.157", "application_id":"a437515e-8295-4fcd-8fa0-f379d9400e35"}], "total_count":1}'
+        content_length: 433
+        body: '{"api_keys":[{"access_key":"SCWBN9HR9AA2PZHPSSNV", "secret_key":null, "description":"test-api-key-list-1", "created_at":"2026-06-16T09:32:01.136614Z", "updated_at":"2026-06-16T09:32:01.136614Z", "expires_at":null, "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"51.159.46.153", "application_id":"a94c31ce-e268-4f19-a5d5-5f5075c46d9b"}], "total_count":1}'
         headers:
             Content-Length:
-                - "434"
+                - "433"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 11 Jun 2026 14:12:33 GMT
+                - Tue, 16 Jun 2026 09:32:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             X-Request-Id:
-                - 77bff7c7-d061-4074-9937-cd2e3a71fa82
+                - eff91a2b-fc13-4ba7-a87b-c5d90cba0c65
         status: 200 OK
         code: 200
-        duration: 353.702143ms
+        duration: 452.222023ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -438,22 +438,22 @@ interactions:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 2790
-        body: '{"api_keys":[{"access_key":"SCWY48KAJYQE3EHTVAG6", "secret_key":null, "description":"esoulard", "created_at":"2026-03-24T15:10:41.081963Z", "updated_at":"2026-03-24T15:10:41.081963Z", "expires_at":"2027-03-24T15:10:40.879Z", "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"51.159.73.9", "user_id":"0b8cc93b-dfd2-4427-b674-8d27affb0334"}, {"access_key":"SCWP7Z6GF21G5C6AHW8A", "secret_key":null, "description":"jremy", "created_at":"2026-03-26T14:38:12.000609Z", "updated_at":"2026-03-26T14:38:12.000609Z", "expires_at":null, "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"51.159.73.145", "user_id":"ee474852-1f90-4cc1-bad0-4a17998c51e7"}, {"access_key":"SCW9S2TRP4KTKS44DZWP", "secret_key":null, "description":"", "created_at":"2026-03-27T14:09:05.244013Z", "updated_at":"2026-03-27T14:09:05.244013Z", "expires_at":null, "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"51.159.46.153", "user_id":"ef29ce05-3f2b-4fa0-a259-d76110850d57"}, {"access_key":"SCW8QZ96TGKZNJ9Y5QBB", "secret_key":null, "description":"lmarabese", "created_at":"2026-04-20T13:06:45.099977Z", "updated_at":"2026-04-20T13:06:45.099977Z", "expires_at":"2027-04-20T13:06:44.943Z", "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"51.159.46.153", "user_id":"29c74dc1-87e7-4c49-91a1-0ad5540ecdd7"}, {"access_key":"SCWC7544PWQDZYCKFXR7", "secret_key":null, "description":"", "created_at":"2026-06-04T16:22:27.164337Z", "updated_at":"2026-06-04T16:22:27.164337Z", "expires_at":null, "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"51.159.73.145", "user_id":"88b4dde1-f3d4-478a-a281-784d53399a30"}, {"access_key":"SCWQJVJ5BWW1BN9G4VBM", "secret_key":null, "description":"Generated by the Scaleway CLI", "created_at":"2026-06-10T15:22:12.947124Z", "updated_at":"2026-06-10T15:22:12.947124Z", "expires_at":null, "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"88.189.216.157", "user_id":"0b8cc93b-dfd2-4427-b674-8d27affb0334"}, {"access_key":"SCWM89BTFYCN0YDNQRJV", "secret_key":null, "description":"test-api-key-list-1", "created_at":"2026-06-11T14:12:30.719319Z", "updated_at":"2026-06-11T14:12:30.719319Z", "expires_at":null, "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"88.189.216.157", "application_id":"a437515e-8295-4fcd-8fa0-f379d9400e35"}], "total_count":7}'
+        content_length: 3201
+        body: '{"api_keys":[{"access_key":"SCWY48KAJYQE3EHTVAG6", "secret_key":null, "description":"esoulard", "created_at":"2026-03-24T15:10:41.081963Z", "updated_at":"2026-03-24T15:10:41.081963Z", "expires_at":"2027-03-24T15:10:40.879Z", "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"51.159.73.9", "user_id":"0b8cc93b-dfd2-4427-b674-8d27affb0334"}, {"access_key":"SCWP7Z6GF21G5C6AHW8A", "secret_key":null, "description":"jremy", "created_at":"2026-03-26T14:38:12.000609Z", "updated_at":"2026-03-26T14:38:12.000609Z", "expires_at":null, "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"51.159.73.145", "user_id":"ee474852-1f90-4cc1-bad0-4a17998c51e7"}, {"access_key":"SCW9S2TRP4KTKS44DZWP", "secret_key":null, "description":"", "created_at":"2026-03-27T14:09:05.244013Z", "updated_at":"2026-03-27T14:09:05.244013Z", "expires_at":null, "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"51.159.46.153", "user_id":"ef29ce05-3f2b-4fa0-a259-d76110850d57"}, {"access_key":"SCW8QZ96TGKZNJ9Y5QBB", "secret_key":null, "description":"lmarabese", "created_at":"2026-04-20T13:06:45.099977Z", "updated_at":"2026-04-20T13:06:45.099977Z", "expires_at":"2027-04-20T13:06:44.943Z", "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"51.159.46.153", "user_id":"29c74dc1-87e7-4c49-91a1-0ad5540ecdd7"}, {"access_key":"SCWC7544PWQDZYCKFXR7", "secret_key":null, "description":"", "created_at":"2026-06-04T16:22:27.164337Z", "updated_at":"2026-06-04T16:22:27.164337Z", "expires_at":null, "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"51.159.73.145", "user_id":"88b4dde1-f3d4-478a-a281-784d53399a30"}, {"access_key":"SCWQJVJ5BWW1BN9G4VBM", "secret_key":null, "description":"Generated by the Scaleway CLI", "created_at":"2026-06-10T15:22:12.947124Z", "updated_at":"2026-06-10T15:22:12.947124Z", "expires_at":null, "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"88.189.216.157", "user_id":"0b8cc93b-dfd2-4427-b674-8d27affb0334"}, {"access_key":"SCW3DN63FVR6JT6W4H7X", "secret_key":null, "description":"API key for packer e2e testing", "created_at":"2026-06-15T16:03:37.273077Z", "updated_at":"2026-06-15T16:03:37.273077Z", "expires_at":null, "default_project_id":"60c2a82f-3d0c-45bf-8c69-62627e5abe4d", "editable":true, "deletable":true, "managed":false, "creation_ip":"51.159.73.9", "application_id":"166d33e7-63d7-48a0-96ec-f372a1c7f766"}, {"access_key":"SCWBN9HR9AA2PZHPSSNV", "secret_key":null, "description":"test-api-key-list-1", "created_at":"2026-06-16T09:32:01.136614Z", "updated_at":"2026-06-16T09:32:01.136614Z", "expires_at":null, "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"51.159.46.153", "application_id":"a94c31ce-e268-4f19-a5d5-5f5075c46d9b"}], "total_count":8}'
         headers:
             Content-Length:
-                - "2790"
+                - "3201"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 11 Jun 2026 14:12:34 GMT
+                - Tue, 16 Jun 2026 09:32:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             X-Request-Id:
-                - 922d0de7-000f-4faf-9511-80c1e632e9c9
+                - da232691-0cce-48d8-9cb8-705e0c8af9df
         status: 200 OK
         code: 200
-        duration: 91.079225ms
+        duration: 430.350148ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -481,22 +481,22 @@ interactions:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 2790
-        body: '{"api_keys":[{"access_key":"SCWY48KAJYQE3EHTVAG6", "secret_key":null, "description":"esoulard", "created_at":"2026-03-24T15:10:41.081963Z", "updated_at":"2026-03-24T15:10:41.081963Z", "expires_at":"2027-03-24T15:10:40.879Z", "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"51.159.73.9", "user_id":"0b8cc93b-dfd2-4427-b674-8d27affb0334"}, {"access_key":"SCWP7Z6GF21G5C6AHW8A", "secret_key":null, "description":"jremy", "created_at":"2026-03-26T14:38:12.000609Z", "updated_at":"2026-03-26T14:38:12.000609Z", "expires_at":null, "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"51.159.73.145", "user_id":"ee474852-1f90-4cc1-bad0-4a17998c51e7"}, {"access_key":"SCW9S2TRP4KTKS44DZWP", "secret_key":null, "description":"", "created_at":"2026-03-27T14:09:05.244013Z", "updated_at":"2026-03-27T14:09:05.244013Z", "expires_at":null, "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"51.159.46.153", "user_id":"ef29ce05-3f2b-4fa0-a259-d76110850d57"}, {"access_key":"SCW8QZ96TGKZNJ9Y5QBB", "secret_key":null, "description":"lmarabese", "created_at":"2026-04-20T13:06:45.099977Z", "updated_at":"2026-04-20T13:06:45.099977Z", "expires_at":"2027-04-20T13:06:44.943Z", "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"51.159.46.153", "user_id":"29c74dc1-87e7-4c49-91a1-0ad5540ecdd7"}, {"access_key":"SCWC7544PWQDZYCKFXR7", "secret_key":null, "description":"", "created_at":"2026-06-04T16:22:27.164337Z", "updated_at":"2026-06-04T16:22:27.164337Z", "expires_at":null, "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"51.159.73.145", "user_id":"88b4dde1-f3d4-478a-a281-784d53399a30"}, {"access_key":"SCWQJVJ5BWW1BN9G4VBM", "secret_key":null, "description":"Generated by the Scaleway CLI", "created_at":"2026-06-10T15:22:12.947124Z", "updated_at":"2026-06-10T15:22:12.947124Z", "expires_at":null, "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"88.189.216.157", "user_id":"0b8cc93b-dfd2-4427-b674-8d27affb0334"}, {"access_key":"SCWM89BTFYCN0YDNQRJV", "secret_key":null, "description":"test-api-key-list-1", "created_at":"2026-06-11T14:12:30.719319Z", "updated_at":"2026-06-11T14:12:30.719319Z", "expires_at":null, "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"88.189.216.157", "application_id":"a437515e-8295-4fcd-8fa0-f379d9400e35"}], "total_count":7}'
+        content_length: 3201
+        body: '{"api_keys":[{"access_key":"SCWY48KAJYQE3EHTVAG6", "secret_key":null, "description":"esoulard", "created_at":"2026-03-24T15:10:41.081963Z", "updated_at":"2026-03-24T15:10:41.081963Z", "expires_at":"2027-03-24T15:10:40.879Z", "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"51.159.73.9", "user_id":"0b8cc93b-dfd2-4427-b674-8d27affb0334"}, {"access_key":"SCWP7Z6GF21G5C6AHW8A", "secret_key":null, "description":"jremy", "created_at":"2026-03-26T14:38:12.000609Z", "updated_at":"2026-03-26T14:38:12.000609Z", "expires_at":null, "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"51.159.73.145", "user_id":"ee474852-1f90-4cc1-bad0-4a17998c51e7"}, {"access_key":"SCW9S2TRP4KTKS44DZWP", "secret_key":null, "description":"", "created_at":"2026-03-27T14:09:05.244013Z", "updated_at":"2026-03-27T14:09:05.244013Z", "expires_at":null, "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"51.159.46.153", "user_id":"ef29ce05-3f2b-4fa0-a259-d76110850d57"}, {"access_key":"SCW8QZ96TGKZNJ9Y5QBB", "secret_key":null, "description":"lmarabese", "created_at":"2026-04-20T13:06:45.099977Z", "updated_at":"2026-04-20T13:06:45.099977Z", "expires_at":"2027-04-20T13:06:44.943Z", "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"51.159.46.153", "user_id":"29c74dc1-87e7-4c49-91a1-0ad5540ecdd7"}, {"access_key":"SCWC7544PWQDZYCKFXR7", "secret_key":null, "description":"", "created_at":"2026-06-04T16:22:27.164337Z", "updated_at":"2026-06-04T16:22:27.164337Z", "expires_at":null, "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"51.159.73.145", "user_id":"88b4dde1-f3d4-478a-a281-784d53399a30"}, {"access_key":"SCWQJVJ5BWW1BN9G4VBM", "secret_key":null, "description":"Generated by the Scaleway CLI", "created_at":"2026-06-10T15:22:12.947124Z", "updated_at":"2026-06-10T15:22:12.947124Z", "expires_at":null, "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"88.189.216.157", "user_id":"0b8cc93b-dfd2-4427-b674-8d27affb0334"}, {"access_key":"SCW3DN63FVR6JT6W4H7X", "secret_key":null, "description":"API key for packer e2e testing", "created_at":"2026-06-15T16:03:37.273077Z", "updated_at":"2026-06-15T16:03:37.273077Z", "expires_at":null, "default_project_id":"60c2a82f-3d0c-45bf-8c69-62627e5abe4d", "editable":true, "deletable":true, "managed":false, "creation_ip":"51.159.73.9", "application_id":"166d33e7-63d7-48a0-96ec-f372a1c7f766"}, {"access_key":"SCWBN9HR9AA2PZHPSSNV", "secret_key":null, "description":"test-api-key-list-1", "created_at":"2026-06-16T09:32:01.136614Z", "updated_at":"2026-06-16T09:32:01.136614Z", "expires_at":null, "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"51.159.46.153", "application_id":"a94c31ce-e268-4f19-a5d5-5f5075c46d9b"}], "total_count":8}'
         headers:
             Content-Length:
-                - "2790"
+                - "3201"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 11 Jun 2026 14:12:34 GMT
+                - Tue, 16 Jun 2026 09:32:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             X-Request-Id:
-                - e5e27a28-4421-4ad4-bbb2-851b98973bce
+                - 80d5d739-2755-4775-a91b-61136a563564
         status: 200 OK
         code: 200
-        duration: 110.99065ms
+        duration: 333.012359ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -506,7 +506,7 @@ interactions:
         host: api.scaleway.com
         form:
             bearer_id:
-                - a437515e-8295-4fcd-8fa0-f379d9400e35
+                - a94c31ce-e268-4f19-a5d5-5f5075c46d9b
             bearer_type:
                 - application
             order_by:
@@ -518,28 +518,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/iam/v1alpha1/api-keys?bearer_id=a437515e-8295-4fcd-8fa0-f379d9400e35&bearer_type=application&order_by=created_at_asc&organization_id=11111111-1111-1111-1111-111111111111&page=1
+        url: https://api.scaleway.com/iam/v1alpha1/api-keys?bearer_id=a94c31ce-e268-4f19-a5d5-5f5075c46d9b&bearer_type=application&order_by=created_at_asc&organization_id=11111111-1111-1111-1111-111111111111&page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 434
-        body: '{"api_keys":[{"access_key":"SCWM89BTFYCN0YDNQRJV", "secret_key":null, "description":"test-api-key-list-1", "created_at":"2026-06-11T14:12:30.719319Z", "updated_at":"2026-06-11T14:12:30.719319Z", "expires_at":null, "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"88.189.216.157", "application_id":"a437515e-8295-4fcd-8fa0-f379d9400e35"}], "total_count":1}'
+        content_length: 433
+        body: '{"api_keys":[{"access_key":"SCWBN9HR9AA2PZHPSSNV", "secret_key":null, "description":"test-api-key-list-1", "created_at":"2026-06-16T09:32:01.136614Z", "updated_at":"2026-06-16T09:32:01.136614Z", "expires_at":null, "default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf", "editable":true, "deletable":true, "managed":false, "creation_ip":"51.159.46.153", "application_id":"a94c31ce-e268-4f19-a5d5-5f5075c46d9b"}], "total_count":1}'
         headers:
             Content-Length:
-                - "434"
+                - "433"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 11 Jun 2026 14:12:34 GMT
+                - Tue, 16 Jun 2026 09:32:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             X-Request-Id:
-                - a4563e7a-77f9-47a5-b942-ae12cddb2f18
+                - 0438bb29-f5ea-448e-b88e-34227f9896c9
         status: 200 OK
         code: 200
-        duration: 230.901237ms
+        duration: 58.085106ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -562,14 +562,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 11 Jun 2026 14:12:35 GMT
+                - Tue, 16 Jun 2026 09:32:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             X-Request-Id:
-                - 98e68781-68c6-4d1f-9d48-d6eb6f6c3793
+                - b6437d7f-ef0e-446f-9e36-86618e84dadf
         status: 204 No Content
         code: 204
-        duration: 230.911683ms
+        duration: 65.914177ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -580,7 +580,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/iam/v1alpha1/applications/a437515e-8295-4fcd-8fa0-f379d9400e35
+        url: https://api.scaleway.com/iam/v1alpha1/applications/a94c31ce-e268-4f19-a5d5-5f5075c46d9b
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -592,14 +592,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 11 Jun 2026 14:12:35 GMT
+                - Tue, 16 Jun 2026 09:32:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             X-Request-Id:
-                - c275c2b7-6a32-425e-97e3-c0b7ab6f02e5
+                - cbb41f79-f836-4c8d-89f9-7a7aa3e2cf89
         status: 204 No Content
         code: 204
-        duration: 133.655651ms
+        duration: 127.952818ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -617,21 +617,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 115
-        body: '{"message":"resource is not found","resource":"access_key","resource_id":"SCWM89BTFYCN0YDNQRJV","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"access_key","resource_id":"SCWBN9HR9AA2PZHPSSNV","type":"not_found"}'
         headers:
             Content-Length:
                 - "115"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 11 Jun 2026 14:12:35 GMT
+                - Tue, 16 Jun 2026 09:32:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             X-Request-Id:
-                - 3a6f945c-3b9a-4204-ada0-ed621d03ed49
+                - 01643517-9023-4f9e-8c18-34bd9a8ecb97
         status: 404 Not Found
         code: 404
-        duration: 54.924889ms
+        duration: 36.648249ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -642,25 +642,25 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/iam/v1alpha1/applications/a437515e-8295-4fcd-8fa0-f379d9400e35
+        url: https://api.scaleway.com/iam/v1alpha1/applications/a94c31ce-e268-4f19-a5d5-5f5075c46d9b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 132
-        body: '{"message":"resource is not found","resource":"application","resource_id":"a437515e-8295-4fcd-8fa0-f379d9400e35","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"application","resource_id":"a94c31ce-e268-4f19-a5d5-5f5075c46d9b","type":"not_found"}'
         headers:
             Content-Length:
                 - "132"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 11 Jun 2026 14:12:35 GMT
+                - Tue, 16 Jun 2026 09:32:06 GMT
             Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             X-Request-Id:
-                - 42c0d9c9-348f-4c92-b706-e9206cbdc018
+                - a6cadb1b-daeb-46ee-8cc7-6ab2e0bbd385
         status: 404 Not Found
         code: 404
-        duration: 34.978136ms
+        duration: 36.326504ms


### PR DESCRIPTION
Recent additions to IAM tests used the same app name, leading to [conflict error in the nightlys](https://github.com/scaleway/terraform-provider-scaleway/actions/runs/27592340132/job/81575576875). 