### PR TITLE
chore(rdb): add exponential backoff in retry on 403

### DIFF
--- a/internal/services/rdb/testdata/list-rdb-database-backups-basic.cassette.yaml
+++ b/internal/services/rdb/testdata/list-rdb-database-backups-basic.cassette.yaml
@@ -36,9 +36,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:37:32 GMT
+                - Mon, 22 Jun 2026 12:55:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -46,22 +46,22 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 548a4cae-74f4-4777-8033-2389082ec7ec
+                - 49253a44-1da8-4fb8-8392-c971c72a8852
         status: 200 OK
         code: 200
-        duration: 311.677547ms
+        duration: 201.315992ms
     - id: 1
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 107
+        content_length: 110
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-project-silly-gates","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","description":""}'
+        body: '{"name":"tf-project-modest-maxwell","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","description":""}'
         form: {}
         headers:
             Content-Type:
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 258
+        content_length: 261
         uncompressed: false
-        body: '{"created_at":"2026-06-18T10:37:34.036620Z","description":"","id":"4e23ecb4-14a1-428d-826d-59003f746cb0","name":"tf-project-silly-gates","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","qualification":null,"updated_at":"2026-06-18T10:37:34.036620Z"}'
+        body: '{"created_at":"2026-06-22T12:55:39.983214Z","description":"","id":"b8609ac7-cfd0-400c-aaf0-2ce98ae41483","name":"tf-project-modest-maxwell","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","qualification":null,"updated_at":"2026-06-22T12:55:39.983214Z"}'
         headers:
             Content-Length:
-                - "258"
+                - "261"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:37:34 GMT
+                - Mon, 22 Jun 2026 12:55:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 46bfd170-fe2d-4c5b-8db4-db2ff31b2f34
+                - 52c14331-4c2c-46b6-84c2-c1ddaa89ecaf
         status: 200 OK
         code: 200
-        duration: 648.950725ms
+        duration: 605.970691ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -117,7 +117,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/account/v3/projects/4e23ecb4-14a1-428d-826d-59003f746cb0
+        url: https://api.scaleway.com/account/v3/projects/b8609ac7-cfd0-400c-aaf0-2ce98ae41483
         method: GET
       response:
         proto: HTTP/2.0
@@ -125,20 +125,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 303
+        content_length: 306
         uncompressed: false
-        body: '{"created_at":"2026-06-18T10:37:34.036620Z","description":"","id":"4e23ecb4-14a1-428d-826d-59003f746cb0","name":"tf-project-silly-gates","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2026-06-18T10:37:34.036620Z"}'
+        body: '{"created_at":"2026-06-22T12:55:39.983214Z","description":"","id":"b8609ac7-cfd0-400c-aaf0-2ce98ae41483","name":"tf-project-modest-maxwell","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2026-06-22T12:55:39.983214Z"}'
         headers:
             Content-Length:
-                - "303"
+                - "306"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:37:34 GMT
+                - Mon, 22 Jun 2026 12:55:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - efa8b09c-7e10-4b5a-a2d9-de214d3d5866
+                - 4df064a0-20ca-42fb-b627-c00f697e24de
         status: 200 OK
         code: 200
-        duration: 284.412351ms
+        duration: 320.58074ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -161,7 +161,7 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"project_id":"4e23ecb4-14a1-428d-826d-59003f746cb0","name":"tf-test-rdb-backup-list-4823616331525728375","engine":"PostgreSQL-17","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["rdb-backup-list-test"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":null,"backup_same_region":false,"encryption":{"enabled":false}}'
+        body: '{"project_id":"b8609ac7-cfd0-400c-aaf0-2ce98ae41483","name":"tf-test-rdb-backup-list-4823616331525728375","engine":"PostgreSQL-17","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["rdb-backup-list-test"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":null,"backup_same_region":false,"encryption":{"enabled":false}}'
         form: {}
         headers:
             Content-Type:
@@ -178,7 +178,7 @@ interactions:
         trailer: {}
         content_length: 786
         uncompressed: false
-        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-18T10:37:35.132115Z","encryption":{"enabled":false},"endpoint":null,"endpoints":[],"engine":"PostgreSQL-17","id":"0a52ba9a-e8d9-47c6-ae98-f7c224ade976","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-backup-list-4823616331525728375","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"4e23ecb4-14a1-428d-826d-59003f746cb0","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["rdb-backup-list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-22T12:55:41.355847Z","encryption":{"enabled":false},"endpoint":null,"endpoints":[],"engine":"PostgreSQL-17","id":"6d13e88d-46a8-49c1-bfe1-8921fad66c96","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-backup-list-4823616331525728375","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"b8609ac7-cfd0-400c-aaf0-2ce98ae41483","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["rdb-backup-list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
         headers:
             Content-Length:
                 - "786"
@@ -187,9 +187,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:37:35 GMT
+                - Mon, 22 Jun 2026 12:55:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -197,10 +197,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dca88acd-fc19-4eaf-ac5d-366d5a4b1e66
+                - b754cdde-2fd4-4ad4-9cc6-7a4039074d78
         status: 200 OK
         code: 200
-        duration: 937.330642ms
+        duration: 1.669531319s
     - id: 4
       request:
         proto: HTTP/1.1
@@ -217,7 +217,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0a52ba9a-e8d9-47c6-ae98-f7c224ade976
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d13e88d-46a8-49c1-bfe1-8921fad66c96
         method: GET
       response:
         proto: HTTP/2.0
@@ -227,7 +227,7 @@ interactions:
         trailer: {}
         content_length: 786
         uncompressed: false
-        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-18T10:37:35.132115Z","encryption":{"enabled":false},"endpoint":null,"endpoints":[],"engine":"PostgreSQL-17","id":"0a52ba9a-e8d9-47c6-ae98-f7c224ade976","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-backup-list-4823616331525728375","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"4e23ecb4-14a1-428d-826d-59003f746cb0","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["rdb-backup-list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-22T12:55:41.355847Z","encryption":{"enabled":false},"endpoint":null,"endpoints":[],"engine":"PostgreSQL-17","id":"6d13e88d-46a8-49c1-bfe1-8921fad66c96","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-backup-list-4823616331525728375","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"b8609ac7-cfd0-400c-aaf0-2ce98ae41483","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["rdb-backup-list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
         headers:
             Content-Length:
                 - "786"
@@ -236,9 +236,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:37:35 GMT
+                - Mon, 22 Jun 2026 12:55:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -246,10 +246,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6a4371b7-6c83-4ef2-b943-89a31e1267b8
+                - 15913fa4-be3b-4d34-aee8-f9a0d005265a
         status: 200 OK
         code: 200
-        duration: 184.844971ms
+        duration: 226.07284ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -266,7 +266,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0a52ba9a-e8d9-47c6-ae98-f7c224ade976
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d13e88d-46a8-49c1-bfe1-8921fad66c96
         method: GET
       response:
         proto: HTTP/2.0
@@ -274,20 +274,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1261
+        content_length: 1257
         uncompressed: false
-        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-18T10:37:35.132115Z","encryption":{"enabled":false},"endpoint":{"id":"db704b91-ebf7-47a2-b3f7-08c6606af968","ip":"51.159.206.182","load_balancer":{},"name":null,"port":10469},"endpoints":[{"id":"db704b91-ebf7-47a2-b3f7-08c6606af968","ip":"51.159.206.182","load_balancer":{},"name":null,"port":10469}],"engine":"PostgreSQL-17","id":"0a52ba9a-e8d9-47c6-ae98-f7c224ade976","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-backup-list-4823616331525728375","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"4e23ecb4-14a1-428d-826d-59003f746cb0","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["rdb-backup-list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-22T12:55:41.355847Z","encryption":{"enabled":false},"endpoint":{"id":"82b37d06-e598-4909-b77b-5ec0e1d49ae8","ip":"51.159.27.100","load_balancer":{},"name":null,"port":9420},"endpoints":[{"id":"82b37d06-e598-4909-b77b-5ec0e1d49ae8","ip":"51.159.27.100","load_balancer":{},"name":null,"port":9420}],"engine":"PostgreSQL-17","id":"6d13e88d-46a8-49c1-bfe1-8921fad66c96","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-backup-list-4823616331525728375","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"b8609ac7-cfd0-400c-aaf0-2ce98ae41483","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["rdb-backup-list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
         headers:
             Content-Length:
-                - "1261"
+                - "1257"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:07 GMT
+                - Mon, 22 Jun 2026 12:58:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -295,10 +295,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 68f33a15-a3a1-4cd4-8bfc-c0570989b2b5
+                - db2b6358-44b9-44b8-a64a-85d3ff2f96d9
         status: 200 OK
         code: 200
-        duration: 189.251417ms
+        duration: 180.942682ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -315,7 +315,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0a52ba9a-e8d9-47c6-ae98-f7c224ade976/certificate
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d13e88d-46a8-49c1-bfe1-8921fad66c96/certificate
         method: GET
       response:
         proto: HTTP/2.0
@@ -323,20 +323,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2011
+        content_length: 2007
         uncompressed: false
-        body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVU0ZKTjB4YWp5WmdiaWdyLzdFMGIyVmFxY3RNd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURZdU1UZ3lNQjRYCkRUSTJNRFl4T0RFd05EQXlObG9YRFRNMk1EWXhOVEV3TkRBeU5sb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRFl1TVRneU1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXZ2QWdJQ2hsOExwdW10YWlvUmo0QkFqMW9xUGVZYXMvV2p6VCswZHAzZWRkT3NFMEVJTDEKc0FaZVJYdnNoYktOZ1hJbm54QWZkMzZveXd5dzhqcE90MUMwaXRiS2lCY2ZYTDVoSXI2ZHlJaDBVdWJlcW0xYQpQb2dpbW44NTJINkNwU3QybFRqWVRXdU0yYmxlYVhQSVJnQmZGRUdYS3RHRHZiUVJrdVYzUkxWSk1JdERwNjg3CnMxY2EwSGlkOHhFSjhSWHhROGc5Rjh5MS9QU0x4TFFHZE1IMVorWnVuZVZJWkYycCs1OU1kQ0VyQTN1SFZ3dWEKazJhUlpsWjM2aXd5Z0NNcXhmZ1pCcys4SjZxZEd6cWtRamJKZnBVZG13MXBVRTEwZmtBVkxhdktLM0JtMGw3Zgpnb3o5cHR1UUlyT3RKZFVxL2p1UVBNclRDTjNJWjErempRSURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9TNHlNRFl1TVRneWdqeHlkeTB3WVRVeVltRTVZUzFsT0dRNUxUUTNZell0WVdVNU9DMW0KTjJNeU1qUmhaR1U1TnpZdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9TNHlNRFl1TVRneQpnanh5ZHkwd1lUVXlZbUU1WVMxbE9HUTVMVFEzWXpZdFlXVTVPQzFtTjJNeU1qUmhaR1U1TnpZdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQkRNUDJYdUhCRE9menJhSEJET2Z6cll3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFGYVFQVkhkQzZJUStEb2pNaGFnOUJ3bDhYSDVKUzIrWlFpRHFEODc0a1hhdHRLUXZpTTNsTzIxU1F0Lwp0N3d5UGdWOGNhOEttV0wxUlVlM2ZuUkdvcDl0bUhjOGRYd2lhaSszOHNUTTdUaU5IcWpGVmV3SmRMVFZRbXZvCmJ1S2tjdDNEVVhRRGZtT0tjM3h6MEVDelNGVmlHeUZiREpaclk5WE1CRnpOa1h4L013eVBoTVZBSXQxRS9WNkQKeWFYV0p0RVkrSDZtUllEV2x3QUZNeUR5WDhjeHhIOWRrQ1h5cVUyU1U4clIxN3YweHhvZm5NWmZ1SDFoVnhtaApoRTFmTG5heTdPb1o0Sk9IcXo3VG1EdW95TVl6aWU0c3FBakxHM2oybjREQnU4UTU5NjVsUzhBaGkvVzFscERRCnY0UUZFVC9ET1Q4UmxJR3VlS3o5T3VoaEkzaz0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+        body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVVEx5UndxN3pSMFJjYkFkUG5WVHlvWWZzQzlVd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tnk0eE1EQXdIaGNOCk1qWXdOakl5TVRJMU9ERXpXaGNOTXpZd05qRTVNVEkxT0RFeldqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTNMakV3TURDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUpPZXoyeThjOHFVUUlOcUpEKzNXVXZVMzV6cHJnUmh6L0ZGZ2xoNXVzbEFXK2RyMXhmbjJOSmwKd3hjcGF3M251SHVZTk9GTTNLclRiNjdyQmVSbkxzSHdpRCs4b1NxWVVzTVJpUllaRTVuK1FXcWZBV0EvbFdiMgo2NnVFWkJuclF5UGExNHZiSGh6bDZIcWtYYkxZa2pvRGwxbnhObTZiYWhBNkJLVXZlbjZZSEk4dWdTUWIreWQvClFNWm5iNGlIdW0vQlhUK1JGQVVPKzdoSFJOb1RhN29xR2hJREZ2ZHdXUHJmL1Nxc1IrUWlWTGhMdlFGWE5GTEMKMVdON0YwTnBnTXpPemRaUlJqTHZIN0ZHWGhua2g4RmUzYlhYOHNzTE1QR1kzVHpyMTI2bERKYStzZVAvTHlTNQpaVVpzV2J0QnBaejVmTGY5N1NaYkdnTXNTQjJKWWhNQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1qY3VNVEF3Z2p4eWR5MDJaREV6WlRnNFpDMDBObUU0TFRRNVl6RXRZbVpsTVMwNE9USXgKWm1Ga05qWmpPVFl1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eU55NHhNRENDUEhKMwpMVFprTVRObE9EaGtMVFEyWVRndE5EbGpNUzFpWm1VeExUZzVNakZtWVdRMk5tTTVOaTV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VvNnlVdm9jRU01OGJaSWNFTTU4YlpEQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKRHhIbWRqcWMzcU1rQXNyMzdlK04wbVI1QmFRZW5xOHZDMndzeU1aRDJWTi9PUkt0VE9lNit0MzJVakF0MTVZbwpQRTlWcnI2S1FzQnArV25mUVloVExDZ2o1SHBlSHd0MGUzMzBJOTM5ZFU3MVJ4ME1YckpnTGRxUmNlcm12VTcwCnEvQnJvTWlHOE9PN29lWEpabnczUmtIc09oMG1mZGhsY1FjdFRNeGF0ZlhIYzI5b2ZzZ3ZqSG0vZzI2eG5LMmMKVFFHczJ4NVgwYzB3dXlIejNnc24rZGNVS3NOblVqWnZpSkxITjBjcWMxSnJwMUhGOWFBRmJjS1dGTmMyZHBjWgp0Y0x6RGowWGp5MEFXMzEwOU5KdUZwWlRPMFJYakNvdFl6MS9pWk9zODJkcmJCdWppRm9xV0FBblI1SDBWWG9aCm0xd0JaODJib3BNVkhPREkyMDZtT3c9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
         headers:
             Content-Length:
-                - "2011"
+                - "2007"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:07 GMT
+                - Mon, 22 Jun 2026 12:58:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -344,10 +344,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ca5b3a49-b800-4fc1-baf0-e988e5eccc8f
+                - b4787393-3c3e-42f0-8df3-6e7cd0cfa2ed
         status: 200 OK
         code: 200
-        duration: 91.85349ms
+        duration: 208.486924ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -364,7 +364,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0a52ba9a-e8d9-47c6-ae98-f7c224ade976
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d13e88d-46a8-49c1-bfe1-8921fad66c96
         method: GET
       response:
         proto: HTTP/2.0
@@ -372,20 +372,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1261
+        content_length: 1257
         uncompressed: false
-        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-18T10:37:35.132115Z","encryption":{"enabled":false},"endpoint":{"id":"db704b91-ebf7-47a2-b3f7-08c6606af968","ip":"51.159.206.182","load_balancer":{},"name":null,"port":10469},"endpoints":[{"id":"db704b91-ebf7-47a2-b3f7-08c6606af968","ip":"51.159.206.182","load_balancer":{},"name":null,"port":10469}],"engine":"PostgreSQL-17","id":"0a52ba9a-e8d9-47c6-ae98-f7c224ade976","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-backup-list-4823616331525728375","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"4e23ecb4-14a1-428d-826d-59003f746cb0","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["rdb-backup-list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-22T12:55:41.355847Z","encryption":{"enabled":false},"endpoint":{"id":"82b37d06-e598-4909-b77b-5ec0e1d49ae8","ip":"51.159.27.100","load_balancer":{},"name":null,"port":9420},"endpoints":[{"id":"82b37d06-e598-4909-b77b-5ec0e1d49ae8","ip":"51.159.27.100","load_balancer":{},"name":null,"port":9420}],"engine":"PostgreSQL-17","id":"6d13e88d-46a8-49c1-bfe1-8921fad66c96","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-backup-list-4823616331525728375","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"b8609ac7-cfd0-400c-aaf0-2ce98ae41483","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["rdb-backup-list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
         headers:
             Content-Length:
-                - "1261"
+                - "1257"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:07 GMT
+                - Mon, 22 Jun 2026 12:58:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -393,10 +393,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 39ee2df5-77ab-43af-9e41-234200b631c4
+                - 95ec9326-c112-4285-a096-104406abf2c1
         status: 200 OK
         code: 200
-        duration: 126.466995ms
+        duration: 204.465167ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -415,7 +415,7 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0a52ba9a-e8d9-47c6-ae98-f7c224ade976/databases
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d13e88d-46a8-49c1-bfe1-8921fad66c96/databases
         method: POST
       response:
         proto: HTTP/2.0
@@ -434,9 +434,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:07 GMT
+                - Mon, 22 Jun 2026 12:58:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -444,10 +444,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 80da655d-bc27-425e-badc-fd85063f6833
+                - f5465024-6cac-4865-abff-263b0553cc30
         status: 200 OK
         code: 200
-        duration: 469.626039ms
+        duration: 403.347891ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -464,7 +464,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0a52ba9a-e8d9-47c6-ae98-f7c224ade976
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d13e88d-46a8-49c1-bfe1-8921fad66c96
         method: GET
       response:
         proto: HTTP/2.0
@@ -472,20 +472,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1261
+        content_length: 1257
         uncompressed: false
-        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-18T10:37:35.132115Z","encryption":{"enabled":false},"endpoint":{"id":"db704b91-ebf7-47a2-b3f7-08c6606af968","ip":"51.159.206.182","load_balancer":{},"name":null,"port":10469},"endpoints":[{"id":"db704b91-ebf7-47a2-b3f7-08c6606af968","ip":"51.159.206.182","load_balancer":{},"name":null,"port":10469}],"engine":"PostgreSQL-17","id":"0a52ba9a-e8d9-47c6-ae98-f7c224ade976","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-backup-list-4823616331525728375","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"4e23ecb4-14a1-428d-826d-59003f746cb0","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["rdb-backup-list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-22T12:55:41.355847Z","encryption":{"enabled":false},"endpoint":{"id":"82b37d06-e598-4909-b77b-5ec0e1d49ae8","ip":"51.159.27.100","load_balancer":{},"name":null,"port":9420},"endpoints":[{"id":"82b37d06-e598-4909-b77b-5ec0e1d49ae8","ip":"51.159.27.100","load_balancer":{},"name":null,"port":9420}],"engine":"PostgreSQL-17","id":"6d13e88d-46a8-49c1-bfe1-8921fad66c96","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-backup-list-4823616331525728375","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"b8609ac7-cfd0-400c-aaf0-2ce98ae41483","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["rdb-backup-list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
         headers:
             Content-Length:
-                - "1261"
+                - "1257"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:08 GMT
+                - Mon, 22 Jun 2026 12:58:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -493,10 +493,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - da643991-01ff-4e63-9ba7-63860761f144
+                - 21f2499d-3fc7-4009-9723-116fd2794896
         status: 200 OK
         code: 200
-        duration: 129.025417ms
+        duration: 203.794026ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -513,7 +513,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0a52ba9a-e8d9-47c6-ae98-f7c224ade976/databases?name=tfdb_backup_list&order_by=name_asc
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d13e88d-46a8-49c1-bfe1-8921fad66c96/databases?name=tfdb_backup_list&order_by=name_asc
         method: GET
       response:
         proto: HTTP/2.0
@@ -532,9 +532,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:08 GMT
+                - Mon, 22 Jun 2026 12:58:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -542,10 +542,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6bf00824-f731-4e72-80c9-504f1ec74d26
+                - 8fb03ac3-affa-4e5c-a6a9-1a6b6c1fd0b9
         status: 200 OK
         code: 200
-        duration: 214.208679ms
+        duration: 231.146739ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -557,7 +557,7 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"instance_id":"0a52ba9a-e8d9-47c6-ae98-f7c224ade976","database_name":"tfdb_backup_list","name":"tf_backup_list_2078923807392667811"}'
+        body: '{"instance_id":"6d13e88d-46a8-49c1-bfe1-8921fad66c96","database_name":"tfdb_backup_list","name":"tf_backup_list_2078923807392667811"}'
         form: {}
         headers:
             Content-Type:
@@ -574,7 +574,7 @@ interactions:
         trailer: {}
         content_length: 439
         uncompressed: false
-        body: '{"created_at":"2026-06-18T10:41:09.656480Z","database_name":"tfdb_backup_list","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"46f379f3-9df6-4a65-bc6d-6afdac57ae73","instance_id":"0a52ba9a-e8d9-47c6-ae98-f7c224ade976","instance_name":"tf-test-rdb-backup-list-4823616331525728375","name":"tf_backup_list_2078923807392667811","region":"fr-par","same_region":false,"size":null,"status":"creating","updated_at":null}'
+        body: '{"created_at":"2026-06-22T12:58:46.497631Z","database_name":"tfdb_backup_list","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"429c745b-d79b-4a86-89b7-e544be515a59","instance_id":"6d13e88d-46a8-49c1-bfe1-8921fad66c96","instance_name":"tf-test-rdb-backup-list-4823616331525728375","name":"tf_backup_list_2078923807392667811","region":"fr-par","same_region":false,"size":null,"status":"creating","updated_at":null}'
         headers:
             Content-Length:
                 - "439"
@@ -583,9 +583,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:09 GMT
+                - Mon, 22 Jun 2026 12:58:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -593,10 +593,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 56de4bdb-139e-4efa-814c-6ef5eb5750d5
+                - bd38bdf1-f25c-4f84-81d8-2e3c5e0f8e6e
         status: 200 OK
         code: 200
-        duration: 1.639572309s
+        duration: 1.81026596s
     - id: 12
       request:
         proto: HTTP/1.1
@@ -613,7 +613,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/46f379f3-9df6-4a65-bc6d-6afdac57ae73
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/429c745b-d79b-4a86-89b7-e544be515a59
         method: GET
       response:
         proto: HTTP/2.0
@@ -623,7 +623,7 @@ interactions:
         trailer: {}
         content_length: 439
         uncompressed: false
-        body: '{"created_at":"2026-06-18T10:41:09.656480Z","database_name":"tfdb_backup_list","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"46f379f3-9df6-4a65-bc6d-6afdac57ae73","instance_id":"0a52ba9a-e8d9-47c6-ae98-f7c224ade976","instance_name":"tf-test-rdb-backup-list-4823616331525728375","name":"tf_backup_list_2078923807392667811","region":"fr-par","same_region":false,"size":null,"status":"creating","updated_at":null}'
+        body: '{"created_at":"2026-06-22T12:58:46.497631Z","database_name":"tfdb_backup_list","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"429c745b-d79b-4a86-89b7-e544be515a59","instance_id":"6d13e88d-46a8-49c1-bfe1-8921fad66c96","instance_name":"tf-test-rdb-backup-list-4823616331525728375","name":"tf_backup_list_2078923807392667811","region":"fr-par","same_region":false,"size":null,"status":"creating","updated_at":null}'
         headers:
             Content-Length:
                 - "439"
@@ -632,9 +632,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:10 GMT
+                - Mon, 22 Jun 2026 12:58:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -642,10 +642,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a2637e42-acb0-423c-96f9-c744a232b48c
+                - 9a3d1a36-7d08-4f08-b6dd-f012455eb63f
         status: 200 OK
         code: 200
-        duration: 142.500504ms
+        duration: 205.427115ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -662,7 +662,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/46f379f3-9df6-4a65-bc6d-6afdac57ae73
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/429c745b-d79b-4a86-89b7-e544be515a59
         method: GET
       response:
         proto: HTTP/2.0
@@ -672,7 +672,7 @@ interactions:
         trailer: {}
         content_length: 461
         uncompressed: false
-        body: '{"created_at":"2026-06-18T10:41:09.656480Z","database_name":"tfdb_backup_list","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"46f379f3-9df6-4a65-bc6d-6afdac57ae73","instance_id":"0a52ba9a-e8d9-47c6-ae98-f7c224ade976","instance_name":"tf-test-rdb-backup-list-4823616331525728375","name":"tf_backup_list_2078923807392667811","region":"fr-par","same_region":false,"size":1333,"status":"ready","updated_at":"2026-06-18T10:41:13.035327Z"}'
+        body: '{"created_at":"2026-06-22T12:58:46.497631Z","database_name":"tfdb_backup_list","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"429c745b-d79b-4a86-89b7-e544be515a59","instance_id":"6d13e88d-46a8-49c1-bfe1-8921fad66c96","instance_name":"tf-test-rdb-backup-list-4823616331525728375","name":"tf_backup_list_2078923807392667811","region":"fr-par","same_region":false,"size":1333,"status":"ready","updated_at":"2026-06-22T12:58:50.493142Z"}'
         headers:
             Content-Length:
                 - "461"
@@ -681,9 +681,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:40 GMT
+                - Mon, 22 Jun 2026 12:59:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -691,10 +691,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 27b2017e-45c5-487b-a142-50197597edb6
+                - ee4eecef-d87b-4273-88df-2dbbb6be51c2
         status: 200 OK
         code: 200
-        duration: 178.661639ms
+        duration: 133.722662ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -711,7 +711,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/46f379f3-9df6-4a65-bc6d-6afdac57ae73
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/429c745b-d79b-4a86-89b7-e544be515a59
         method: GET
       response:
         proto: HTTP/2.0
@@ -721,7 +721,7 @@ interactions:
         trailer: {}
         content_length: 461
         uncompressed: false
-        body: '{"created_at":"2026-06-18T10:41:09.656480Z","database_name":"tfdb_backup_list","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"46f379f3-9df6-4a65-bc6d-6afdac57ae73","instance_id":"0a52ba9a-e8d9-47c6-ae98-f7c224ade976","instance_name":"tf-test-rdb-backup-list-4823616331525728375","name":"tf_backup_list_2078923807392667811","region":"fr-par","same_region":false,"size":1333,"status":"ready","updated_at":"2026-06-18T10:41:13.035327Z"}'
+        body: '{"created_at":"2026-06-22T12:58:46.497631Z","database_name":"tfdb_backup_list","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"429c745b-d79b-4a86-89b7-e544be515a59","instance_id":"6d13e88d-46a8-49c1-bfe1-8921fad66c96","instance_name":"tf-test-rdb-backup-list-4823616331525728375","name":"tf_backup_list_2078923807392667811","region":"fr-par","same_region":false,"size":1333,"status":"ready","updated_at":"2026-06-22T12:58:50.493142Z"}'
         headers:
             Content-Length:
                 - "461"
@@ -730,9 +730,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:40 GMT
+                - Mon, 22 Jun 2026 12:59:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -740,10 +740,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ad9f577e-91c0-454e-ba88-77e594b4e398
+                - 54d54152-a80b-4353-8552-26d6ec559b48
         status: 200 OK
         code: 200
-        duration: 180.615189ms
+        duration: 117.825238ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -760,7 +760,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/account/v3/projects/4e23ecb4-14a1-428d-826d-59003f746cb0
+        url: https://api.scaleway.com/account/v3/projects/b8609ac7-cfd0-400c-aaf0-2ce98ae41483
         method: GET
       response:
         proto: HTTP/2.0
@@ -768,20 +768,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 303
+        content_length: 306
         uncompressed: false
-        body: '{"created_at":"2026-06-18T10:37:34.036620Z","description":"","id":"4e23ecb4-14a1-428d-826d-59003f746cb0","name":"tf-project-silly-gates","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2026-06-18T10:37:34.036620Z"}'
+        body: '{"created_at":"2026-06-22T12:55:39.983214Z","description":"","id":"b8609ac7-cfd0-400c-aaf0-2ce98ae41483","name":"tf-project-modest-maxwell","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2026-06-22T12:55:39.983214Z"}'
         headers:
             Content-Length:
-                - "303"
+                - "306"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:41 GMT
+                - Mon, 22 Jun 2026 12:59:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -789,10 +789,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5cb7a531-25a3-465e-8ad2-d2571c900b9d
+                - b8de0d00-5bc3-44de-982b-d800653ce914
         status: 200 OK
         code: 200
-        duration: 268.718154ms
+        duration: 268.451895ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -809,7 +809,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0a52ba9a-e8d9-47c6-ae98-f7c224ade976
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d13e88d-46a8-49c1-bfe1-8921fad66c96
         method: GET
       response:
         proto: HTTP/2.0
@@ -817,20 +817,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1261
+        content_length: 1257
         uncompressed: false
-        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-18T10:37:35.132115Z","encryption":{"enabled":false},"endpoint":{"id":"db704b91-ebf7-47a2-b3f7-08c6606af968","ip":"51.159.206.182","load_balancer":{},"name":null,"port":10469},"endpoints":[{"id":"db704b91-ebf7-47a2-b3f7-08c6606af968","ip":"51.159.206.182","load_balancer":{},"name":null,"port":10469}],"engine":"PostgreSQL-17","id":"0a52ba9a-e8d9-47c6-ae98-f7c224ade976","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-backup-list-4823616331525728375","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"4e23ecb4-14a1-428d-826d-59003f746cb0","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["rdb-backup-list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-22T12:55:41.355847Z","encryption":{"enabled":false},"endpoint":{"id":"82b37d06-e598-4909-b77b-5ec0e1d49ae8","ip":"51.159.27.100","load_balancer":{},"name":null,"port":9420},"endpoints":[{"id":"82b37d06-e598-4909-b77b-5ec0e1d49ae8","ip":"51.159.27.100","load_balancer":{},"name":null,"port":9420}],"engine":"PostgreSQL-17","id":"6d13e88d-46a8-49c1-bfe1-8921fad66c96","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-backup-list-4823616331525728375","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"b8609ac7-cfd0-400c-aaf0-2ce98ae41483","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["rdb-backup-list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
         headers:
             Content-Length:
-                - "1261"
+                - "1257"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:41 GMT
+                - Mon, 22 Jun 2026 12:59:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -838,10 +838,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dcea2d98-6b22-4c8c-a370-586cb250ef1d
+                - ed3f8975-61cb-41d8-94c0-427a78666865
         status: 200 OK
         code: 200
-        duration: 111.758425ms
+        duration: 179.448654ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -858,7 +858,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0a52ba9a-e8d9-47c6-ae98-f7c224ade976/certificate
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d13e88d-46a8-49c1-bfe1-8921fad66c96/certificate
         method: GET
       response:
         proto: HTTP/2.0
@@ -866,20 +866,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2011
+        content_length: 2007
         uncompressed: false
-        body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVU0ZKTjB4YWp5WmdiaWdyLzdFMGIyVmFxY3RNd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURZdU1UZ3lNQjRYCkRUSTJNRFl4T0RFd05EQXlObG9YRFRNMk1EWXhOVEV3TkRBeU5sb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRFl1TVRneU1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXZ2QWdJQ2hsOExwdW10YWlvUmo0QkFqMW9xUGVZYXMvV2p6VCswZHAzZWRkT3NFMEVJTDEKc0FaZVJYdnNoYktOZ1hJbm54QWZkMzZveXd5dzhqcE90MUMwaXRiS2lCY2ZYTDVoSXI2ZHlJaDBVdWJlcW0xYQpQb2dpbW44NTJINkNwU3QybFRqWVRXdU0yYmxlYVhQSVJnQmZGRUdYS3RHRHZiUVJrdVYzUkxWSk1JdERwNjg3CnMxY2EwSGlkOHhFSjhSWHhROGc5Rjh5MS9QU0x4TFFHZE1IMVorWnVuZVZJWkYycCs1OU1kQ0VyQTN1SFZ3dWEKazJhUlpsWjM2aXd5Z0NNcXhmZ1pCcys4SjZxZEd6cWtRamJKZnBVZG13MXBVRTEwZmtBVkxhdktLM0JtMGw3Zgpnb3o5cHR1UUlyT3RKZFVxL2p1UVBNclRDTjNJWjErempRSURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9TNHlNRFl1TVRneWdqeHlkeTB3WVRVeVltRTVZUzFsT0dRNUxUUTNZell0WVdVNU9DMW0KTjJNeU1qUmhaR1U1TnpZdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9TNHlNRFl1TVRneQpnanh5ZHkwd1lUVXlZbUU1WVMxbE9HUTVMVFEzWXpZdFlXVTVPQzFtTjJNeU1qUmhaR1U1TnpZdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQkRNUDJYdUhCRE9menJhSEJET2Z6cll3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFGYVFQVkhkQzZJUStEb2pNaGFnOUJ3bDhYSDVKUzIrWlFpRHFEODc0a1hhdHRLUXZpTTNsTzIxU1F0Lwp0N3d5UGdWOGNhOEttV0wxUlVlM2ZuUkdvcDl0bUhjOGRYd2lhaSszOHNUTTdUaU5IcWpGVmV3SmRMVFZRbXZvCmJ1S2tjdDNEVVhRRGZtT0tjM3h6MEVDelNGVmlHeUZiREpaclk5WE1CRnpOa1h4L013eVBoTVZBSXQxRS9WNkQKeWFYV0p0RVkrSDZtUllEV2x3QUZNeUR5WDhjeHhIOWRrQ1h5cVUyU1U4clIxN3YweHhvZm5NWmZ1SDFoVnhtaApoRTFmTG5heTdPb1o0Sk9IcXo3VG1EdW95TVl6aWU0c3FBakxHM2oybjREQnU4UTU5NjVsUzhBaGkvVzFscERRCnY0UUZFVC9ET1Q4UmxJR3VlS3o5T3VoaEkzaz0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+        body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVVEx5UndxN3pSMFJjYkFkUG5WVHlvWWZzQzlVd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tnk0eE1EQXdIaGNOCk1qWXdOakl5TVRJMU9ERXpXaGNOTXpZd05qRTVNVEkxT0RFeldqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTNMakV3TURDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUpPZXoyeThjOHFVUUlOcUpEKzNXVXZVMzV6cHJnUmh6L0ZGZ2xoNXVzbEFXK2RyMXhmbjJOSmwKd3hjcGF3M251SHVZTk9GTTNLclRiNjdyQmVSbkxzSHdpRCs4b1NxWVVzTVJpUllaRTVuK1FXcWZBV0EvbFdiMgo2NnVFWkJuclF5UGExNHZiSGh6bDZIcWtYYkxZa2pvRGwxbnhObTZiYWhBNkJLVXZlbjZZSEk4dWdTUWIreWQvClFNWm5iNGlIdW0vQlhUK1JGQVVPKzdoSFJOb1RhN29xR2hJREZ2ZHdXUHJmL1Nxc1IrUWlWTGhMdlFGWE5GTEMKMVdON0YwTnBnTXpPemRaUlJqTHZIN0ZHWGhua2g4RmUzYlhYOHNzTE1QR1kzVHpyMTI2bERKYStzZVAvTHlTNQpaVVpzV2J0QnBaejVmTGY5N1NaYkdnTXNTQjJKWWhNQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1qY3VNVEF3Z2p4eWR5MDJaREV6WlRnNFpDMDBObUU0TFRRNVl6RXRZbVpsTVMwNE9USXgKWm1Ga05qWmpPVFl1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eU55NHhNRENDUEhKMwpMVFprTVRObE9EaGtMVFEyWVRndE5EbGpNUzFpWm1VeExUZzVNakZtWVdRMk5tTTVOaTV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VvNnlVdm9jRU01OGJaSWNFTTU4YlpEQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKRHhIbWRqcWMzcU1rQXNyMzdlK04wbVI1QmFRZW5xOHZDMndzeU1aRDJWTi9PUkt0VE9lNit0MzJVakF0MTVZbwpQRTlWcnI2S1FzQnArV25mUVloVExDZ2o1SHBlSHd0MGUzMzBJOTM5ZFU3MVJ4ME1YckpnTGRxUmNlcm12VTcwCnEvQnJvTWlHOE9PN29lWEpabnczUmtIc09oMG1mZGhsY1FjdFRNeGF0ZlhIYzI5b2ZzZ3ZqSG0vZzI2eG5LMmMKVFFHczJ4NVgwYzB3dXlIejNnc24rZGNVS3NOblVqWnZpSkxITjBjcWMxSnJwMUhGOWFBRmJjS1dGTmMyZHBjWgp0Y0x6RGowWGp5MEFXMzEwOU5KdUZwWlRPMFJYakNvdFl6MS9pWk9zODJkcmJCdWppRm9xV0FBblI1SDBWWG9aCm0xd0JaODJib3BNVkhPREkyMDZtT3c9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
         headers:
             Content-Length:
-                - "2011"
+                - "2007"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:41 GMT
+                - Mon, 22 Jun 2026 12:59:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -887,10 +887,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0118be05-c531-470b-9762-83cae3b59cd1
+                - 0b83a302-1ee1-4897-b556-4f69379e696d
         status: 200 OK
         code: 200
-        duration: 88.321747ms
+        duration: 71.883762ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -907,7 +907,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0a52ba9a-e8d9-47c6-ae98-f7c224ade976/databases?name=tfdb_backup_list&order_by=name_asc
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d13e88d-46a8-49c1-bfe1-8921fad66c96/databases?name=tfdb_backup_list&order_by=name_asc
         method: GET
       response:
         proto: HTTP/2.0
@@ -926,9 +926,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:41 GMT
+                - Mon, 22 Jun 2026 12:59:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -936,10 +936,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7e8b2a87-0fad-4d73-b575-74442c41fa9a
+                - d02de631-57ab-42e6-aac5-293ee193034a
         status: 200 OK
         code: 200
-        duration: 240.830112ms
+        duration: 195.963462ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -956,7 +956,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/46f379f3-9df6-4a65-bc6d-6afdac57ae73
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/429c745b-d79b-4a86-89b7-e544be515a59
         method: GET
       response:
         proto: HTTP/2.0
@@ -966,7 +966,7 @@ interactions:
         trailer: {}
         content_length: 461
         uncompressed: false
-        body: '{"created_at":"2026-06-18T10:41:09.656480Z","database_name":"tfdb_backup_list","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"46f379f3-9df6-4a65-bc6d-6afdac57ae73","instance_id":"0a52ba9a-e8d9-47c6-ae98-f7c224ade976","instance_name":"tf-test-rdb-backup-list-4823616331525728375","name":"tf_backup_list_2078923807392667811","region":"fr-par","same_region":false,"size":1333,"status":"ready","updated_at":"2026-06-18T10:41:13.035327Z"}'
+        body: '{"created_at":"2026-06-22T12:58:46.497631Z","database_name":"tfdb_backup_list","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"429c745b-d79b-4a86-89b7-e544be515a59","instance_id":"6d13e88d-46a8-49c1-bfe1-8921fad66c96","instance_name":"tf-test-rdb-backup-list-4823616331525728375","name":"tf_backup_list_2078923807392667811","region":"fr-par","same_region":false,"size":1333,"status":"ready","updated_at":"2026-06-22T12:58:50.493142Z"}'
         headers:
             Content-Length:
                 - "461"
@@ -975,9 +975,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:41 GMT
+                - Mon, 22 Jun 2026 12:59:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -985,10 +985,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 36315b2c-7255-4156-a7ab-f2afee7bbea4
+                - 1152a285-3201-46d9-bb27-f5f5be30f4b8
         status: 200 OK
         code: 200
-        duration: 162.992316ms
+        duration: 156.083802ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1005,7 +1005,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0a52ba9a-e8d9-47c6-ae98-f7c224ade976
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d13e88d-46a8-49c1-bfe1-8921fad66c96
         method: GET
       response:
         proto: HTTP/2.0
@@ -1013,20 +1013,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1261
+        content_length: 1257
         uncompressed: false
-        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-18T10:37:35.132115Z","encryption":{"enabled":false},"endpoint":{"id":"db704b91-ebf7-47a2-b3f7-08c6606af968","ip":"51.159.206.182","load_balancer":{},"name":null,"port":10469},"endpoints":[{"id":"db704b91-ebf7-47a2-b3f7-08c6606af968","ip":"51.159.206.182","load_balancer":{},"name":null,"port":10469}],"engine":"PostgreSQL-17","id":"0a52ba9a-e8d9-47c6-ae98-f7c224ade976","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-backup-list-4823616331525728375","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"4e23ecb4-14a1-428d-826d-59003f746cb0","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["rdb-backup-list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-22T12:55:41.355847Z","encryption":{"enabled":false},"endpoint":{"id":"82b37d06-e598-4909-b77b-5ec0e1d49ae8","ip":"51.159.27.100","load_balancer":{},"name":null,"port":9420},"endpoints":[{"id":"82b37d06-e598-4909-b77b-5ec0e1d49ae8","ip":"51.159.27.100","load_balancer":{},"name":null,"port":9420}],"engine":"PostgreSQL-17","id":"6d13e88d-46a8-49c1-bfe1-8921fad66c96","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-backup-list-4823616331525728375","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"b8609ac7-cfd0-400c-aaf0-2ce98ae41483","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["rdb-backup-list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
         headers:
             Content-Length:
-                - "1261"
+                - "1257"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:42 GMT
+                - Mon, 22 Jun 2026 12:59:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1034,10 +1034,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b70f9bd4-c68a-460d-bbe0-336a2a6aa035
+                - ece2f9bc-8409-4ce3-bfaf-c719ae31739f
         status: 200 OK
         code: 200
-        duration: 178.053072ms
+        duration: 122.007951ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1054,7 +1054,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups?instance_id=0a52ba9a-e8d9-47c6-ae98-f7c224ade976&name=tf_backup_list_2078923807392667811&order_by=created_at_asc&page=1&project_id=4e23ecb4-14a1-428d-826d-59003f746cb0
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups?instance_id=6d13e88d-46a8-49c1-bfe1-8921fad66c96&name=tf_backup_list_2078923807392667811&order_by=created_at_asc&page=1&project_id=b8609ac7-cfd0-400c-aaf0-2ce98ae41483
         method: GET
       response:
         proto: HTTP/2.0
@@ -1064,7 +1064,7 @@ interactions:
         trailer: {}
         content_length: 500
         uncompressed: false
-        body: '{"database_backups":[{"created_at":"2026-06-18T10:41:09.656480Z","database_name":"tfdb_backup_list","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"46f379f3-9df6-4a65-bc6d-6afdac57ae73","instance_id":"0a52ba9a-e8d9-47c6-ae98-f7c224ade976","instance_name":"tf-test-rdb-backup-list-4823616331525728375","name":"tf_backup_list_2078923807392667811","region":"fr-par","same_region":false,"size":1333,"status":"ready","updated_at":"2026-06-18T10:41:13.035327Z"}],"total_count":1}'
+        body: '{"database_backups":[{"created_at":"2026-06-22T12:58:46.497631Z","database_name":"tfdb_backup_list","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"429c745b-d79b-4a86-89b7-e544be515a59","instance_id":"6d13e88d-46a8-49c1-bfe1-8921fad66c96","instance_name":"tf-test-rdb-backup-list-4823616331525728375","name":"tf_backup_list_2078923807392667811","region":"fr-par","same_region":false,"size":1333,"status":"ready","updated_at":"2026-06-22T12:58:50.493142Z"}],"total_count":1}'
         headers:
             Content-Length:
                 - "500"
@@ -1073,9 +1073,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:42 GMT
+                - Mon, 22 Jun 2026 12:59:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1083,10 +1083,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 937753fe-f947-4c12-b932-746221f7d609
+                - 675fd4c3-a657-4fbf-91a8-180a046daf0a
         status: 200 OK
         code: 200
-        duration: 176.859092ms
+        duration: 171.739295ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1103,7 +1103,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances?order_by=created_at_asc&page=1&project_id=4e23ecb4-14a1-428d-826d-59003f746cb0
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances?order_by=created_at_asc&page=1&project_id=b8609ac7-cfd0-400c-aaf0-2ce98ae41483
         method: GET
       response:
         proto: HTTP/2.0
@@ -1111,20 +1111,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1293
+        content_length: 1289
         uncompressed: false
-        body: '{"instances":[{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-18T10:37:35.132115Z","encryption":{"enabled":false},"endpoint":{"id":"db704b91-ebf7-47a2-b3f7-08c6606af968","ip":"51.159.206.182","load_balancer":{},"name":null,"port":10469},"endpoints":[{"id":"db704b91-ebf7-47a2-b3f7-08c6606af968","ip":"51.159.206.182","load_balancer":{},"name":null,"port":10469}],"engine":"PostgreSQL-17","id":"0a52ba9a-e8d9-47c6-ae98-f7c224ade976","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-backup-list-4823616331525728375","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"4e23ecb4-14a1-428d-826d-59003f746cb0","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["rdb-backup-list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}],"total_count":1}'
+        body: '{"instances":[{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-22T12:55:41.355847Z","encryption":{"enabled":false},"endpoint":{"id":"82b37d06-e598-4909-b77b-5ec0e1d49ae8","ip":"51.159.27.100","load_balancer":{},"name":null,"port":9420},"endpoints":[{"id":"82b37d06-e598-4909-b77b-5ec0e1d49ae8","ip":"51.159.27.100","load_balancer":{},"name":null,"port":9420}],"engine":"PostgreSQL-17","id":"6d13e88d-46a8-49c1-bfe1-8921fad66c96","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-backup-list-4823616331525728375","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"b8609ac7-cfd0-400c-aaf0-2ce98ae41483","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["rdb-backup-list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}],"total_count":1}'
         headers:
             Content-Length:
-                - "1293"
+                - "1289"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:42 GMT
+                - Mon, 22 Jun 2026 12:59:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1132,10 +1132,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f722c1da-1ce5-41f8-98d0-a86e5f1dc2f9
+                - 4c018d69-6781-4280-a672-8abfc0e92f82
         status: 200 OK
         code: 200
-        duration: 197.53553ms
+        duration: 202.487035ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1152,7 +1152,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups?instance_id=0a52ba9a-e8d9-47c6-ae98-f7c224ade976&name=tf_backup_list_2078923807392667811&order_by=created_at_asc&page=1&project_id=4e23ecb4-14a1-428d-826d-59003f746cb0
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups?instance_id=6d13e88d-46a8-49c1-bfe1-8921fad66c96&name=tf_backup_list_2078923807392667811&order_by=created_at_asc&page=1&project_id=b8609ac7-cfd0-400c-aaf0-2ce98ae41483
         method: GET
       response:
         proto: HTTP/2.0
@@ -1162,7 +1162,7 @@ interactions:
         trailer: {}
         content_length: 500
         uncompressed: false
-        body: '{"database_backups":[{"created_at":"2026-06-18T10:41:09.656480Z","database_name":"tfdb_backup_list","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"46f379f3-9df6-4a65-bc6d-6afdac57ae73","instance_id":"0a52ba9a-e8d9-47c6-ae98-f7c224ade976","instance_name":"tf-test-rdb-backup-list-4823616331525728375","name":"tf_backup_list_2078923807392667811","region":"fr-par","same_region":false,"size":1333,"status":"ready","updated_at":"2026-06-18T10:41:13.035327Z"}],"total_count":1}'
+        body: '{"database_backups":[{"created_at":"2026-06-22T12:58:46.497631Z","database_name":"tfdb_backup_list","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"429c745b-d79b-4a86-89b7-e544be515a59","instance_id":"6d13e88d-46a8-49c1-bfe1-8921fad66c96","instance_name":"tf-test-rdb-backup-list-4823616331525728375","name":"tf_backup_list_2078923807392667811","region":"fr-par","same_region":false,"size":1333,"status":"ready","updated_at":"2026-06-22T12:58:50.493142Z"}],"total_count":1}'
         headers:
             Content-Length:
                 - "500"
@@ -1171,9 +1171,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:42 GMT
+                - Mon, 22 Jun 2026 12:59:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1181,10 +1181,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 228308a4-54af-420e-bc7c-e29a707a465e
+                - 27c28120-101a-49e9-8f5d-b74ca6a4d9f9
         status: 200 OK
         code: 200
-        duration: 173.834835ms
+        duration: 164.073028ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1201,7 +1201,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/46f379f3-9df6-4a65-bc6d-6afdac57ae73
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/429c745b-d79b-4a86-89b7-e544be515a59
         method: GET
       response:
         proto: HTTP/2.0
@@ -1211,7 +1211,7 @@ interactions:
         trailer: {}
         content_length: 461
         uncompressed: false
-        body: '{"created_at":"2026-06-18T10:41:09.656480Z","database_name":"tfdb_backup_list","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"46f379f3-9df6-4a65-bc6d-6afdac57ae73","instance_id":"0a52ba9a-e8d9-47c6-ae98-f7c224ade976","instance_name":"tf-test-rdb-backup-list-4823616331525728375","name":"tf_backup_list_2078923807392667811","region":"fr-par","same_region":false,"size":1333,"status":"ready","updated_at":"2026-06-18T10:41:13.035327Z"}'
+        body: '{"created_at":"2026-06-22T12:58:46.497631Z","database_name":"tfdb_backup_list","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"429c745b-d79b-4a86-89b7-e544be515a59","instance_id":"6d13e88d-46a8-49c1-bfe1-8921fad66c96","instance_name":"tf-test-rdb-backup-list-4823616331525728375","name":"tf_backup_list_2078923807392667811","region":"fr-par","same_region":false,"size":1333,"status":"ready","updated_at":"2026-06-22T12:58:50.493142Z"}'
         headers:
             Content-Length:
                 - "461"
@@ -1220,9 +1220,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:43 GMT
+                - Mon, 22 Jun 2026 12:59:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1230,10 +1230,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b052cfc9-13f6-497c-8314-cdca221aaef9
+                - 67431432-93c2-4491-aef2-bdad54389a29
         status: 200 OK
         code: 200
-        duration: 169.823367ms
+        duration: 161.530815ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1250,7 +1250,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/46f379f3-9df6-4a65-bc6d-6afdac57ae73
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/429c745b-d79b-4a86-89b7-e544be515a59
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1260,7 +1260,7 @@ interactions:
         trailer: {}
         content_length: 464
         uncompressed: false
-        body: '{"created_at":"2026-06-18T10:41:09.656480Z","database_name":"tfdb_backup_list","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"46f379f3-9df6-4a65-bc6d-6afdac57ae73","instance_id":"0a52ba9a-e8d9-47c6-ae98-f7c224ade976","instance_name":"tf-test-rdb-backup-list-4823616331525728375","name":"tf_backup_list_2078923807392667811","region":"fr-par","same_region":false,"size":1333,"status":"deleting","updated_at":"2026-06-18T10:41:13.035327Z"}'
+        body: '{"created_at":"2026-06-22T12:58:46.497631Z","database_name":"tfdb_backup_list","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"429c745b-d79b-4a86-89b7-e544be515a59","instance_id":"6d13e88d-46a8-49c1-bfe1-8921fad66c96","instance_name":"tf-test-rdb-backup-list-4823616331525728375","name":"tf_backup_list_2078923807392667811","region":"fr-par","same_region":false,"size":1333,"status":"deleting","updated_at":"2026-06-22T12:58:50.493142Z"}'
         headers:
             Content-Length:
                 - "464"
@@ -1269,9 +1269,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:43 GMT
+                - Mon, 22 Jun 2026 12:59:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1279,10 +1279,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c2f09c07-9791-445c-97df-334f3d2253d9
+                - a162b5ad-7ca5-4a1b-ab53-8880e4aa86be
         status: 200 OK
         code: 200
-        duration: 397.040799ms
+        duration: 301.243813ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1299,7 +1299,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/46f379f3-9df6-4a65-bc6d-6afdac57ae73
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/429c745b-d79b-4a86-89b7-e544be515a59
         method: GET
       response:
         proto: HTTP/2.0
@@ -1309,7 +1309,7 @@ interactions:
         trailer: {}
         content_length: 136
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"database_backup","resource_id":"46f379f3-9df6-4a65-bc6d-6afdac57ae73","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"database_backup","resource_id":"429c745b-d79b-4a86-89b7-e544be515a59","type":"not_found"}'
         headers:
             Content-Length:
                 - "136"
@@ -1318,9 +1318,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:43 GMT
+                - Mon, 22 Jun 2026 12:59:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1328,10 +1328,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3f29538c-fbca-4892-b463-f910548da670
+                - 2fab8b1c-15e4-45a7-885e-afb778ff4687
         status: 404 Not Found
         code: 404
-        duration: 58.403659ms
+        duration: 31.081963ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1348,7 +1348,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0a52ba9a-e8d9-47c6-ae98-f7c224ade976
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d13e88d-46a8-49c1-bfe1-8921fad66c96
         method: GET
       response:
         proto: HTTP/2.0
@@ -1356,20 +1356,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1261
+        content_length: 1257
         uncompressed: false
-        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-18T10:37:35.132115Z","encryption":{"enabled":false},"endpoint":{"id":"db704b91-ebf7-47a2-b3f7-08c6606af968","ip":"51.159.206.182","load_balancer":{},"name":null,"port":10469},"endpoints":[{"id":"db704b91-ebf7-47a2-b3f7-08c6606af968","ip":"51.159.206.182","load_balancer":{},"name":null,"port":10469}],"engine":"PostgreSQL-17","id":"0a52ba9a-e8d9-47c6-ae98-f7c224ade976","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-backup-list-4823616331525728375","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"4e23ecb4-14a1-428d-826d-59003f746cb0","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["rdb-backup-list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-22T12:55:41.355847Z","encryption":{"enabled":false},"endpoint":{"id":"82b37d06-e598-4909-b77b-5ec0e1d49ae8","ip":"51.159.27.100","load_balancer":{},"name":null,"port":9420},"endpoints":[{"id":"82b37d06-e598-4909-b77b-5ec0e1d49ae8","ip":"51.159.27.100","load_balancer":{},"name":null,"port":9420}],"engine":"PostgreSQL-17","id":"6d13e88d-46a8-49c1-bfe1-8921fad66c96","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-backup-list-4823616331525728375","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"b8609ac7-cfd0-400c-aaf0-2ce98ae41483","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["rdb-backup-list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
         headers:
             Content-Length:
-                - "1261"
+                - "1257"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:43 GMT
+                - Mon, 22 Jun 2026 12:59:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1377,10 +1377,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bedebd1c-cc40-4f4b-8db5-11fe586736d3
+                - 7918fc69-ed3a-4a1c-a434-a244eb61fb66
         status: 200 OK
         code: 200
-        duration: 114.599769ms
+        duration: 101.692505ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1397,7 +1397,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0a52ba9a-e8d9-47c6-ae98-f7c224ade976/databases/tfdb_backup_list
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d13e88d-46a8-49c1-bfe1-8921fad66c96/databases/tfdb_backup_list
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1414,9 +1414,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:44 GMT
+                - Mon, 22 Jun 2026 12:59:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1424,10 +1424,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4ab66ee8-86a5-43b9-a269-afca21abd37f
+                - 701f66ec-caf7-43c1-892e-daf9f05d7110
         status: 204 No Content
         code: 204
-        duration: 955.379352ms
+        duration: 457.61499ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1444,7 +1444,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0a52ba9a-e8d9-47c6-ae98-f7c224ade976
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d13e88d-46a8-49c1-bfe1-8921fad66c96
         method: GET
       response:
         proto: HTTP/2.0
@@ -1452,20 +1452,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1261
+        content_length: 1257
         uncompressed: false
-        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-18T10:37:35.132115Z","encryption":{"enabled":false},"endpoint":{"id":"db704b91-ebf7-47a2-b3f7-08c6606af968","ip":"51.159.206.182","load_balancer":{},"name":null,"port":10469},"endpoints":[{"id":"db704b91-ebf7-47a2-b3f7-08c6606af968","ip":"51.159.206.182","load_balancer":{},"name":null,"port":10469}],"engine":"PostgreSQL-17","id":"0a52ba9a-e8d9-47c6-ae98-f7c224ade976","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-backup-list-4823616331525728375","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"4e23ecb4-14a1-428d-826d-59003f746cb0","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["rdb-backup-list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-22T12:55:41.355847Z","encryption":{"enabled":false},"endpoint":{"id":"82b37d06-e598-4909-b77b-5ec0e1d49ae8","ip":"51.159.27.100","load_balancer":{},"name":null,"port":9420},"endpoints":[{"id":"82b37d06-e598-4909-b77b-5ec0e1d49ae8","ip":"51.159.27.100","load_balancer":{},"name":null,"port":9420}],"engine":"PostgreSQL-17","id":"6d13e88d-46a8-49c1-bfe1-8921fad66c96","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-backup-list-4823616331525728375","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"b8609ac7-cfd0-400c-aaf0-2ce98ae41483","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["rdb-backup-list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
         headers:
             Content-Length:
-                - "1261"
+                - "1257"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:44 GMT
+                - Mon, 22 Jun 2026 12:59:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1473,10 +1473,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a9c5fa50-c0c5-44b9-b514-42231e0308fe
+                - d7fdcdd9-808f-48bc-a9ec-f286353ec2bd
         status: 200 OK
         code: 200
-        duration: 206.987508ms
+        duration: 199.831681ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1493,7 +1493,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0a52ba9a-e8d9-47c6-ae98-f7c224ade976
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d13e88d-46a8-49c1-bfe1-8921fad66c96
         method: GET
       response:
         proto: HTTP/2.0
@@ -1501,20 +1501,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1261
+        content_length: 1257
         uncompressed: false
-        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-18T10:37:35.132115Z","encryption":{"enabled":false},"endpoint":{"id":"db704b91-ebf7-47a2-b3f7-08c6606af968","ip":"51.159.206.182","load_balancer":{},"name":null,"port":10469},"endpoints":[{"id":"db704b91-ebf7-47a2-b3f7-08c6606af968","ip":"51.159.206.182","load_balancer":{},"name":null,"port":10469}],"engine":"PostgreSQL-17","id":"0a52ba9a-e8d9-47c6-ae98-f7c224ade976","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-backup-list-4823616331525728375","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"4e23ecb4-14a1-428d-826d-59003f746cb0","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["rdb-backup-list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-22T12:55:41.355847Z","encryption":{"enabled":false},"endpoint":{"id":"82b37d06-e598-4909-b77b-5ec0e1d49ae8","ip":"51.159.27.100","load_balancer":{},"name":null,"port":9420},"endpoints":[{"id":"82b37d06-e598-4909-b77b-5ec0e1d49ae8","ip":"51.159.27.100","load_balancer":{},"name":null,"port":9420}],"engine":"PostgreSQL-17","id":"6d13e88d-46a8-49c1-bfe1-8921fad66c96","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-backup-list-4823616331525728375","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"b8609ac7-cfd0-400c-aaf0-2ce98ae41483","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["rdb-backup-list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
         headers:
             Content-Length:
-                - "1261"
+                - "1257"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:45 GMT
+                - Mon, 22 Jun 2026 12:59:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1522,10 +1522,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0aec85d9-ded4-49f0-a5b2-343fe36c898d
+                - 81e3a7d9-07cf-4d32-8b89-08cfcee1b02e
         status: 200 OK
         code: 200
-        duration: 103.817584ms
+        duration: 108.246623ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1542,7 +1542,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0a52ba9a-e8d9-47c6-ae98-f7c224ade976
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d13e88d-46a8-49c1-bfe1-8921fad66c96
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1550,20 +1550,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1264
+        content_length: 1260
         uncompressed: false
-        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-18T10:37:35.132115Z","encryption":{"enabled":false},"endpoint":{"id":"db704b91-ebf7-47a2-b3f7-08c6606af968","ip":"51.159.206.182","load_balancer":{},"name":null,"port":10469},"endpoints":[{"id":"db704b91-ebf7-47a2-b3f7-08c6606af968","ip":"51.159.206.182","load_balancer":{},"name":null,"port":10469}],"engine":"PostgreSQL-17","id":"0a52ba9a-e8d9-47c6-ae98-f7c224ade976","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-backup-list-4823616331525728375","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"4e23ecb4-14a1-428d-826d-59003f746cb0","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["rdb-backup-list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-22T12:55:41.355847Z","encryption":{"enabled":false},"endpoint":{"id":"82b37d06-e598-4909-b77b-5ec0e1d49ae8","ip":"51.159.27.100","load_balancer":{},"name":null,"port":9420},"endpoints":[{"id":"82b37d06-e598-4909-b77b-5ec0e1d49ae8","ip":"51.159.27.100","load_balancer":{},"name":null,"port":9420}],"engine":"PostgreSQL-17","id":"6d13e88d-46a8-49c1-bfe1-8921fad66c96","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-backup-list-4823616331525728375","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"b8609ac7-cfd0-400c-aaf0-2ce98ae41483","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["rdb-backup-list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
         headers:
             Content-Length:
-                - "1264"
+                - "1260"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:45 GMT
+                - Mon, 22 Jun 2026 12:59:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1571,10 +1571,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 121634c2-8390-40fb-b2dc-170ca429c7e7
+                - 11b02775-16d8-48c6-9ea0-c24a89a87700
         status: 200 OK
         code: 200
-        duration: 518.976662ms
+        duration: 355.722406ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1591,7 +1591,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0a52ba9a-e8d9-47c6-ae98-f7c224ade976
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d13e88d-46a8-49c1-bfe1-8921fad66c96
         method: GET
       response:
         proto: HTTP/2.0
@@ -1599,20 +1599,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1264
+        content_length: 1260
         uncompressed: false
-        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-18T10:37:35.132115Z","encryption":{"enabled":false},"endpoint":{"id":"db704b91-ebf7-47a2-b3f7-08c6606af968","ip":"51.159.206.182","load_balancer":{},"name":null,"port":10469},"endpoints":[{"id":"db704b91-ebf7-47a2-b3f7-08c6606af968","ip":"51.159.206.182","load_balancer":{},"name":null,"port":10469}],"engine":"PostgreSQL-17","id":"0a52ba9a-e8d9-47c6-ae98-f7c224ade976","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-backup-list-4823616331525728375","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"4e23ecb4-14a1-428d-826d-59003f746cb0","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["rdb-backup-list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-22T12:55:41.355847Z","encryption":{"enabled":false},"endpoint":{"id":"82b37d06-e598-4909-b77b-5ec0e1d49ae8","ip":"51.159.27.100","load_balancer":{},"name":null,"port":9420},"endpoints":[{"id":"82b37d06-e598-4909-b77b-5ec0e1d49ae8","ip":"51.159.27.100","load_balancer":{},"name":null,"port":9420}],"engine":"PostgreSQL-17","id":"6d13e88d-46a8-49c1-bfe1-8921fad66c96","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-backup-list-4823616331525728375","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"b8609ac7-cfd0-400c-aaf0-2ce98ae41483","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["rdb-backup-list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
         headers:
             Content-Length:
-                - "1264"
+                - "1260"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:45 GMT
+                - Mon, 22 Jun 2026 12:59:21 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1620,10 +1620,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 68da372c-a95e-453d-a46d-2bc03bef15cb
+                - 45a1e358-58d6-4ce4-8a74-1b62602224d2
         status: 200 OK
         code: 200
-        duration: 119.462371ms
+        duration: 103.119686ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1640,7 +1640,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0a52ba9a-e8d9-47c6-ae98-f7c224ade976
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d13e88d-46a8-49c1-bfe1-8921fad66c96
         method: GET
       response:
         proto: HTTP/2.0
@@ -1650,7 +1650,7 @@ interactions:
         trailer: {}
         content_length: 129
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance","resource_id":"0a52ba9a-e8d9-47c6-ae98-f7c224ade976","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance","resource_id":"6d13e88d-46a8-49c1-bfe1-8921fad66c96","type":"not_found"}'
         headers:
             Content-Length:
                 - "129"
@@ -1659,9 +1659,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:42:15 GMT
+                - Mon, 22 Jun 2026 12:59:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1669,10 +1669,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 84b7efae-09e6-41ca-8b65-6a32ad17ca2d
+                - d140f9fe-f7c5-487b-bee1-134538ea8e6f
         status: 404 Not Found
         code: 404
-        duration: 189.01525ms
+        duration: 134.899922ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1689,7 +1689,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/account/v3/projects/4e23ecb4-14a1-428d-826d-59003f746cb0
+        url: https://api.scaleway.com/account/v3/projects/b8609ac7-cfd0-400c-aaf0-2ce98ae41483
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1706,9 +1706,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:42:17 GMT
+                - Mon, 22 Jun 2026 12:59:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1716,10 +1716,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f983c61e-b4e6-4177-a3f9-e0579a0881c5
+                - 32ef1e83-e48a-48f3-805f-20a30c3c1a96
         status: 204 No Content
         code: 204
-        duration: 1.637914188s
+        duration: 1.757449587s
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1736,7 +1736,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/account/v3/projects/4e23ecb4-14a1-428d-826d-59003f746cb0
+        url: https://api.scaleway.com/account/v3/projects/b8609ac7-cfd0-400c-aaf0-2ce98ae41483
         method: GET
       response:
         proto: HTTP/2.0
@@ -1746,7 +1746,7 @@ interactions:
         trailer: {}
         content_length: 131
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"project_id","resource_id":"4e23ecb4-14a1-428d-826d-59003f746cb0","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"project_id","resource_id":"b8609ac7-cfd0-400c-aaf0-2ce98ae41483","type":"not_found"}'
         headers:
             Content-Length:
                 - "131"
@@ -1755,9 +1755,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:42:17 GMT
+                - Mon, 22 Jun 2026 12:59:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1765,7 +1765,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c4ed00e6-7ad1-4058-bb76-e019a16b40b9
+                - c9adddd2-42f4-4d4a-9425-03bab53ab460
         status: 404 Not Found
         code: 404
-        duration: 37.402872ms
+        duration: 24.470667ms

--- a/internal/services/rdb/testdata/list-rdb-databases-basic.cassette.yaml
+++ b/internal/services/rdb/testdata/list-rdb-databases-basic.cassette.yaml
@@ -36,9 +36,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:37:32 GMT
+                - Mon, 22 Jun 2026 12:55:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -46,22 +46,22 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1ef19956-d162-4636-8c2b-1a7662ff1941
+                - 8fb07f36-46f2-4931-be58-8304e7fc3763
         status: 200 OK
         code: 200
-        duration: 184.703483ms
+        duration: 168.455016ms
     - id: 1
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 110
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-project-elated-hypatia","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","description":""}'
+        body: '{"name":"tf-project-agitated-chandrasekhar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","description":""}'
         form: {}
         headers:
             Content-Type:
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 261
+        content_length: 269
         uncompressed: false
-        body: '{"created_at":"2026-06-18T10:37:34.053412Z","description":"","id":"7ddc15e4-abf7-4470-ac89-12313c26686a","name":"tf-project-elated-hypatia","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","qualification":null,"updated_at":"2026-06-18T10:37:34.053412Z"}'
+        body: '{"created_at":"2026-06-22T12:55:39.993979Z","description":"","id":"7f623653-5b63-47ec-8d78-a2340b52b706","name":"tf-project-agitated-chandrasekhar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","qualification":null,"updated_at":"2026-06-22T12:55:39.993979Z"}'
         headers:
             Content-Length:
-                - "261"
+                - "269"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:37:34 GMT
+                - Mon, 22 Jun 2026 12:55:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d8df067c-25bf-4313-9bbd-23a6e8739f05
+                - 5c70277c-8af9-4730-aac4-12ce04b66488
         status: 200 OK
         code: 200
-        duration: 670.252487ms
+        duration: 644.048456ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -117,7 +117,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/account/v3/projects/7ddc15e4-abf7-4470-ac89-12313c26686a
+        url: https://api.scaleway.com/account/v3/projects/7f623653-5b63-47ec-8d78-a2340b52b706
         method: GET
       response:
         proto: HTTP/2.0
@@ -125,20 +125,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 306
+        content_length: 314
         uncompressed: false
-        body: '{"created_at":"2026-06-18T10:37:34.053412Z","description":"","id":"7ddc15e4-abf7-4470-ac89-12313c26686a","name":"tf-project-elated-hypatia","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2026-06-18T10:37:34.053412Z"}'
+        body: '{"created_at":"2026-06-22T12:55:39.993979Z","description":"","id":"7f623653-5b63-47ec-8d78-a2340b52b706","name":"tf-project-agitated-chandrasekhar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2026-06-22T12:55:39.993979Z"}'
         headers:
             Content-Length:
-                - "306"
+                - "314"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:37:34 GMT
+                - Mon, 22 Jun 2026 12:55:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2cd6018d-50fb-47df-ba67-cd052eca9210
+                - 90c578c0-10ab-4df4-9743-ccbed63f7de3
         status: 200 OK
         code: 200
-        duration: 241.538268ms
+        duration: 366.831323ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -161,7 +161,7 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"project_id":"7ddc15e4-abf7-4470-ac89-12313c26686a","name":"tf-test-rdb-db-list-4823616331525728375","engine":"PostgreSQL-17","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["rdb-db-list-test"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":null,"backup_same_region":false,"encryption":{"enabled":false}}'
+        body: '{"project_id":"7f623653-5b63-47ec-8d78-a2340b52b706","name":"tf-test-rdb-db-list-4823616331525728375","engine":"PostgreSQL-17","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["rdb-db-list-test"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":null,"backup_same_region":false,"encryption":{"enabled":false}}'
         form: {}
         headers:
             Content-Type:
@@ -178,7 +178,7 @@ interactions:
         trailer: {}
         content_length: 778
         uncompressed: false
-        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-18T10:37:35.055942Z","encryption":{"enabled":false},"endpoint":null,"endpoints":[],"engine":"PostgreSQL-17","id":"745346ff-6407-42d6-ab43-c6eb56b3b056","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-db-list-4823616331525728375","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"7ddc15e4-abf7-4470-ac89-12313c26686a","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["rdb-db-list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-22T12:55:41.675624Z","encryption":{"enabled":false},"endpoint":null,"endpoints":[],"engine":"PostgreSQL-17","id":"b2e6aa9b-01f5-4fef-be39-6b0ff87072fa","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-db-list-4823616331525728375","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"7f623653-5b63-47ec-8d78-a2340b52b706","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["rdb-db-list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
         headers:
             Content-Length:
                 - "778"
@@ -187,9 +187,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:37:35 GMT
+                - Mon, 22 Jun 2026 12:55:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -197,10 +197,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b14cb762-49b5-4d4b-8c20-75ac968f5dc7
+                - 90b18400-1d4f-44b1-b8d6-22dfc03cd4e3
         status: 200 OK
         code: 200
-        duration: 727.809161ms
+        duration: 1.716353967s
     - id: 4
       request:
         proto: HTTP/1.1
@@ -217,7 +217,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/745346ff-6407-42d6-ab43-c6eb56b3b056
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b2e6aa9b-01f5-4fef-be39-6b0ff87072fa
         method: GET
       response:
         proto: HTTP/2.0
@@ -227,7 +227,7 @@ interactions:
         trailer: {}
         content_length: 778
         uncompressed: false
-        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-18T10:37:35.055942Z","encryption":{"enabled":false},"endpoint":null,"endpoints":[],"engine":"PostgreSQL-17","id":"745346ff-6407-42d6-ab43-c6eb56b3b056","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-db-list-4823616331525728375","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"7ddc15e4-abf7-4470-ac89-12313c26686a","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["rdb-db-list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-22T12:55:41.675624Z","encryption":{"enabled":false},"endpoint":null,"endpoints":[],"engine":"PostgreSQL-17","id":"b2e6aa9b-01f5-4fef-be39-6b0ff87072fa","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-db-list-4823616331525728375","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"7f623653-5b63-47ec-8d78-a2340b52b706","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["rdb-db-list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
         headers:
             Content-Length:
                 - "778"
@@ -236,9 +236,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:37:35 GMT
+                - Mon, 22 Jun 2026 12:55:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -246,10 +246,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5037a282-2cde-4b75-92a2-50a1f43250e6
+                - 55dc4f21-5981-4e22-b0de-3f34a0b0df0a
         status: 200 OK
         code: 200
-        duration: 197.434749ms
+        duration: 188.004102ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -266,7 +266,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/745346ff-6407-42d6-ab43-c6eb56b3b056
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b2e6aa9b-01f5-4fef-be39-6b0ff87072fa
         method: GET
       response:
         proto: HTTP/2.0
@@ -274,20 +274,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1247
+        content_length: 1255
         uncompressed: false
-        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-18T10:37:35.055942Z","encryption":{"enabled":false},"endpoint":{"id":"6e1cf0aa-c5a2-468b-9bc4-e2c052de9c21","ip":"51.15.134.48","load_balancer":{},"name":null,"port":2566},"endpoints":[{"id":"6e1cf0aa-c5a2-468b-9bc4-e2c052de9c21","ip":"51.15.134.48","load_balancer":{},"name":null,"port":2566}],"engine":"PostgreSQL-17","id":"745346ff-6407-42d6-ab43-c6eb56b3b056","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-db-list-4823616331525728375","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"7ddc15e4-abf7-4470-ac89-12313c26686a","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["rdb-db-list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-22T12:55:41.675624Z","encryption":{"enabled":false},"endpoint":{"id":"12269688-3914-4a93-aada-5e457186bee4","ip":"163.172.139.167","load_balancer":{},"name":null,"port":15455},"endpoints":[{"id":"12269688-3914-4a93-aada-5e457186bee4","ip":"163.172.139.167","load_balancer":{},"name":null,"port":15455}],"engine":"PostgreSQL-17","id":"b2e6aa9b-01f5-4fef-be39-6b0ff87072fa","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-db-list-4823616331525728375","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"7f623653-5b63-47ec-8d78-a2340b52b706","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["rdb-db-list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
         headers:
             Content-Length:
-                - "1247"
+                - "1255"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:07 GMT
+                - Mon, 22 Jun 2026 12:59:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -295,10 +295,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1de1afda-6c52-456c-b71c-b18747696984
+                - 3c79a39d-d29a-4bf7-abf0-cf0cb7867e5e
         status: 200 OK
         code: 200
-        duration: 221.387976ms
+        duration: 174.166821ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -315,7 +315,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/745346ff-6407-42d6-ab43-c6eb56b3b056/certificate
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b2e6aa9b-01f5-4fef-be39-6b0ff87072fa/certificate
         method: GET
       response:
         proto: HTTP/2.0
@@ -323,20 +323,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1995
+        content_length: 2015
         uncompressed: false
-        body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQrRENDQXVDZ0F3SUJBZ0lVQ3phbXJ3SEoxa29sbWZjZWdmWTU4eC9IWDYwd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFMakV6TkM0ME9EQWVGdzB5Ck5qQTJNVGd4TURRd01qTmFGdzB6TmpBMk1UVXhNRFF3TWpOYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlM0eE16UXVORGd3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURjUUNEaWNDN2trM0RGa1gxQVRINnRreEdnTnVicVNDV3BKZXVUWnhDaTBLWHI1VlZ1UVpSQm12TjcKa3Bxa0VjSCt4OVlqbVdQSVo2ejBCV2Z0NmRLbTF6enpBUW01YTZ4Z0ZZK3htdjVSYkNzZmR1blEyc1lqa0VZUAp6LzZIcy9KdkN0TFR3cktMRXgzTkpPUlp4T21LM0ZnZ1JacFAyS3ZUOUtZY2R3SXZSK2xxT0xETlJwT050VnhmCjhBbUYvaWdrUUZIV3VyY0RNRVJrWjNHak4vL2JOb2VHM3dJNUNVQ1pjR0UyRFJIaXAyNE55Qmt3QmpCZU5CR1oKOFozNVhyd2Rhek5tSUVIM2xHaXJBWElxYlF5cUpHWDBTVEp6QllDdWdEUzg5MFl0RmpnL0twcWJpTmR2MHJrSwpocGlIOHJWbUI5dmJYNGlNTmY1TnpiWXVsTk5wQWdNQkFBR2pnYnN3Z2Jnd2diVUdBMVVkRVFTQnJUQ0Jxb0lNCk5URXVNVFV1TVRNMExqUTRnanh5ZHkwM05EVXpORFptWmkwMk5EQTNMVFF5WkRZdFlXSTBNeTFqTm1WaU5UWmkKTTJJd05UWXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRERVeExqRTFMakV6TkM0ME9JSThjbmN0TnpRMQpNelEyWm1ZdE5qUXdOeTAwTW1RMkxXRmlORE10WXpabFlqVTJZak5pTURVMkxuSmtZaTVtY2kxd1lYSXVjMk4zCkxtTnNiM1ZraHdTanJLZ0pod1F6RDRZd2h3UXpENFl3TUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFDVWFwU1IKbHB1NGlxRTZrdVd4QnBmN1AyUE1wSjVoWWNKdXZ1NGJZS1R6OEYvN1kzM2RyeUdmMHJ0WXZKRG1aWFF4OHdtUwo3TU9MZnkwSEhLb01iNVFLQ2d5TENpNzYyTGtuWHpVeFpTSUR1RlRrY1BiSlV0US9qbnA4dXVuUkxzOFFFSjgvCk9MeGZ5SFpEenZhL0dKYjlncTR2ZGZuZ1lsQVpvOVdoRU9xdXVyT2ZhcTY0cis5Y2J0T3pyYWR0MndJd3JMb2oKTi9KSExIWG04NjAzdUh3dkJSTjFPTnA2VUZya3N4cVpYdk9FbmRCZFMrNzhCTDQwN1I5U0tFd1NXTUVUVUZLbwowUGswZERUTW5ZUXA4VkV3RlBlVXk1UzM3MXpBaFQyZ0NDSk9WY28yc2lWNWhjNGFZdUdtRE9pNGF4U1pOZU5yCkltdUJJYWhqekhEbWlidkkKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+        body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVT2JGRW5vR1UvVmR3QnNFUXNzWmFZSElYUXkwd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFMk15NHhOekl1TVRNNUxqRTJOekFlCkZ3MHlOakEyTWpJeE1qVTROVEZhRncwek5qQTJNVGt4TWpVNE5URmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4TmpNdU1UY3lMakV6T1M0eE5qY3dnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRRFFGYkwvMjZQcGk4Z2k4Rkh3UHJhWDVWMWUvQ2pNRCtOa0xWbWtVRmlDZjYrUzgrRGkKQmd2MTFWaklHWkdoWU5TQkw1cnRZTExJYmhsZUVYTVZDN1h6dzc3ZWNpNVEvb2h1V2tHK0FZWG52VUNxQ1krdQpCWUlqSmF4UHJ0N0wyUWNxY3BhY3RLYStPWHFJcWUyR2VNbGgxalRVYW80TmRHelVleC9hbjkxa3lMV3NPVFI1Cjh2Njd3cm9rK2pRNUQzZlJZeHliZVM5VW03L3VOVndhWWtLSWZBR2VpQlJnL1NEaVg3Q2ozd0lrZWVJcDNLZC8KZENkRDlmQ2Q1dFBVb2VXQXhvbzdDaElBa21SeE53UWpKdFFkNUxIMHhjcjZSYWhtV05IVUwwNlpWUEMzOGFnWgpmaFNWODBqaVRLWkJmZDRZVm5oVTdaVG44YmtRMURQVmNWdGJBZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRZekxqRTNNaTR4TXprdU1UWTNnanh5ZHkxaU1tVTJZV0U1WWkwd01XWTFMVFJtWldZdFltVXoKT1MwMllqQm1aamczTURjeVptRXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFMk15NHhOekl1TVRNNQpMakUyTjRJOGNuY3RZakpsTm1GaE9XSXRNREZtTlMwMFptVm1MV0psTXprdE5tSXdabVk0TnpBM01tWmhMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3UXpEOVo4aHdTanJJdW5od1Nqckl1bk1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUE5TTA3RFB5bFB0M1EveHJHa3lvalpqVmN3bmVIRDRqTURDazZZRlRyRXF5aUlDV200aWwvWAovMm4zaFMrd0EzV0tUZHJFd2NhRm9GaHZpbm8yTkloSTBOUU5PVnhaZ29nRHZ4dW1CRDJjUVZ5Qi9OcU83Y0hiClo2K1ZoTkFnZkg3ZXQrQjZIN3VQSGpaVjk0VGR1eklnUXpnV3NHWEdUTk1xVndleFArT1lPOXg1K0VGdSt2QVcKV1hHOHFwUmVBck1jYjY4cTdIcllYVTNTSlYvVWpRb2pQOXVYM1F5d2U3aWhMMHhtWHAyaktPT2dkNG0vTFE5OAo5L255NFg5djRWZzFiMVNqYXRhamF5SkJmQmUrWTlGUitObCtFL3FkeFZiUFpXeU5RUG5vd2Q3UGlIUVhCeUQwCjhGZ0wxamVoUlc4TkpEUnF3Y09Ic2tQVVRWK01FRHBhCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
         headers:
             Content-Length:
-                - "1995"
+                - "2015"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:07 GMT
+                - Mon, 22 Jun 2026 12:59:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -344,10 +344,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bcf82d02-9eb4-473a-b390-a5ca2b03ceb2
+                - 38efca54-aa3e-4fd8-9725-8e02e8b31e68
         status: 200 OK
         code: 200
-        duration: 104.966497ms
+        duration: 68.732975ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -364,7 +364,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/745346ff-6407-42d6-ab43-c6eb56b3b056
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b2e6aa9b-01f5-4fef-be39-6b0ff87072fa
         method: GET
       response:
         proto: HTTP/2.0
@@ -372,20 +372,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1247
+        content_length: 1255
         uncompressed: false
-        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-18T10:37:35.055942Z","encryption":{"enabled":false},"endpoint":{"id":"6e1cf0aa-c5a2-468b-9bc4-e2c052de9c21","ip":"51.15.134.48","load_balancer":{},"name":null,"port":2566},"endpoints":[{"id":"6e1cf0aa-c5a2-468b-9bc4-e2c052de9c21","ip":"51.15.134.48","load_balancer":{},"name":null,"port":2566}],"engine":"PostgreSQL-17","id":"745346ff-6407-42d6-ab43-c6eb56b3b056","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-db-list-4823616331525728375","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"7ddc15e4-abf7-4470-ac89-12313c26686a","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["rdb-db-list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-22T12:55:41.675624Z","encryption":{"enabled":false},"endpoint":{"id":"12269688-3914-4a93-aada-5e457186bee4","ip":"163.172.139.167","load_balancer":{},"name":null,"port":15455},"endpoints":[{"id":"12269688-3914-4a93-aada-5e457186bee4","ip":"163.172.139.167","load_balancer":{},"name":null,"port":15455}],"engine":"PostgreSQL-17","id":"b2e6aa9b-01f5-4fef-be39-6b0ff87072fa","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-db-list-4823616331525728375","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"7f623653-5b63-47ec-8d78-a2340b52b706","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["rdb-db-list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
         headers:
             Content-Length:
-                - "1247"
+                - "1255"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:07 GMT
+                - Mon, 22 Jun 2026 12:59:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -393,10 +393,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f5450136-0a5c-4464-9d3e-e4034c9353c9
+                - 64afc45d-68e2-4b9a-b0d3-238057537f10
         status: 200 OK
         code: 200
-        duration: 137.199757ms
+        duration: 148.518067ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -415,7 +415,7 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/745346ff-6407-42d6-ab43-c6eb56b3b056/databases
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b2e6aa9b-01f5-4fef-be39-6b0ff87072fa/databases
         method: POST
       response:
         proto: HTTP/2.0
@@ -434,9 +434,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:08 GMT
+                - Mon, 22 Jun 2026 12:59:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -444,10 +444,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 885ce0c3-fb79-477a-a8dd-fec4d584e47a
+                - 00a1d129-2882-4ad3-b9c7-0416fddac0f8
         status: 200 OK
         code: 200
-        duration: 546.547036ms
+        duration: 496.433681ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -464,7 +464,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/745346ff-6407-42d6-ab43-c6eb56b3b056
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b2e6aa9b-01f5-4fef-be39-6b0ff87072fa
         method: GET
       response:
         proto: HTTP/2.0
@@ -472,20 +472,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1247
+        content_length: 1255
         uncompressed: false
-        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-18T10:37:35.055942Z","encryption":{"enabled":false},"endpoint":{"id":"6e1cf0aa-c5a2-468b-9bc4-e2c052de9c21","ip":"51.15.134.48","load_balancer":{},"name":null,"port":2566},"endpoints":[{"id":"6e1cf0aa-c5a2-468b-9bc4-e2c052de9c21","ip":"51.15.134.48","load_balancer":{},"name":null,"port":2566}],"engine":"PostgreSQL-17","id":"745346ff-6407-42d6-ab43-c6eb56b3b056","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-db-list-4823616331525728375","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"7ddc15e4-abf7-4470-ac89-12313c26686a","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["rdb-db-list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-22T12:55:41.675624Z","encryption":{"enabled":false},"endpoint":{"id":"12269688-3914-4a93-aada-5e457186bee4","ip":"163.172.139.167","load_balancer":{},"name":null,"port":15455},"endpoints":[{"id":"12269688-3914-4a93-aada-5e457186bee4","ip":"163.172.139.167","load_balancer":{},"name":null,"port":15455}],"engine":"PostgreSQL-17","id":"b2e6aa9b-01f5-4fef-be39-6b0ff87072fa","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-db-list-4823616331525728375","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"7f623653-5b63-47ec-8d78-a2340b52b706","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["rdb-db-list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
         headers:
             Content-Length:
-                - "1247"
+                - "1255"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:08 GMT
+                - Mon, 22 Jun 2026 12:59:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -493,10 +493,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fb456800-251e-4f44-b2a2-2c6ae1c5c419
+                - ba0cb684-441e-4357-b765-a3dcddd18c9a
         status: 200 OK
         code: 200
-        duration: 200.532322ms
+        duration: 162.615056ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -513,7 +513,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/745346ff-6407-42d6-ab43-c6eb56b3b056/databases?name=tfdb_list_2078923807392667811&order_by=name_asc
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b2e6aa9b-01f5-4fef-be39-6b0ff87072fa/databases?name=tfdb_list_2078923807392667811&order_by=name_asc
         method: GET
       response:
         proto: HTTP/2.0
@@ -532,9 +532,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:08 GMT
+                - Mon, 22 Jun 2026 12:59:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -542,10 +542,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 163b49c2-3c15-4f27-bc73-140e15e81495
+                - a742b280-d1e0-4f1a-b540-fe57aeb8bfd2
         status: 200 OK
         code: 200
-        duration: 178.954386ms
+        duration: 194.119364ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -562,7 +562,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/account/v3/projects/7ddc15e4-abf7-4470-ac89-12313c26686a
+        url: https://api.scaleway.com/account/v3/projects/7f623653-5b63-47ec-8d78-a2340b52b706
         method: GET
       response:
         proto: HTTP/2.0
@@ -570,20 +570,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 306
+        content_length: 314
         uncompressed: false
-        body: '{"created_at":"2026-06-18T10:37:34.053412Z","description":"","id":"7ddc15e4-abf7-4470-ac89-12313c26686a","name":"tf-project-elated-hypatia","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2026-06-18T10:37:34.053412Z"}'
+        body: '{"created_at":"2026-06-22T12:55:39.993979Z","description":"","id":"7f623653-5b63-47ec-8d78-a2340b52b706","name":"tf-project-agitated-chandrasekhar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2026-06-22T12:55:39.993979Z"}'
         headers:
             Content-Length:
-                - "306"
+                - "314"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:09 GMT
+                - Mon, 22 Jun 2026 12:59:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -591,10 +591,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 786e431d-06d2-4b11-a95b-5deb7c3612fb
+                - aab7380b-0e56-40ef-a1b3-e050a0bd3bc0
         status: 200 OK
         code: 200
-        duration: 277.582812ms
+        duration: 230.692094ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -611,7 +611,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/745346ff-6407-42d6-ab43-c6eb56b3b056
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b2e6aa9b-01f5-4fef-be39-6b0ff87072fa
         method: GET
       response:
         proto: HTTP/2.0
@@ -619,20 +619,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1247
+        content_length: 1255
         uncompressed: false
-        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-18T10:37:35.055942Z","encryption":{"enabled":false},"endpoint":{"id":"6e1cf0aa-c5a2-468b-9bc4-e2c052de9c21","ip":"51.15.134.48","load_balancer":{},"name":null,"port":2566},"endpoints":[{"id":"6e1cf0aa-c5a2-468b-9bc4-e2c052de9c21","ip":"51.15.134.48","load_balancer":{},"name":null,"port":2566}],"engine":"PostgreSQL-17","id":"745346ff-6407-42d6-ab43-c6eb56b3b056","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-db-list-4823616331525728375","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"7ddc15e4-abf7-4470-ac89-12313c26686a","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["rdb-db-list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-22T12:55:41.675624Z","encryption":{"enabled":false},"endpoint":{"id":"12269688-3914-4a93-aada-5e457186bee4","ip":"163.172.139.167","load_balancer":{},"name":null,"port":15455},"endpoints":[{"id":"12269688-3914-4a93-aada-5e457186bee4","ip":"163.172.139.167","load_balancer":{},"name":null,"port":15455}],"engine":"PostgreSQL-17","id":"b2e6aa9b-01f5-4fef-be39-6b0ff87072fa","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-db-list-4823616331525728375","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"7f623653-5b63-47ec-8d78-a2340b52b706","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["rdb-db-list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
         headers:
             Content-Length:
-                - "1247"
+                - "1255"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:09 GMT
+                - Mon, 22 Jun 2026 12:59:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -640,10 +640,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ebd59e3a-d9c6-4b42-bb1a-4840b8de2ec7
+                - 8200e470-898d-4645-bcc3-abdb36a7c5e5
         status: 200 OK
         code: 200
-        duration: 119.177221ms
+        duration: 106.618622ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -660,7 +660,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/745346ff-6407-42d6-ab43-c6eb56b3b056/certificate
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b2e6aa9b-01f5-4fef-be39-6b0ff87072fa/certificate
         method: GET
       response:
         proto: HTTP/2.0
@@ -668,20 +668,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1995
+        content_length: 2015
         uncompressed: false
-        body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQrRENDQXVDZ0F3SUJBZ0lVQ3phbXJ3SEoxa29sbWZjZWdmWTU4eC9IWDYwd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFMakV6TkM0ME9EQWVGdzB5Ck5qQTJNVGd4TURRd01qTmFGdzB6TmpBMk1UVXhNRFF3TWpOYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlM0eE16UXVORGd3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURjUUNEaWNDN2trM0RGa1gxQVRINnRreEdnTnVicVNDV3BKZXVUWnhDaTBLWHI1VlZ1UVpSQm12TjcKa3Bxa0VjSCt4OVlqbVdQSVo2ejBCV2Z0NmRLbTF6enpBUW01YTZ4Z0ZZK3htdjVSYkNzZmR1blEyc1lqa0VZUAp6LzZIcy9KdkN0TFR3cktMRXgzTkpPUlp4T21LM0ZnZ1JacFAyS3ZUOUtZY2R3SXZSK2xxT0xETlJwT050VnhmCjhBbUYvaWdrUUZIV3VyY0RNRVJrWjNHak4vL2JOb2VHM3dJNUNVQ1pjR0UyRFJIaXAyNE55Qmt3QmpCZU5CR1oKOFozNVhyd2Rhek5tSUVIM2xHaXJBWElxYlF5cUpHWDBTVEp6QllDdWdEUzg5MFl0RmpnL0twcWJpTmR2MHJrSwpocGlIOHJWbUI5dmJYNGlNTmY1TnpiWXVsTk5wQWdNQkFBR2pnYnN3Z2Jnd2diVUdBMVVkRVFTQnJUQ0Jxb0lNCk5URXVNVFV1TVRNMExqUTRnanh5ZHkwM05EVXpORFptWmkwMk5EQTNMVFF5WkRZdFlXSTBNeTFqTm1WaU5UWmkKTTJJd05UWXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRERVeExqRTFMakV6TkM0ME9JSThjbmN0TnpRMQpNelEyWm1ZdE5qUXdOeTAwTW1RMkxXRmlORE10WXpabFlqVTJZak5pTURVMkxuSmtZaTVtY2kxd1lYSXVjMk4zCkxtTnNiM1ZraHdTanJLZ0pod1F6RDRZd2h3UXpENFl3TUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFDVWFwU1IKbHB1NGlxRTZrdVd4QnBmN1AyUE1wSjVoWWNKdXZ1NGJZS1R6OEYvN1kzM2RyeUdmMHJ0WXZKRG1aWFF4OHdtUwo3TU9MZnkwSEhLb01iNVFLQ2d5TENpNzYyTGtuWHpVeFpTSUR1RlRrY1BiSlV0US9qbnA4dXVuUkxzOFFFSjgvCk9MeGZ5SFpEenZhL0dKYjlncTR2ZGZuZ1lsQVpvOVdoRU9xdXVyT2ZhcTY0cis5Y2J0T3pyYWR0MndJd3JMb2oKTi9KSExIWG04NjAzdUh3dkJSTjFPTnA2VUZya3N4cVpYdk9FbmRCZFMrNzhCTDQwN1I5U0tFd1NXTUVUVUZLbwowUGswZERUTW5ZUXA4VkV3RlBlVXk1UzM3MXpBaFQyZ0NDSk9WY28yc2lWNWhjNGFZdUdtRE9pNGF4U1pOZU5yCkltdUJJYWhqekhEbWlidkkKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+        body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVT2JGRW5vR1UvVmR3QnNFUXNzWmFZSElYUXkwd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFMk15NHhOekl1TVRNNUxqRTJOekFlCkZ3MHlOakEyTWpJeE1qVTROVEZhRncwek5qQTJNVGt4TWpVNE5URmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4TmpNdU1UY3lMakV6T1M0eE5qY3dnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRRFFGYkwvMjZQcGk4Z2k4Rkh3UHJhWDVWMWUvQ2pNRCtOa0xWbWtVRmlDZjYrUzgrRGkKQmd2MTFWaklHWkdoWU5TQkw1cnRZTExJYmhsZUVYTVZDN1h6dzc3ZWNpNVEvb2h1V2tHK0FZWG52VUNxQ1krdQpCWUlqSmF4UHJ0N0wyUWNxY3BhY3RLYStPWHFJcWUyR2VNbGgxalRVYW80TmRHelVleC9hbjkxa3lMV3NPVFI1Cjh2Njd3cm9rK2pRNUQzZlJZeHliZVM5VW03L3VOVndhWWtLSWZBR2VpQlJnL1NEaVg3Q2ozd0lrZWVJcDNLZC8KZENkRDlmQ2Q1dFBVb2VXQXhvbzdDaElBa21SeE53UWpKdFFkNUxIMHhjcjZSYWhtV05IVUwwNlpWUEMzOGFnWgpmaFNWODBqaVRLWkJmZDRZVm5oVTdaVG44YmtRMURQVmNWdGJBZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRZekxqRTNNaTR4TXprdU1UWTNnanh5ZHkxaU1tVTJZV0U1WWkwd01XWTFMVFJtWldZdFltVXoKT1MwMllqQm1aamczTURjeVptRXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFMk15NHhOekl1TVRNNQpMakUyTjRJOGNuY3RZakpsTm1GaE9XSXRNREZtTlMwMFptVm1MV0psTXprdE5tSXdabVk0TnpBM01tWmhMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3UXpEOVo4aHdTanJJdW5od1Nqckl1bk1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUE5TTA3RFB5bFB0M1EveHJHa3lvalpqVmN3bmVIRDRqTURDazZZRlRyRXF5aUlDV200aWwvWAovMm4zaFMrd0EzV0tUZHJFd2NhRm9GaHZpbm8yTkloSTBOUU5PVnhaZ29nRHZ4dW1CRDJjUVZ5Qi9OcU83Y0hiClo2K1ZoTkFnZkg3ZXQrQjZIN3VQSGpaVjk0VGR1eklnUXpnV3NHWEdUTk1xVndleFArT1lPOXg1K0VGdSt2QVcKV1hHOHFwUmVBck1jYjY4cTdIcllYVTNTSlYvVWpRb2pQOXVYM1F5d2U3aWhMMHhtWHAyaktPT2dkNG0vTFE5OAo5L255NFg5djRWZzFiMVNqYXRhamF5SkJmQmUrWTlGUitObCtFL3FkeFZiUFpXeU5RUG5vd2Q3UGlIUVhCeUQwCjhGZ0wxamVoUlc4TkpEUnF3Y09Ic2tQVVRWK01FRHBhCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
         headers:
             Content-Length:
-                - "1995"
+                - "2015"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:09 GMT
+                - Mon, 22 Jun 2026 12:59:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -689,10 +689,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d6ed0adc-bac5-489a-94eb-123da83f9239
+                - bac18f8e-8096-420a-97e5-64123e011e64
         status: 200 OK
         code: 200
-        duration: 92.494919ms
+        duration: 170.650974ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -709,7 +709,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/745346ff-6407-42d6-ab43-c6eb56b3b056/databases?name=tfdb_list_2078923807392667811&order_by=name_asc
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b2e6aa9b-01f5-4fef-be39-6b0ff87072fa/databases?name=tfdb_list_2078923807392667811&order_by=name_asc
         method: GET
       response:
         proto: HTTP/2.0
@@ -728,9 +728,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:09 GMT
+                - Mon, 22 Jun 2026 12:59:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -738,10 +738,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6c76c2bb-3a4c-4687-8a70-d868935fe4c6
+                - 9e5008ee-00f6-4740-829d-391387e3b99b
         status: 200 OK
         code: 200
-        duration: 178.889283ms
+        duration: 188.013725ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -758,7 +758,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/745346ff-6407-42d6-ab43-c6eb56b3b056
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b2e6aa9b-01f5-4fef-be39-6b0ff87072fa
         method: GET
       response:
         proto: HTTP/2.0
@@ -766,20 +766,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1247
+        content_length: 1255
         uncompressed: false
-        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-18T10:37:35.055942Z","encryption":{"enabled":false},"endpoint":{"id":"6e1cf0aa-c5a2-468b-9bc4-e2c052de9c21","ip":"51.15.134.48","load_balancer":{},"name":null,"port":2566},"endpoints":[{"id":"6e1cf0aa-c5a2-468b-9bc4-e2c052de9c21","ip":"51.15.134.48","load_balancer":{},"name":null,"port":2566}],"engine":"PostgreSQL-17","id":"745346ff-6407-42d6-ab43-c6eb56b3b056","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-db-list-4823616331525728375","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"7ddc15e4-abf7-4470-ac89-12313c26686a","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["rdb-db-list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-22T12:55:41.675624Z","encryption":{"enabled":false},"endpoint":{"id":"12269688-3914-4a93-aada-5e457186bee4","ip":"163.172.139.167","load_balancer":{},"name":null,"port":15455},"endpoints":[{"id":"12269688-3914-4a93-aada-5e457186bee4","ip":"163.172.139.167","load_balancer":{},"name":null,"port":15455}],"engine":"PostgreSQL-17","id":"b2e6aa9b-01f5-4fef-be39-6b0ff87072fa","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-db-list-4823616331525728375","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"7f623653-5b63-47ec-8d78-a2340b52b706","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["rdb-db-list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
         headers:
             Content-Length:
-                - "1247"
+                - "1255"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:09 GMT
+                - Mon, 22 Jun 2026 12:59:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -787,10 +787,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c8d9c981-3cfe-4e0a-b3e5-933ec958c255
+                - 438aa267-d2f2-4907-84c9-041cdb34facf
         status: 200 OK
         code: 200
-        duration: 107.88176ms
+        duration: 179.920515ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -807,7 +807,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/745346ff-6407-42d6-ab43-c6eb56b3b056/databases?name=tfdb_list_2078923807392667811&order_by=name_asc&page=1
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b2e6aa9b-01f5-4fef-be39-6b0ff87072fa/databases?name=tfdb_list_2078923807392667811&order_by=name_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -826,9 +826,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:10 GMT
+                - Mon, 22 Jun 2026 12:59:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -836,10 +836,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9a887a1e-321e-470b-ad9e-4103e6fedb19
+                - f24451e2-034b-441e-b6aa-ad7862e30d4d
         status: 200 OK
         code: 200
-        duration: 288.243008ms
+        duration: 203.342361ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -856,7 +856,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances?order_by=created_at_asc&page=1&project_id=7ddc15e4-abf7-4470-ac89-12313c26686a
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances?order_by=created_at_asc&page=1&project_id=7f623653-5b63-47ec-8d78-a2340b52b706
         method: GET
       response:
         proto: HTTP/2.0
@@ -864,20 +864,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1279
+        content_length: 1287
         uncompressed: false
-        body: '{"instances":[{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-18T10:37:35.055942Z","encryption":{"enabled":false},"endpoint":{"id":"6e1cf0aa-c5a2-468b-9bc4-e2c052de9c21","ip":"51.15.134.48","load_balancer":{},"name":null,"port":2566},"endpoints":[{"id":"6e1cf0aa-c5a2-468b-9bc4-e2c052de9c21","ip":"51.15.134.48","load_balancer":{},"name":null,"port":2566}],"engine":"PostgreSQL-17","id":"745346ff-6407-42d6-ab43-c6eb56b3b056","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-db-list-4823616331525728375","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"7ddc15e4-abf7-4470-ac89-12313c26686a","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["rdb-db-list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}],"total_count":1}'
+        body: '{"instances":[{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-22T12:55:41.675624Z","encryption":{"enabled":false},"endpoint":{"id":"12269688-3914-4a93-aada-5e457186bee4","ip":"163.172.139.167","load_balancer":{},"name":null,"port":15455},"endpoints":[{"id":"12269688-3914-4a93-aada-5e457186bee4","ip":"163.172.139.167","load_balancer":{},"name":null,"port":15455}],"engine":"PostgreSQL-17","id":"b2e6aa9b-01f5-4fef-be39-6b0ff87072fa","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-db-list-4823616331525728375","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"7f623653-5b63-47ec-8d78-a2340b52b706","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["rdb-db-list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}],"total_count":1}'
         headers:
             Content-Length:
-                - "1279"
+                - "1287"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:10 GMT
+                - Mon, 22 Jun 2026 12:59:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -885,10 +885,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - cc1987d5-d250-43ac-bd53-64e7af682036
+                - b8acd131-3e28-4d8e-90f7-fe5e6b82e7f1
         status: 200 OK
         code: 200
-        duration: 230.518269ms
+        duration: 197.946133ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -905,7 +905,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/745346ff-6407-42d6-ab43-c6eb56b3b056/databases?name=tfdb_list_2078923807392667811&order_by=name_asc&page=1
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b2e6aa9b-01f5-4fef-be39-6b0ff87072fa/databases?name=tfdb_list_2078923807392667811&order_by=name_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -924,9 +924,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:10 GMT
+                - Mon, 22 Jun 2026 12:59:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -934,10 +934,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a58ee409-2d40-483f-9a26-d4ee20896480
+                - 64bc4515-a681-4a94-b465-16c575f5b034
         status: 200 OK
         code: 200
-        duration: 177.678534ms
+        duration: 165.701284ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -954,7 +954,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/745346ff-6407-42d6-ab43-c6eb56b3b056
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b2e6aa9b-01f5-4fef-be39-6b0ff87072fa
         method: GET
       response:
         proto: HTTP/2.0
@@ -962,20 +962,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1247
+        content_length: 1255
         uncompressed: false
-        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-18T10:37:35.055942Z","encryption":{"enabled":false},"endpoint":{"id":"6e1cf0aa-c5a2-468b-9bc4-e2c052de9c21","ip":"51.15.134.48","load_balancer":{},"name":null,"port":2566},"endpoints":[{"id":"6e1cf0aa-c5a2-468b-9bc4-e2c052de9c21","ip":"51.15.134.48","load_balancer":{},"name":null,"port":2566}],"engine":"PostgreSQL-17","id":"745346ff-6407-42d6-ab43-c6eb56b3b056","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-db-list-4823616331525728375","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"7ddc15e4-abf7-4470-ac89-12313c26686a","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["rdb-db-list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-22T12:55:41.675624Z","encryption":{"enabled":false},"endpoint":{"id":"12269688-3914-4a93-aada-5e457186bee4","ip":"163.172.139.167","load_balancer":{},"name":null,"port":15455},"endpoints":[{"id":"12269688-3914-4a93-aada-5e457186bee4","ip":"163.172.139.167","load_balancer":{},"name":null,"port":15455}],"engine":"PostgreSQL-17","id":"b2e6aa9b-01f5-4fef-be39-6b0ff87072fa","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-db-list-4823616331525728375","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"7f623653-5b63-47ec-8d78-a2340b52b706","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["rdb-db-list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
         headers:
             Content-Length:
-                - "1247"
+                - "1255"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:11 GMT
+                - Mon, 22 Jun 2026 12:59:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -983,10 +983,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1b082aed-508f-4e42-8cbc-5c85826d7bbf
+                - 94cc5deb-9a1c-42bc-8271-27d8eee8253e
         status: 200 OK
         code: 200
-        duration: 213.955002ms
+        duration: 187.861749ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1003,7 +1003,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/745346ff-6407-42d6-ab43-c6eb56b3b056/databases/tfdb_list_2078923807392667811
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b2e6aa9b-01f5-4fef-be39-6b0ff87072fa/databases/tfdb_list_2078923807392667811
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1020,9 +1020,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:11 GMT
+                - Mon, 22 Jun 2026 12:59:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1030,10 +1030,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 734b9659-b41c-4f3f-9a64-92725560bcb1
+                - 3d1eb578-0b8c-45b9-803f-6a867569b5e9
         status: 204 No Content
         code: 204
-        duration: 733.336787ms
+        duration: 823.62726ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1050,7 +1050,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/745346ff-6407-42d6-ab43-c6eb56b3b056
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b2e6aa9b-01f5-4fef-be39-6b0ff87072fa
         method: GET
       response:
         proto: HTTP/2.0
@@ -1058,20 +1058,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1247
+        content_length: 1255
         uncompressed: false
-        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-18T10:37:35.055942Z","encryption":{"enabled":false},"endpoint":{"id":"6e1cf0aa-c5a2-468b-9bc4-e2c052de9c21","ip":"51.15.134.48","load_balancer":{},"name":null,"port":2566},"endpoints":[{"id":"6e1cf0aa-c5a2-468b-9bc4-e2c052de9c21","ip":"51.15.134.48","load_balancer":{},"name":null,"port":2566}],"engine":"PostgreSQL-17","id":"745346ff-6407-42d6-ab43-c6eb56b3b056","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-db-list-4823616331525728375","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"7ddc15e4-abf7-4470-ac89-12313c26686a","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["rdb-db-list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-22T12:55:41.675624Z","encryption":{"enabled":false},"endpoint":{"id":"12269688-3914-4a93-aada-5e457186bee4","ip":"163.172.139.167","load_balancer":{},"name":null,"port":15455},"endpoints":[{"id":"12269688-3914-4a93-aada-5e457186bee4","ip":"163.172.139.167","load_balancer":{},"name":null,"port":15455}],"engine":"PostgreSQL-17","id":"b2e6aa9b-01f5-4fef-be39-6b0ff87072fa","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-db-list-4823616331525728375","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"7f623653-5b63-47ec-8d78-a2340b52b706","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["rdb-db-list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
         headers:
             Content-Length:
-                - "1247"
+                - "1255"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:11 GMT
+                - Mon, 22 Jun 2026 12:59:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1079,10 +1079,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - eae8d2a9-09b8-4826-bba2-cad62f6b334a
+                - 2aa82ae4-a584-4cb3-a345-de4c02216d62
         status: 200 OK
         code: 200
-        duration: 114.965437ms
+        duration: 117.344756ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1099,7 +1099,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/745346ff-6407-42d6-ab43-c6eb56b3b056
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b2e6aa9b-01f5-4fef-be39-6b0ff87072fa
         method: GET
       response:
         proto: HTTP/2.0
@@ -1107,20 +1107,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1247
+        content_length: 1255
         uncompressed: false
-        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-18T10:37:35.055942Z","encryption":{"enabled":false},"endpoint":{"id":"6e1cf0aa-c5a2-468b-9bc4-e2c052de9c21","ip":"51.15.134.48","load_balancer":{},"name":null,"port":2566},"endpoints":[{"id":"6e1cf0aa-c5a2-468b-9bc4-e2c052de9c21","ip":"51.15.134.48","load_balancer":{},"name":null,"port":2566}],"engine":"PostgreSQL-17","id":"745346ff-6407-42d6-ab43-c6eb56b3b056","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-db-list-4823616331525728375","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"7ddc15e4-abf7-4470-ac89-12313c26686a","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["rdb-db-list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-22T12:55:41.675624Z","encryption":{"enabled":false},"endpoint":{"id":"12269688-3914-4a93-aada-5e457186bee4","ip":"163.172.139.167","load_balancer":{},"name":null,"port":15455},"endpoints":[{"id":"12269688-3914-4a93-aada-5e457186bee4","ip":"163.172.139.167","load_balancer":{},"name":null,"port":15455}],"engine":"PostgreSQL-17","id":"b2e6aa9b-01f5-4fef-be39-6b0ff87072fa","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-db-list-4823616331525728375","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"7f623653-5b63-47ec-8d78-a2340b52b706","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["rdb-db-list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
         headers:
             Content-Length:
-                - "1247"
+                - "1255"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:12 GMT
+                - Mon, 22 Jun 2026 12:59:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1128,10 +1128,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ca845119-0748-4b40-90b5-d4b09d3f3ed0
+                - e8c31567-995c-45da-8d14-53fd195adffb
         status: 200 OK
         code: 200
-        duration: 115.053231ms
+        duration: 168.874531ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1148,7 +1148,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/745346ff-6407-42d6-ab43-c6eb56b3b056
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b2e6aa9b-01f5-4fef-be39-6b0ff87072fa
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1156,20 +1156,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1250
+        content_length: 1258
         uncompressed: false
-        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-18T10:37:35.055942Z","encryption":{"enabled":false},"endpoint":{"id":"6e1cf0aa-c5a2-468b-9bc4-e2c052de9c21","ip":"51.15.134.48","load_balancer":{},"name":null,"port":2566},"endpoints":[{"id":"6e1cf0aa-c5a2-468b-9bc4-e2c052de9c21","ip":"51.15.134.48","load_balancer":{},"name":null,"port":2566}],"engine":"PostgreSQL-17","id":"745346ff-6407-42d6-ab43-c6eb56b3b056","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-db-list-4823616331525728375","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"7ddc15e4-abf7-4470-ac89-12313c26686a","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["rdb-db-list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-22T12:55:41.675624Z","encryption":{"enabled":false},"endpoint":{"id":"12269688-3914-4a93-aada-5e457186bee4","ip":"163.172.139.167","load_balancer":{},"name":null,"port":15455},"endpoints":[{"id":"12269688-3914-4a93-aada-5e457186bee4","ip":"163.172.139.167","load_balancer":{},"name":null,"port":15455}],"engine":"PostgreSQL-17","id":"b2e6aa9b-01f5-4fef-be39-6b0ff87072fa","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-db-list-4823616331525728375","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"7f623653-5b63-47ec-8d78-a2340b52b706","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["rdb-db-list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
         headers:
             Content-Length:
-                - "1250"
+                - "1258"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:12 GMT
+                - Mon, 22 Jun 2026 12:59:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1177,10 +1177,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 729d076c-d07c-4b5a-9b46-b51e483f8779
+                - e9085e1b-3b8f-4d0b-b3d0-403e1d506b40
         status: 200 OK
         code: 200
-        duration: 675.015635ms
+        duration: 399.232429ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1197,7 +1197,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/745346ff-6407-42d6-ab43-c6eb56b3b056
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b2e6aa9b-01f5-4fef-be39-6b0ff87072fa
         method: GET
       response:
         proto: HTTP/2.0
@@ -1205,20 +1205,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1250
+        content_length: 1258
         uncompressed: false
-        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-18T10:37:35.055942Z","encryption":{"enabled":false},"endpoint":{"id":"6e1cf0aa-c5a2-468b-9bc4-e2c052de9c21","ip":"51.15.134.48","load_balancer":{},"name":null,"port":2566},"endpoints":[{"id":"6e1cf0aa-c5a2-468b-9bc4-e2c052de9c21","ip":"51.15.134.48","load_balancer":{},"name":null,"port":2566}],"engine":"PostgreSQL-17","id":"745346ff-6407-42d6-ab43-c6eb56b3b056","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-db-list-4823616331525728375","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"7ddc15e4-abf7-4470-ac89-12313c26686a","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["rdb-db-list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-22T12:55:41.675624Z","encryption":{"enabled":false},"endpoint":{"id":"12269688-3914-4a93-aada-5e457186bee4","ip":"163.172.139.167","load_balancer":{},"name":null,"port":15455},"endpoints":[{"id":"12269688-3914-4a93-aada-5e457186bee4","ip":"163.172.139.167","load_balancer":{},"name":null,"port":15455}],"engine":"PostgreSQL-17","id":"b2e6aa9b-01f5-4fef-be39-6b0ff87072fa","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-db-list-4823616331525728375","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"7f623653-5b63-47ec-8d78-a2340b52b706","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["rdb-db-list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
         headers:
             Content-Length:
-                - "1250"
+                - "1258"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:12 GMT
+                - Mon, 22 Jun 2026 12:59:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1226,10 +1226,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bd6f1bf1-1818-4dad-9a57-da07cef9005c
+                - da060288-936b-4062-a7b4-30b42d915b4f
         status: 200 OK
         code: 200
-        duration: 134.865912ms
+        duration: 111.576947ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1246,7 +1246,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/745346ff-6407-42d6-ab43-c6eb56b3b056
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b2e6aa9b-01f5-4fef-be39-6b0ff87072fa
         method: GET
       response:
         proto: HTTP/2.0
@@ -1256,7 +1256,7 @@ interactions:
         trailer: {}
         content_length: 129
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance","resource_id":"745346ff-6407-42d6-ab43-c6eb56b3b056","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance","resource_id":"b2e6aa9b-01f5-4fef-be39-6b0ff87072fa","type":"not_found"}'
         headers:
             Content-Length:
                 - "129"
@@ -1265,9 +1265,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:43 GMT
+                - Mon, 22 Jun 2026 12:59:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1275,10 +1275,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9eee77f6-3581-447e-96a2-820f232b7250
+                - 763160f8-ebb7-4781-9453-740993621191
         status: 404 Not Found
         code: 404
-        duration: 164.04563ms
+        duration: 86.144932ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1295,7 +1295,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/account/v3/projects/7ddc15e4-abf7-4470-ac89-12313c26686a
+        url: https://api.scaleway.com/account/v3/projects/7f623653-5b63-47ec-8d78-a2340b52b706
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1312,9 +1312,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:44 GMT
+                - Mon, 22 Jun 2026 12:59:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1322,10 +1322,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3741f7f4-095d-42d3-9d36-69d2f618f517
+                - 955e7ae1-842f-4fb1-ab9e-f84e9999b029
         status: 204 No Content
         code: 204
-        duration: 1.629579921s
+        duration: 1.767932774s
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1342,7 +1342,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/account/v3/projects/7ddc15e4-abf7-4470-ac89-12313c26686a
+        url: https://api.scaleway.com/account/v3/projects/7f623653-5b63-47ec-8d78-a2340b52b706
         method: GET
       response:
         proto: HTTP/2.0
@@ -1352,7 +1352,7 @@ interactions:
         trailer: {}
         content_length: 131
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"project_id","resource_id":"7ddc15e4-abf7-4470-ac89-12313c26686a","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"project_id","resource_id":"7f623653-5b63-47ec-8d78-a2340b52b706","type":"not_found"}'
         headers:
             Content-Length:
                 - "131"
@@ -1361,9 +1361,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:44 GMT
+                - Mon, 22 Jun 2026 12:59:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1371,7 +1371,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d04f53de-378e-48f8-85ae-e588e0ae61c4
+                - a0be05e5-2c7f-49af-9d40-46d72fc8ee7f
         status: 404 Not Found
         code: 404
-        duration: 36.331302ms
+        duration: 25.319192ms

--- a/internal/services/rdb/testdata/list-rdb-instances-basic.cassette.yaml
+++ b/internal/services/rdb/testdata/list-rdb-instances-basic.cassette.yaml
@@ -36,9 +36,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:37:32 GMT
+                - Mon, 22 Jun 2026 12:55:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -46,22 +46,22 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6ec4cfc4-0469-44f9-ba5f-e2f7d6e8757e
+                - 9dd23c25-390c-4058-bd31-476d20557ba5
         status: 200 OK
         code: 200
-        duration: 167.451472ms
+        duration: 170.43236ms
     - id: 1
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 113
+        content_length: 114
         transfer_encoding: []
         trailer: {}
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"name":"tf-project-pedantic-mahavira","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","description":""}'
+        body: '{"name":"tf-project-recursing-meninsky","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","description":""}'
         form: {}
         headers:
             Content-Type:
@@ -76,20 +76,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 264
+        content_length: 265
         uncompressed: false
-        body: '{"created_at":"2026-06-18T10:37:34.049808Z","description":"","id":"2ef576f7-e73b-49d0-af3a-cf51f7e882f1","name":"tf-project-pedantic-mahavira","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","qualification":null,"updated_at":"2026-06-18T10:37:34.049808Z"}'
+        body: '{"created_at":"2026-06-22T12:55:40.681011Z","description":"","id":"3692ebc2-5ed2-4de8-bc4a-a55d1bbcb29c","name":"tf-project-recursing-meninsky","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","qualification":null,"updated_at":"2026-06-22T12:55:40.681011Z"}'
         headers:
             Content-Length:
-                - "264"
+                - "265"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:37:34 GMT
+                - Mon, 22 Jun 2026 12:55:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3e93bb90-8213-4d34-b544-fe0d1b506831
+                - 145c4cc7-0eff-474b-aa5c-0328d93ba566
         status: 200 OK
         code: 200
-        duration: 797.766538ms
+        duration: 1.235778336s
     - id: 2
       request:
         proto: HTTP/1.1
@@ -117,7 +117,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/account/v3/projects/2ef576f7-e73b-49d0-af3a-cf51f7e882f1
+        url: https://api.scaleway.com/account/v3/projects/3692ebc2-5ed2-4de8-bc4a-a55d1bbcb29c
         method: GET
       response:
         proto: HTTP/2.0
@@ -125,20 +125,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 309
+        content_length: 310
         uncompressed: false
-        body: '{"created_at":"2026-06-18T10:37:34.049808Z","description":"","id":"2ef576f7-e73b-49d0-af3a-cf51f7e882f1","name":"tf-project-pedantic-mahavira","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2026-06-18T10:37:34.049808Z"}'
+        body: '{"created_at":"2026-06-22T12:55:40.681011Z","description":"","id":"3692ebc2-5ed2-4de8-bc4a-a55d1bbcb29c","name":"tf-project-recursing-meninsky","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2026-06-22T12:55:40.681011Z"}'
         headers:
             Content-Length:
-                - "309"
+                - "310"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:37:34 GMT
+                - Mon, 22 Jun 2026 12:55:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0a4bd1a3-9e1c-4280-8655-2f0227c39491
+                - 283969c0-0545-4c7c-98c8-7e4f767f5bb3
         status: 200 OK
         code: 200
-        duration: 280.744962ms
+        duration: 317.280979ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -161,7 +161,7 @@ interactions:
         host: api.scaleway.com
         remote_addr: ""
         request_uri: ""
-        body: '{"project_id":"2ef576f7-e73b-49d0-af3a-cf51f7e882f1","name":"test-rdb-list-1","engine":"PostgreSQL-17","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["list-test"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":null,"backup_same_region":false,"encryption":{"enabled":false}}'
+        body: '{"project_id":"3692ebc2-5ed2-4de8-bc4a-a55d1bbcb29c","name":"test-rdb-list-1","engine":"PostgreSQL-17","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["list-test"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":null,"backup_same_region":false,"encryption":{"enabled":false}}'
         form: {}
         headers:
             Content-Type:
@@ -178,7 +178,7 @@ interactions:
         trailer: {}
         content_length: 747
         uncompressed: false
-        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-18T10:37:35.292174Z","encryption":{"enabled":false},"endpoint":null,"endpoints":[],"engine":"PostgreSQL-17","id":"6b441ef7-34a8-4775-a99b-1751e3fe64aa","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-list-1","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"2ef576f7-e73b-49d0-af3a-cf51f7e882f1","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-22T12:55:42.780606Z","encryption":{"enabled":false},"endpoint":null,"endpoints":[],"engine":"PostgreSQL-17","id":"6bf4b27e-972c-4461-8dc5-d2bf98ed8f0e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-list-1","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"3692ebc2-5ed2-4de8-bc4a-a55d1bbcb29c","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
         headers:
             Content-Length:
                 - "747"
@@ -187,9 +187,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:37:35 GMT
+                - Mon, 22 Jun 2026 12:55:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -197,10 +197,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ee9779b1-993d-4714-97a3-2b4311082881
+                - daf5cad3-d829-4a5a-b968-41b066fbe60e
         status: 200 OK
         code: 200
-        duration: 831.030016ms
+        duration: 2.117529371s
     - id: 4
       request:
         proto: HTTP/1.1
@@ -217,7 +217,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6b441ef7-34a8-4775-a99b-1751e3fe64aa
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6bf4b27e-972c-4461-8dc5-d2bf98ed8f0e
         method: GET
       response:
         proto: HTTP/2.0
@@ -227,7 +227,7 @@ interactions:
         trailer: {}
         content_length: 747
         uncompressed: false
-        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-18T10:37:35.292174Z","encryption":{"enabled":false},"endpoint":null,"endpoints":[],"engine":"PostgreSQL-17","id":"6b441ef7-34a8-4775-a99b-1751e3fe64aa","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-list-1","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"2ef576f7-e73b-49d0-af3a-cf51f7e882f1","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-22T12:55:42.780606Z","encryption":{"enabled":false},"endpoint":null,"endpoints":[],"engine":"PostgreSQL-17","id":"6bf4b27e-972c-4461-8dc5-d2bf98ed8f0e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-list-1","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"3692ebc2-5ed2-4de8-bc4a-a55d1bbcb29c","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
         headers:
             Content-Length:
                 - "747"
@@ -236,9 +236,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:37:35 GMT
+                - Mon, 22 Jun 2026 12:55:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -246,10 +246,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5c90ff7e-bf53-48b9-8103-bbb1282d3370
+                - 6841fef5-9525-461e-ae31-0594ba0bdbf4
         status: 200 OK
         code: 200
-        duration: 232.780168ms
+        duration: 174.201743ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -266,7 +266,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6b441ef7-34a8-4775-a99b-1751e3fe64aa
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6bf4b27e-972c-4461-8dc5-d2bf98ed8f0e
         method: GET
       response:
         proto: HTTP/2.0
@@ -274,20 +274,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1216
+        content_length: 1218
         uncompressed: false
-        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-18T10:37:35.292174Z","encryption":{"enabled":false},"endpoint":{"id":"b50a9080-a649-4088-9b04-d320d079955a","ip":"51.15.134.48","load_balancer":{},"name":null,"port":3846},"endpoints":[{"id":"b50a9080-a649-4088-9b04-d320d079955a","ip":"51.15.134.48","load_balancer":{},"name":null,"port":3846}],"engine":"PostgreSQL-17","id":"6b441ef7-34a8-4775-a99b-1751e3fe64aa","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-list-1","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"2ef576f7-e73b-49d0-af3a-cf51f7e882f1","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-22T12:55:42.780606Z","encryption":{"enabled":false},"endpoint":{"id":"ec894c2e-1b4c-469e-9682-92c58c32a421","ip":"51.159.27.100","load_balancer":{},"name":null,"port":5799},"endpoints":[{"id":"ec894c2e-1b4c-469e-9682-92c58c32a421","ip":"51.159.27.100","load_balancer":{},"name":null,"port":5799}],"engine":"PostgreSQL-17","id":"6bf4b27e-972c-4461-8dc5-d2bf98ed8f0e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-list-1","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"3692ebc2-5ed2-4de8-bc4a-a55d1bbcb29c","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
         headers:
             Content-Length:
-                - "1216"
+                - "1218"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:07 GMT
+                - Mon, 22 Jun 2026 13:01:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -295,10 +295,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a523bcad-5ff8-4d5a-9c4a-bac09c5fe40b
+                - 5e1fa27f-5298-40e2-bf0f-b8318c1df07f
         status: 200 OK
         code: 200
-        duration: 216.333702ms
+        duration: 164.102485ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -315,7 +315,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6b441ef7-34a8-4775-a99b-1751e3fe64aa/certificate
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6bf4b27e-972c-4461-8dc5-d2bf98ed8f0e/certificate
         method: GET
       response:
         proto: HTTP/2.0
@@ -323,20 +323,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1995
+        content_length: 2007
         uncompressed: false
-        body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQrRENDQXVDZ0F3SUJBZ0lVRzdzRlM3ZVZnUXJuVmF0UzljVTFzQXhJMjBFd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFMakV6TkM0ME9EQWVGdzB5Ck5qQTJNVGd4TURRd01qTmFGdzB6TmpBMk1UVXhNRFF3TWpOYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlM0eE16UXVORGd3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUNnenU1eFN2Q2p2VXUyVWNpVUtxQkNEWWtlbmFISlNxNiswdjBBNlNicVhicWU0SGtPU3N1ZHg4ZisKQXJGZjFURWRQdEd6QmhwQzBwRU84aDNrVlk4cXpXUUlyWXh0SlBwQkNzZmp0dFN3Ly8zY04zd05pRUJkYi9adQpUbGZaeHpkV3dRZzFjbW9wMGd6aFpYenliRkxhK3kwejZBZTAycC84Y05wYnFtdkM0eGN6ejNOSDNkWGRrcHdwCnl6eUtTTENFcG0wcEVyQUNvUW5GV2NnMi96c0Flclh3dEc1VVpIb0IrM0wraGN0VmI1cmNqbGhxcmF1MFNlRHUKYVhlNDNNeEVISHFPbWxlNk5hd0RWeHVIYXF1TEM1VEV0RVRiTkxIY014UWkyTHZpeWdzQ2draVl1WmRBN3pUNgo1SlU5UXk5L1lMWU9BNGkwdU5GcEJYRGlLZko3QWdNQkFBR2pnYnN3Z2Jnd2diVUdBMVVkRVFTQnJUQ0Jxb0lNCk5URXVNVFV1TVRNMExqUTRnanh5ZHkwMllqUTBNV1ZtTnkwek5HRTRMVFEzTnpVdFlUazVZaTB4TnpVeFpUTm0KWlRZMFlXRXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRERVeExqRTFMakV6TkM0ME9JSThjbmN0Tm1JMApOREZsWmpjdE16UmhPQzAwTnpjMUxXRTVPV0l0TVRjMU1XVXpabVUyTkdGaExuSmtZaTVtY2kxd1lYSXVjMk4zCkxtTnNiM1ZraHdTanJMVmRod1F6RDRZd2h3UXpENFl3TUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFCTFRzSXUKaWZkc0VKWjQ2M2RSbXl2TXB4TGE3TVBSREt3b0FIci82ZjdxZHR3WEJRVVNkYkNtK3pCSElCQVZLQVJWV3YvawpsQjQzZSs5R3Bkd08vODZrVXZvdXNybUd0V1BPeDRjaS9zMlFRM2NXSXZDWVJOQWc2TWFmaURCT0czUkNzV21lCjdXdDIvdmNBaHFOTG5GZFNrck1adHQ2ZEZ1RXA5OG04VlRkTTFqdUZFRFhmVlBCKy9JNHpIT3FBQlV4MTllK2IKa3JlTW5NaTZ2cTBjTlNucHlBWExJc3dSZDNQMWRlSnoyVmlYVXFHTXR0Q2hGZHo4dWVZUi9NVXl4RDZUMHU5bApKTmUwK093UDZXaU5Kejcwc0RsRURKNFdrK081MHBkR3JXaUZOeVZzdzFmQnQ1TnFuQVhvdTYwT3BjSmRSelh4Ck55VkRIWGRCV3IzbXB5S3kKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+        body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVWjIrZzNXRkJnK0U3RUxzbEtmZ3h6ZzFQTzJnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tnk0eE1EQXdIaGNOCk1qWXdOakl5TVRNd01EUXhXaGNOTXpZd05qRTVNVE13TURReFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTNMakV3TURDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtYaHNBVUN3Z0MzdElBNWVLbG9BQ1hwcGhNSDZHL0lmcHMvTXpaaTVPak1uOGRuaWt2VkVPczMKbFpGU1ZUZnYwd1p5dS9hOWh4VDg4TzRoUFc2NGUzZkVxZ2ZRaEJCOTcyeit0US9TZmNaRHlURGZQV1d2WDdCbApMNjFVeGU0Ri8zVkNydmpRd3JlSkJTcmsyWXVuY0lQN0hRQ3JiWnRLc3NBQ2xmR0lnVmh1WTFGYW1PMFBiYUJyCno1L2VtQTJyMnFpRUUxSjNodXN5c2p6N0VpSFIwSkg0bjNJdUQ4OFR6VnNRdWdscmh3c1pSRzZaZEo0WU0yOFkKS2R6S21ySk04RDZQbmZlMmtodmRjbGVEZGgxSyt5NDRJKzJROWdLaG9TUm01Y2RkcUh1OXhTOUdacm9zRkY0aApxZitMVlY0dkQwbEg2dFFvSCs1Y3BhNytVK3ZxQmdjQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1qY3VNVEF3Z2p4eWR5MDJZbVkwWWpJM1pTMDVOekpqTFRRME5qRXRPR1JqTlMxa01tSm0KT1RobFpEaG1NR1V1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eU55NHhNRENDUEhKMwpMVFppWmpSaU1qZGxMVGszTW1NdE5EUTJNUzA0WkdNMUxXUXlZbVk1T0dWa09HWXdaUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VvNnk3ZUljRU01OGJaSWNFTTU4YlpEQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKbE1rVDZmZU1wKzJFdlJuVVNkQVdxc1gyNkwzM0p6NTNnNGF4UTlIbDIvaVNLTUViVk81MDFodmd5RTFzM2hGNwpyYkoyNEw2TG1VWGpNWE5Ec2kyKzRSdllDTE9yMFNuYkxvWEhsSGNKTE8wajhHeE9ua1NNVi9TR08zaU4zMHd2CkljaEhmYUJhRnpEd1NBc2RIc044SFowd0hSaGJhRDlGMVdkSEFDVEZQTzVJMUVqeXVvOXVGZnRIaW1jK0RMdTkKMGVXV3hjMnd2cTV0N2I3WVIydWZsWGE4TEoyL3hETkZzWnZtNjlRbHc4dnh1YUd5dDdiNlJ5Sm9OZlYycjZydQpZSERpZFpob0J1Yk16Q051YUJGbFBOL3Q4Skl4cDQvZy9jTytOcWU1dGw0K0tkVDMrVEhaQTdDZzFEOXoxUHd4CndDeTlBUkhiWGl4dnZjM25Cenc3bFE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
         headers:
             Content-Length:
-                - "1995"
+                - "2007"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:07 GMT
+                - Mon, 22 Jun 2026 13:01:15 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -344,10 +344,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ec12a463-ea68-4b7a-a6c9-3b6e8f418d0b
+                - 0083e892-818e-4cfb-b63e-6c7cb8236bad
         status: 200 OK
         code: 200
-        duration: 95.114885ms
+        duration: 146.33596ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -364,7 +364,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/account/v3/projects/2ef576f7-e73b-49d0-af3a-cf51f7e882f1
+        url: https://api.scaleway.com/account/v3/projects/3692ebc2-5ed2-4de8-bc4a-a55d1bbcb29c
         method: GET
       response:
         proto: HTTP/2.0
@@ -372,20 +372,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 309
+        content_length: 310
         uncompressed: false
-        body: '{"created_at":"2026-06-18T10:37:34.049808Z","description":"","id":"2ef576f7-e73b-49d0-af3a-cf51f7e882f1","name":"tf-project-pedantic-mahavira","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2026-06-18T10:37:34.049808Z"}'
+        body: '{"created_at":"2026-06-22T12:55:40.681011Z","description":"","id":"3692ebc2-5ed2-4de8-bc4a-a55d1bbcb29c","name":"tf-project-recursing-meninsky","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","qualification":{"architecture_type":"unknown_architecture_type"},"updated_at":"2026-06-22T12:55:40.681011Z"}'
         headers:
             Content-Length:
-                - "309"
+                - "310"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:07 GMT
+                - Mon, 22 Jun 2026 13:01:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -393,10 +393,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 01a3a703-533b-44db-a303-81bd4f46958b
+                - bef67916-743a-4d3a-bd56-f13fa41f32bf
         status: 200 OK
         code: 200
-        duration: 239.805566ms
+        duration: 234.761008ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -413,7 +413,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6b441ef7-34a8-4775-a99b-1751e3fe64aa
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6bf4b27e-972c-4461-8dc5-d2bf98ed8f0e
         method: GET
       response:
         proto: HTTP/2.0
@@ -421,20 +421,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1216
+        content_length: 1218
         uncompressed: false
-        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-18T10:37:35.292174Z","encryption":{"enabled":false},"endpoint":{"id":"b50a9080-a649-4088-9b04-d320d079955a","ip":"51.15.134.48","load_balancer":{},"name":null,"port":3846},"endpoints":[{"id":"b50a9080-a649-4088-9b04-d320d079955a","ip":"51.15.134.48","load_balancer":{},"name":null,"port":3846}],"engine":"PostgreSQL-17","id":"6b441ef7-34a8-4775-a99b-1751e3fe64aa","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-list-1","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"2ef576f7-e73b-49d0-af3a-cf51f7e882f1","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-22T12:55:42.780606Z","encryption":{"enabled":false},"endpoint":{"id":"ec894c2e-1b4c-469e-9682-92c58c32a421","ip":"51.159.27.100","load_balancer":{},"name":null,"port":5799},"endpoints":[{"id":"ec894c2e-1b4c-469e-9682-92c58c32a421","ip":"51.159.27.100","load_balancer":{},"name":null,"port":5799}],"engine":"PostgreSQL-17","id":"6bf4b27e-972c-4461-8dc5-d2bf98ed8f0e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-list-1","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"3692ebc2-5ed2-4de8-bc4a-a55d1bbcb29c","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
         headers:
             Content-Length:
-                - "1216"
+                - "1218"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:08 GMT
+                - Mon, 22 Jun 2026 13:01:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -442,10 +442,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e63b1fb3-05fa-47ba-8473-9721c0483a84
+                - df075dad-e6a2-40c2-86f1-84c212fc577d
         status: 200 OK
         code: 200
-        duration: 201.91696ms
+        duration: 203.213327ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -462,7 +462,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6b441ef7-34a8-4775-a99b-1751e3fe64aa/certificate
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6bf4b27e-972c-4461-8dc5-d2bf98ed8f0e/certificate
         method: GET
       response:
         proto: HTTP/2.0
@@ -470,20 +470,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1995
+        content_length: 2007
         uncompressed: false
-        body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQrRENDQXVDZ0F3SUJBZ0lVRzdzRlM3ZVZnUXJuVmF0UzljVTFzQXhJMjBFd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFMakV6TkM0ME9EQWVGdzB5Ck5qQTJNVGd4TURRd01qTmFGdzB6TmpBMk1UVXhNRFF3TWpOYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlM0eE16UXVORGd3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUNnenU1eFN2Q2p2VXUyVWNpVUtxQkNEWWtlbmFISlNxNiswdjBBNlNicVhicWU0SGtPU3N1ZHg4ZisKQXJGZjFURWRQdEd6QmhwQzBwRU84aDNrVlk4cXpXUUlyWXh0SlBwQkNzZmp0dFN3Ly8zY04zd05pRUJkYi9adQpUbGZaeHpkV3dRZzFjbW9wMGd6aFpYenliRkxhK3kwejZBZTAycC84Y05wYnFtdkM0eGN6ejNOSDNkWGRrcHdwCnl6eUtTTENFcG0wcEVyQUNvUW5GV2NnMi96c0Flclh3dEc1VVpIb0IrM0wraGN0VmI1cmNqbGhxcmF1MFNlRHUKYVhlNDNNeEVISHFPbWxlNk5hd0RWeHVIYXF1TEM1VEV0RVRiTkxIY014UWkyTHZpeWdzQ2draVl1WmRBN3pUNgo1SlU5UXk5L1lMWU9BNGkwdU5GcEJYRGlLZko3QWdNQkFBR2pnYnN3Z2Jnd2diVUdBMVVkRVFTQnJUQ0Jxb0lNCk5URXVNVFV1TVRNMExqUTRnanh5ZHkwMllqUTBNV1ZtTnkwek5HRTRMVFEzTnpVdFlUazVZaTB4TnpVeFpUTm0KWlRZMFlXRXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRERVeExqRTFMakV6TkM0ME9JSThjbmN0Tm1JMApOREZsWmpjdE16UmhPQzAwTnpjMUxXRTVPV0l0TVRjMU1XVXpabVUyTkdGaExuSmtZaTVtY2kxd1lYSXVjMk4zCkxtTnNiM1ZraHdTanJMVmRod1F6RDRZd2h3UXpENFl3TUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFCTFRzSXUKaWZkc0VKWjQ2M2RSbXl2TXB4TGE3TVBSREt3b0FIci82ZjdxZHR3WEJRVVNkYkNtK3pCSElCQVZLQVJWV3YvawpsQjQzZSs5R3Bkd08vODZrVXZvdXNybUd0V1BPeDRjaS9zMlFRM2NXSXZDWVJOQWc2TWFmaURCT0czUkNzV21lCjdXdDIvdmNBaHFOTG5GZFNrck1adHQ2ZEZ1RXA5OG04VlRkTTFqdUZFRFhmVlBCKy9JNHpIT3FBQlV4MTllK2IKa3JlTW5NaTZ2cTBjTlNucHlBWExJc3dSZDNQMWRlSnoyVmlYVXFHTXR0Q2hGZHo4dWVZUi9NVXl4RDZUMHU5bApKTmUwK093UDZXaU5Kejcwc0RsRURKNFdrK081MHBkR3JXaUZOeVZzdzFmQnQ1TnFuQVhvdTYwT3BjSmRSelh4Ck55VkRIWGRCV3IzbXB5S3kKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+        body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVWjIrZzNXRkJnK0U3RUxzbEtmZ3h6ZzFQTzJnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tnk0eE1EQXdIaGNOCk1qWXdOakl5TVRNd01EUXhXaGNOTXpZd05qRTVNVE13TURReFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTNMakV3TURDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtYaHNBVUN3Z0MzdElBNWVLbG9BQ1hwcGhNSDZHL0lmcHMvTXpaaTVPak1uOGRuaWt2VkVPczMKbFpGU1ZUZnYwd1p5dS9hOWh4VDg4TzRoUFc2NGUzZkVxZ2ZRaEJCOTcyeit0US9TZmNaRHlURGZQV1d2WDdCbApMNjFVeGU0Ri8zVkNydmpRd3JlSkJTcmsyWXVuY0lQN0hRQ3JiWnRLc3NBQ2xmR0lnVmh1WTFGYW1PMFBiYUJyCno1L2VtQTJyMnFpRUUxSjNodXN5c2p6N0VpSFIwSkg0bjNJdUQ4OFR6VnNRdWdscmh3c1pSRzZaZEo0WU0yOFkKS2R6S21ySk04RDZQbmZlMmtodmRjbGVEZGgxSyt5NDRJKzJROWdLaG9TUm01Y2RkcUh1OXhTOUdacm9zRkY0aApxZitMVlY0dkQwbEg2dFFvSCs1Y3BhNytVK3ZxQmdjQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1qY3VNVEF3Z2p4eWR5MDJZbVkwWWpJM1pTMDVOekpqTFRRME5qRXRPR1JqTlMxa01tSm0KT1RobFpEaG1NR1V1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eU55NHhNRENDUEhKMwpMVFppWmpSaU1qZGxMVGszTW1NdE5EUTJNUzA0WkdNMUxXUXlZbVk1T0dWa09HWXdaUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VvNnk3ZUljRU01OGJaSWNFTTU4YlpEQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKbE1rVDZmZU1wKzJFdlJuVVNkQVdxc1gyNkwzM0p6NTNnNGF4UTlIbDIvaVNLTUViVk81MDFodmd5RTFzM2hGNwpyYkoyNEw2TG1VWGpNWE5Ec2kyKzRSdllDTE9yMFNuYkxvWEhsSGNKTE8wajhHeE9ua1NNVi9TR08zaU4zMHd2CkljaEhmYUJhRnpEd1NBc2RIc044SFowd0hSaGJhRDlGMVdkSEFDVEZQTzVJMUVqeXVvOXVGZnRIaW1jK0RMdTkKMGVXV3hjMnd2cTV0N2I3WVIydWZsWGE4TEoyL3hETkZzWnZtNjlRbHc4dnh1YUd5dDdiNlJ5Sm9OZlYycjZydQpZSERpZFpob0J1Yk16Q051YUJGbFBOL3Q4Skl4cDQvZy9jTytOcWU1dGw0K0tkVDMrVEhaQTdDZzFEOXoxUHd4CndDeTlBUkhiWGl4dnZjM25Cenc3bFE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
         headers:
             Content-Length:
-                - "1995"
+                - "2007"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:08 GMT
+                - Mon, 22 Jun 2026 13:01:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -491,10 +491,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 93bc9f0d-51b3-4814-9d84-962a09fd94fc
+                - 3a014da2-0a6e-40c3-b0fa-6831ef37b753
         status: 200 OK
         code: 200
-        duration: 90.859329ms
+        duration: 140.639848ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -511,7 +511,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances?order_by=created_at_asc&page=1&project_id=2ef576f7-e73b-49d0-af3a-cf51f7e882f1
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances?order_by=created_at_asc&page=1&project_id=3692ebc2-5ed2-4de8-bc4a-a55d1bbcb29c
         method: GET
       response:
         proto: HTTP/2.0
@@ -519,20 +519,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1248
+        content_length: 1250
         uncompressed: false
-        body: '{"instances":[{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-18T10:37:35.292174Z","encryption":{"enabled":false},"endpoint":{"id":"b50a9080-a649-4088-9b04-d320d079955a","ip":"51.15.134.48","load_balancer":{},"name":null,"port":3846},"endpoints":[{"id":"b50a9080-a649-4088-9b04-d320d079955a","ip":"51.15.134.48","load_balancer":{},"name":null,"port":3846}],"engine":"PostgreSQL-17","id":"6b441ef7-34a8-4775-a99b-1751e3fe64aa","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-list-1","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"2ef576f7-e73b-49d0-af3a-cf51f7e882f1","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}],"total_count":1}'
+        body: '{"instances":[{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-22T12:55:42.780606Z","encryption":{"enabled":false},"endpoint":{"id":"ec894c2e-1b4c-469e-9682-92c58c32a421","ip":"51.159.27.100","load_balancer":{},"name":null,"port":5799},"endpoints":[{"id":"ec894c2e-1b4c-469e-9682-92c58c32a421","ip":"51.159.27.100","load_balancer":{},"name":null,"port":5799}],"engine":"PostgreSQL-17","id":"6bf4b27e-972c-4461-8dc5-d2bf98ed8f0e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-list-1","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"3692ebc2-5ed2-4de8-bc4a-a55d1bbcb29c","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}],"total_count":1}'
         headers:
             Content-Length:
-                - "1248"
+                - "1250"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:08 GMT
+                - Mon, 22 Jun 2026 13:01:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -540,10 +540,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 688df10e-09a6-4f05-9902-98151dd24cd2
+                - 38a873fc-f61e-4a27-af6e-bf32d5510e0d
         status: 200 OK
         code: 200
-        duration: 192.841422ms
+        duration: 233.676349ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -560,7 +560,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6b441ef7-34a8-4775-a99b-1751e3fe64aa/users?order_by=name_asc&page=1
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6bf4b27e-972c-4461-8dc5-d2bf98ed8f0e/users?order_by=name_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -579,9 +579,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:08 GMT
+                - Mon, 22 Jun 2026 13:01:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -589,10 +589,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f5c51a53-dc64-4faa-9465-3381b257fca8
+                - 83c603c6-24fd-4468-9134-da743a1c4b88
         status: 200 OK
         code: 200
-        duration: 206.588022ms
+        duration: 373.71284ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -609,7 +609,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6b441ef7-34a8-4775-a99b-1751e3fe64aa/certificate
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6bf4b27e-972c-4461-8dc5-d2bf98ed8f0e/certificate
         method: GET
       response:
         proto: HTTP/2.0
@@ -617,20 +617,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1995
+        content_length: 2007
         uncompressed: false
-        body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQrRENDQXVDZ0F3SUJBZ0lVRzdzRlM3ZVZnUXJuVmF0UzljVTFzQXhJMjBFd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFMakV6TkM0ME9EQWVGdzB5Ck5qQTJNVGd4TURRd01qTmFGdzB6TmpBMk1UVXhNRFF3TWpOYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlM0eE16UXVORGd3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUNnenU1eFN2Q2p2VXUyVWNpVUtxQkNEWWtlbmFISlNxNiswdjBBNlNicVhicWU0SGtPU3N1ZHg4ZisKQXJGZjFURWRQdEd6QmhwQzBwRU84aDNrVlk4cXpXUUlyWXh0SlBwQkNzZmp0dFN3Ly8zY04zd05pRUJkYi9adQpUbGZaeHpkV3dRZzFjbW9wMGd6aFpYenliRkxhK3kwejZBZTAycC84Y05wYnFtdkM0eGN6ejNOSDNkWGRrcHdwCnl6eUtTTENFcG0wcEVyQUNvUW5GV2NnMi96c0Flclh3dEc1VVpIb0IrM0wraGN0VmI1cmNqbGhxcmF1MFNlRHUKYVhlNDNNeEVISHFPbWxlNk5hd0RWeHVIYXF1TEM1VEV0RVRiTkxIY014UWkyTHZpeWdzQ2draVl1WmRBN3pUNgo1SlU5UXk5L1lMWU9BNGkwdU5GcEJYRGlLZko3QWdNQkFBR2pnYnN3Z2Jnd2diVUdBMVVkRVFTQnJUQ0Jxb0lNCk5URXVNVFV1TVRNMExqUTRnanh5ZHkwMllqUTBNV1ZtTnkwek5HRTRMVFEzTnpVdFlUazVZaTB4TnpVeFpUTm0KWlRZMFlXRXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRERVeExqRTFMakV6TkM0ME9JSThjbmN0Tm1JMApOREZsWmpjdE16UmhPQzAwTnpjMUxXRTVPV0l0TVRjMU1XVXpabVUyTkdGaExuSmtZaTVtY2kxd1lYSXVjMk4zCkxtTnNiM1ZraHdTanJMVmRod1F6RDRZd2h3UXpENFl3TUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFCTFRzSXUKaWZkc0VKWjQ2M2RSbXl2TXB4TGE3TVBSREt3b0FIci82ZjdxZHR3WEJRVVNkYkNtK3pCSElCQVZLQVJWV3YvawpsQjQzZSs5R3Bkd08vODZrVXZvdXNybUd0V1BPeDRjaS9zMlFRM2NXSXZDWVJOQWc2TWFmaURCT0czUkNzV21lCjdXdDIvdmNBaHFOTG5GZFNrck1adHQ2ZEZ1RXA5OG04VlRkTTFqdUZFRFhmVlBCKy9JNHpIT3FBQlV4MTllK2IKa3JlTW5NaTZ2cTBjTlNucHlBWExJc3dSZDNQMWRlSnoyVmlYVXFHTXR0Q2hGZHo4dWVZUi9NVXl4RDZUMHU5bApKTmUwK093UDZXaU5Kejcwc0RsRURKNFdrK081MHBkR3JXaUZOeVZzdzFmQnQ1TnFuQVhvdTYwT3BjSmRSelh4Ck55VkRIWGRCV3IzbXB5S3kKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+        body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVWjIrZzNXRkJnK0U3RUxzbEtmZ3h6ZzFQTzJnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tnk0eE1EQXdIaGNOCk1qWXdOakl5TVRNd01EUXhXaGNOTXpZd05qRTVNVE13TURReFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTNMakV3TURDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtYaHNBVUN3Z0MzdElBNWVLbG9BQ1hwcGhNSDZHL0lmcHMvTXpaaTVPak1uOGRuaWt2VkVPczMKbFpGU1ZUZnYwd1p5dS9hOWh4VDg4TzRoUFc2NGUzZkVxZ2ZRaEJCOTcyeit0US9TZmNaRHlURGZQV1d2WDdCbApMNjFVeGU0Ri8zVkNydmpRd3JlSkJTcmsyWXVuY0lQN0hRQ3JiWnRLc3NBQ2xmR0lnVmh1WTFGYW1PMFBiYUJyCno1L2VtQTJyMnFpRUUxSjNodXN5c2p6N0VpSFIwSkg0bjNJdUQ4OFR6VnNRdWdscmh3c1pSRzZaZEo0WU0yOFkKS2R6S21ySk04RDZQbmZlMmtodmRjbGVEZGgxSyt5NDRJKzJROWdLaG9TUm01Y2RkcUh1OXhTOUdacm9zRkY0aApxZitMVlY0dkQwbEg2dFFvSCs1Y3BhNytVK3ZxQmdjQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1qY3VNVEF3Z2p4eWR5MDJZbVkwWWpJM1pTMDVOekpqTFRRME5qRXRPR1JqTlMxa01tSm0KT1RobFpEaG1NR1V1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eU55NHhNRENDUEhKMwpMVFppWmpSaU1qZGxMVGszTW1NdE5EUTJNUzA0WkdNMUxXUXlZbVk1T0dWa09HWXdaUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VvNnk3ZUljRU01OGJaSWNFTTU4YlpEQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKbE1rVDZmZU1wKzJFdlJuVVNkQVdxc1gyNkwzM0p6NTNnNGF4UTlIbDIvaVNLTUViVk81MDFodmd5RTFzM2hGNwpyYkoyNEw2TG1VWGpNWE5Ec2kyKzRSdllDTE9yMFNuYkxvWEhsSGNKTE8wajhHeE9ua1NNVi9TR08zaU4zMHd2CkljaEhmYUJhRnpEd1NBc2RIc044SFowd0hSaGJhRDlGMVdkSEFDVEZQTzVJMUVqeXVvOXVGZnRIaW1jK0RMdTkKMGVXV3hjMnd2cTV0N2I3WVIydWZsWGE4TEoyL3hETkZzWnZtNjlRbHc4dnh1YUd5dDdiNlJ5Sm9OZlYycjZydQpZSERpZFpob0J1Yk16Q051YUJGbFBOL3Q4Skl4cDQvZy9jTytOcWU1dGw0K0tkVDMrVEhaQTdDZzFEOXoxUHd4CndDeTlBUkhiWGl4dnZjM25Cenc3bFE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
         headers:
             Content-Length:
-                - "1995"
+                - "2007"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:09 GMT
+                - Mon, 22 Jun 2026 13:01:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -638,10 +638,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5468d946-1dfc-48c8-905c-11fba6e013eb
+                - 7b5beb92-a747-4c84-aa79-bf9261ef75b0
         status: 200 OK
         code: 200
-        duration: 101.690435ms
+        duration: 207.016077ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -658,7 +658,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances?name=test-rdb-list-1&order_by=created_at_asc&page=1&project_id=2ef576f7-e73b-49d0-af3a-cf51f7e882f1
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances?name=test-rdb-list-1&order_by=created_at_asc&page=1&project_id=3692ebc2-5ed2-4de8-bc4a-a55d1bbcb29c
         method: GET
       response:
         proto: HTTP/2.0
@@ -666,20 +666,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1248
+        content_length: 1250
         uncompressed: false
-        body: '{"instances":[{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-18T10:37:35.292174Z","encryption":{"enabled":false},"endpoint":{"id":"b50a9080-a649-4088-9b04-d320d079955a","ip":"51.15.134.48","load_balancer":{},"name":null,"port":3846},"endpoints":[{"id":"b50a9080-a649-4088-9b04-d320d079955a","ip":"51.15.134.48","load_balancer":{},"name":null,"port":3846}],"engine":"PostgreSQL-17","id":"6b441ef7-34a8-4775-a99b-1751e3fe64aa","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-list-1","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"2ef576f7-e73b-49d0-af3a-cf51f7e882f1","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}],"total_count":1}'
+        body: '{"instances":[{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-22T12:55:42.780606Z","encryption":{"enabled":false},"endpoint":{"id":"ec894c2e-1b4c-469e-9682-92c58c32a421","ip":"51.159.27.100","load_balancer":{},"name":null,"port":5799},"endpoints":[{"id":"ec894c2e-1b4c-469e-9682-92c58c32a421","ip":"51.159.27.100","load_balancer":{},"name":null,"port":5799}],"engine":"PostgreSQL-17","id":"6bf4b27e-972c-4461-8dc5-d2bf98ed8f0e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-list-1","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"3692ebc2-5ed2-4de8-bc4a-a55d1bbcb29c","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}],"total_count":1}'
         headers:
             Content-Length:
-                - "1248"
+                - "1250"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:09 GMT
+                - Mon, 22 Jun 2026 13:01:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -687,10 +687,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1a0c839d-8d72-4125-b5a4-57baebdd3007
+                - edb837e4-c88a-4e38-b4b8-ffe9f9ca8289
         status: 200 OK
         code: 200
-        duration: 148.043628ms
+        duration: 248.631097ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -707,7 +707,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6b441ef7-34a8-4775-a99b-1751e3fe64aa/users?order_by=name_asc&page=1
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6bf4b27e-972c-4461-8dc5-d2bf98ed8f0e/users?order_by=name_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -726,9 +726,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:09 GMT
+                - Mon, 22 Jun 2026 13:01:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -736,10 +736,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6331f8f0-d7f5-4ab7-8ac4-eb08e23a7cff
+                - 3a6824ce-ff33-4367-8220-cbbcf178a176
         status: 200 OK
         code: 200
-        duration: 180.784545ms
+        duration: 175.379719ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -756,7 +756,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6b441ef7-34a8-4775-a99b-1751e3fe64aa/certificate
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6bf4b27e-972c-4461-8dc5-d2bf98ed8f0e/certificate
         method: GET
       response:
         proto: HTTP/2.0
@@ -764,20 +764,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1995
+        content_length: 2007
         uncompressed: false
-        body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQrRENDQXVDZ0F3SUJBZ0lVRzdzRlM3ZVZnUXJuVmF0UzljVTFzQXhJMjBFd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFMakV6TkM0ME9EQWVGdzB5Ck5qQTJNVGd4TURRd01qTmFGdzB6TmpBMk1UVXhNRFF3TWpOYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlM0eE16UXVORGd3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUNnenU1eFN2Q2p2VXUyVWNpVUtxQkNEWWtlbmFISlNxNiswdjBBNlNicVhicWU0SGtPU3N1ZHg4ZisKQXJGZjFURWRQdEd6QmhwQzBwRU84aDNrVlk4cXpXUUlyWXh0SlBwQkNzZmp0dFN3Ly8zY04zd05pRUJkYi9adQpUbGZaeHpkV3dRZzFjbW9wMGd6aFpYenliRkxhK3kwejZBZTAycC84Y05wYnFtdkM0eGN6ejNOSDNkWGRrcHdwCnl6eUtTTENFcG0wcEVyQUNvUW5GV2NnMi96c0Flclh3dEc1VVpIb0IrM0wraGN0VmI1cmNqbGhxcmF1MFNlRHUKYVhlNDNNeEVISHFPbWxlNk5hd0RWeHVIYXF1TEM1VEV0RVRiTkxIY014UWkyTHZpeWdzQ2draVl1WmRBN3pUNgo1SlU5UXk5L1lMWU9BNGkwdU5GcEJYRGlLZko3QWdNQkFBR2pnYnN3Z2Jnd2diVUdBMVVkRVFTQnJUQ0Jxb0lNCk5URXVNVFV1TVRNMExqUTRnanh5ZHkwMllqUTBNV1ZtTnkwek5HRTRMVFEzTnpVdFlUazVZaTB4TnpVeFpUTm0KWlRZMFlXRXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRERVeExqRTFMakV6TkM0ME9JSThjbmN0Tm1JMApOREZsWmpjdE16UmhPQzAwTnpjMUxXRTVPV0l0TVRjMU1XVXpabVUyTkdGaExuSmtZaTVtY2kxd1lYSXVjMk4zCkxtTnNiM1ZraHdTanJMVmRod1F6RDRZd2h3UXpENFl3TUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFCTFRzSXUKaWZkc0VKWjQ2M2RSbXl2TXB4TGE3TVBSREt3b0FIci82ZjdxZHR3WEJRVVNkYkNtK3pCSElCQVZLQVJWV3YvawpsQjQzZSs5R3Bkd08vODZrVXZvdXNybUd0V1BPeDRjaS9zMlFRM2NXSXZDWVJOQWc2TWFmaURCT0czUkNzV21lCjdXdDIvdmNBaHFOTG5GZFNrck1adHQ2ZEZ1RXA5OG04VlRkTTFqdUZFRFhmVlBCKy9JNHpIT3FBQlV4MTllK2IKa3JlTW5NaTZ2cTBjTlNucHlBWExJc3dSZDNQMWRlSnoyVmlYVXFHTXR0Q2hGZHo4dWVZUi9NVXl4RDZUMHU5bApKTmUwK093UDZXaU5Kejcwc0RsRURKNFdrK081MHBkR3JXaUZOeVZzdzFmQnQ1TnFuQVhvdTYwT3BjSmRSelh4Ck55VkRIWGRCV3IzbXB5S3kKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+        body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVWjIrZzNXRkJnK0U3RUxzbEtmZ3h6ZzFQTzJnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tnk0eE1EQXdIaGNOCk1qWXdOakl5TVRNd01EUXhXaGNOTXpZd05qRTVNVE13TURReFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTNMakV3TURDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtYaHNBVUN3Z0MzdElBNWVLbG9BQ1hwcGhNSDZHL0lmcHMvTXpaaTVPak1uOGRuaWt2VkVPczMKbFpGU1ZUZnYwd1p5dS9hOWh4VDg4TzRoUFc2NGUzZkVxZ2ZRaEJCOTcyeit0US9TZmNaRHlURGZQV1d2WDdCbApMNjFVeGU0Ri8zVkNydmpRd3JlSkJTcmsyWXVuY0lQN0hRQ3JiWnRLc3NBQ2xmR0lnVmh1WTFGYW1PMFBiYUJyCno1L2VtQTJyMnFpRUUxSjNodXN5c2p6N0VpSFIwSkg0bjNJdUQ4OFR6VnNRdWdscmh3c1pSRzZaZEo0WU0yOFkKS2R6S21ySk04RDZQbmZlMmtodmRjbGVEZGgxSyt5NDRJKzJROWdLaG9TUm01Y2RkcUh1OXhTOUdacm9zRkY0aApxZitMVlY0dkQwbEg2dFFvSCs1Y3BhNytVK3ZxQmdjQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1qY3VNVEF3Z2p4eWR5MDJZbVkwWWpJM1pTMDVOekpqTFRRME5qRXRPR1JqTlMxa01tSm0KT1RobFpEaG1NR1V1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eU55NHhNRENDUEhKMwpMVFppWmpSaU1qZGxMVGszTW1NdE5EUTJNUzA0WkdNMUxXUXlZbVk1T0dWa09HWXdaUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VvNnk3ZUljRU01OGJaSWNFTTU4YlpEQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKbE1rVDZmZU1wKzJFdlJuVVNkQVdxc1gyNkwzM0p6NTNnNGF4UTlIbDIvaVNLTUViVk81MDFodmd5RTFzM2hGNwpyYkoyNEw2TG1VWGpNWE5Ec2kyKzRSdllDTE9yMFNuYkxvWEhsSGNKTE8wajhHeE9ua1NNVi9TR08zaU4zMHd2CkljaEhmYUJhRnpEd1NBc2RIc044SFowd0hSaGJhRDlGMVdkSEFDVEZQTzVJMUVqeXVvOXVGZnRIaW1jK0RMdTkKMGVXV3hjMnd2cTV0N2I3WVIydWZsWGE4TEoyL3hETkZzWnZtNjlRbHc4dnh1YUd5dDdiNlJ5Sm9OZlYycjZydQpZSERpZFpob0J1Yk16Q051YUJGbFBOL3Q4Skl4cDQvZy9jTytOcWU1dGw0K0tkVDMrVEhaQTdDZzFEOXoxUHd4CndDeTlBUkhiWGl4dnZjM25Cenc3bFE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
         headers:
             Content-Length:
-                - "1995"
+                - "2007"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:09 GMT
+                - Mon, 22 Jun 2026 13:01:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -785,10 +785,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0a61a3ed-da39-426b-b80a-028b34fa3dae
+                - b4ad2a50-8de8-489a-9586-907e221d57f9
         status: 200 OK
         code: 200
-        duration: 95.210125ms
+        duration: 148.497811ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -805,7 +805,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances?order_by=created_at_asc&page=1&project_id=2ef576f7-e73b-49d0-af3a-cf51f7e882f1&tags=list-test
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances?order_by=created_at_asc&page=1&project_id=3692ebc2-5ed2-4de8-bc4a-a55d1bbcb29c&tags=list-test
         method: GET
       response:
         proto: HTTP/2.0
@@ -813,20 +813,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1248
+        content_length: 1250
         uncompressed: false
-        body: '{"instances":[{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-18T10:37:35.292174Z","encryption":{"enabled":false},"endpoint":{"id":"b50a9080-a649-4088-9b04-d320d079955a","ip":"51.15.134.48","load_balancer":{},"name":null,"port":3846},"endpoints":[{"id":"b50a9080-a649-4088-9b04-d320d079955a","ip":"51.15.134.48","load_balancer":{},"name":null,"port":3846}],"engine":"PostgreSQL-17","id":"6b441ef7-34a8-4775-a99b-1751e3fe64aa","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-list-1","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"2ef576f7-e73b-49d0-af3a-cf51f7e882f1","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}],"total_count":1}'
+        body: '{"instances":[{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-22T12:55:42.780606Z","encryption":{"enabled":false},"endpoint":{"id":"ec894c2e-1b4c-469e-9682-92c58c32a421","ip":"51.159.27.100","load_balancer":{},"name":null,"port":5799},"endpoints":[{"id":"ec894c2e-1b4c-469e-9682-92c58c32a421","ip":"51.159.27.100","load_balancer":{},"name":null,"port":5799}],"engine":"PostgreSQL-17","id":"6bf4b27e-972c-4461-8dc5-d2bf98ed8f0e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-list-1","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"3692ebc2-5ed2-4de8-bc4a-a55d1bbcb29c","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}],"total_count":1}'
         headers:
             Content-Length:
-                - "1248"
+                - "1250"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:09 GMT
+                - Mon, 22 Jun 2026 13:01:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -834,10 +834,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 879d5158-6036-4a51-bfea-d29472d4d09a
+                - a39bcaeb-13c2-4ba0-8bb7-a44a5119fe5c
         status: 200 OK
         code: 200
-        duration: 203.851295ms
+        duration: 208.385643ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -854,7 +854,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6b441ef7-34a8-4775-a99b-1751e3fe64aa/users?order_by=name_asc&page=1
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6bf4b27e-972c-4461-8dc5-d2bf98ed8f0e/users?order_by=name_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -873,9 +873,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:10 GMT
+                - Mon, 22 Jun 2026 13:01:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -883,10 +883,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 09cd65c6-209c-49dc-a543-2c1e85bcf9c2
+                - dc077250-2f81-41f4-9f21-97a15788152e
         status: 200 OK
         code: 200
-        duration: 182.227634ms
+        duration: 198.388405ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -903,7 +903,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6b441ef7-34a8-4775-a99b-1751e3fe64aa/certificate
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6bf4b27e-972c-4461-8dc5-d2bf98ed8f0e/certificate
         method: GET
       response:
         proto: HTTP/2.0
@@ -911,20 +911,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1995
+        content_length: 2007
         uncompressed: false
-        body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQrRENDQXVDZ0F3SUJBZ0lVRzdzRlM3ZVZnUXJuVmF0UzljVTFzQXhJMjBFd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFMakV6TkM0ME9EQWVGdzB5Ck5qQTJNVGd4TURRd01qTmFGdzB6TmpBMk1UVXhNRFF3TWpOYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlM0eE16UXVORGd3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUNnenU1eFN2Q2p2VXUyVWNpVUtxQkNEWWtlbmFISlNxNiswdjBBNlNicVhicWU0SGtPU3N1ZHg4ZisKQXJGZjFURWRQdEd6QmhwQzBwRU84aDNrVlk4cXpXUUlyWXh0SlBwQkNzZmp0dFN3Ly8zY04zd05pRUJkYi9adQpUbGZaeHpkV3dRZzFjbW9wMGd6aFpYenliRkxhK3kwejZBZTAycC84Y05wYnFtdkM0eGN6ejNOSDNkWGRrcHdwCnl6eUtTTENFcG0wcEVyQUNvUW5GV2NnMi96c0Flclh3dEc1VVpIb0IrM0wraGN0VmI1cmNqbGhxcmF1MFNlRHUKYVhlNDNNeEVISHFPbWxlNk5hd0RWeHVIYXF1TEM1VEV0RVRiTkxIY014UWkyTHZpeWdzQ2draVl1WmRBN3pUNgo1SlU5UXk5L1lMWU9BNGkwdU5GcEJYRGlLZko3QWdNQkFBR2pnYnN3Z2Jnd2diVUdBMVVkRVFTQnJUQ0Jxb0lNCk5URXVNVFV1TVRNMExqUTRnanh5ZHkwMllqUTBNV1ZtTnkwek5HRTRMVFEzTnpVdFlUazVZaTB4TnpVeFpUTm0KWlRZMFlXRXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRERVeExqRTFMakV6TkM0ME9JSThjbmN0Tm1JMApOREZsWmpjdE16UmhPQzAwTnpjMUxXRTVPV0l0TVRjMU1XVXpabVUyTkdGaExuSmtZaTVtY2kxd1lYSXVjMk4zCkxtTnNiM1ZraHdTanJMVmRod1F6RDRZd2h3UXpENFl3TUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFCTFRzSXUKaWZkc0VKWjQ2M2RSbXl2TXB4TGE3TVBSREt3b0FIci82ZjdxZHR3WEJRVVNkYkNtK3pCSElCQVZLQVJWV3YvawpsQjQzZSs5R3Bkd08vODZrVXZvdXNybUd0V1BPeDRjaS9zMlFRM2NXSXZDWVJOQWc2TWFmaURCT0czUkNzV21lCjdXdDIvdmNBaHFOTG5GZFNrck1adHQ2ZEZ1RXA5OG04VlRkTTFqdUZFRFhmVlBCKy9JNHpIT3FBQlV4MTllK2IKa3JlTW5NaTZ2cTBjTlNucHlBWExJc3dSZDNQMWRlSnoyVmlYVXFHTXR0Q2hGZHo4dWVZUi9NVXl4RDZUMHU5bApKTmUwK093UDZXaU5Kejcwc0RsRURKNFdrK081MHBkR3JXaUZOeVZzdzFmQnQ1TnFuQVhvdTYwT3BjSmRSelh4Ck55VkRIWGRCV3IzbXB5S3kKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+        body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVWjIrZzNXRkJnK0U3RUxzbEtmZ3h6ZzFQTzJnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tnk0eE1EQXdIaGNOCk1qWXdOakl5TVRNd01EUXhXaGNOTXpZd05qRTVNVE13TURReFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTNMakV3TURDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtYaHNBVUN3Z0MzdElBNWVLbG9BQ1hwcGhNSDZHL0lmcHMvTXpaaTVPak1uOGRuaWt2VkVPczMKbFpGU1ZUZnYwd1p5dS9hOWh4VDg4TzRoUFc2NGUzZkVxZ2ZRaEJCOTcyeit0US9TZmNaRHlURGZQV1d2WDdCbApMNjFVeGU0Ri8zVkNydmpRd3JlSkJTcmsyWXVuY0lQN0hRQ3JiWnRLc3NBQ2xmR0lnVmh1WTFGYW1PMFBiYUJyCno1L2VtQTJyMnFpRUUxSjNodXN5c2p6N0VpSFIwSkg0bjNJdUQ4OFR6VnNRdWdscmh3c1pSRzZaZEo0WU0yOFkKS2R6S21ySk04RDZQbmZlMmtodmRjbGVEZGgxSyt5NDRJKzJROWdLaG9TUm01Y2RkcUh1OXhTOUdacm9zRkY0aApxZitMVlY0dkQwbEg2dFFvSCs1Y3BhNytVK3ZxQmdjQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1qY3VNVEF3Z2p4eWR5MDJZbVkwWWpJM1pTMDVOekpqTFRRME5qRXRPR1JqTlMxa01tSm0KT1RobFpEaG1NR1V1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eU55NHhNRENDUEhKMwpMVFppWmpSaU1qZGxMVGszTW1NdE5EUTJNUzA0WkdNMUxXUXlZbVk1T0dWa09HWXdaUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VvNnk3ZUljRU01OGJaSWNFTTU4YlpEQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKbE1rVDZmZU1wKzJFdlJuVVNkQVdxc1gyNkwzM0p6NTNnNGF4UTlIbDIvaVNLTUViVk81MDFodmd5RTFzM2hGNwpyYkoyNEw2TG1VWGpNWE5Ec2kyKzRSdllDTE9yMFNuYkxvWEhsSGNKTE8wajhHeE9ua1NNVi9TR08zaU4zMHd2CkljaEhmYUJhRnpEd1NBc2RIc044SFowd0hSaGJhRDlGMVdkSEFDVEZQTzVJMUVqeXVvOXVGZnRIaW1jK0RMdTkKMGVXV3hjMnd2cTV0N2I3WVIydWZsWGE4TEoyL3hETkZzWnZtNjlRbHc4dnh1YUd5dDdiNlJ5Sm9OZlYycjZydQpZSERpZFpob0J1Yk16Q051YUJGbFBOL3Q4Skl4cDQvZy9jTytOcWU1dGw0K0tkVDMrVEhaQTdDZzFEOXoxUHd4CndDeTlBUkhiWGl4dnZjM25Cenc3bFE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
         headers:
             Content-Length:
-                - "1995"
+                - "2007"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:10 GMT
+                - Mon, 22 Jun 2026 13:01:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -932,10 +932,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fb221fd5-e5ad-43c4-9b0a-bb52670f6009
+                - df3024bb-d02a-4836-9018-49ffadd11662
         status: 200 OK
         code: 200
-        duration: 157.925688ms
+        duration: 164.621547ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -952,7 +952,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances?has_maintenances=false&order_by=created_at_asc&page=1&project_id=2ef576f7-e73b-49d0-af3a-cf51f7e882f1
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances?has_maintenances=false&order_by=created_at_asc&page=1&project_id=3692ebc2-5ed2-4de8-bc4a-a55d1bbcb29c
         method: GET
       response:
         proto: HTTP/2.0
@@ -960,20 +960,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1248
+        content_length: 1250
         uncompressed: false
-        body: '{"instances":[{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-18T10:37:35.292174Z","encryption":{"enabled":false},"endpoint":{"id":"b50a9080-a649-4088-9b04-d320d079955a","ip":"51.15.134.48","load_balancer":{},"name":null,"port":3846},"endpoints":[{"id":"b50a9080-a649-4088-9b04-d320d079955a","ip":"51.15.134.48","load_balancer":{},"name":null,"port":3846}],"engine":"PostgreSQL-17","id":"6b441ef7-34a8-4775-a99b-1751e3fe64aa","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-list-1","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"2ef576f7-e73b-49d0-af3a-cf51f7e882f1","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}],"total_count":1}'
+        body: '{"instances":[{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-22T12:55:42.780606Z","encryption":{"enabled":false},"endpoint":{"id":"ec894c2e-1b4c-469e-9682-92c58c32a421","ip":"51.159.27.100","load_balancer":{},"name":null,"port":5799},"endpoints":[{"id":"ec894c2e-1b4c-469e-9682-92c58c32a421","ip":"51.159.27.100","load_balancer":{},"name":null,"port":5799}],"engine":"PostgreSQL-17","id":"6bf4b27e-972c-4461-8dc5-d2bf98ed8f0e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-list-1","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"3692ebc2-5ed2-4de8-bc4a-a55d1bbcb29c","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}],"total_count":1}'
         headers:
             Content-Length:
-                - "1248"
+                - "1250"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:10 GMT
+                - Mon, 22 Jun 2026 13:01:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -981,10 +981,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f3166c5d-627f-4ce6-8dba-958ca3c75147
+                - bd3e339d-3e1a-45ea-becf-3c9044cccaac
         status: 200 OK
         code: 200
-        duration: 169.490306ms
+        duration: 197.917265ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1001,7 +1001,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6b441ef7-34a8-4775-a99b-1751e3fe64aa/users?order_by=name_asc&page=1
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6bf4b27e-972c-4461-8dc5-d2bf98ed8f0e/users?order_by=name_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -1020,9 +1020,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:10 GMT
+                - Mon, 22 Jun 2026 13:01:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1030,10 +1030,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8377e102-89d3-4ed2-86ab-edaf423f4764
+                - 265f04ee-6cd9-4c52-ac49-8c05400c10c9
         status: 200 OK
         code: 200
-        duration: 179.365812ms
+        duration: 201.462947ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1050,7 +1050,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6b441ef7-34a8-4775-a99b-1751e3fe64aa/certificate
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6bf4b27e-972c-4461-8dc5-d2bf98ed8f0e/certificate
         method: GET
       response:
         proto: HTTP/2.0
@@ -1058,20 +1058,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1995
+        content_length: 2007
         uncompressed: false
-        body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQrRENDQXVDZ0F3SUJBZ0lVRzdzRlM3ZVZnUXJuVmF0UzljVTFzQXhJMjBFd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFMakV6TkM0ME9EQWVGdzB5Ck5qQTJNVGd4TURRd01qTmFGdzB6TmpBMk1UVXhNRFF3TWpOYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlM0eE16UXVORGd3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUNnenU1eFN2Q2p2VXUyVWNpVUtxQkNEWWtlbmFISlNxNiswdjBBNlNicVhicWU0SGtPU3N1ZHg4ZisKQXJGZjFURWRQdEd6QmhwQzBwRU84aDNrVlk4cXpXUUlyWXh0SlBwQkNzZmp0dFN3Ly8zY04zd05pRUJkYi9adQpUbGZaeHpkV3dRZzFjbW9wMGd6aFpYenliRkxhK3kwejZBZTAycC84Y05wYnFtdkM0eGN6ejNOSDNkWGRrcHdwCnl6eUtTTENFcG0wcEVyQUNvUW5GV2NnMi96c0Flclh3dEc1VVpIb0IrM0wraGN0VmI1cmNqbGhxcmF1MFNlRHUKYVhlNDNNeEVISHFPbWxlNk5hd0RWeHVIYXF1TEM1VEV0RVRiTkxIY014UWkyTHZpeWdzQ2draVl1WmRBN3pUNgo1SlU5UXk5L1lMWU9BNGkwdU5GcEJYRGlLZko3QWdNQkFBR2pnYnN3Z2Jnd2diVUdBMVVkRVFTQnJUQ0Jxb0lNCk5URXVNVFV1TVRNMExqUTRnanh5ZHkwMllqUTBNV1ZtTnkwek5HRTRMVFEzTnpVdFlUazVZaTB4TnpVeFpUTm0KWlRZMFlXRXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRERVeExqRTFMakV6TkM0ME9JSThjbmN0Tm1JMApOREZsWmpjdE16UmhPQzAwTnpjMUxXRTVPV0l0TVRjMU1XVXpabVUyTkdGaExuSmtZaTVtY2kxd1lYSXVjMk4zCkxtTnNiM1ZraHdTanJMVmRod1F6RDRZd2h3UXpENFl3TUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFCTFRzSXUKaWZkc0VKWjQ2M2RSbXl2TXB4TGE3TVBSREt3b0FIci82ZjdxZHR3WEJRVVNkYkNtK3pCSElCQVZLQVJWV3YvawpsQjQzZSs5R3Bkd08vODZrVXZvdXNybUd0V1BPeDRjaS9zMlFRM2NXSXZDWVJOQWc2TWFmaURCT0czUkNzV21lCjdXdDIvdmNBaHFOTG5GZFNrck1adHQ2ZEZ1RXA5OG04VlRkTTFqdUZFRFhmVlBCKy9JNHpIT3FBQlV4MTllK2IKa3JlTW5NaTZ2cTBjTlNucHlBWExJc3dSZDNQMWRlSnoyVmlYVXFHTXR0Q2hGZHo4dWVZUi9NVXl4RDZUMHU5bApKTmUwK093UDZXaU5Kejcwc0RsRURKNFdrK081MHBkR3JXaUZOeVZzdzFmQnQ1TnFuQVhvdTYwT3BjSmRSelh4Ck55VkRIWGRCV3IzbXB5S3kKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+        body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVWjIrZzNXRkJnK0U3RUxzbEtmZ3h6ZzFQTzJnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tnk0eE1EQXdIaGNOCk1qWXdOakl5TVRNd01EUXhXaGNOTXpZd05qRTVNVE13TURReFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTNMakV3TURDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtYaHNBVUN3Z0MzdElBNWVLbG9BQ1hwcGhNSDZHL0lmcHMvTXpaaTVPak1uOGRuaWt2VkVPczMKbFpGU1ZUZnYwd1p5dS9hOWh4VDg4TzRoUFc2NGUzZkVxZ2ZRaEJCOTcyeit0US9TZmNaRHlURGZQV1d2WDdCbApMNjFVeGU0Ri8zVkNydmpRd3JlSkJTcmsyWXVuY0lQN0hRQ3JiWnRLc3NBQ2xmR0lnVmh1WTFGYW1PMFBiYUJyCno1L2VtQTJyMnFpRUUxSjNodXN5c2p6N0VpSFIwSkg0bjNJdUQ4OFR6VnNRdWdscmh3c1pSRzZaZEo0WU0yOFkKS2R6S21ySk04RDZQbmZlMmtodmRjbGVEZGgxSyt5NDRJKzJROWdLaG9TUm01Y2RkcUh1OXhTOUdacm9zRkY0aApxZitMVlY0dkQwbEg2dFFvSCs1Y3BhNytVK3ZxQmdjQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1qY3VNVEF3Z2p4eWR5MDJZbVkwWWpJM1pTMDVOekpqTFRRME5qRXRPR1JqTlMxa01tSm0KT1RobFpEaG1NR1V1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eU55NHhNRENDUEhKMwpMVFppWmpSaU1qZGxMVGszTW1NdE5EUTJNUzA0WkdNMUxXUXlZbVk1T0dWa09HWXdaUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VvNnk3ZUljRU01OGJaSWNFTTU4YlpEQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKbE1rVDZmZU1wKzJFdlJuVVNkQVdxc1gyNkwzM0p6NTNnNGF4UTlIbDIvaVNLTUViVk81MDFodmd5RTFzM2hGNwpyYkoyNEw2TG1VWGpNWE5Ec2kyKzRSdllDTE9yMFNuYkxvWEhsSGNKTE8wajhHeE9ua1NNVi9TR08zaU4zMHd2CkljaEhmYUJhRnpEd1NBc2RIc044SFowd0hSaGJhRDlGMVdkSEFDVEZQTzVJMUVqeXVvOXVGZnRIaW1jK0RMdTkKMGVXV3hjMnd2cTV0N2I3WVIydWZsWGE4TEoyL3hETkZzWnZtNjlRbHc4dnh1YUd5dDdiNlJ5Sm9OZlYycjZydQpZSERpZFpob0J1Yk16Q051YUJGbFBOL3Q4Skl4cDQvZy9jTytOcWU1dGw0K0tkVDMrVEhaQTdDZzFEOXoxUHd4CndDeTlBUkhiWGl4dnZjM25Cenc3bFE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
         headers:
             Content-Length:
-                - "1995"
+                - "2007"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:10 GMT
+                - Mon, 22 Jun 2026 13:01:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1079,10 +1079,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - af7f7c94-fdcd-402d-be7e-57ff3cd5fe74
+                - 30833f4f-4d5c-448f-9044-50cf9391cd8c
         status: 200 OK
         code: 200
-        duration: 94.579306ms
+        duration: 167.949348ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1099,7 +1099,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6b441ef7-34a8-4775-a99b-1751e3fe64aa
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6bf4b27e-972c-4461-8dc5-d2bf98ed8f0e
         method: GET
       response:
         proto: HTTP/2.0
@@ -1107,20 +1107,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1216
+        content_length: 1218
         uncompressed: false
-        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-18T10:37:35.292174Z","encryption":{"enabled":false},"endpoint":{"id":"b50a9080-a649-4088-9b04-d320d079955a","ip":"51.15.134.48","load_balancer":{},"name":null,"port":3846},"endpoints":[{"id":"b50a9080-a649-4088-9b04-d320d079955a","ip":"51.15.134.48","load_balancer":{},"name":null,"port":3846}],"engine":"PostgreSQL-17","id":"6b441ef7-34a8-4775-a99b-1751e3fe64aa","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-list-1","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"2ef576f7-e73b-49d0-af3a-cf51f7e882f1","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-22T12:55:42.780606Z","encryption":{"enabled":false},"endpoint":{"id":"ec894c2e-1b4c-469e-9682-92c58c32a421","ip":"51.159.27.100","load_balancer":{},"name":null,"port":5799},"endpoints":[{"id":"ec894c2e-1b4c-469e-9682-92c58c32a421","ip":"51.159.27.100","load_balancer":{},"name":null,"port":5799}],"engine":"PostgreSQL-17","id":"6bf4b27e-972c-4461-8dc5-d2bf98ed8f0e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-list-1","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"3692ebc2-5ed2-4de8-bc4a-a55d1bbcb29c","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
         headers:
             Content-Length:
-                - "1216"
+                - "1218"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:11 GMT
+                - Mon, 22 Jun 2026 13:01:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1128,10 +1128,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4f5ecf91-1dab-4ac1-8805-b1faa69e31b0
+                - 0b207d2c-4213-4d54-901c-6829bf70927d
         status: 200 OK
         code: 200
-        duration: 223.095554ms
+        duration: 169.470835ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1148,7 +1148,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6b441ef7-34a8-4775-a99b-1751e3fe64aa
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6bf4b27e-972c-4461-8dc5-d2bf98ed8f0e
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1156,20 +1156,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1219
+        content_length: 1221
         uncompressed: false
-        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-18T10:37:35.292174Z","encryption":{"enabled":false},"endpoint":{"id":"b50a9080-a649-4088-9b04-d320d079955a","ip":"51.15.134.48","load_balancer":{},"name":null,"port":3846},"endpoints":[{"id":"b50a9080-a649-4088-9b04-d320d079955a","ip":"51.15.134.48","load_balancer":{},"name":null,"port":3846}],"engine":"PostgreSQL-17","id":"6b441ef7-34a8-4775-a99b-1751e3fe64aa","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-list-1","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"2ef576f7-e73b-49d0-af3a-cf51f7e882f1","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-22T12:55:42.780606Z","encryption":{"enabled":false},"endpoint":{"id":"ec894c2e-1b4c-469e-9682-92c58c32a421","ip":"51.159.27.100","load_balancer":{},"name":null,"port":5799},"endpoints":[{"id":"ec894c2e-1b4c-469e-9682-92c58c32a421","ip":"51.159.27.100","load_balancer":{},"name":null,"port":5799}],"engine":"PostgreSQL-17","id":"6bf4b27e-972c-4461-8dc5-d2bf98ed8f0e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-list-1","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"3692ebc2-5ed2-4de8-bc4a-a55d1bbcb29c","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
         headers:
             Content-Length:
-                - "1219"
+                - "1221"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:11 GMT
+                - Mon, 22 Jun 2026 13:01:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1177,10 +1177,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 87e0f09f-0ad8-4257-8e3b-4ca141ba28b4
+                - 375774ca-fc88-4533-ba0e-3ab50da95d9d
         status: 200 OK
         code: 200
-        duration: 459.462821ms
+        duration: 407.602529ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1197,7 +1197,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6b441ef7-34a8-4775-a99b-1751e3fe64aa
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6bf4b27e-972c-4461-8dc5-d2bf98ed8f0e
         method: GET
       response:
         proto: HTTP/2.0
@@ -1205,20 +1205,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1219
+        content_length: 1221
         uncompressed: false
-        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-18T10:37:35.292174Z","encryption":{"enabled":false},"endpoint":{"id":"b50a9080-a649-4088-9b04-d320d079955a","ip":"51.15.134.48","load_balancer":{},"name":null,"port":3846},"endpoints":[{"id":"b50a9080-a649-4088-9b04-d320d079955a","ip":"51.15.134.48","load_balancer":{},"name":null,"port":3846}],"engine":"PostgreSQL-17","id":"6b441ef7-34a8-4775-a99b-1751e3fe64aa","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-list-1","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"2ef576f7-e73b-49d0-af3a-cf51f7e882f1","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-22T12:55:42.780606Z","encryption":{"enabled":false},"endpoint":{"id":"ec894c2e-1b4c-469e-9682-92c58c32a421","ip":"51.159.27.100","load_balancer":{},"name":null,"port":5799},"endpoints":[{"id":"ec894c2e-1b4c-469e-9682-92c58c32a421","ip":"51.159.27.100","load_balancer":{},"name":null,"port":5799}],"engine":"PostgreSQL-17","id":"6bf4b27e-972c-4461-8dc5-d2bf98ed8f0e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-list-1","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"3692ebc2-5ed2-4de8-bc4a-a55d1bbcb29c","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["list-test"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
         headers:
             Content-Length:
-                - "1219"
+                - "1221"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:11 GMT
+                - Mon, 22 Jun 2026 13:01:20 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1226,10 +1226,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - db7a24ca-985d-46a2-a921-361a8dc0b40b
+                - 5736d3ae-1151-404e-a1c5-80ac1fc38995
         status: 200 OK
         code: 200
-        duration: 115.075334ms
+        duration: 158.655216ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1246,7 +1246,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6b441ef7-34a8-4775-a99b-1751e3fe64aa
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6bf4b27e-972c-4461-8dc5-d2bf98ed8f0e
         method: GET
       response:
         proto: HTTP/2.0
@@ -1256,7 +1256,7 @@ interactions:
         trailer: {}
         content_length: 129
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance","resource_id":"6b441ef7-34a8-4775-a99b-1751e3fe64aa","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance","resource_id":"6bf4b27e-972c-4461-8dc5-d2bf98ed8f0e","type":"not_found"}'
         headers:
             Content-Length:
                 - "129"
@@ -1265,9 +1265,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:41 GMT
+                - Mon, 22 Jun 2026 13:01:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge03)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1275,10 +1275,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 77b25fd2-190e-468e-82e1-1c6e3112a8fb
+                - 837e0830-d02a-4f62-af77-361de5f13f0e
         status: 404 Not Found
         code: 404
-        duration: 75.467479ms
+        duration: 145.056544ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1295,7 +1295,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/account/v3/projects/2ef576f7-e73b-49d0-af3a-cf51f7e882f1
+        url: https://api.scaleway.com/account/v3/projects/3692ebc2-5ed2-4de8-bc4a-a55d1bbcb29c
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1312,9 +1312,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:43 GMT
+                - Mon, 22 Jun 2026 13:01:52 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1322,10 +1322,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - dc239323-3c98-429e-a864-c387355c7441
+                - 223e7d9c-3cbe-4396-a2f4-68f41164a42d
         status: 204 No Content
         code: 204
-        duration: 1.727899546s
+        duration: 1.724735912s
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1342,7 +1342,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/account/v3/projects/2ef576f7-e73b-49d0-af3a-cf51f7e882f1
+        url: https://api.scaleway.com/account/v3/projects/3692ebc2-5ed2-4de8-bc4a-a55d1bbcb29c
         method: GET
       response:
         proto: HTTP/2.0
@@ -1352,7 +1352,7 @@ interactions:
         trailer: {}
         content_length: 131
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"project_id","resource_id":"2ef576f7-e73b-49d0-af3a-cf51f7e882f1","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"project_id","resource_id":"3692ebc2-5ed2-4de8-bc4a-a55d1bbcb29c","type":"not_found"}'
         headers:
             Content-Length:
                 - "131"
@@ -1361,9 +1361,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:43 GMT
+                - Mon, 22 Jun 2026 13:01:52 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1371,7 +1371,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 77583809-a906-4cd9-9bd0-7a29f8f32447
+                - 481b6e4f-68ce-46c4-bc03-ada158fb446c
         status: 404 Not Found
         code: 404
-        duration: 32.63615ms
+        duration: 18.634124ms

--- a/internal/services/rdb/testdata/list-rdb-snapshots-basic.cassette.yaml
+++ b/internal/services/rdb/testdata/list-rdb-snapshots-basic.cassette.yaml
@@ -36,9 +36,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:37:33 GMT
+                - Mon, 22 Jun 2026 12:55:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -46,10 +46,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 60d52503-d5c5-48f1-b2bb-be1bb54e77ff
+                - 2aa758c9-b763-4986-885f-f152d293477d
         status: 200 OK
         code: 200
-        duration: 138.709833ms
+        duration: 112.69101ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -78,7 +78,7 @@ interactions:
         trailer: {}
         content_length: 753
         uncompressed: false
-        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-18T10:37:34.289709Z","encryption":{"enabled":false},"endpoint":null,"endpoints":[],"engine":"PostgreSQL-17","id":"33be5c2b-5927-4c67-b739-813898b0d2b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-snapshot-list-inst","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"sbs","size":10000000000,"type":"sbs_5k"}}'
+        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-22T12:55:41.052539Z","encryption":{"enabled":false},"endpoint":null,"endpoints":[],"engine":"PostgreSQL-17","id":"d984bf47-8a2a-421f-8e2e-b6832d5a2cd1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-snapshot-list-inst","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"sbs","size":10000000000,"type":"sbs_5k"}}'
         headers:
             Content-Length:
                 - "753"
@@ -87,9 +87,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:37:34 GMT
+                - Mon, 22 Jun 2026 12:55:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -97,10 +97,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 36e762a6-55e0-477b-89a2-c179e5baca39
+                - 27cb3379-7cef-4d31-94c5-c2256499c510
         status: 200 OK
         code: 200
-        duration: 786.219825ms
+        duration: 2.55601562s
     - id: 2
       request:
         proto: HTTP/1.1
@@ -117,7 +117,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/33be5c2b-5927-4c67-b739-813898b0d2b5
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d984bf47-8a2a-421f-8e2e-b6832d5a2cd1
         method: GET
       response:
         proto: HTTP/2.0
@@ -127,7 +127,7 @@ interactions:
         trailer: {}
         content_length: 753
         uncompressed: false
-        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-18T10:37:34.289709Z","encryption":{"enabled":false},"endpoint":null,"endpoints":[],"engine":"PostgreSQL-17","id":"33be5c2b-5927-4c67-b739-813898b0d2b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-snapshot-list-inst","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"sbs","size":10000000000,"type":"sbs_5k"}}'
+        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-22T12:55:41.052539Z","encryption":{"enabled":false},"endpoint":null,"endpoints":[],"engine":"PostgreSQL-17","id":"d984bf47-8a2a-421f-8e2e-b6832d5a2cd1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-snapshot-list-inst","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"sbs","size":10000000000,"type":"sbs_5k"}}'
         headers:
             Content-Length:
                 - "753"
@@ -136,9 +136,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:37:34 GMT
+                - Mon, 22 Jun 2026 12:55:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -146,10 +146,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ea856f48-d69b-485d-b139-52c24343d6b0
+                - 9670e1b1-28d2-40de-add1-5a76b0c9cd77
         status: 200 OK
         code: 200
-        duration: 205.101733ms
+        duration: 159.305554ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -166,7 +166,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/33be5c2b-5927-4c67-b739-813898b0d2b5
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d984bf47-8a2a-421f-8e2e-b6832d5a2cd1
         method: GET
       response:
         proto: HTTP/2.0
@@ -176,7 +176,7 @@ interactions:
         trailer: {}
         content_length: 1224
         uncompressed: false
-        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-18T10:37:34.289709Z","encryption":{"enabled":false},"endpoint":{"id":"7aadf453-b5e3-4518-9430-689aaa1c46cd","ip":"51.15.134.48","load_balancer":{},"name":null,"port":20793},"endpoints":[{"id":"7aadf453-b5e3-4518-9430-689aaa1c46cd","ip":"51.15.134.48","load_balancer":{},"name":null,"port":20793}],"engine":"PostgreSQL-17","id":"33be5c2b-5927-4c67-b739-813898b0d2b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-snapshot-list-inst","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"sbs","size":10000000000,"type":"sbs_5k"}}'
+        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-22T12:55:41.052539Z","encryption":{"enabled":false},"endpoint":{"id":"0720e0fb-3960-4569-827a-c74dd7bc5720","ip":"51.15.248.243","load_balancer":{},"name":null,"port":3524},"endpoints":[{"id":"0720e0fb-3960-4569-827a-c74dd7bc5720","ip":"51.15.248.243","load_balancer":{},"name":null,"port":3524}],"engine":"PostgreSQL-17","id":"d984bf47-8a2a-421f-8e2e-b6832d5a2cd1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-snapshot-list-inst","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"sbs","size":10000000000,"type":"sbs_5k"}}'
         headers:
             Content-Length:
                 - "1224"
@@ -185,9 +185,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:06 GMT
+                - Mon, 22 Jun 2026 12:59:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -195,10 +195,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 74da48ff-3a6e-4f16-8634-3000f7d7f376
+                - c2cf52ef-bb5b-4b03-aaec-26182de9bfb7
         status: 200 OK
         code: 200
-        duration: 229.287397ms
+        duration: 208.5513ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -215,7 +215,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/33be5c2b-5927-4c67-b739-813898b0d2b5/certificate
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d984bf47-8a2a-421f-8e2e-b6832d5a2cd1/certificate
         method: GET
       response:
         proto: HTTP/2.0
@@ -223,20 +223,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1995
+        content_length: 2007
         uncompressed: false
-        body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQrRENDQXVDZ0F3SUJBZ0lVUkROT3JDYTU0THhROGx2dEZ6ZDVsTTFESFNrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFMakV6TkM0ME9EQWVGdzB5Ck5qQTJNVGd4TURRd01qSmFGdzB6TmpBMk1UVXhNRFF3TWpKYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlM0eE16UXVORGd3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURRVDNPVk1sVWhUT1Z4UlI4dE14U0QzL01oUTc5V2xyN1RDK3BkaDhMZlFUSkNNb1AwS2t3cVFQdi8KZDYyUjBLTldxNkxNck1XYnY2SkZBMzF1eHg5bndKcHFFb05rb3k1Q0xyUnBHM3pDdWtBZm9MTjJhZ2pFRmVFZwpPNTRlTTRFK3ZtYzRUTjBoSXJPMkdmUHMyWW9DcUpJb0NNZWhVQ0tzVGtud1N5TVUxcHNrSm1uMHR3YVFFcUdYCmhqZk0xc1hodVhaMHZmTStkVjlvUEFHMWdpYTFwYUdKQjRrOCs1SC8rUmRoMFJua2ZZZjlwZkJoNGNFUGMwSDIKK05YUXdhS2RtKzRGcDlsMXl1c2Q2NWI0cWFmYWluZGRlNFlEQjdXcHQ0cTBzSmNDSTFYRG9VUmg2WFZacmNURQpRekZEUlU4QjZaSGZ3MTdPMG9DWk9mM0U4UlRmQWdNQkFBR2pnYnN3Z2Jnd2diVUdBMVVkRVFTQnJUQ0Jxb0lNCk5URXVNVFV1TVRNMExqUTRnanh5ZHkwek0ySmxOV015WWkwMU9USTNMVFJqTmpjdFlqY3pPUzA0TVRNNE9UaGkKTUdReVlqVXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRERVeExqRTFMakV6TkM0ME9JSThjbmN0TXpOaQpaVFZqTW1JdE5Ua3lOeTAwWXpZM0xXSTNNemt0T0RFek9EazRZakJrTW1JMUxuSmtZaTVtY2kxd1lYSXVjMk4zCkxtTnNiM1ZraHdUVUwvTU9od1F6RDRZd2h3UXpENFl3TUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFCdXdRYlQKWlZ1QXFKNHVMQlVUbVFFek1YajAwaFhyWnZYazVGSEV6S3NmcXp4R0pUR2JHdWMxV3NyQ0p1VHg2ckcvK0V4WApWQVVXYUR6SFl5a1Bmakw2ck0wWmZqZkI3aGtHOXZUemFSa0hUVW0yOWlCQ3ZyVENyQlZqdU1WemNrdldMcHBlCmxvc0hmNVQwL2hYUUkxUDYwZkVsVWVDMkRuLy8vRkQ5eDlOS25ENUh2Qlp2VTlzbkN0WnA5TlNSZzZtNFBLL1IKVEtWL3JjckRxc3FqUy9BRjRmS2oxZlZlMllLNXlTcWZ6VlRjRXhUeER6WDRUcnFNak1LR0tIRi9ueWxGQ2tmZgowc01TQW5tdXN2N0Vmakh0czJBUEprN1VvUnNEZ3lGV1h1a2lrZ0hjMEVOTG5WbkRTN1pWbW9nUU1rQ3cwM1RSCm5QMSttNnBIbHZGODBVU1kKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+        body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVWHJOSEcvd3BDb0pGR21jYjF6NEsveTBtcEVvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFMakkwT0M0eU5ETXdIaGNOCk1qWXdOakl5TVRJMU9EUTVXaGNOTXpZd05qRTVNVEkxT0RRNVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVdU1qUTRMakkwTXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxCRlJlNjh4ZWFwNkp5RXplVVRKenBYMUtyRU5rWnZPdUZSQlp6YUtQMURKbUVGL2ZtdzdDVEUKK0VFTHZKRTl5U2VwNWU1Nmg2WmltM1hGc2lyeC9SQXJHYitLSzBkbFgrRSswY01ZRzlrRHhuc0F3OFoxaWZJbgpMdEtUT1JyQkJGSTNoTitPVlhBL1lPSnhYVVBpd05JZHl2LzN0bDRVWHJreDdNU0k0TmJYaHYyc1QveEUzTHdiCmpxTzloVGcvd0l6dDczR1hUblVzNmkxTUliSGFkNGtJZWxLUTVob3owcEpRVWpPYUlmL2Y0L1hBMkZ3K0JpRVoKS2hKbjFERytjSUxCOTJxaWNCRkpiVkV5Qmt4SjVOOWsvaEUxM1orT29pZlZGSWdCUEdWMzNlcWVOT3Nxb2tBNwphUklRSWU1c01zbWlOeW1NeUlmUmY0akJhZFp2RXRNQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlM0eU5EZ3VNalF6Z2p4eWR5MWtPVGcwWW1ZME55MDRZVEpoTFRReU1XWXRPR1V5WlMxaU5qZ3oKTW1RMVlUSmpaREV1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxTGpJME9DNHlORE9DUEhKMwpMV1E1T0RSaVpqUTNMVGhoTW1FdE5ESXhaaTA0WlRKbExXSTJPRE15WkRWaE1tTmtNUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNNTVsK0ljRU13LzQ4NGNFTXcvNDh6QU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKZlRLeThvSndlbUZ0OHdWdEZLZ05lLzBYWXYrVEV5K0JhZE1PaWNOdjJTaDZ5a3R2dGl6aFRrYkgvY0tXZE1ZOApINlNqb3RNOXlXNk5MQklKNkhERHRoVE1iZ2ZVQlRqL0NKa295YnZjVmxaUkFPZnFETTBkaEF2dmM4RFluQ0cvCjZUaWs1RGFxdUxFQ0VZVEN3UGpJM0twWWw3MnNyeHRwL1k4QnZFSm5hb1BmNkl3Wmh1aEthWkd4Vm5yLzhTVnQKeGdBZjFydWY5UHRCU0xWWU1Na0ZTMXRpN2ZLL1RmaHJsMWhncTRVME5hZ053K3EzYUo0R29MeG8zRXU2ZDMvdAo2RFRrakNhQ3E2K0RCOERJN2V0c29vNWVxTVVpZFZFT3phTWlrQXBEVG9hdlhlNDVkRTVkb2ErRS9CaUkray9rCi81WW80ZHAwY09MYzR2UzhJZ0FMK3c9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
         headers:
             Content-Length:
-                - "1995"
+                - "2007"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:06 GMT
+                - Mon, 22 Jun 2026 12:59:13 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -244,10 +244,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 92e17c58-92b1-4615-8dbe-5c2c1a6a30d7
+                - 13509e0f-8416-4e1c-b7e1-4fdc6b48060b
         status: 200 OK
         code: 200
-        duration: 184.517688ms
+        duration: 162.691524ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -266,7 +266,7 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/33be5c2b-5927-4c67-b739-813898b0d2b5/snapshots
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d984bf47-8a2a-421f-8e2e-b6832d5a2cd1/snapshots
         method: POST
       response:
         proto: HTTP/2.0
@@ -276,7 +276,7 @@ interactions:
         trailer: {}
         content_length: 405
         uncompressed: false
-        body: '{"created_at":"2026-06-18T10:41:07.103545Z","expires_at":"2027-06-18T10:41:07.103545Z","id":"9dc07a0e-6b60-4a8e-a346-a29afb050271","instance_id":"33be5c2b-5927-4c67-b739-813898b0d2b5","instance_name":"tf-test-rdb-snapshot-list-inst","name":"tf-test-rdb-snapshot-list","node_type":"db-dev-s","region":"fr-par","size":null,"status":"creating","updated_at":null,"volume_type":{"class":"sbs","type":"sbs_5k"}}'
+        body: '{"created_at":"2026-06-22T12:59:14.549065Z","expires_at":"2027-06-22T12:59:14.549065Z","id":"187cbc2f-03b1-4174-afbc-37673fd46e19","instance_id":"d984bf47-8a2a-421f-8e2e-b6832d5a2cd1","instance_name":"tf-test-rdb-snapshot-list-inst","name":"tf-test-rdb-snapshot-list","node_type":"db-dev-s","region":"fr-par","size":null,"status":"creating","updated_at":null,"volume_type":{"class":"sbs","type":"sbs_5k"}}'
         headers:
             Content-Length:
                 - "405"
@@ -285,9 +285,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:07 GMT
+                - Mon, 22 Jun 2026 12:59:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -295,10 +295,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 788e7064-37d7-4c33-9779-34395b636540
+                - 2aeb0b79-fdd6-428b-ae82-2878f035f765
         status: 200 OK
         code: 200
-        duration: 829.838463ms
+        duration: 834.241432ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -315,7 +315,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/snapshots/9dc07a0e-6b60-4a8e-a346-a29afb050271
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/snapshots/187cbc2f-03b1-4174-afbc-37673fd46e19
         method: GET
       response:
         proto: HTTP/2.0
@@ -325,7 +325,7 @@ interactions:
         trailer: {}
         content_length: 405
         uncompressed: false
-        body: '{"created_at":"2026-06-18T10:41:07.103545Z","expires_at":"2027-06-18T10:41:07.103545Z","id":"9dc07a0e-6b60-4a8e-a346-a29afb050271","instance_id":"33be5c2b-5927-4c67-b739-813898b0d2b5","instance_name":"tf-test-rdb-snapshot-list-inst","name":"tf-test-rdb-snapshot-list","node_type":"db-dev-s","region":"fr-par","size":null,"status":"creating","updated_at":null,"volume_type":{"class":"sbs","type":"sbs_5k"}}'
+        body: '{"created_at":"2026-06-22T12:59:14.549065Z","expires_at":"2027-06-22T12:59:14.549065Z","id":"187cbc2f-03b1-4174-afbc-37673fd46e19","instance_id":"d984bf47-8a2a-421f-8e2e-b6832d5a2cd1","instance_name":"tf-test-rdb-snapshot-list-inst","name":"tf-test-rdb-snapshot-list","node_type":"db-dev-s","region":"fr-par","size":null,"status":"creating","updated_at":null,"volume_type":{"class":"sbs","type":"sbs_5k"}}'
         headers:
             Content-Length:
                 - "405"
@@ -334,9 +334,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:07 GMT
+                - Mon, 22 Jun 2026 12:59:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -344,10 +344,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3f85026f-448a-4934-a80f-94508d38ff6e
+                - 0d96c166-3bd3-4abb-b075-09a2fad48954
         status: 200 OK
         code: 200
-        duration: 168.113782ms
+        duration: 155.187798ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -364,7 +364,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/snapshots/9dc07a0e-6b60-4a8e-a346-a29afb050271
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/snapshots/187cbc2f-03b1-4174-afbc-37673fd46e19
         method: GET
       response:
         proto: HTTP/2.0
@@ -374,7 +374,7 @@ interactions:
         trailer: {}
         content_length: 434
         uncompressed: false
-        body: '{"created_at":"2026-06-18T10:41:07.103545Z","expires_at":"2027-06-18T10:41:07.103545Z","id":"9dc07a0e-6b60-4a8e-a346-a29afb050271","instance_id":"33be5c2b-5927-4c67-b739-813898b0d2b5","instance_name":"tf-test-rdb-snapshot-list-inst","name":"tf-test-rdb-snapshot-list","node_type":"db-dev-s","region":"fr-par","size":10000000000,"status":"ready","updated_at":"2026-06-18T10:41:15.261705Z","volume_type":{"class":"sbs","type":"sbs_5k"}}'
+        body: '{"created_at":"2026-06-22T12:59:14.549065Z","expires_at":"2027-06-22T12:59:14.549065Z","id":"187cbc2f-03b1-4174-afbc-37673fd46e19","instance_id":"d984bf47-8a2a-421f-8e2e-b6832d5a2cd1","instance_name":"tf-test-rdb-snapshot-list-inst","name":"tf-test-rdb-snapshot-list","node_type":"db-dev-s","region":"fr-par","size":10000000000,"status":"ready","updated_at":"2026-06-22T12:59:23.078828Z","volume_type":{"class":"sbs","type":"sbs_5k"}}'
         headers:
             Content-Length:
                 - "434"
@@ -383,9 +383,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:37 GMT
+                - Mon, 22 Jun 2026 12:59:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -393,10 +393,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ecb6a071-2597-4e0b-a15e-9f66def7b730
+                - 76b2cf75-048f-498a-a4d1-0b323e2c6f18
         status: 200 OK
         code: 200
-        duration: 186.784151ms
+        duration: 136.567838ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -413,7 +413,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/snapshots/9dc07a0e-6b60-4a8e-a346-a29afb050271
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/snapshots/187cbc2f-03b1-4174-afbc-37673fd46e19
         method: GET
       response:
         proto: HTTP/2.0
@@ -423,7 +423,7 @@ interactions:
         trailer: {}
         content_length: 434
         uncompressed: false
-        body: '{"created_at":"2026-06-18T10:41:07.103545Z","expires_at":"2027-06-18T10:41:07.103545Z","id":"9dc07a0e-6b60-4a8e-a346-a29afb050271","instance_id":"33be5c2b-5927-4c67-b739-813898b0d2b5","instance_name":"tf-test-rdb-snapshot-list-inst","name":"tf-test-rdb-snapshot-list","node_type":"db-dev-s","region":"fr-par","size":10000000000,"status":"ready","updated_at":"2026-06-18T10:41:15.261705Z","volume_type":{"class":"sbs","type":"sbs_5k"}}'
+        body: '{"created_at":"2026-06-22T12:59:14.549065Z","expires_at":"2027-06-22T12:59:14.549065Z","id":"187cbc2f-03b1-4174-afbc-37673fd46e19","instance_id":"d984bf47-8a2a-421f-8e2e-b6832d5a2cd1","instance_name":"tf-test-rdb-snapshot-list-inst","name":"tf-test-rdb-snapshot-list","node_type":"db-dev-s","region":"fr-par","size":10000000000,"status":"ready","updated_at":"2026-06-22T12:59:23.078828Z","volume_type":{"class":"sbs","type":"sbs_5k"}}'
         headers:
             Content-Length:
                 - "434"
@@ -432,9 +432,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:37 GMT
+                - Mon, 22 Jun 2026 12:59:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -442,10 +442,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e6ba80ee-4f2c-43b6-906b-5163674c75ab
+                - 0d3ecffa-c2c7-4d90-be40-5c076a8d49d6
         status: 200 OK
         code: 200
-        duration: 88.589803ms
+        duration: 137.379861ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -462,7 +462,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/33be5c2b-5927-4c67-b739-813898b0d2b5
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d984bf47-8a2a-421f-8e2e-b6832d5a2cd1
         method: GET
       response:
         proto: HTTP/2.0
@@ -472,7 +472,7 @@ interactions:
         trailer: {}
         content_length: 1224
         uncompressed: false
-        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-18T10:37:34.289709Z","encryption":{"enabled":false},"endpoint":{"id":"7aadf453-b5e3-4518-9430-689aaa1c46cd","ip":"51.15.134.48","load_balancer":{},"name":null,"port":20793},"endpoints":[{"id":"7aadf453-b5e3-4518-9430-689aaa1c46cd","ip":"51.15.134.48","load_balancer":{},"name":null,"port":20793}],"engine":"PostgreSQL-17","id":"33be5c2b-5927-4c67-b739-813898b0d2b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-snapshot-list-inst","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"sbs","size":10000000000,"type":"sbs_5k"}}'
+        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-22T12:55:41.052539Z","encryption":{"enabled":false},"endpoint":{"id":"0720e0fb-3960-4569-827a-c74dd7bc5720","ip":"51.15.248.243","load_balancer":{},"name":null,"port":3524},"endpoints":[{"id":"0720e0fb-3960-4569-827a-c74dd7bc5720","ip":"51.15.248.243","load_balancer":{},"name":null,"port":3524}],"engine":"PostgreSQL-17","id":"d984bf47-8a2a-421f-8e2e-b6832d5a2cd1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-snapshot-list-inst","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"sbs","size":10000000000,"type":"sbs_5k"}}'
         headers:
             Content-Length:
                 - "1224"
@@ -481,9 +481,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:38 GMT
+                - Mon, 22 Jun 2026 12:59:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -491,10 +491,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f508c2c1-50bf-48c0-9238-d56a38de1d7d
+                - d40bfaf2-a341-4720-9a6c-0520cec6bc90
         status: 200 OK
         code: 200
-        duration: 139.67887ms
+        duration: 201.814314ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -511,7 +511,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/33be5c2b-5927-4c67-b739-813898b0d2b5/certificate
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d984bf47-8a2a-421f-8e2e-b6832d5a2cd1/certificate
         method: GET
       response:
         proto: HTTP/2.0
@@ -519,20 +519,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1995
+        content_length: 2007
         uncompressed: false
-        body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQrRENDQXVDZ0F3SUJBZ0lVUkROT3JDYTU0THhROGx2dEZ6ZDVsTTFESFNrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFMakV6TkM0ME9EQWVGdzB5Ck5qQTJNVGd4TURRd01qSmFGdzB6TmpBMk1UVXhNRFF3TWpKYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlM0eE16UXVORGd3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURRVDNPVk1sVWhUT1Z4UlI4dE14U0QzL01oUTc5V2xyN1RDK3BkaDhMZlFUSkNNb1AwS2t3cVFQdi8KZDYyUjBLTldxNkxNck1XYnY2SkZBMzF1eHg5bndKcHFFb05rb3k1Q0xyUnBHM3pDdWtBZm9MTjJhZ2pFRmVFZwpPNTRlTTRFK3ZtYzRUTjBoSXJPMkdmUHMyWW9DcUpJb0NNZWhVQ0tzVGtud1N5TVUxcHNrSm1uMHR3YVFFcUdYCmhqZk0xc1hodVhaMHZmTStkVjlvUEFHMWdpYTFwYUdKQjRrOCs1SC8rUmRoMFJua2ZZZjlwZkJoNGNFUGMwSDIKK05YUXdhS2RtKzRGcDlsMXl1c2Q2NWI0cWFmYWluZGRlNFlEQjdXcHQ0cTBzSmNDSTFYRG9VUmg2WFZacmNURQpRekZEUlU4QjZaSGZ3MTdPMG9DWk9mM0U4UlRmQWdNQkFBR2pnYnN3Z2Jnd2diVUdBMVVkRVFTQnJUQ0Jxb0lNCk5URXVNVFV1TVRNMExqUTRnanh5ZHkwek0ySmxOV015WWkwMU9USTNMVFJqTmpjdFlqY3pPUzA0TVRNNE9UaGkKTUdReVlqVXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRERVeExqRTFMakV6TkM0ME9JSThjbmN0TXpOaQpaVFZqTW1JdE5Ua3lOeTAwWXpZM0xXSTNNemt0T0RFek9EazRZakJrTW1JMUxuSmtZaTVtY2kxd1lYSXVjMk4zCkxtTnNiM1ZraHdUVUwvTU9od1F6RDRZd2h3UXpENFl3TUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFCdXdRYlQKWlZ1QXFKNHVMQlVUbVFFek1YajAwaFhyWnZYazVGSEV6S3NmcXp4R0pUR2JHdWMxV3NyQ0p1VHg2ckcvK0V4WApWQVVXYUR6SFl5a1Bmakw2ck0wWmZqZkI3aGtHOXZUemFSa0hUVW0yOWlCQ3ZyVENyQlZqdU1WemNrdldMcHBlCmxvc0hmNVQwL2hYUUkxUDYwZkVsVWVDMkRuLy8vRkQ5eDlOS25ENUh2Qlp2VTlzbkN0WnA5TlNSZzZtNFBLL1IKVEtWL3JjckRxc3FqUy9BRjRmS2oxZlZlMllLNXlTcWZ6VlRjRXhUeER6WDRUcnFNak1LR0tIRi9ueWxGQ2tmZgowc01TQW5tdXN2N0Vmakh0czJBUEprN1VvUnNEZ3lGV1h1a2lrZ0hjMEVOTG5WbkRTN1pWbW9nUU1rQ3cwM1RSCm5QMSttNnBIbHZGODBVU1kKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+        body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVWHJOSEcvd3BDb0pGR21jYjF6NEsveTBtcEVvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFMakkwT0M0eU5ETXdIaGNOCk1qWXdOakl5TVRJMU9EUTVXaGNOTXpZd05qRTVNVEkxT0RRNVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVdU1qUTRMakkwTXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxCRlJlNjh4ZWFwNkp5RXplVVRKenBYMUtyRU5rWnZPdUZSQlp6YUtQMURKbUVGL2ZtdzdDVEUKK0VFTHZKRTl5U2VwNWU1Nmg2WmltM1hGc2lyeC9SQXJHYitLSzBkbFgrRSswY01ZRzlrRHhuc0F3OFoxaWZJbgpMdEtUT1JyQkJGSTNoTitPVlhBL1lPSnhYVVBpd05JZHl2LzN0bDRVWHJreDdNU0k0TmJYaHYyc1QveEUzTHdiCmpxTzloVGcvd0l6dDczR1hUblVzNmkxTUliSGFkNGtJZWxLUTVob3owcEpRVWpPYUlmL2Y0L1hBMkZ3K0JpRVoKS2hKbjFERytjSUxCOTJxaWNCRkpiVkV5Qmt4SjVOOWsvaEUxM1orT29pZlZGSWdCUEdWMzNlcWVOT3Nxb2tBNwphUklRSWU1c01zbWlOeW1NeUlmUmY0akJhZFp2RXRNQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlM0eU5EZ3VNalF6Z2p4eWR5MWtPVGcwWW1ZME55MDRZVEpoTFRReU1XWXRPR1V5WlMxaU5qZ3oKTW1RMVlUSmpaREV1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxTGpJME9DNHlORE9DUEhKMwpMV1E1T0RSaVpqUTNMVGhoTW1FdE5ESXhaaTA0WlRKbExXSTJPRE15WkRWaE1tTmtNUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNNTVsK0ljRU13LzQ4NGNFTXcvNDh6QU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKZlRLeThvSndlbUZ0OHdWdEZLZ05lLzBYWXYrVEV5K0JhZE1PaWNOdjJTaDZ5a3R2dGl6aFRrYkgvY0tXZE1ZOApINlNqb3RNOXlXNk5MQklKNkhERHRoVE1iZ2ZVQlRqL0NKa295YnZjVmxaUkFPZnFETTBkaEF2dmM4RFluQ0cvCjZUaWs1RGFxdUxFQ0VZVEN3UGpJM0twWWw3MnNyeHRwL1k4QnZFSm5hb1BmNkl3Wmh1aEthWkd4Vm5yLzhTVnQKeGdBZjFydWY5UHRCU0xWWU1Na0ZTMXRpN2ZLL1RmaHJsMWhncTRVME5hZ053K3EzYUo0R29MeG8zRXU2ZDMvdAo2RFRrakNhQ3E2K0RCOERJN2V0c29vNWVxTVVpZFZFT3phTWlrQXBEVG9hdlhlNDVkRTVkb2ErRS9CaUkray9rCi81WW80ZHAwY09MYzR2UzhJZ0FMK3c9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
         headers:
             Content-Length:
-                - "1995"
+                - "2007"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:38 GMT
+                - Mon, 22 Jun 2026 12:59:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -540,10 +540,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 26c2ba61-08f1-4686-838e-aeeb2779fda3
+                - 74dc8505-9875-4ec2-856f-a94d34983eb5
         status: 200 OK
         code: 200
-        duration: 163.420452ms
+        duration: 156.840666ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -560,7 +560,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/snapshots/9dc07a0e-6b60-4a8e-a346-a29afb050271
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/snapshots/187cbc2f-03b1-4174-afbc-37673fd46e19
         method: GET
       response:
         proto: HTTP/2.0
@@ -570,7 +570,7 @@ interactions:
         trailer: {}
         content_length: 434
         uncompressed: false
-        body: '{"created_at":"2026-06-18T10:41:07.103545Z","expires_at":"2027-06-18T10:41:07.103545Z","id":"9dc07a0e-6b60-4a8e-a346-a29afb050271","instance_id":"33be5c2b-5927-4c67-b739-813898b0d2b5","instance_name":"tf-test-rdb-snapshot-list-inst","name":"tf-test-rdb-snapshot-list","node_type":"db-dev-s","region":"fr-par","size":10000000000,"status":"ready","updated_at":"2026-06-18T10:41:15.261705Z","volume_type":{"class":"sbs","type":"sbs_5k"}}'
+        body: '{"created_at":"2026-06-22T12:59:14.549065Z","expires_at":"2027-06-22T12:59:14.549065Z","id":"187cbc2f-03b1-4174-afbc-37673fd46e19","instance_id":"d984bf47-8a2a-421f-8e2e-b6832d5a2cd1","instance_name":"tf-test-rdb-snapshot-list-inst","name":"tf-test-rdb-snapshot-list","node_type":"db-dev-s","region":"fr-par","size":10000000000,"status":"ready","updated_at":"2026-06-22T12:59:23.078828Z","volume_type":{"class":"sbs","type":"sbs_5k"}}'
         headers:
             Content-Length:
                 - "434"
@@ -579,9 +579,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:38 GMT
+                - Mon, 22 Jun 2026 12:59:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -589,10 +589,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 41a6b6c6-6ecb-4bc2-8651-23e5456a6aa6
+                - 0f5621cf-97bd-45fb-a043-8d92a0e68206
         status: 200 OK
         code: 200
-        duration: 186.412211ms
+        duration: 138.561524ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -609,7 +609,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/33be5c2b-5927-4c67-b739-813898b0d2b5
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d984bf47-8a2a-421f-8e2e-b6832d5a2cd1
         method: GET
       response:
         proto: HTTP/2.0
@@ -619,7 +619,7 @@ interactions:
         trailer: {}
         content_length: 1224
         uncompressed: false
-        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-18T10:37:34.289709Z","encryption":{"enabled":false},"endpoint":{"id":"7aadf453-b5e3-4518-9430-689aaa1c46cd","ip":"51.15.134.48","load_balancer":{},"name":null,"port":20793},"endpoints":[{"id":"7aadf453-b5e3-4518-9430-689aaa1c46cd","ip":"51.15.134.48","load_balancer":{},"name":null,"port":20793}],"engine":"PostgreSQL-17","id":"33be5c2b-5927-4c67-b739-813898b0d2b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-snapshot-list-inst","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"sbs","size":10000000000,"type":"sbs_5k"}}'
+        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-22T12:55:41.052539Z","encryption":{"enabled":false},"endpoint":{"id":"0720e0fb-3960-4569-827a-c74dd7bc5720","ip":"51.15.248.243","load_balancer":{},"name":null,"port":3524},"endpoints":[{"id":"0720e0fb-3960-4569-827a-c74dd7bc5720","ip":"51.15.248.243","load_balancer":{},"name":null,"port":3524}],"engine":"PostgreSQL-17","id":"d984bf47-8a2a-421f-8e2e-b6832d5a2cd1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-snapshot-list-inst","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"sbs","size":10000000000,"type":"sbs_5k"}}'
         headers:
             Content-Length:
                 - "1224"
@@ -628,9 +628,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:39 GMT
+                - Mon, 22 Jun 2026 12:59:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -638,10 +638,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b69d28a0-4346-46c0-af9a-7208746a097e
+                - 534363b8-0a6b-4fd2-8c9e-26e20696726e
         status: 200 OK
         code: 200
-        duration: 294.927876ms
+        duration: 196.15095ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -658,7 +658,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/snapshots?instance_id=33be5c2b-5927-4c67-b739-813898b0d2b5&name=tf-test-rdb-snapshot-list&order_by=created_at_asc&page=1&project_id=105bdce1-64c0-48ab-899d-868455867ecf
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/snapshots?instance_id=d984bf47-8a2a-421f-8e2e-b6832d5a2cd1&name=tf-test-rdb-snapshot-list&order_by=created_at_asc&page=1&project_id=105bdce1-64c0-48ab-899d-868455867ecf
         method: GET
       response:
         proto: HTTP/2.0
@@ -668,7 +668,7 @@ interactions:
         trailer: {}
         content_length: 466
         uncompressed: false
-        body: '{"snapshots":[{"created_at":"2026-06-18T10:41:07.103545Z","expires_at":"2027-06-18T10:41:07.103545Z","id":"9dc07a0e-6b60-4a8e-a346-a29afb050271","instance_id":"33be5c2b-5927-4c67-b739-813898b0d2b5","instance_name":"tf-test-rdb-snapshot-list-inst","name":"tf-test-rdb-snapshot-list","node_type":"db-dev-s","region":"fr-par","size":10000000000,"status":"ready","updated_at":"2026-06-18T10:41:15.261705Z","volume_type":{"class":"sbs","type":"sbs_5k"}}],"total_count":1}'
+        body: '{"snapshots":[{"created_at":"2026-06-22T12:59:14.549065Z","expires_at":"2027-06-22T12:59:14.549065Z","id":"187cbc2f-03b1-4174-afbc-37673fd46e19","instance_id":"d984bf47-8a2a-421f-8e2e-b6832d5a2cd1","instance_name":"tf-test-rdb-snapshot-list-inst","name":"tf-test-rdb-snapshot-list","node_type":"db-dev-s","region":"fr-par","size":10000000000,"status":"ready","updated_at":"2026-06-22T12:59:23.078828Z","volume_type":{"class":"sbs","type":"sbs_5k"}}],"total_count":1}'
         headers:
             Content-Length:
                 - "466"
@@ -677,9 +677,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:39 GMT
+                - Mon, 22 Jun 2026 12:59:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -687,10 +687,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 1f0dcb0e-ea50-4c3f-8ecb-b81cf73bc5a8
+                - 30fd8715-78bc-4e60-afec-152c0ae8d9d2
         status: 200 OK
         code: 200
-        duration: 177.404119ms
+        duration: 155.676097ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -717,7 +717,7 @@ interactions:
         trailer: {}
         content_length: 1256
         uncompressed: false
-        body: '{"instances":[{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-18T10:37:34.289709Z","encryption":{"enabled":false},"endpoint":{"id":"7aadf453-b5e3-4518-9430-689aaa1c46cd","ip":"51.15.134.48","load_balancer":{},"name":null,"port":20793},"endpoints":[{"id":"7aadf453-b5e3-4518-9430-689aaa1c46cd","ip":"51.15.134.48","load_balancer":{},"name":null,"port":20793}],"engine":"PostgreSQL-17","id":"33be5c2b-5927-4c67-b739-813898b0d2b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-snapshot-list-inst","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"sbs","size":10000000000,"type":"sbs_5k"}}],"total_count":1}'
+        body: '{"instances":[{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-22T12:55:41.052539Z","encryption":{"enabled":false},"endpoint":{"id":"0720e0fb-3960-4569-827a-c74dd7bc5720","ip":"51.15.248.243","load_balancer":{},"name":null,"port":3524},"endpoints":[{"id":"0720e0fb-3960-4569-827a-c74dd7bc5720","ip":"51.15.248.243","load_balancer":{},"name":null,"port":3524}],"engine":"PostgreSQL-17","id":"d984bf47-8a2a-421f-8e2e-b6832d5a2cd1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-snapshot-list-inst","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"sbs","size":10000000000,"type":"sbs_5k"}}],"total_count":1}'
         headers:
             Content-Length:
                 - "1256"
@@ -726,9 +726,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:39 GMT
+                - Mon, 22 Jun 2026 12:59:46 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -736,10 +736,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4ce00d2b-27ca-40fd-b520-4214c1ff4c5f
+                - 1a34ed3f-98d1-4ad7-8898-75341130a89a
         status: 200 OK
         code: 200
-        duration: 242.78847ms
+        duration: 145.810415ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -756,7 +756,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/snapshots?instance_id=33be5c2b-5927-4c67-b739-813898b0d2b5&name=tf-test-rdb-snapshot-list&order_by=created_at_asc&page=1&project_id=105bdce1-64c0-48ab-899d-868455867ecf
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/snapshots?instance_id=d984bf47-8a2a-421f-8e2e-b6832d5a2cd1&name=tf-test-rdb-snapshot-list&order_by=created_at_asc&page=1&project_id=105bdce1-64c0-48ab-899d-868455867ecf
         method: GET
       response:
         proto: HTTP/2.0
@@ -766,7 +766,7 @@ interactions:
         trailer: {}
         content_length: 466
         uncompressed: false
-        body: '{"snapshots":[{"created_at":"2026-06-18T10:41:07.103545Z","expires_at":"2027-06-18T10:41:07.103545Z","id":"9dc07a0e-6b60-4a8e-a346-a29afb050271","instance_id":"33be5c2b-5927-4c67-b739-813898b0d2b5","instance_name":"tf-test-rdb-snapshot-list-inst","name":"tf-test-rdb-snapshot-list","node_type":"db-dev-s","region":"fr-par","size":10000000000,"status":"ready","updated_at":"2026-06-18T10:41:15.261705Z","volume_type":{"class":"sbs","type":"sbs_5k"}}],"total_count":1}'
+        body: '{"snapshots":[{"created_at":"2026-06-22T12:59:14.549065Z","expires_at":"2027-06-22T12:59:14.549065Z","id":"187cbc2f-03b1-4174-afbc-37673fd46e19","instance_id":"d984bf47-8a2a-421f-8e2e-b6832d5a2cd1","instance_name":"tf-test-rdb-snapshot-list-inst","name":"tf-test-rdb-snapshot-list","node_type":"db-dev-s","region":"fr-par","size":10000000000,"status":"ready","updated_at":"2026-06-22T12:59:23.078828Z","volume_type":{"class":"sbs","type":"sbs_5k"}}],"total_count":1}'
         headers:
             Content-Length:
                 - "466"
@@ -775,9 +775,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:39 GMT
+                - Mon, 22 Jun 2026 12:59:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -785,10 +785,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6c0d0887-3073-4fff-9866-4b4a9f6e5991
+                - c7d09683-8f4f-479b-9b84-7d1224751c14
         status: 200 OK
         code: 200
-        duration: 128.177441ms
+        duration: 152.713997ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -805,7 +805,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/snapshots/9dc07a0e-6b60-4a8e-a346-a29afb050271
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/snapshots/187cbc2f-03b1-4174-afbc-37673fd46e19
         method: GET
       response:
         proto: HTTP/2.0
@@ -815,7 +815,7 @@ interactions:
         trailer: {}
         content_length: 434
         uncompressed: false
-        body: '{"created_at":"2026-06-18T10:41:07.103545Z","expires_at":"2027-06-18T10:41:07.103545Z","id":"9dc07a0e-6b60-4a8e-a346-a29afb050271","instance_id":"33be5c2b-5927-4c67-b739-813898b0d2b5","instance_name":"tf-test-rdb-snapshot-list-inst","name":"tf-test-rdb-snapshot-list","node_type":"db-dev-s","region":"fr-par","size":10000000000,"status":"ready","updated_at":"2026-06-18T10:41:15.261705Z","volume_type":{"class":"sbs","type":"sbs_5k"}}'
+        body: '{"created_at":"2026-06-22T12:59:14.549065Z","expires_at":"2027-06-22T12:59:14.549065Z","id":"187cbc2f-03b1-4174-afbc-37673fd46e19","instance_id":"d984bf47-8a2a-421f-8e2e-b6832d5a2cd1","instance_name":"tf-test-rdb-snapshot-list-inst","name":"tf-test-rdb-snapshot-list","node_type":"db-dev-s","region":"fr-par","size":10000000000,"status":"ready","updated_at":"2026-06-22T12:59:23.078828Z","volume_type":{"class":"sbs","type":"sbs_5k"}}'
         headers:
             Content-Length:
                 - "434"
@@ -824,9 +824,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:40 GMT
+                - Mon, 22 Jun 2026 12:59:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -834,10 +834,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f5820b39-1902-4a8c-b152-09b438e03e39
+                - fc61e4b0-5657-4f05-8b44-974f79232447
         status: 200 OK
         code: 200
-        duration: 193.644147ms
+        duration: 140.468063ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -854,7 +854,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/snapshots/9dc07a0e-6b60-4a8e-a346-a29afb050271
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/snapshots/187cbc2f-03b1-4174-afbc-37673fd46e19
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -864,7 +864,7 @@ interactions:
         trailer: {}
         content_length: 437
         uncompressed: false
-        body: '{"created_at":"2026-06-18T10:41:07.103545Z","expires_at":"2027-06-18T10:41:07.103545Z","id":"9dc07a0e-6b60-4a8e-a346-a29afb050271","instance_id":"33be5c2b-5927-4c67-b739-813898b0d2b5","instance_name":"tf-test-rdb-snapshot-list-inst","name":"tf-test-rdb-snapshot-list","node_type":"db-dev-s","region":"fr-par","size":10000000000,"status":"deleting","updated_at":"2026-06-18T10:41:15.261705Z","volume_type":{"class":"sbs","type":"sbs_5k"}}'
+        body: '{"created_at":"2026-06-22T12:59:14.549065Z","expires_at":"2027-06-22T12:59:14.549065Z","id":"187cbc2f-03b1-4174-afbc-37673fd46e19","instance_id":"d984bf47-8a2a-421f-8e2e-b6832d5a2cd1","instance_name":"tf-test-rdb-snapshot-list-inst","name":"tf-test-rdb-snapshot-list","node_type":"db-dev-s","region":"fr-par","size":10000000000,"status":"deleting","updated_at":"2026-06-22T12:59:23.078828Z","volume_type":{"class":"sbs","type":"sbs_5k"}}'
         headers:
             Content-Length:
                 - "437"
@@ -873,9 +873,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:40 GMT
+                - Mon, 22 Jun 2026 12:59:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -883,10 +883,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6c0bb08e-0fd2-4530-bbba-507901b5d437
+                - 54e0c1e7-be21-43e1-9b75-1849bad342c1
         status: 200 OK
         code: 200
-        duration: 312.250855ms
+        duration: 272.224403ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -903,7 +903,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/33be5c2b-5927-4c67-b739-813898b0d2b5
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d984bf47-8a2a-421f-8e2e-b6832d5a2cd1
         method: GET
       response:
         proto: HTTP/2.0
@@ -913,7 +913,7 @@ interactions:
         trailer: {}
         content_length: 1224
         uncompressed: false
-        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-18T10:37:34.289709Z","encryption":{"enabled":false},"endpoint":{"id":"7aadf453-b5e3-4518-9430-689aaa1c46cd","ip":"51.15.134.48","load_balancer":{},"name":null,"port":20793},"endpoints":[{"id":"7aadf453-b5e3-4518-9430-689aaa1c46cd","ip":"51.15.134.48","load_balancer":{},"name":null,"port":20793}],"engine":"PostgreSQL-17","id":"33be5c2b-5927-4c67-b739-813898b0d2b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-snapshot-list-inst","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"sbs","size":10000000000,"type":"sbs_5k"}}'
+        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-22T12:55:41.052539Z","encryption":{"enabled":false},"endpoint":{"id":"0720e0fb-3960-4569-827a-c74dd7bc5720","ip":"51.15.248.243","load_balancer":{},"name":null,"port":3524},"endpoints":[{"id":"0720e0fb-3960-4569-827a-c74dd7bc5720","ip":"51.15.248.243","load_balancer":{},"name":null,"port":3524}],"engine":"PostgreSQL-17","id":"d984bf47-8a2a-421f-8e2e-b6832d5a2cd1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-snapshot-list-inst","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"sbs","size":10000000000,"type":"sbs_5k"}}'
         headers:
             Content-Length:
                 - "1224"
@@ -922,9 +922,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:40 GMT
+                - Mon, 22 Jun 2026 12:59:47 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -932,10 +932,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9793cd36-5ed4-4dfc-a6fd-c94c1301c014
+                - 56f7e1f9-97d0-4bad-8852-7343338587bc
         status: 200 OK
         code: 200
-        duration: 136.673017ms
+        duration: 182.028332ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -952,7 +952,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/33be5c2b-5927-4c67-b739-813898b0d2b5
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d984bf47-8a2a-421f-8e2e-b6832d5a2cd1
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -962,7 +962,7 @@ interactions:
         trailer: {}
         content_length: 1227
         uncompressed: false
-        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-18T10:37:34.289709Z","encryption":{"enabled":false},"endpoint":{"id":"7aadf453-b5e3-4518-9430-689aaa1c46cd","ip":"51.15.134.48","load_balancer":{},"name":null,"port":20793},"endpoints":[{"id":"7aadf453-b5e3-4518-9430-689aaa1c46cd","ip":"51.15.134.48","load_balancer":{},"name":null,"port":20793}],"engine":"PostgreSQL-17","id":"33be5c2b-5927-4c67-b739-813898b0d2b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-snapshot-list-inst","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"sbs","size":10000000000,"type":"sbs_5k"}}'
+        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-22T12:55:41.052539Z","encryption":{"enabled":false},"endpoint":{"id":"0720e0fb-3960-4569-827a-c74dd7bc5720","ip":"51.15.248.243","load_balancer":{},"name":null,"port":3524},"endpoints":[{"id":"0720e0fb-3960-4569-827a-c74dd7bc5720","ip":"51.15.248.243","load_balancer":{},"name":null,"port":3524}],"engine":"PostgreSQL-17","id":"d984bf47-8a2a-421f-8e2e-b6832d5a2cd1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-snapshot-list-inst","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"sbs","size":10000000000,"type":"sbs_5k"}}'
         headers:
             Content-Length:
                 - "1227"
@@ -971,9 +971,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:41 GMT
+                - Mon, 22 Jun 2026 12:59:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -981,10 +981,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 76847eba-cc6f-448e-87c6-d8b4404eeefd
+                - 4f26ecff-c985-4221-96c3-be99a3caab9f
         status: 200 OK
         code: 200
-        duration: 374.809483ms
+        duration: 476.896253ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1001,7 +1001,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/33be5c2b-5927-4c67-b739-813898b0d2b5
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d984bf47-8a2a-421f-8e2e-b6832d5a2cd1
         method: GET
       response:
         proto: HTTP/2.0
@@ -1011,7 +1011,7 @@ interactions:
         trailer: {}
         content_length: 1227
         uncompressed: false
-        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-18T10:37:34.289709Z","encryption":{"enabled":false},"endpoint":{"id":"7aadf453-b5e3-4518-9430-689aaa1c46cd","ip":"51.15.134.48","load_balancer":{},"name":null,"port":20793},"endpoints":[{"id":"7aadf453-b5e3-4518-9430-689aaa1c46cd","ip":"51.15.134.48","load_balancer":{},"name":null,"port":20793}],"engine":"PostgreSQL-17","id":"33be5c2b-5927-4c67-b739-813898b0d2b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-snapshot-list-inst","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"sbs","size":10000000000,"type":"sbs_5k"}}'
+        body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2026-06-22T12:55:41.052539Z","encryption":{"enabled":false},"endpoint":{"id":"0720e0fb-3960-4569-827a-c74dd7bc5720","ip":"51.15.248.243","load_balancer":{},"name":null,"port":3524},"endpoints":[{"id":"0720e0fb-3960-4569-827a-c74dd7bc5720","ip":"51.15.248.243","load_balancer":{},"name":null,"port":3524}],"engine":"PostgreSQL-17","id":"d984bf47-8a2a-421f-8e2e-b6832d5a2cd1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"tf-test-rdb-snapshot-list-inst","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"sbs","size":10000000000,"type":"sbs_5k"}}'
         headers:
             Content-Length:
                 - "1227"
@@ -1020,9 +1020,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:41:41 GMT
+                - Mon, 22 Jun 2026 12:59:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1030,10 +1030,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 451b3f27-fce9-4fbb-ba9d-c1fa46e802d8
+                - d52a94d5-6488-4e5a-bc80-f340bf110e73
         status: 200 OK
         code: 200
-        duration: 165.146424ms
+        duration: 187.435618ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1050,7 +1050,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/33be5c2b-5927-4c67-b739-813898b0d2b5
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d984bf47-8a2a-421f-8e2e-b6832d5a2cd1
         method: GET
       response:
         proto: HTTP/2.0
@@ -1060,7 +1060,7 @@ interactions:
         trailer: {}
         content_length: 129
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance","resource_id":"33be5c2b-5927-4c67-b739-813898b0d2b5","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance","resource_id":"d984bf47-8a2a-421f-8e2e-b6832d5a2cd1","type":"not_found"}'
         headers:
             Content-Length:
                 - "129"
@@ -1069,9 +1069,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:42:11 GMT
+                - Mon, 22 Jun 2026 13:00:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1079,10 +1079,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4f89d631-fac6-49b0-851c-2ee9f7e3d595
+                - 2536cb98-d1e3-4c28-9261-112d22452ccf
         status: 404 Not Found
         code: 404
-        duration: 176.832265ms
+        duration: 145.5024ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1099,7 +1099,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/33be5c2b-5927-4c67-b739-813898b0d2b5
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d984bf47-8a2a-421f-8e2e-b6832d5a2cd1
         method: GET
       response:
         proto: HTTP/2.0
@@ -1109,7 +1109,7 @@ interactions:
         trailer: {}
         content_length: 129
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance","resource_id":"33be5c2b-5927-4c67-b739-813898b0d2b5","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance","resource_id":"d984bf47-8a2a-421f-8e2e-b6832d5a2cd1","type":"not_found"}'
         headers:
             Content-Length:
                 - "129"
@@ -1118,9 +1118,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:42:11 GMT
+                - Mon, 22 Jun 2026 13:00:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1128,10 +1128,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b011e52d-2db1-43a1-b676-ae302f241ec8
+                - 165e8336-76f9-4eaf-913c-739ace226767
         status: 404 Not Found
         code: 404
-        duration: 75.629606ms
+        duration: 134.286385ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1148,7 +1148,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/rdb/v1/regions/fr-par/snapshots/9dc07a0e-6b60-4a8e-a346-a29afb050271
+        url: https://api.scaleway.com/rdb/v1/regions/fr-par/snapshots/187cbc2f-03b1-4174-afbc-37673fd46e19
         method: GET
       response:
         proto: HTTP/2.0
@@ -1158,7 +1158,7 @@ interactions:
         trailer: {}
         content_length: 138
         uncompressed: false
-        body: '{"message":"resource is not found","resource":"instance_snapshot","resource_id":"9dc07a0e-6b60-4a8e-a346-a29afb050271","type":"not_found"}'
+        body: '{"message":"resource is not found","resource":"instance_snapshot","resource_id":"187cbc2f-03b1-4174-afbc-37673fd46e19","type":"not_found"}'
         headers:
             Content-Length:
                 - "138"
@@ -1167,9 +1167,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 18 Jun 2026 10:42:11 GMT
+                - Mon, 22 Jun 2026 13:00:18 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-3;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1177,7 +1177,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - aacb47a2-0dfc-429c-be03-e51cdabd3178
+                - cabad419-5e7e-4675-a774-ffae400b665f
         status: 404 Not Found
         code: 404
-        duration: 44.440351ms
+        duration: 31.81552ms

--- a/internal/services/rdb/waiters.go
+++ b/internal/services/rdb/waiters.go
@@ -2,46 +2,12 @@ package rdb
 
 import (
 	"context"
-	"errors"
-	"net/http"
 	"time"
 
 	"github.com/scaleway/scaleway-sdk-go/api/rdb/v1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/transport"
 )
-
-var (
-	maxRetriesOnForbidden = 3
-	waitTime              = 1 * time.Second
-)
-
-// Mitigate transient permission issue during provisioning,
-// caused by IAM permissions propagation delta.
-func retryOn403(ctx context.Context, fn func() error) error {
-	var lastErr error
-
-	for range maxRetriesOnForbidden {
-		lastErr = fn()
-		if lastErr == nil {
-			return nil
-		}
-
-		var respErr *scw.ResponseError
-		if errors.As(lastErr, &respErr) && respErr.StatusCode == http.StatusForbidden {
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case <-time.After(waitTime):
-				continue
-			}
-		}
-
-		return lastErr
-	}
-
-	return lastErr
-}
 
 func waitForRDBInstance(ctx context.Context, api *rdb.API, region scw.Region, id string, timeout time.Duration) (*rdb.Instance, error) {
 	retryInterval := defaultWaitRetryInterval
@@ -51,7 +17,7 @@ func waitForRDBInstance(ctx context.Context, api *rdb.API, region scw.Region, id
 
 	var instance *rdb.Instance
 
-	err := retryOn403(ctx, func() error {
+	err := transport.RetryOn403(ctx, func() error {
 		var err error
 
 		instance, err = api.WaitForInstance(&rdb.WaitForInstanceRequest{
@@ -75,7 +41,7 @@ func waitForRDBDatabaseBackup(ctx context.Context, api *rdb.API, region scw.Regi
 
 	var backup *rdb.DatabaseBackup
 
-	err := retryOn403(ctx, func() error {
+	err := transport.RetryOn403(ctx, func() error {
 		var err error
 
 		backup, err = api.WaitForDatabaseBackup(&rdb.WaitForDatabaseBackupRequest{
@@ -99,7 +65,7 @@ func waitForRDBReadReplica(ctx context.Context, api *rdb.API, region scw.Region,
 
 	var replica *rdb.ReadReplica
 
-	err := retryOn403(ctx, func() error {
+	err := transport.RetryOn403(ctx, func() error {
 		var err error
 
 		replica, err = api.WaitForReadReplica(&rdb.WaitForReadReplicaRequest{
@@ -123,7 +89,7 @@ func waitForRDBSnapshot(ctx context.Context, api *rdb.API, region scw.Region, sn
 
 	var snapshot *rdb.Snapshot
 
-	err := retryOn403(ctx, func() error {
+	err := transport.RetryOn403(ctx, func() error {
 		var err error
 
 		snapshot, err = api.WaitForSnapshot(&rdb.WaitForSnapshotRequest{

--- a/internal/transport/retry.go
+++ b/internal/transport/retry.go
@@ -10,15 +10,18 @@ import (
 
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/scaleway/scaleway-sdk-go/scw"
-	"github.com/scaleway/terraform-provider-scaleway/v2/internal/httperrors"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/logging"
 )
 
 const (
 	// MaxRetriesOnForbidden is the number of retries when a request fails with HTTP 403.
+	//
+	// For a 2s RetryOn403WaitTime, timeout will occur at most after 62s, enabling the
+	// retries to go over IAM's 60s cache.
+	// (Current exponential backoff: 2s/4s/8s/16s/32s, max total time 62s)
 	MaxRetriesOnForbidden = 5
 
-	// RetryOn403WaitTime is the delay between retries on HTTP 403.
+	// RetryOn403WaitTime is the initial delay between retries on HTTP 403.
 	RetryOn403WaitTime = 2 * time.Second
 )
 
@@ -124,17 +127,20 @@ func (c *RetryableTransport) RoundTrip(r *http.Request) (*http.Response, error) 
 func RetryOn403(ctx context.Context, fn func() error) error {
 	var lastErr error
 
-	for range MaxRetriesOnForbidden {
+	for i := range MaxRetriesOnForbidden {
 		lastErr = fn()
 		if lastErr == nil {
 			return nil
 		}
 
-		if httperrors.Is403(lastErr) {
+		var respErr *scw.ResponseError
+		if errors.As(lastErr, &respErr) && respErr.StatusCode == http.StatusForbidden {
+			wait := RetryOn403WaitTime * time.Duration(1<<i) // exponential backoff
+
 			select {
 			case <-ctx.Done():
 				return ctx.Err()
-			case <-time.After(RetryOn403WaitTime):
+			case <-time.After(wait):
 				continue
 			}
 		}
@@ -152,17 +158,20 @@ func RetryOn403Value[T any](ctx context.Context, fn func() (T, error)) (T, error
 		lastErr error
 	)
 
-	for range MaxRetriesOnForbidden {
+	for i := range MaxRetriesOnForbidden {
 		result, lastErr = fn()
 		if lastErr == nil {
 			return result, nil
 		}
 
-		if httperrors.Is403(lastErr) {
+		var respErr *scw.ResponseError
+		if errors.As(lastErr, &respErr) && respErr.StatusCode == http.StatusForbidden {
+			wait := RetryOn403WaitTime * time.Duration(1<<i) // exponential backoff
+
 			select {
 			case <-ctx.Done():
 				return result, ctx.Err()
-			case <-time.After(RetryOn403WaitTime):
+			case <-time.After(wait):
 				continue
 			}
 		}


### PR DESCRIPTION
[Back to draft: we are debating moving to a test-only solution]

Following https://github.com/scaleway/terraform-provider-scaleway/commit/90421aaae7904478832a4daa89fb408e87a361cc, nightly tests still fail because IAM has a 60s permissions cache. Added an exponential backoff with a total 62s to mitigate this unfortunate limitation.

I thought about adding an additional preventative `sleep` in the tests in the project creation wrapper to avoid triggering the IAM cache until the permissions are likely propagated, but I decided against it in order for the tests to stick to actual behaviour.