### PR TITLE
fix(secret): add versions to secret resource and datasource

### DIFF
--- a/internal/services/secret/helpers.go
+++ b/internal/services/secret/helpers.go
@@ -189,7 +189,7 @@ func flattenEphemeralPolicy(policy *secret.EphemeralPolicy) []map[string]any {
 	return []map[string]any{policyElem}
 }
 
-func setSecretState(d *schema.ResourceData, secret *secret.Secret) {
+func setSecretState(d *schema.ResourceData, secret *secret.Secret, versions *secret.ListSecretVersionsResponse) {
 	_ = d.Set("name", secret.Name)
 	_ = d.Set("description", types.FlattenStringPtr(secret.Description))
 	_ = d.Set("created_at", types.FlattenTime(secret.CreatedAt))
@@ -202,6 +202,25 @@ func setSecretState(d *schema.ResourceData, secret *secret.Secret) {
 	_ = d.Set("ephemeral_policy", flattenEphemeralPolicy(secret.EphemeralPolicy))
 	_ = d.Set("type", secret.Type)
 	_ = d.Set("tags", types.FlattenSliceString(secret.Tags))
+
+	// versions is not populated for list secret
+	if versions != nil {
+		versionsList := make([]map[string]any, 0, len(versions.Versions))
+		for _, version := range versions.Versions {
+			versionsList = append(versionsList, map[string]any{
+				"revision":    strconv.Itoa(int(version.Revision)),
+				"secret_id":   version.SecretID,
+				"status":      version.Status.String(),
+				"created_at":  types.FlattenTime(version.CreatedAt),
+				"updated_at":  types.FlattenTime(version.UpdatedAt),
+				"description": types.FlattenStringPtr(version.Description),
+				"latest":      types.FlattenBoolPtr(&version.Latest),
+			})
+		}
+
+		_ = d.Set("version_count", int(versions.TotalCount))
+		_ = d.Set("versions", versionsList)
+	}
 }
 
 func setVersionState(d *schema.ResourceData, version *secret.SecretVersion) {

--- a/internal/services/secret/secret.go
+++ b/internal/services/secret/secret.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
-	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -255,7 +254,7 @@ func ResourceSecretRead(ctx context.Context, d *schema.ResourceData, m any) diag
 		_ = d.Set("tags", types.FlattenSliceString(secretResponse.Tags))
 	}
 
-	versions, err := api.ListSecretVersions(&secret.ListSecretVersionsRequest{
+	versionsResponse, err := api.ListSecretVersions(&secret.ListSecretVersionsRequest{
 		Region:   region,
 		SecretID: id,
 	}, scw.WithAllPages(), scw.WithContext(ctx))
@@ -269,28 +268,12 @@ func ResourceSecretRead(ctx context.Context, d *schema.ResourceData, m any) diag
 		return diag.FromErr(err)
 	}
 
-	setSecretState(d, secretResponse)
+	setSecretState(d, secretResponse, versionsResponse)
 
 	err = identity.SetRegionalIdentity(d, region, id)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-
-	versionsList := make([]map[string]any, 0, len(versions.Versions))
-	for _, version := range versions.Versions {
-		versionsList = append(versionsList, map[string]any{
-			"revision":    strconv.Itoa(int(version.Revision)),
-			"secret_id":   version.SecretID,
-			"status":      version.Status.String(),
-			"created_at":  types.FlattenTime(version.CreatedAt),
-			"updated_at":  types.FlattenTime(version.UpdatedAt),
-			"description": types.FlattenStringPtr(version.Description),
-			"latest":      types.FlattenBoolPtr(&version.Latest),
-		})
-	}
-
-	_ = d.Set("version_count", int(versions.TotalCount))
-	_ = d.Set("versions", versionsList)
 
 	return nil
 }

--- a/internal/services/secret/secret_data_source.go
+++ b/internal/services/secret/secret_data_source.go
@@ -104,7 +104,21 @@ func DataSourceSecretRead(ctx context.Context, d *schema.ResourceData, m any) di
 		return diag.FromErr(err)
 	}
 
-	setSecretState(d, secretResponse)
+	versionsResponse, err := api.ListSecretVersions(&secret.ListSecretVersionsRequest{
+		Region:   region,
+		SecretID: secretID.(string),
+	}, scw.WithAllPages(), scw.WithContext(ctx))
+	if err != nil {
+		if httperrors.Is404(err) {
+			d.SetId("")
+
+			return nil
+		}
+
+		return diag.FromErr(err)
+	}
+
+	setSecretState(d, secretResponse, versionsResponse)
 
 	return nil
 }

--- a/internal/services/secret/secret_data_source_test.go
+++ b/internal/services/secret/secret_data_source_test.go
@@ -81,3 +81,75 @@ func TestAccDataSourceSecret_Path(t *testing.T) {
 		},
 	})
 }
+
+func TestAccDataSourceSecret_WithVersions(t *testing.T) {
+	tt := acctest.NewTestTools(t)
+	defer tt.Cleanup()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: tt.ProviderFactories,
+		CheckDestroy:             secrettestfuncs.CheckSecretDestroy(tt),
+		Steps: []resource.TestStep{
+			{
+				Config: `
+					resource "scaleway_secret" "main" {
+						name        = "test-secret-versions"
+						description = "Secret with versions"
+					}
+
+					resource "scaleway_secret_version" "v1" {
+						secret_id = scaleway_secret.main.id
+						data_wo   = "first-version-data"
+					}
+
+					resource "scaleway_secret_version" "v2" {
+						secret_id = scaleway_secret.main.id
+						data_wo   = "second-version-data"
+					}
+
+					data "scaleway_secret" "with_versions" {
+						secret_id  = scaleway_secret.main.id
+						depends_on = [scaleway_secret_version.v1, scaleway_secret_version.v2]
+					}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSecretExists(tt, "data.scaleway_secret.with_versions"),
+					resource.TestCheckResourceAttr("data.scaleway_secret.with_versions", "version_count", "2"),
+					resource.TestCheckResourceAttr("data.scaleway_secret.with_versions", "versions.#", "2"),
+					resource.TestCheckResourceAttr("data.scaleway_secret.with_versions", "versions.0.revision", "2"),
+					resource.TestCheckResourceAttrSet("data.scaleway_secret.with_versions", "versions.0.created_at"),
+					resource.TestCheckResourceAttrSet("data.scaleway_secret.with_versions", "versions.0.status"),
+					resource.TestCheckResourceAttr("data.scaleway_secret.with_versions", "versions.1.revision", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceSecret_NoVersions(t *testing.T) {
+	tt := acctest.NewTestTools(t)
+	defer tt.Cleanup()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: tt.ProviderFactories,
+		CheckDestroy:             secrettestfuncs.CheckSecretDestroy(tt),
+		Steps: []resource.TestStep{
+			{
+				Config: `
+					resource "scaleway_secret" "main" {
+						name = "test-secret-no-versions"
+					}
+
+					data "scaleway_secret" "fresh" {
+						secret_id  = scaleway_secret.main.id
+						depends_on = [scaleway_secret.main]
+					}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.scaleway_secret.fresh", "version_count", "0"),
+					resource.TestCheckResourceAttr("data.scaleway_secret.fresh", "versions.#", "0"),
+				),
+			},
+		},
+	})
+}

--- a/internal/services/secret/secret_list.go
+++ b/internal/services/secret/secret_list.go
@@ -235,7 +235,7 @@ func (r *SecretListResource) List(ctx context.Context, req list.ListRequest, str
 			identitySetDiags := result.Identity.Set(ctx, *tfTypeIdentity)
 			result.Diagnostics.Append(identitySetDiags...)
 
-			setSecretState(resourceData, secret)
+			setSecretState(resourceData, secret, nil)
 
 			tfTypeResource, errTfTypeResourceState := resourceData.TfTypeResourceState()
 			if errTfTypeResourceState != nil {

--- a/internal/services/secret/secret_test.go
+++ b/internal/services/secret/secret_test.go
@@ -296,6 +296,62 @@ func TestAccSecret_EphemeralPolicy(t *testing.T) {
 	})
 }
 
+func TestAccSecret_WithVersions(t *testing.T) {
+	tt := acctest.NewTestTools(t)
+	defer tt.Cleanup()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: tt.ProviderFactories,
+		CheckDestroy:             secrettestfuncs.CheckSecretDestroy(tt),
+		Steps: []resource.TestStep{
+			{
+				Config: `
+					resource "scaleway_secret" "main" {
+						name = "test-secret-resource-versions"
+					}
+
+					resource "scaleway_secret_version" "v1" {
+						secret_id = scaleway_secret.main.id
+						data_wo   = "version-data"
+					}
+
+					resource "scaleway_secret_version" "v2" {
+						secret_id = scaleway_secret.main.id
+						data_wo   = "updated-version-data"
+					}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSecretExists(tt, "scaleway_secret.main"),
+				),
+			},
+			{
+				Config: `
+					resource "scaleway_secret" "main" {
+						name = "test-secret-resource-versions"
+					}
+
+					resource "scaleway_secret_version" "v1" {
+						secret_id = scaleway_secret.main.id
+						data_wo   = "version-data"
+					}
+
+					resource "scaleway_secret_version" "v2" {
+						secret_id = scaleway_secret.main.id
+						data_wo   = "updated-version-data"
+					}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSecretExists(tt, "scaleway_secret.main"),
+					resource.TestCheckResourceAttr("scaleway_secret.main", "version_count", "2"),
+					resource.TestCheckResourceAttr("scaleway_secret.main", "versions.#", "2"),
+					resource.TestCheckResourceAttr("scaleway_secret.main", "versions.0.revision", "2"),
+					resource.TestCheckResourceAttr("scaleway_secret.main", "versions.1.revision", "1"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckSecretExists(tt *acctest.TestTools, n string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
 		rs, ok := state.RootModule().Resources[n]

--- a/internal/services/secret/testdata/data-source-secret-basic.cassette.yaml
+++ b/internal/services/secret/testdata/data-source-secret-basic.cassette.yaml
@@ -21,21 +21,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 476
-        body: '{"id":"1a30518b-7b5f-492f-81e0-e03e961fc197","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-05-28T14:08:03.418857Z","updated_at":"2026-05-28T14:08:03.418857Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"21025838-d5b7-42ed-84e9-60935778dc39","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-06-24T09:38:48.111189Z","updated_at":"2026-06-24T09:38:48.111189Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "476"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:08:03 GMT
+                - Wed, 24 Jun 2026 09:38:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - e9194f83-56b5-41bb-bfbd-ce02be51916e
+                - 375887a8-9fc8-4613-8916-615f9ec23cb5
         status: 200 OK
         code: 200
-        duration: 166.998438ms
+        duration: 183.755569ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -46,28 +46,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1a30518b-7b5f-492f-81e0-e03e961fc197
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/21025838-d5b7-42ed-84e9-60935778dc39
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 476
-        body: '{"id":"1a30518b-7b5f-492f-81e0-e03e961fc197","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-05-28T14:08:03.418857Z","updated_at":"2026-05-28T14:08:03.418857Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"21025838-d5b7-42ed-84e9-60935778dc39","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-06-24T09:38:48.111189Z","updated_at":"2026-06-24T09:38:48.111189Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "476"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:08:03 GMT
+                - Wed, 24 Jun 2026 09:38:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - f2581e94-92a5-4275-b1ec-4b8b7fa893a5
+                - 0da2a7f0-7367-4a51-94fc-2cd08d95cb49
         status: 200 OK
         code: 200
-        duration: 46.260704ms
+        duration: 30.446609ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -81,7 +81,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1a30518b-7b5f-492f-81e0-e03e961fc197/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/21025838-d5b7-42ed-84e9-60935778dc39/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -95,14 +95,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:08:03 GMT
+                - Wed, 24 Jun 2026 09:38:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - fcf12ce8-1993-47f0-86fb-2d4e3151724d
+                - 178b278c-95c2-4ba8-a272-0c72f694fc54
         status: 200 OK
         code: 200
-        duration: 34.021563ms
+        duration: 32.122725ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -113,307 +113,29 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1a30518b-7b5f-492f-81e0-e03e961fc197
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/21025838-d5b7-42ed-84e9-60935778dc39
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 476
-        body: '{"id":"1a30518b-7b5f-492f-81e0-e03e961fc197","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-05-28T14:08:03.418857Z","updated_at":"2026-05-28T14:08:03.418857Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"21025838-d5b7-42ed-84e9-60935778dc39","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-06-24T09:38:48.111189Z","updated_at":"2026-06-24T09:38:48.111189Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "476"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:08:03 GMT
+                - Wed, 24 Jun 2026 09:38:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - d213f566-fe89-43f3-bdf0-ad2598321f5c
+                - cd16581a-26a9-48d6-a6f2-dee2d3608af4
         status: 200 OK
         code: 200
-        duration: 42.415389ms
+        duration: 18.665223ms
     - id: 4
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        form:
-            name:
-                - scalewayDataSourceSecretBasic
-            order_by:
-                - name_asc
-            project_id:
-                - 105bdce1-64c0-48ab-899d-868455867ecf
-            scheduled_for_deletion:
-                - "false"
-            type:
-                - unknown_type
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets?name=scalewayDataSourceSecretBasic&order_by=name_asc&project_id=105bdce1-64c0-48ab-899d-868455867ecf&scheduled_for_deletion=false&type=unknown_type
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 506
-        body: '{"secrets":[{"id":"1a30518b-7b5f-492f-81e0-e03e961fc197","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-05-28T14:08:03.418857Z","updated_at":"2026-05-28T14:08:03.418857Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}],"total_count":1}'
-        headers:
-            Content-Length:
-                - "506"
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 28 May 2026 14:08:03 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            X-Request-Id:
-                - 652ee712-beec-40f3-835e-81f0811fc018
-        status: 200 OK
-        code: 200
-        duration: 98.671712ms
-    - id: 5
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1a30518b-7b5f-492f-81e0-e03e961fc197
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 476
-        body: '{"id":"1a30518b-7b5f-492f-81e0-e03e961fc197","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-05-28T14:08:03.418857Z","updated_at":"2026-05-28T14:08:03.418857Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
-        headers:
-            Content-Length:
-                - "476"
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 28 May 2026 14:08:03 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            X-Request-Id:
-                - 368dd031-2437-4b25-8937-76d73355b845
-        status: 200 OK
-        code: 200
-        duration: 41.718855ms
-    - id: 6
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1a30518b-7b5f-492f-81e0-e03e961fc197
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 476
-        body: '{"id":"1a30518b-7b5f-492f-81e0-e03e961fc197","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-05-28T14:08:03.418857Z","updated_at":"2026-05-28T14:08:03.418857Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
-        headers:
-            Content-Length:
-                - "476"
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 28 May 2026 14:08:03 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            X-Request-Id:
-                - f1992d5a-7c57-46a9-a4f4-48aef4f5bcdb
-        status: 200 OK
-        code: 200
-        duration: 33.226744ms
-    - id: 7
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1a30518b-7b5f-492f-81e0-e03e961fc197
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 476
-        body: '{"id":"1a30518b-7b5f-492f-81e0-e03e961fc197","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-05-28T14:08:03.418857Z","updated_at":"2026-05-28T14:08:03.418857Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
-        headers:
-            Content-Length:
-                - "476"
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 28 May 2026 14:08:03 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            X-Request-Id:
-                - 60c576df-ca7e-4bcc-b2a8-a47a221bd655
-        status: 200 OK
-        code: 200
-        duration: 37.74546ms
-    - id: 8
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        form:
-            name:
-                - scalewayDataSourceSecretBasic
-            order_by:
-                - name_asc
-            project_id:
-                - 105bdce1-64c0-48ab-899d-868455867ecf
-            scheduled_for_deletion:
-                - "false"
-            type:
-                - unknown_type
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets?name=scalewayDataSourceSecretBasic&order_by=name_asc&project_id=105bdce1-64c0-48ab-899d-868455867ecf&scheduled_for_deletion=false&type=unknown_type
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 506
-        body: '{"secrets":[{"id":"1a30518b-7b5f-492f-81e0-e03e961fc197","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-05-28T14:08:03.418857Z","updated_at":"2026-05-28T14:08:03.418857Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}],"total_count":1}'
-        headers:
-            Content-Length:
-                - "506"
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 28 May 2026 14:08:03 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            X-Request-Id:
-                - fa336d6a-d8ba-4afa-8d46-6c3ea31f3597
-        status: 200 OK
-        code: 200
-        duration: 41.122707ms
-    - id: 9
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1a30518b-7b5f-492f-81e0-e03e961fc197
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 476
-        body: '{"id":"1a30518b-7b5f-492f-81e0-e03e961fc197","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-05-28T14:08:03.418857Z","updated_at":"2026-05-28T14:08:03.418857Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
-        headers:
-            Content-Length:
-                - "476"
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 28 May 2026 14:08:03 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            X-Request-Id:
-                - 8c5a90a5-b468-48f7-b9e3-2f5cf766ea11
-        status: 200 OK
-        code: 200
-        duration: 42.713538ms
-    - id: 10
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1a30518b-7b5f-492f-81e0-e03e961fc197
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 476
-        body: '{"id":"1a30518b-7b5f-492f-81e0-e03e961fc197","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-05-28T14:08:03.418857Z","updated_at":"2026-05-28T14:08:03.418857Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
-        headers:
-            Content-Length:
-                - "476"
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 28 May 2026 14:08:04 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            X-Request-Id:
-                - 3374e73f-b477-4312-998b-ff77f6b5f164
-        status: 200 OK
-        code: 200
-        duration: 38.859448ms
-    - id: 11
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1a30518b-7b5f-492f-81e0-e03e961fc197
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 476
-        body: '{"id":"1a30518b-7b5f-492f-81e0-e03e961fc197","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-05-28T14:08:03.418857Z","updated_at":"2026-05-28T14:08:03.418857Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
-        headers:
-            Content-Length:
-                - "476"
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 28 May 2026 14:08:04 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            X-Request-Id:
-                - 2608b2a5-44a3-4f6d-bebf-cd053004ed5f
-        status: 200 OK
-        code: 200
-        duration: 33.895026ms
-    - id: 12
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -426,7 +148,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1a30518b-7b5f-492f-81e0-e03e961fc197/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/21025838-d5b7-42ed-84e9-60935778dc39/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -440,47 +162,15 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:08:04 GMT
+                - Wed, 24 Jun 2026 09:38:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 0cadd60a-36e9-4fbc-b1e6-a869bb77f26e
+                - f9b56eb0-6c2d-4888-bcdc-71f54da67dc9
         status: 200 OK
         code: 200
-        duration: 65.368866ms
-    - id: 13
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1a30518b-7b5f-492f-81e0-e03e961fc197
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 476
-        body: '{"id":"1a30518b-7b5f-492f-81e0-e03e961fc197","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-05-28T14:08:03.418857Z","updated_at":"2026-05-28T14:08:03.418857Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
-        headers:
-            Content-Length:
-                - "476"
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 28 May 2026 14:08:04 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            X-Request-Id:
-                - f0b4c676-552e-431b-a8d7-b5b7111269a1
-        status: 200 OK
-        code: 200
-        duration: 36.657371ms
-    - id: 14
+        duration: 53.02446ms
+    - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -508,21 +198,329 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 506
-        body: '{"secrets":[{"id":"1a30518b-7b5f-492f-81e0-e03e961fc197","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-05-28T14:08:03.418857Z","updated_at":"2026-05-28T14:08:03.418857Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}],"total_count":1}'
+        body: '{"secrets":[{"id":"21025838-d5b7-42ed-84e9-60935778dc39","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-06-24T09:38:48.111189Z","updated_at":"2026-06-24T09:38:48.111189Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
                 - "506"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:08:04 GMT
+                - Wed, 24 Jun 2026 09:38:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 685c788d-3e73-4694-bc26-cbe97e6f98b0
+                - 8ae74b3f-5a42-447b-8578-c5973339ec46
         status: 200 OK
         code: 200
-        duration: 85.269722ms
+        duration: 100.676402ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/21025838-d5b7-42ed-84e9-60935778dc39
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 476
+        body: '{"id":"21025838-d5b7-42ed-84e9-60935778dc39","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-06-24T09:38:48.111189Z","updated_at":"2026-06-24T09:38:48.111189Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "476"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - b30ee1a1-a255-4b0d-80cc-60960d23a922
+        status: 200 OK
+        code: 200
+        duration: 22.237718ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/21025838-d5b7-42ed-84e9-60935778dc39/versions?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 31
+        body: '{"versions":[],"total_count":0}'
+        headers:
+            Content-Length:
+                - "31"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - eea3435d-c33d-4e35-9e5e-47a9003505e6
+        status: 200 OK
+        code: 200
+        duration: 19.514684ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/21025838-d5b7-42ed-84e9-60935778dc39
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 476
+        body: '{"id":"21025838-d5b7-42ed-84e9-60935778dc39","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-06-24T09:38:48.111189Z","updated_at":"2026-06-24T09:38:48.111189Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "476"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 6eb5b77c-d5e1-4642-b90a-6f6e324c3f75
+        status: 200 OK
+        code: 200
+        duration: 21.746196ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/21025838-d5b7-42ed-84e9-60935778dc39
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 476
+        body: '{"id":"21025838-d5b7-42ed-84e9-60935778dc39","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-06-24T09:38:48.111189Z","updated_at":"2026-06-24T09:38:48.111189Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "476"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 79fb289e-3c03-4b53-80e8-80d73370ce1a
+        status: 200 OK
+        code: 200
+        duration: 17.744778ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/21025838-d5b7-42ed-84e9-60935778dc39
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 476
+        body: '{"id":"21025838-d5b7-42ed-84e9-60935778dc39","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-06-24T09:38:48.111189Z","updated_at":"2026-06-24T09:38:48.111189Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "476"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - fe6f4bbc-5b3e-4b11-9828-8771b53a6ea1
+        status: 200 OK
+        code: 200
+        duration: 27.19461ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/21025838-d5b7-42ed-84e9-60935778dc39/versions?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 31
+        body: '{"versions":[],"total_count":0}'
+        headers:
+            Content-Length:
+                - "31"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - d2d59748-cbfb-45ad-a44b-e0bb8d040c36
+        status: 200 OK
+        code: 200
+        duration: 18.06399ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            name:
+                - scalewayDataSourceSecretBasic
+            order_by:
+                - name_asc
+            project_id:
+                - 105bdce1-64c0-48ab-899d-868455867ecf
+            scheduled_for_deletion:
+                - "false"
+            type:
+                - unknown_type
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets?name=scalewayDataSourceSecretBasic&order_by=name_asc&project_id=105bdce1-64c0-48ab-899d-868455867ecf&scheduled_for_deletion=false&type=unknown_type
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 506
+        body: '{"secrets":[{"id":"21025838-d5b7-42ed-84e9-60935778dc39","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-06-24T09:38:48.111189Z","updated_at":"2026-06-24T09:38:48.111189Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "506"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 6fab9d61-881a-472a-8e5b-b9c4c9f591f9
+        status: 200 OK
+        code: 200
+        duration: 114.872962ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/21025838-d5b7-42ed-84e9-60935778dc39
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 476
+        body: '{"id":"21025838-d5b7-42ed-84e9-60935778dc39","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-06-24T09:38:48.111189Z","updated_at":"2026-06-24T09:38:48.111189Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "476"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 39a94e84-7bd2-476d-9ae5-194872808c68
+        status: 200 OK
+        code: 200
+        duration: 15.844581ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/21025838-d5b7-42ed-84e9-60935778dc39/versions?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 31
+        body: '{"versions":[],"total_count":0}'
+        headers:
+            Content-Length:
+                - "31"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 7f58ae0a-8193-423a-b7c1-e9b917380e9f
+        status: 200 OK
+        code: 200
+        duration: 23.134399ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -533,29 +531,64 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1a30518b-7b5f-492f-81e0-e03e961fc197
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/21025838-d5b7-42ed-84e9-60935778dc39
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 476
-        body: '{"id":"1a30518b-7b5f-492f-81e0-e03e961fc197","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-05-28T14:08:03.418857Z","updated_at":"2026-05-28T14:08:03.418857Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"21025838-d5b7-42ed-84e9-60935778dc39","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-06-24T09:38:48.111189Z","updated_at":"2026-06-24T09:38:48.111189Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "476"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:08:04 GMT
+                - Wed, 24 Jun 2026 09:38:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - f3468dd7-1013-4414-82a0-d775fd01a621
+                - 877ea185-a9a9-43f6-b932-d6539ef229c8
         status: 200 OK
         code: 200
-        duration: 45.558078ms
+        duration: 21.659039ms
     - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/21025838-d5b7-42ed-84e9-60935778dc39/versions?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 31
+        body: '{"versions":[],"total_count":0}'
+        headers:
+            Content-Length:
+                - "31"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 197bfa75-4fcb-4207-bf84-1acff974a1bd
+        status: 200 OK
+        code: 200
+        duration: 25.147752ms
+    - id: 17
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -565,7 +598,184 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1a30518b-7b5f-492f-81e0-e03e961fc197
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/21025838-d5b7-42ed-84e9-60935778dc39
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 476
+        body: '{"id":"21025838-d5b7-42ed-84e9-60935778dc39","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-06-24T09:38:48.111189Z","updated_at":"2026-06-24T09:38:48.111189Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "476"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - c8d3d639-cf05-4fb0-aae1-ac6ac12061a0
+        status: 200 OK
+        code: 200
+        duration: 17.97501ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            name:
+                - scalewayDataSourceSecretBasic
+            order_by:
+                - name_asc
+            project_id:
+                - 105bdce1-64c0-48ab-899d-868455867ecf
+            scheduled_for_deletion:
+                - "false"
+            type:
+                - unknown_type
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets?name=scalewayDataSourceSecretBasic&order_by=name_asc&project_id=105bdce1-64c0-48ab-899d-868455867ecf&scheduled_for_deletion=false&type=unknown_type
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 506
+        body: '{"secrets":[{"id":"21025838-d5b7-42ed-84e9-60935778dc39","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-06-24T09:38:48.111189Z","updated_at":"2026-06-24T09:38:48.111189Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "506"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 752a76b8-0e9b-4007-8a6b-f3dcbba056da
+        status: 200 OK
+        code: 200
+        duration: 21.997978ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/21025838-d5b7-42ed-84e9-60935778dc39
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 476
+        body: '{"id":"21025838-d5b7-42ed-84e9-60935778dc39","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-06-24T09:38:48.111189Z","updated_at":"2026-06-24T09:38:48.111189Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "476"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - ed25c1e5-3ae3-4429-ace7-03121b361fe9
+        status: 200 OK
+        code: 200
+        duration: 20.273911ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/21025838-d5b7-42ed-84e9-60935778dc39/versions?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 31
+        body: '{"versions":[],"total_count":0}'
+        headers:
+            Content-Length:
+                - "31"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - f5afb466-8d96-4598-a90e-a52e3fd6699a
+        status: 200 OK
+        code: 200
+        duration: 25.248846ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/21025838-d5b7-42ed-84e9-60935778dc39/versions?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 31
+        body: '{"versions":[],"total_count":0}'
+        headers:
+            Content-Length:
+                - "31"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 9773dc21-3199-408f-8092-1b647dbc34b0
+        status: 200 OK
+        code: 200
+        duration: 18.723065ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/21025838-d5b7-42ed-84e9-60935778dc39
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -577,15 +787,15 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:08:05 GMT
+                - Wed, 24 Jun 2026 09:38:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 7b8a2c27-c31a-4fa4-8b0f-a00aedc1866e
+                - 73957af3-18ee-4380-bce5-0446a93f1e77
         status: 204 No Content
         code: 204
-        duration: 102.387875ms
-    - id: 17
+        duration: 116.486688ms
+    - id: 23
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -595,29 +805,29 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1a30518b-7b5f-492f-81e0-e03e961fc197
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/21025838-d5b7-42ed-84e9-60935778dc39
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 501
-        body: '{"id":"1a30518b-7b5f-492f-81e0-e03e961fc197","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-05-28T14:08:03.418857Z","updated_at":"2026-05-28T14:08:03.418857Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-05-28T14:08:05.360530Z","key_id":null,"region":"fr-par"}'
+        body: '{"id":"21025838-d5b7-42ed-84e9-60935778dc39","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-06-24T09:38:48.111189Z","updated_at":"2026-06-24T09:38:49.401742Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-06-24T09:38:49.401742Z","key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "501"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:08:05 GMT
+                - Wed, 24 Jun 2026 09:38:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 4575bd0f-447b-42ef-81b5-a320dacacae6
+                - eb49f218-aada-41e6-8f9a-71ab9c37b4f6
         status: 200 OK
         code: 200
-        duration: 36.649807ms
-    - id: 18
+        duration: 36.16976ms
+    - id: 24
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -627,29 +837,29 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1a30518b-7b5f-492f-81e0-e03e961fc197
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/21025838-d5b7-42ed-84e9-60935778dc39
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 501
-        body: '{"id":"1a30518b-7b5f-492f-81e0-e03e961fc197","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-05-28T14:08:03.418857Z","updated_at":"2026-05-28T14:08:03.418857Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-05-28T14:08:05.360530Z","key_id":null,"region":"fr-par"}'
+        body: '{"id":"21025838-d5b7-42ed-84e9-60935778dc39","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-06-24T09:38:48.111189Z","updated_at":"2026-06-24T09:38:49.401742Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-06-24T09:38:49.401742Z","key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "501"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:08:05 GMT
+                - Wed, 24 Jun 2026 09:38:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - b7cc3f24-e3c4-425c-a203-21b0cb2fd965
+                - 9fa650e5-4bd4-4658-a4a3-f59cb208b350
         status: 200 OK
         code: 200
-        duration: 31.7248ms
-    - id: 19
+        duration: 18.597964ms
+    - id: 25
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -659,25 +869,25 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1a30518b-7b5f-492f-81e0-e03e961fc197
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/21025838-d5b7-42ed-84e9-60935778dc39
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 501
-        body: '{"id":"1a30518b-7b5f-492f-81e0-e03e961fc197","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-05-28T14:08:03.418857Z","updated_at":"2026-05-28T14:08:03.418857Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-05-28T14:08:05.360530Z","key_id":null,"region":"fr-par"}'
+        body: '{"id":"21025838-d5b7-42ed-84e9-60935778dc39","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"scalewayDataSourceSecretBasic","status":"ready","created_at":"2026-06-24T09:38:48.111189Z","updated_at":"2026-06-24T09:38:49.401742Z","tags":[],"version_count":0,"description":"DataSourceSecret test description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-06-24T09:38:49.401742Z","key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "501"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:08:05 GMT
+                - Wed, 24 Jun 2026 09:38:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 3622fcdd-8ab4-4dbc-bf92-7d9c86f1b537
+                - 5579f9a3-811d-4ac4-afb8-d3a8a9fcbb8d
         status: 200 OK
         code: 200
-        duration: 29.465958ms
+        duration: 32.051017ms

--- a/internal/services/secret/testdata/data-source-secret-no-versions.cassette.yaml
+++ b/internal/services/secret/testdata/data-source-secret-no-versions.cassette.yaml
@@ -1,0 +1,467 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 143
+        host: api.scaleway.com
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-no-versions","tags":null,"type":"opaque","path":"/","protected":false}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 437
+        body: '{"id":"6c1598c9-6f70-40b6-bfd2-3ef5ac0afc08","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-no-versions","status":"ready","created_at":"2026-06-24T09:38:48.150599Z","updated_at":"2026-06-24T09:38:48.150599Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "437"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - bcc8570d-28ba-49d0-8f5e-fcdbaeb8d2d2
+        status: 200 OK
+        code: 200
+        duration: 212.507737ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6c1598c9-6f70-40b6-bfd2-3ef5ac0afc08
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 437
+        body: '{"id":"6c1598c9-6f70-40b6-bfd2-3ef5ac0afc08","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-no-versions","status":"ready","created_at":"2026-06-24T09:38:48.150599Z","updated_at":"2026-06-24T09:38:48.150599Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "437"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 1f850779-4e58-4a4f-8641-62a4dbdd123a
+        status: 200 OK
+        code: 200
+        duration: 26.669592ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6c1598c9-6f70-40b6-bfd2-3ef5ac0afc08/versions?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 31
+        body: '{"versions":[],"total_count":0}'
+        headers:
+            Content-Length:
+                - "31"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 0c265801-6459-4043-8354-e5da0cf8d92c
+        status: 200 OK
+        code: 200
+        duration: 24.5941ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6c1598c9-6f70-40b6-bfd2-3ef5ac0afc08
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 437
+        body: '{"id":"6c1598c9-6f70-40b6-bfd2-3ef5ac0afc08","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-no-versions","status":"ready","created_at":"2026-06-24T09:38:48.150599Z","updated_at":"2026-06-24T09:38:48.150599Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "437"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 98d6811f-db76-48e3-ad97-90fda5191c1a
+        status: 200 OK
+        code: 200
+        duration: 21.755052ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6c1598c9-6f70-40b6-bfd2-3ef5ac0afc08/versions?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 31
+        body: '{"versions":[],"total_count":0}'
+        headers:
+            Content-Length:
+                - "31"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 21f06f25-d1ff-4e07-b3c1-669f059bf58e
+        status: 200 OK
+        code: 200
+        duration: 38.036993ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6c1598c9-6f70-40b6-bfd2-3ef5ac0afc08
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 437
+        body: '{"id":"6c1598c9-6f70-40b6-bfd2-3ef5ac0afc08","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-no-versions","status":"ready","created_at":"2026-06-24T09:38:48.150599Z","updated_at":"2026-06-24T09:38:48.150599Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "437"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 11b517d0-f285-4d32-8d67-f24e46fe70eb
+        status: 200 OK
+        code: 200
+        duration: 33.442017ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6c1598c9-6f70-40b6-bfd2-3ef5ac0afc08/versions?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 31
+        body: '{"versions":[],"total_count":0}'
+        headers:
+            Content-Length:
+                - "31"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 12f029d5-8de4-4a07-be87-0b3531658850
+        status: 200 OK
+        code: 200
+        duration: 20.666023ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6c1598c9-6f70-40b6-bfd2-3ef5ac0afc08
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 437
+        body: '{"id":"6c1598c9-6f70-40b6-bfd2-3ef5ac0afc08","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-no-versions","status":"ready","created_at":"2026-06-24T09:38:48.150599Z","updated_at":"2026-06-24T09:38:48.150599Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "437"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 087e1b4a-ac5f-468e-8449-a089c2dda4e7
+        status: 200 OK
+        code: 200
+        duration: 21.44635ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6c1598c9-6f70-40b6-bfd2-3ef5ac0afc08/versions?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 31
+        body: '{"versions":[],"total_count":0}'
+        headers:
+            Content-Length:
+                - "31"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 7d9b17a5-2703-4971-b17c-edfb6defef11
+        status: 200 OK
+        code: 200
+        duration: 22.632336ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6c1598c9-6f70-40b6-bfd2-3ef5ac0afc08
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 437
+        body: '{"id":"6c1598c9-6f70-40b6-bfd2-3ef5ac0afc08","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-no-versions","status":"ready","created_at":"2026-06-24T09:38:48.150599Z","updated_at":"2026-06-24T09:38:48.150599Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "437"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - d76d65f0-742e-41af-9100-77cdfcac8653
+        status: 200 OK
+        code: 200
+        duration: 17.093788ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6c1598c9-6f70-40b6-bfd2-3ef5ac0afc08/versions?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 31
+        body: '{"versions":[],"total_count":0}'
+        headers:
+            Content-Length:
+                - "31"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 9b6bdf97-256f-4886-9f8a-a6671065157d
+        status: 200 OK
+        code: 200
+        duration: 23.85469ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6c1598c9-6f70-40b6-bfd2-3ef5ac0afc08
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - ba993348-1620-484f-98d4-8ce1e5bc0f56
+        status: 204 No Content
+        code: 204
+        duration: 122.248924ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6c1598c9-6f70-40b6-bfd2-3ef5ac0afc08
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 462
+        body: '{"id":"6c1598c9-6f70-40b6-bfd2-3ef5ac0afc08","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-no-versions","status":"ready","created_at":"2026-06-24T09:38:48.150599Z","updated_at":"2026-06-24T09:38:49.161416Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-06-24T09:38:49.161416Z","key_id":null,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "462"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 3486be5e-e92e-4485-ae37-dcadaa5792fe
+        status: 200 OK
+        code: 200
+        duration: 22.216948ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6c1598c9-6f70-40b6-bfd2-3ef5ac0afc08
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 462
+        body: '{"id":"6c1598c9-6f70-40b6-bfd2-3ef5ac0afc08","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-no-versions","status":"ready","created_at":"2026-06-24T09:38:48.150599Z","updated_at":"2026-06-24T09:38:49.161416Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-06-24T09:38:49.161416Z","key_id":null,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "462"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 37fad687-bc67-4f70-9de7-71c9722c8731
+        status: 200 OK
+        code: 200
+        duration: 35.397969ms

--- a/internal/services/secret/testdata/data-source-secret-path.cassette.yaml
+++ b/internal/services/secret/testdata/data-source-secret-path.cassette.yaml
@@ -21,21 +21,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 457
-        body: '{"id":"6df781ff-4886-4e65-a274-7b19db42c7dd","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-ds-path","status":"ready","created_at":"2026-05-28T14:08:03.489953Z","updated_at":"2026-05-28T14:08:03.489953Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-ds-path-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"192e7723-09ec-4a4a-b9e5-36f3954969fb","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-ds-path","status":"ready","created_at":"2026-06-24T09:38:48.185097Z","updated_at":"2026-06-24T09:38:48.185097Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-ds-path-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "457"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:08:03 GMT
+                - Wed, 24 Jun 2026 09:38:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 9abd621d-4c4a-41c0-a31e-f1b34ad2a753
+                - d75bd8b9-7a4b-48ad-acde-88ff2b2cfb32
         status: 200 OK
         code: 200
-        duration: 228.764553ms
+        duration: 254.059484ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -46,28 +46,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6df781ff-4886-4e65-a274-7b19db42c7dd
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/192e7723-09ec-4a4a-b9e5-36f3954969fb
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 457
-        body: '{"id":"6df781ff-4886-4e65-a274-7b19db42c7dd","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-ds-path","status":"ready","created_at":"2026-05-28T14:08:03.489953Z","updated_at":"2026-05-28T14:08:03.489953Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-ds-path-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"192e7723-09ec-4a4a-b9e5-36f3954969fb","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-ds-path","status":"ready","created_at":"2026-06-24T09:38:48.185097Z","updated_at":"2026-06-24T09:38:48.185097Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-ds-path-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "457"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:08:03 GMT
+                - Wed, 24 Jun 2026 09:38:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - fd1befbf-64a0-4ad1-8dfb-c76fb53fe3b4
+                - a3f83096-6924-4259-8114-db2af13091d9
         status: 200 OK
         code: 200
-        duration: 41.771032ms
+        duration: 37.204376ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -81,7 +81,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6df781ff-4886-4e65-a274-7b19db42c7dd/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/192e7723-09ec-4a4a-b9e5-36f3954969fb/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -95,14 +95,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:08:03 GMT
+                - Wed, 24 Jun 2026 09:38:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - b9cb98b2-f8c3-4fc6-9a99-3e3e2dcd5076
+                - 6a322542-1dc4-4ab1-a7d2-91f6debc6591
         status: 200 OK
         code: 200
-        duration: 36.16563ms
+        duration: 20.949367ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -133,21 +133,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 487
-        body: '{"secrets":[{"id":"6df781ff-4886-4e65-a274-7b19db42c7dd","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-ds-path","status":"ready","created_at":"2026-05-28T14:08:03.489953Z","updated_at":"2026-05-28T14:08:03.489953Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-ds-path-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}],"total_count":1}'
+        body: '{"secrets":[{"id":"192e7723-09ec-4a4a-b9e5-36f3954969fb","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-ds-path","status":"ready","created_at":"2026-06-24T09:38:48.185097Z","updated_at":"2026-06-24T09:38:48.185097Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-ds-path-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
                 - "487"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:08:03 GMT
+                - Wed, 24 Jun 2026 09:38:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 62c378ec-1e00-4b47-a6ee-64e152640718
+                - 328f0f24-1c55-4306-9cf1-102491a8af56
         status: 200 OK
         code: 200
-        duration: 96.878582ms
+        duration: 36.905522ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -158,170 +158,29 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6df781ff-4886-4e65-a274-7b19db42c7dd
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/192e7723-09ec-4a4a-b9e5-36f3954969fb
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 457
-        body: '{"id":"6df781ff-4886-4e65-a274-7b19db42c7dd","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-ds-path","status":"ready","created_at":"2026-05-28T14:08:03.489953Z","updated_at":"2026-05-28T14:08:03.489953Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-ds-path-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"192e7723-09ec-4a4a-b9e5-36f3954969fb","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-ds-path","status":"ready","created_at":"2026-06-24T09:38:48.185097Z","updated_at":"2026-06-24T09:38:48.185097Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-ds-path-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "457"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:08:03 GMT
+                - Wed, 24 Jun 2026 09:38:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 4540c0a6-1e3c-4cd3-87cd-176ac13c2c9d
+                - 577eddf2-66b3-49ff-aa96-3502c51d31a2
         status: 200 OK
         code: 200
-        duration: 51.860396ms
+        duration: 32.445655ms
     - id: 5
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6df781ff-4886-4e65-a274-7b19db42c7dd
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 457
-        body: '{"id":"6df781ff-4886-4e65-a274-7b19db42c7dd","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-ds-path","status":"ready","created_at":"2026-05-28T14:08:03.489953Z","updated_at":"2026-05-28T14:08:03.489953Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-ds-path-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
-        headers:
-            Content-Length:
-                - "457"
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 28 May 2026 14:08:03 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            X-Request-Id:
-                - e6bbfa3f-0d65-4e26-ade7-a12d5a26ecc1
-        status: 200 OK
-        code: 200
-        duration: 40.395455ms
-    - id: 6
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        form:
-            name:
-                - test-secret-ds-path
-            order_by:
-                - name_asc
-            path:
-                - /test-secret-ds-path-path
-            project_id:
-                - 105bdce1-64c0-48ab-899d-868455867ecf
-            scheduled_for_deletion:
-                - "false"
-            type:
-                - unknown_type
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets?name=test-secret-ds-path&order_by=name_asc&path=%2Ftest-secret-ds-path-path&project_id=105bdce1-64c0-48ab-899d-868455867ecf&scheduled_for_deletion=false&type=unknown_type
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 487
-        body: '{"secrets":[{"id":"6df781ff-4886-4e65-a274-7b19db42c7dd","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-ds-path","status":"ready","created_at":"2026-05-28T14:08:03.489953Z","updated_at":"2026-05-28T14:08:03.489953Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-ds-path-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}],"total_count":1}'
-        headers:
-            Content-Length:
-                - "487"
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 28 May 2026 14:08:04 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            X-Request-Id:
-                - 4e7776c7-549b-4b23-9b0e-180fbec20d35
-        status: 200 OK
-        code: 200
-        duration: 40.831954ms
-    - id: 7
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6df781ff-4886-4e65-a274-7b19db42c7dd
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 457
-        body: '{"id":"6df781ff-4886-4e65-a274-7b19db42c7dd","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-ds-path","status":"ready","created_at":"2026-05-28T14:08:03.489953Z","updated_at":"2026-05-28T14:08:03.489953Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-ds-path-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
-        headers:
-            Content-Length:
-                - "457"
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 28 May 2026 14:08:04 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            X-Request-Id:
-                - 89e8f927-ccad-42f1-9be7-f27462045064
-        status: 200 OK
-        code: 200
-        duration: 39.339436ms
-    - id: 8
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6df781ff-4886-4e65-a274-7b19db42c7dd
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 457
-        body: '{"id":"6df781ff-4886-4e65-a274-7b19db42c7dd","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-ds-path","status":"ready","created_at":"2026-05-28T14:08:03.489953Z","updated_at":"2026-05-28T14:08:03.489953Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-ds-path-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
-        headers:
-            Content-Length:
-                - "457"
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 28 May 2026 14:08:04 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
-            X-Request-Id:
-                - ab573038-b421-4d3e-85a4-e4ff33a919c9
-        status: 200 OK
-        code: 200
-        duration: 37.21157ms
-    - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -334,7 +193,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6df781ff-4886-4e65-a274-7b19db42c7dd/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/192e7723-09ec-4a4a-b9e5-36f3954969fb/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -348,15 +207,47 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:08:04 GMT
+                - Wed, 24 Jun 2026 09:38:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 639c332b-3647-4949-8da6-e34a367a8479
+                - 96297c5e-ae16-4dd4-b466-171fd6d82659
         status: 200 OK
         code: 200
-        duration: 52.345826ms
-    - id: 10
+        duration: 31.736003ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/192e7723-09ec-4a4a-b9e5-36f3954969fb
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 457
+        body: '{"id":"192e7723-09ec-4a4a-b9e5-36f3954969fb","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-ds-path","status":"ready","created_at":"2026-06-24T09:38:48.185097Z","updated_at":"2026-06-24T09:38:48.185097Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-ds-path-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "457"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 6b821e68-885a-4f83-b164-98754b547a9c
+        status: 200 OK
+        code: 200
+        duration: 19.885635ms
+    - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -386,21 +277,120 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 487
-        body: '{"secrets":[{"id":"6df781ff-4886-4e65-a274-7b19db42c7dd","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-ds-path","status":"ready","created_at":"2026-05-28T14:08:03.489953Z","updated_at":"2026-05-28T14:08:03.489953Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-ds-path-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}],"total_count":1}'
+        body: '{"secrets":[{"id":"192e7723-09ec-4a4a-b9e5-36f3954969fb","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-ds-path","status":"ready","created_at":"2026-06-24T09:38:48.185097Z","updated_at":"2026-06-24T09:38:48.185097Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-ds-path-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}],"total_count":1}'
         headers:
             Content-Length:
                 - "487"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:08:04 GMT
+                - Wed, 24 Jun 2026 09:38:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - b7834366-25ae-44a4-a810-00648803e28c
+                - 30a0411b-d5d2-4b1c-a68b-0ae44a9454e9
         status: 200 OK
         code: 200
-        duration: 41.755493ms
+        duration: 19.931714ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/192e7723-09ec-4a4a-b9e5-36f3954969fb
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 457
+        body: '{"id":"192e7723-09ec-4a4a-b9e5-36f3954969fb","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-ds-path","status":"ready","created_at":"2026-06-24T09:38:48.185097Z","updated_at":"2026-06-24T09:38:48.185097Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-ds-path-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "457"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - a6aa8a7b-145a-41e0-8af2-90b26a5349a4
+        status: 200 OK
+        code: 200
+        duration: 23.81771ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/192e7723-09ec-4a4a-b9e5-36f3954969fb/versions?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 31
+        body: '{"versions":[],"total_count":0}'
+        headers:
+            Content-Length:
+                - "31"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 75a81085-e5af-44a6-b750-31b4a10ba4d1
+        status: 200 OK
+        code: 200
+        duration: 18.612593ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/192e7723-09ec-4a4a-b9e5-36f3954969fb
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 457
+        body: '{"id":"192e7723-09ec-4a4a-b9e5-36f3954969fb","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-ds-path","status":"ready","created_at":"2026-06-24T09:38:48.185097Z","updated_at":"2026-06-24T09:38:48.185097Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-ds-path-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "457"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 069b14ba-e98f-4672-86b5-3160101652b0
+        status: 200 OK
+        code: 200
+        duration: 18.699811ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -408,32 +398,80 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: api.scaleway.com
+        form:
+            page:
+                - "1"
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6df781ff-4886-4e65-a274-7b19db42c7dd
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/192e7723-09ec-4a4a-b9e5-36f3954969fb/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 457
-        body: '{"id":"6df781ff-4886-4e65-a274-7b19db42c7dd","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-ds-path","status":"ready","created_at":"2026-05-28T14:08:03.489953Z","updated_at":"2026-05-28T14:08:03.489953Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-ds-path-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        content_length: 31
+        body: '{"versions":[],"total_count":0}'
         headers:
             Content-Length:
-                - "457"
+                - "31"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:08:04 GMT
+                - Wed, 24 Jun 2026 09:38:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 351f0dea-8a1d-4eb1-b3aa-2f6f027e59da
+                - 083421c8-09bf-4367-b418-92a5fcf4f906
         status: 200 OK
         code: 200
-        duration: 39.683962ms
+        duration: 23.876643ms
     - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            name:
+                - test-secret-ds-path
+            order_by:
+                - name_asc
+            path:
+                - /test-secret-ds-path-path
+            project_id:
+                - 105bdce1-64c0-48ab-899d-868455867ecf
+            scheduled_for_deletion:
+                - "false"
+            type:
+                - unknown_type
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets?name=test-secret-ds-path&order_by=name_asc&path=%2Ftest-secret-ds-path-path&project_id=105bdce1-64c0-48ab-899d-868455867ecf&scheduled_for_deletion=false&type=unknown_type
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 487
+        body: '{"secrets":[{"id":"192e7723-09ec-4a4a-b9e5-36f3954969fb","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-ds-path","status":"ready","created_at":"2026-06-24T09:38:48.185097Z","updated_at":"2026-06-24T09:38:48.185097Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-ds-path-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "487"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 31863ee9-58f5-4d43-8ccb-52292f415fb3
+        status: 200 OK
+        code: 200
+        duration: 18.062888ms
+    - id: 13
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -443,7 +481,74 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6df781ff-4886-4e65-a274-7b19db42c7dd
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/192e7723-09ec-4a4a-b9e5-36f3954969fb
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 457
+        body: '{"id":"192e7723-09ec-4a4a-b9e5-36f3954969fb","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-ds-path","status":"ready","created_at":"2026-06-24T09:38:48.185097Z","updated_at":"2026-06-24T09:38:48.185097Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-ds-path-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "457"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 30d1f53a-92d3-4ff4-9de0-135db28b59a4
+        status: 200 OK
+        code: 200
+        duration: 21.338664ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/192e7723-09ec-4a4a-b9e5-36f3954969fb/versions?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 31
+        body: '{"versions":[],"total_count":0}'
+        headers:
+            Content-Length:
+                - "31"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - e4737f68-867e-4864-b2c8-464f74f40e3c
+        status: 200 OK
+        code: 200
+        duration: 25.818158ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/192e7723-09ec-4a4a-b9e5-36f3954969fb
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -455,15 +560,15 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:08:05 GMT
+                - Wed, 24 Jun 2026 09:38:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 5e44cf0a-d34d-43a0-a2ee-26d23f95aee2
+                - e4b4806a-1bf5-46b7-898b-aff8cd5b640c
         status: 204 No Content
         code: 204
-        duration: 60.577869ms
-    - id: 13
+        duration: 126.53657ms
+    - id: 16
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -473,29 +578,29 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6df781ff-4886-4e65-a274-7b19db42c7dd
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/192e7723-09ec-4a4a-b9e5-36f3954969fb
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 482
-        body: '{"id":"6df781ff-4886-4e65-a274-7b19db42c7dd","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-ds-path","status":"ready","created_at":"2026-05-28T14:08:03.489953Z","updated_at":"2026-05-28T14:08:03.489953Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-ds-path-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-05-28T14:08:05.349054Z","key_id":null,"region":"fr-par"}'
+        body: '{"id":"192e7723-09ec-4a4a-b9e5-36f3954969fb","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-ds-path","status":"ready","created_at":"2026-06-24T09:38:48.185097Z","updated_at":"2026-06-24T09:38:49.347276Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-ds-path-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-06-24T09:38:49.347276Z","key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "482"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:08:05 GMT
+                - Wed, 24 Jun 2026 09:38:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - 9ed2ede5-1374-455e-917a-eaf3336c6884
+                - 7d44f9f6-54fd-400d-9e51-5a0ee4255adf
         status: 200 OK
         code: 200
-        duration: 31.509116ms
-    - id: 14
+        duration: 29.064116ms
+    - id: 17
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -505,25 +610,25 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/6df781ff-4886-4e65-a274-7b19db42c7dd
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/192e7723-09ec-4a4a-b9e5-36f3954969fb
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 482
-        body: '{"id":"6df781ff-4886-4e65-a274-7b19db42c7dd","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-ds-path","status":"ready","created_at":"2026-05-28T14:08:03.489953Z","updated_at":"2026-05-28T14:08:03.489953Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-ds-path-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-05-28T14:08:05.349054Z","key_id":null,"region":"fr-par"}'
+        body: '{"id":"192e7723-09ec-4a4a-b9e5-36f3954969fb","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-ds-path","status":"ready","created_at":"2026-06-24T09:38:48.185097Z","updated_at":"2026-06-24T09:38:49.347276Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-ds-path-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-06-24T09:38:49.347276Z","key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "482"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:08:05 GMT
+                - Wed, 24 Jun 2026 09:38:49 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge02)
+                - Scaleway API Gateway (fr-par-3;edge01)
             X-Request-Id:
-                - c6c80850-7563-439a-bbdb-ece5098b9ac9
+                - 5856ee4d-cd4d-477a-99c9-d6e470eec8b6
         status: 200 OK
         code: 200
-        duration: 31.67124ms
+        duration: 19.252961ms

--- a/internal/services/secret/testdata/data-source-secret-with-versions.cassette.yaml
+++ b/internal/services/secret/testdata/data-source-secret-with-versions.cassette.yaml
@@ -1,0 +1,757 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 177
+        host: api.scaleway.com
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-versions","tags":null,"description":"Secret with versions","type":"opaque","path":"/","protected":false}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 454
+        body: '{"id":"b4b900f5-76ab-435e-81fe-efae7b2f8127","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-versions","status":"ready","created_at":"2026-06-24T09:38:48.050553Z","updated_at":"2026-06-24T09:38:48.050553Z","tags":[],"version_count":0,"description":"Secret with versions","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "454"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - a4437a58-45e6-4190-9013-28f9c0a08079
+        status: 200 OK
+        code: 200
+        duration: 118.924084ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b4b900f5-76ab-435e-81fe-efae7b2f8127
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 454
+        body: '{"id":"b4b900f5-76ab-435e-81fe-efae7b2f8127","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-versions","status":"ready","created_at":"2026-06-24T09:38:48.050553Z","updated_at":"2026-06-24T09:38:48.050553Z","tags":[],"version_count":0,"description":"Secret with versions","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "454"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - b725f2b4-9127-4fac-9934-aa6d52b91c13
+        status: 200 OK
+        code: 200
+        duration: 28.882238ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b4b900f5-76ab-435e-81fe-efae7b2f8127/versions?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 31
+        body: '{"versions":[],"total_count":0}'
+        headers:
+            Content-Length:
+                - "31"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - e02f594b-628d-4862-81f2-8f5ce5d1adf8
+        status: 200 OK
+        code: 200
+        duration: 20.146045ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 35
+        host: api.scaleway.com
+        body: '{"data":"Zmlyc3QtdmVyc2lvbi1kYXRh"}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b4b900f5-76ab-435e-81fe-efae7b2f8127/versions
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 294
+        body: '{"revision":1,"secret_id":"b4b900f5-76ab-435e-81fe-efae7b2f8127","status":"enabled","created_at":"2026-06-24T09:38:48.459695Z","updated_at":"2026-06-24T09:38:48.459695Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "294"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - f7b50a48-534f-4fea-b7cb-ceb28d08d0e5
+        status: 200 OK
+        code: 200
+        duration: 339.727137ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b4b900f5-76ab-435e-81fe-efae7b2f8127/versions/1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 294
+        body: '{"revision":1,"secret_id":"b4b900f5-76ab-435e-81fe-efae7b2f8127","status":"enabled","created_at":"2026-06-24T09:38:48.459695Z","updated_at":"2026-06-24T09:38:48.459695Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "294"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 565abd20-f6b6-43e5-8fd3-bf16e12aedff
+        status: 200 OK
+        code: 200
+        duration: 32.035588ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 39
+        host: api.scaleway.com
+        body: '{"data":"c2Vjb25kLXZlcnNpb24tZGF0YQ=="}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b4b900f5-76ab-435e-81fe-efae7b2f8127/versions
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 294
+        body: '{"revision":2,"secret_id":"b4b900f5-76ab-435e-81fe-efae7b2f8127","status":"enabled","created_at":"2026-06-24T09:38:48.664475Z","updated_at":"2026-06-24T09:38:48.664475Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "294"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - f401ccaa-233f-4686-9a9f-b47d805e1be9
+        status: 200 OK
+        code: 200
+        duration: 529.164648ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b4b900f5-76ab-435e-81fe-efae7b2f8127/versions/2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 294
+        body: '{"revision":2,"secret_id":"b4b900f5-76ab-435e-81fe-efae7b2f8127","status":"enabled","created_at":"2026-06-24T09:38:48.664475Z","updated_at":"2026-06-24T09:38:48.664475Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "294"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 5435b190-d483-49ca-9f5f-5ebdf8fe34f5
+        status: 200 OK
+        code: 200
+        duration: 18.180613ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b4b900f5-76ab-435e-81fe-efae7b2f8127
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 454
+        body: '{"id":"b4b900f5-76ab-435e-81fe-efae7b2f8127","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-versions","status":"ready","created_at":"2026-06-24T09:38:48.050553Z","updated_at":"2026-06-24T09:38:48.050553Z","tags":[],"version_count":2,"description":"Secret with versions","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "454"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 8a46d2ce-6d8a-4c56-b1e6-65c4d421a820
+        status: 200 OK
+        code: 200
+        duration: 14.692561ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b4b900f5-76ab-435e-81fe-efae7b2f8127/versions?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 621
+        body: '{"versions":[{"revision":2,"secret_id":"b4b900f5-76ab-435e-81fe-efae7b2f8127","status":"enabled","created_at":"2026-06-24T09:38:48.664475Z","updated_at":"2026-06-24T09:38:48.664475Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"b4b900f5-76ab-435e-81fe-efae7b2f8127","status":"enabled","created_at":"2026-06-24T09:38:48.459695Z","updated_at":"2026-06-24T09:38:48.459695Z","deleted_at":null,"description":"","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":2}'
+        headers:
+            Content-Length:
+                - "621"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 4ad4001d-954c-4d0c-80f4-89ab0afced08
+        status: 200 OK
+        code: 200
+        duration: 43.607161ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b4b900f5-76ab-435e-81fe-efae7b2f8127
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 454
+        body: '{"id":"b4b900f5-76ab-435e-81fe-efae7b2f8127","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-versions","status":"ready","created_at":"2026-06-24T09:38:48.050553Z","updated_at":"2026-06-24T09:38:48.050553Z","tags":[],"version_count":2,"description":"Secret with versions","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "454"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - b0995157-854e-4847-9126-85e0008cb603
+        status: 200 OK
+        code: 200
+        duration: 22.828673ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b4b900f5-76ab-435e-81fe-efae7b2f8127
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 454
+        body: '{"id":"b4b900f5-76ab-435e-81fe-efae7b2f8127","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-versions","status":"ready","created_at":"2026-06-24T09:38:48.050553Z","updated_at":"2026-06-24T09:38:48.050553Z","tags":[],"version_count":2,"description":"Secret with versions","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "454"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - f844508e-5d6a-4db8-84a0-76c9190ab6de
+        status: 200 OK
+        code: 200
+        duration: 24.32317ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b4b900f5-76ab-435e-81fe-efae7b2f8127/versions?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 621
+        body: '{"versions":[{"revision":2,"secret_id":"b4b900f5-76ab-435e-81fe-efae7b2f8127","status":"enabled","created_at":"2026-06-24T09:38:48.664475Z","updated_at":"2026-06-24T09:38:48.664475Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"b4b900f5-76ab-435e-81fe-efae7b2f8127","status":"enabled","created_at":"2026-06-24T09:38:48.459695Z","updated_at":"2026-06-24T09:38:48.459695Z","deleted_at":null,"description":"","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":2}'
+        headers:
+            Content-Length:
+                - "621"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 2d35ccad-18d6-4427-a399-e35646b927b3
+        status: 200 OK
+        code: 200
+        duration: 28.853643ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b4b900f5-76ab-435e-81fe-efae7b2f8127
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 454
+        body: '{"id":"b4b900f5-76ab-435e-81fe-efae7b2f8127","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-versions","status":"ready","created_at":"2026-06-24T09:38:48.050553Z","updated_at":"2026-06-24T09:38:48.050553Z","tags":[],"version_count":2,"description":"Secret with versions","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "454"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - bafbb06f-7a9b-499b-b407-7e634946dc96
+        status: 200 OK
+        code: 200
+        duration: 32.73465ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b4b900f5-76ab-435e-81fe-efae7b2f8127/versions?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 621
+        body: '{"versions":[{"revision":2,"secret_id":"b4b900f5-76ab-435e-81fe-efae7b2f8127","status":"enabled","created_at":"2026-06-24T09:38:48.664475Z","updated_at":"2026-06-24T09:38:48.664475Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"b4b900f5-76ab-435e-81fe-efae7b2f8127","status":"enabled","created_at":"2026-06-24T09:38:48.459695Z","updated_at":"2026-06-24T09:38:48.459695Z","deleted_at":null,"description":"","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":2}'
+        headers:
+            Content-Length:
+                - "621"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - acbd4020-5be3-48ee-8c8b-ff6856e669e6
+        status: 200 OK
+        code: 200
+        duration: 27.636106ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b4b900f5-76ab-435e-81fe-efae7b2f8127/versions/1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 295
+        body: '{"revision":1,"secret_id":"b4b900f5-76ab-435e-81fe-efae7b2f8127","status":"enabled","created_at":"2026-06-24T09:38:48.459695Z","updated_at":"2026-06-24T09:38:48.459695Z","deleted_at":null,"description":"","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "295"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - b8069daa-7c3a-408b-80ad-b9fe32629de8
+        status: 200 OK
+        code: 200
+        duration: 22.968751ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b4b900f5-76ab-435e-81fe-efae7b2f8127/versions/2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 294
+        body: '{"revision":2,"secret_id":"b4b900f5-76ab-435e-81fe-efae7b2f8127","status":"enabled","created_at":"2026-06-24T09:38:48.664475Z","updated_at":"2026-06-24T09:38:48.664475Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "294"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 369e6ac5-c13b-4c34-af43-46d6905b52dc
+        status: 200 OK
+        code: 200
+        duration: 28.74291ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b4b900f5-76ab-435e-81fe-efae7b2f8127
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 454
+        body: '{"id":"b4b900f5-76ab-435e-81fe-efae7b2f8127","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-versions","status":"ready","created_at":"2026-06-24T09:38:48.050553Z","updated_at":"2026-06-24T09:38:48.050553Z","tags":[],"version_count":2,"description":"Secret with versions","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "454"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - bdf48957-41f3-44ca-92e6-9b1c4a4e2185
+        status: 200 OK
+        code: 200
+        duration: 23.872074ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            page:
+                - "1"
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b4b900f5-76ab-435e-81fe-efae7b2f8127/versions?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 621
+        body: '{"versions":[{"revision":2,"secret_id":"b4b900f5-76ab-435e-81fe-efae7b2f8127","status":"enabled","created_at":"2026-06-24T09:38:48.664475Z","updated_at":"2026-06-24T09:38:48.664475Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"b4b900f5-76ab-435e-81fe-efae7b2f8127","status":"enabled","created_at":"2026-06-24T09:38:48.459695Z","updated_at":"2026-06-24T09:38:48.459695Z","deleted_at":null,"description":"","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":2}'
+        headers:
+            Content-Length:
+                - "621"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - a66d5149-61a4-4a11-8a74-7abe924d3499
+        status: 200 OK
+        code: 200
+        duration: 26.944319ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b4b900f5-76ab-435e-81fe-efae7b2f8127/versions/1
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 05ea496b-9cc9-4043-a35b-734f90d40c21
+        status: 204 No Content
+        code: 204
+        duration: 93.758989ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b4b900f5-76ab-435e-81fe-efae7b2f8127/versions/2
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 6e0a25a1-7623-4fc1-837a-bc7116c9084f
+        status: 204 No Content
+        code: 204
+        duration: 104.896178ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b4b900f5-76ab-435e-81fe-efae7b2f8127
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - 2029b8c1-ffd9-441b-890c-b0a91b961963
+        status: 204 No Content
+        code: 204
+        duration: 38.189956ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b4b900f5-76ab-435e-81fe-efae7b2f8127
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 479
+        body: '{"id":"b4b900f5-76ab-435e-81fe-efae7b2f8127","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-versions","status":"ready","created_at":"2026-06-24T09:38:48.050553Z","updated_at":"2026-06-24T09:38:49.769883Z","tags":[],"version_count":2,"description":"Secret with versions","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-06-24T09:38:49.769883Z","key_id":null,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "479"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - ac8b0b98-2fff-47d6-abf6-7a696175e1c0
+        status: 200 OK
+        code: 200
+        duration: 28.725166ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/b4b900f5-76ab-435e-81fe-efae7b2f8127
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 479
+        body: '{"id":"b4b900f5-76ab-435e-81fe-efae7b2f8127","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-versions","status":"ready","created_at":"2026-06-24T09:38:48.050553Z","updated_at":"2026-06-24T09:38:49.769883Z","tags":[],"version_count":2,"description":"Secret with versions","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-06-24T09:38:49.769883Z","key_id":null,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "479"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge01)
+            X-Request-Id:
+                - e4cb3afb-6b24-4dc9-b027-b5160407c73a
+        status: 200 OK
+        code: 200
+        duration: 27.663559ms

--- a/internal/services/secret/testdata/secret-basic.cassette.yaml
+++ b/internal/services/secret/testdata/secret-basic.cassette.yaml
@@ -21,21 +21,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 480
-        body: '{"id":"96e16dd4-13b3-4445-8276-57aa20a4ba46","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasic","status":"ready","created_at":"2026-05-28T14:07:35.200069Z","updated_at":"2026-05-28T14:07:35.200069Z","tags":["devtools","provider","terraform"],"version_count":0,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"93ac26bb-9ff1-423c-b95d-ff11c5ac91e2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasic","status":"ready","created_at":"2026-06-24T09:38:38.866269Z","updated_at":"2026-06-24T09:38:38.866269Z","tags":["devtools","provider","terraform"],"version_count":0,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "480"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:35 GMT
+                - Wed, 24 Jun 2026 09:38:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - d1b5be15-94e2-4a1c-bd16-0092e14aad8a
+                - 14bde24a-136c-4246-850e-57027d670cd4
         status: 200 OK
         code: 200
-        duration: 170.870025ms
+        duration: 311.450492ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -46,28 +46,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/96e16dd4-13b3-4445-8276-57aa20a4ba46
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/93ac26bb-9ff1-423c-b95d-ff11c5ac91e2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 480
-        body: '{"id":"96e16dd4-13b3-4445-8276-57aa20a4ba46","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasic","status":"ready","created_at":"2026-05-28T14:07:35.200069Z","updated_at":"2026-05-28T14:07:35.200069Z","tags":["devtools","provider","terraform"],"version_count":0,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"93ac26bb-9ff1-423c-b95d-ff11c5ac91e2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasic","status":"ready","created_at":"2026-06-24T09:38:38.866269Z","updated_at":"2026-06-24T09:38:38.866269Z","tags":["devtools","provider","terraform"],"version_count":0,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "480"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:35 GMT
+                - Wed, 24 Jun 2026 09:38:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 163e1cee-425c-4cba-89fc-cb9e42ba1414
+                - 511d4590-d802-4752-860a-b79b1fa95d63
         status: 200 OK
         code: 200
-        duration: 86.11398ms
+        duration: 103.032463ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -81,7 +81,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/96e16dd4-13b3-4445-8276-57aa20a4ba46/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/93ac26bb-9ff1-423c-b95d-ff11c5ac91e2/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -95,14 +95,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:35 GMT
+                - Wed, 24 Jun 2026 09:38:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 1bd15965-96f2-46d2-8575-36c7096913ba
+                - 3638ba4d-0b4a-4fa7-a4df-b2b724e1a817
         status: 200 OK
         code: 200
-        duration: 96.201728ms
+        duration: 25.708317ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -113,28 +113,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/96e16dd4-13b3-4445-8276-57aa20a4ba46
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/93ac26bb-9ff1-423c-b95d-ff11c5ac91e2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 480
-        body: '{"id":"96e16dd4-13b3-4445-8276-57aa20a4ba46","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasic","status":"ready","created_at":"2026-05-28T14:07:35.200069Z","updated_at":"2026-05-28T14:07:35.200069Z","tags":["devtools","provider","terraform"],"version_count":0,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"93ac26bb-9ff1-423c-b95d-ff11c5ac91e2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasic","status":"ready","created_at":"2026-06-24T09:38:38.866269Z","updated_at":"2026-06-24T09:38:38.866269Z","tags":["devtools","provider","terraform"],"version_count":0,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "480"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:35 GMT
+                - Wed, 24 Jun 2026 09:38:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 57be5429-a752-4bbd-a100-a5a9e06bb628
+                - 88a21857-e628-40ef-8951-4c09593665b0
         status: 200 OK
         code: 200
-        duration: 35.568315ms
+        duration: 107.794319ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -145,28 +145,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/96e16dd4-13b3-4445-8276-57aa20a4ba46
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/93ac26bb-9ff1-423c-b95d-ff11c5ac91e2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 480
-        body: '{"id":"96e16dd4-13b3-4445-8276-57aa20a4ba46","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasic","status":"ready","created_at":"2026-05-28T14:07:35.200069Z","updated_at":"2026-05-28T14:07:35.200069Z","tags":["devtools","provider","terraform"],"version_count":0,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"93ac26bb-9ff1-423c-b95d-ff11c5ac91e2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasic","status":"ready","created_at":"2026-06-24T09:38:38.866269Z","updated_at":"2026-06-24T09:38:38.866269Z","tags":["devtools","provider","terraform"],"version_count":0,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "480"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:36 GMT
+                - Wed, 24 Jun 2026 09:38:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 9cb9178a-efea-41e7-aa05-5084adf3a4be
+                - f0143bc1-0aaf-4422-923e-2b5e30aa425d
         status: 200 OK
         code: 200
-        duration: 33.170223ms
+        duration: 22.354813ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -180,7 +180,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/96e16dd4-13b3-4445-8276-57aa20a4ba46/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/93ac26bb-9ff1-423c-b95d-ff11c5ac91e2/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -194,14 +194,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:36 GMT
+                - Wed, 24 Jun 2026 09:38:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 3981de43-707d-4d58-8673-a3fc87ef3f36
+                - 1c2dbd26-ae5b-43be-9cda-f3caecd43669
         status: 200 OK
         code: 200
-        duration: 48.143845ms
+        duration: 116.078474ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -212,28 +212,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/96e16dd4-13b3-4445-8276-57aa20a4ba46
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/93ac26bb-9ff1-423c-b95d-ff11c5ac91e2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 480
-        body: '{"id":"96e16dd4-13b3-4445-8276-57aa20a4ba46","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasic","status":"ready","created_at":"2026-05-28T14:07:35.200069Z","updated_at":"2026-05-28T14:07:35.200069Z","tags":["devtools","provider","terraform"],"version_count":0,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"93ac26bb-9ff1-423c-b95d-ff11c5ac91e2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasic","status":"ready","created_at":"2026-06-24T09:38:38.866269Z","updated_at":"2026-06-24T09:38:38.866269Z","tags":["devtools","provider","terraform"],"version_count":0,"description":"secret description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "480"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:36 GMT
+                - Wed, 24 Jun 2026 09:38:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 582a2c19-c1cf-441f-a812-d9f0d131d849
+                - ed72cd7e-be7c-493c-8ca8-c29052d9fb32
         status: 200 OK
         code: 200
-        duration: 45.767472ms
+        duration: 22.755612ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -247,7 +247,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/96e16dd4-13b3-4445-8276-57aa20a4ba46/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/93ac26bb-9ff1-423c-b95d-ff11c5ac91e2/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -261,14 +261,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:36 GMT
+                - Wed, 24 Jun 2026 09:38:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - a1856b24-d374-41df-bdce-a5416e68978b
+                - 969713c9-ad5e-4f26-b6e7-97b98e9ef6b9
         status: 200 OK
         code: 200
-        duration: 48.30678ms
+        duration: 20.168217ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -282,28 +282,28 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/96e16dd4-13b3-4445-8276-57aa20a4ba46
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/93ac26bb-9ff1-423c-b95d-ff11c5ac91e2
         method: PATCH
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 464
-        body: '{"id":"96e16dd4-13b3-4445-8276-57aa20a4ba46","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasicUpdated","status":"ready","created_at":"2026-05-28T14:07:35.200069Z","updated_at":"2026-05-28T14:07:37.374066Z","tags":["devtools"],"version_count":0,"description":"update description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"93ac26bb-9ff1-423c-b95d-ff11c5ac91e2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasicUpdated","status":"ready","created_at":"2026-06-24T09:38:38.866269Z","updated_at":"2026-06-24T09:38:40.269297Z","tags":["devtools"],"version_count":0,"description":"update description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "464"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:37 GMT
+                - Wed, 24 Jun 2026 09:38:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 025313b5-a837-4cfc-9186-45b8aa516969
+                - 3dedd87b-bcb9-4f9e-a7e2-b37c4dc7fc87
         status: 200 OK
         code: 200
-        duration: 100.318902ms
+        duration: 180.002839ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -314,28 +314,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/96e16dd4-13b3-4445-8276-57aa20a4ba46
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/93ac26bb-9ff1-423c-b95d-ff11c5ac91e2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 464
-        body: '{"id":"96e16dd4-13b3-4445-8276-57aa20a4ba46","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasicUpdated","status":"ready","created_at":"2026-05-28T14:07:35.200069Z","updated_at":"2026-05-28T14:07:37.374066Z","tags":["devtools"],"version_count":0,"description":"update description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"93ac26bb-9ff1-423c-b95d-ff11c5ac91e2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasicUpdated","status":"ready","created_at":"2026-06-24T09:38:38.866269Z","updated_at":"2026-06-24T09:38:40.269297Z","tags":["devtools"],"version_count":0,"description":"update description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "464"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:37 GMT
+                - Wed, 24 Jun 2026 09:38:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - fcf66a3d-a385-4c6c-81ff-1795a4839036
+                - 026c148d-2fe9-4260-9023-04a5f289396c
         status: 200 OK
         code: 200
-        duration: 44.643177ms
+        duration: 29.51414ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -349,7 +349,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/96e16dd4-13b3-4445-8276-57aa20a4ba46/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/93ac26bb-9ff1-423c-b95d-ff11c5ac91e2/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -363,14 +363,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:37 GMT
+                - Wed, 24 Jun 2026 09:38:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 91ef3ff7-b27a-47fb-bd45-445cbd8fe906
+                - 4c8c7c52-3ee6-4b2b-8d5f-de8596c87ebe
         status: 200 OK
         code: 200
-        duration: 35.060274ms
+        duration: 23.878677ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -381,28 +381,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/96e16dd4-13b3-4445-8276-57aa20a4ba46
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/93ac26bb-9ff1-423c-b95d-ff11c5ac91e2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 464
-        body: '{"id":"96e16dd4-13b3-4445-8276-57aa20a4ba46","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasicUpdated","status":"ready","created_at":"2026-05-28T14:07:35.200069Z","updated_at":"2026-05-28T14:07:37.374066Z","tags":["devtools"],"version_count":0,"description":"update description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"93ac26bb-9ff1-423c-b95d-ff11c5ac91e2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasicUpdated","status":"ready","created_at":"2026-06-24T09:38:38.866269Z","updated_at":"2026-06-24T09:38:40.269297Z","tags":["devtools"],"version_count":0,"description":"update description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "464"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:37 GMT
+                - Wed, 24 Jun 2026 09:38:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 504da8e5-780a-425e-86ce-2c4341154984
+                - 8662f971-fb4e-4bcb-9e4c-d94b54e1837c
         status: 200 OK
         code: 200
-        duration: 31.746696ms
+        duration: 22.340236ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -413,28 +413,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/96e16dd4-13b3-4445-8276-57aa20a4ba46
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/93ac26bb-9ff1-423c-b95d-ff11c5ac91e2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 464
-        body: '{"id":"96e16dd4-13b3-4445-8276-57aa20a4ba46","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasicUpdated","status":"ready","created_at":"2026-05-28T14:07:35.200069Z","updated_at":"2026-05-28T14:07:37.374066Z","tags":["devtools"],"version_count":0,"description":"update description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"93ac26bb-9ff1-423c-b95d-ff11c5ac91e2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasicUpdated","status":"ready","created_at":"2026-06-24T09:38:38.866269Z","updated_at":"2026-06-24T09:38:40.269297Z","tags":["devtools"],"version_count":0,"description":"update description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "464"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:38 GMT
+                - Wed, 24 Jun 2026 09:38:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - b13de76c-97c8-4783-8cef-f55e91e48a96
+                - fa997123-c8c5-451b-a893-04230fb270b9
         status: 200 OK
         code: 200
-        duration: 32.515877ms
+        duration: 99.328665ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -448,7 +448,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/96e16dd4-13b3-4445-8276-57aa20a4ba46/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/93ac26bb-9ff1-423c-b95d-ff11c5ac91e2/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -462,14 +462,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:38 GMT
+                - Wed, 24 Jun 2026 09:38:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 2c43d051-d65a-4dba-a019-d889e2e97a50
+                - 4f5f88ea-ae1f-48e6-af16-273cdb03afb8
         status: 200 OK
         code: 200
-        duration: 52.695572ms
+        duration: 27.397649ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -480,28 +480,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/96e16dd4-13b3-4445-8276-57aa20a4ba46
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/93ac26bb-9ff1-423c-b95d-ff11c5ac91e2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 464
-        body: '{"id":"96e16dd4-13b3-4445-8276-57aa20a4ba46","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasicUpdated","status":"ready","created_at":"2026-05-28T14:07:35.200069Z","updated_at":"2026-05-28T14:07:37.374066Z","tags":["devtools"],"version_count":0,"description":"update description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"93ac26bb-9ff1-423c-b95d-ff11c5ac91e2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasicUpdated","status":"ready","created_at":"2026-06-24T09:38:38.866269Z","updated_at":"2026-06-24T09:38:40.269297Z","tags":["devtools"],"version_count":0,"description":"update description","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "464"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:38 GMT
+                - Wed, 24 Jun 2026 09:38:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - d35a017d-985d-465b-9d0b-f6ae1808e08e
+                - f879ab81-c7f7-4166-96b0-f6857c2f7a95
         status: 200 OK
         code: 200
-        duration: 38.151906ms
+        duration: 26.486591ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -515,7 +515,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/96e16dd4-13b3-4445-8276-57aa20a4ba46/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/93ac26bb-9ff1-423c-b95d-ff11c5ac91e2/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -529,14 +529,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:38 GMT
+                - Wed, 24 Jun 2026 09:38:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 09edd4a0-ff8b-41cc-a759-f1855ee99d09
+                - 4ca18041-37f4-4952-b640-5f9e396919a8
         status: 200 OK
         code: 200
-        duration: 36.453133ms
+        duration: 26.316775ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -550,28 +550,28 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/96e16dd4-13b3-4445-8276-57aa20a4ba46
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/93ac26bb-9ff1-423c-b95d-ff11c5ac91e2
         method: PATCH
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 429
-        body: '{"id":"96e16dd4-13b3-4445-8276-57aa20a4ba46","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasic","status":"ready","created_at":"2026-05-28T14:07:35.200069Z","updated_at":"2026-05-28T14:07:39.193406Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"93ac26bb-9ff1-423c-b95d-ff11c5ac91e2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasic","status":"ready","created_at":"2026-06-24T09:38:38.866269Z","updated_at":"2026-06-24T09:38:41.483263Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "429"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:39 GMT
+                - Wed, 24 Jun 2026 09:38:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - ef6d0bc3-b9e7-4039-b052-a2ad1240a62b
+                - cac5de8d-48d6-48a9-9df4-18071fbd79d7
         status: 200 OK
         code: 200
-        duration: 57.130913ms
+        duration: 117.858409ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -582,28 +582,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/96e16dd4-13b3-4445-8276-57aa20a4ba46
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/93ac26bb-9ff1-423c-b95d-ff11c5ac91e2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 429
-        body: '{"id":"96e16dd4-13b3-4445-8276-57aa20a4ba46","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasic","status":"ready","created_at":"2026-05-28T14:07:35.200069Z","updated_at":"2026-05-28T14:07:39.193406Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"93ac26bb-9ff1-423c-b95d-ff11c5ac91e2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasic","status":"ready","created_at":"2026-06-24T09:38:38.866269Z","updated_at":"2026-06-24T09:38:41.483263Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "429"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:39 GMT
+                - Wed, 24 Jun 2026 09:38:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 8c7fae02-c8ad-4b6c-a576-eaa1ff3f1e6d
+                - 2e3a3e4d-3c95-441f-9782-93d0082d4c73
         status: 200 OK
         code: 200
-        duration: 48.374658ms
+        duration: 27.496459ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -617,7 +617,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/96e16dd4-13b3-4445-8276-57aa20a4ba46/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/93ac26bb-9ff1-423c-b95d-ff11c5ac91e2/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -631,14 +631,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:39 GMT
+                - Wed, 24 Jun 2026 09:38:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - eebdc718-58bc-4b4a-a53d-a5c7d3f8e2ca
+                - 75386456-0483-4b57-889e-0ca2b171d649
         status: 200 OK
         code: 200
-        duration: 40.210182ms
+        duration: 32.597907ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -649,28 +649,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/96e16dd4-13b3-4445-8276-57aa20a4ba46
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/93ac26bb-9ff1-423c-b95d-ff11c5ac91e2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 429
-        body: '{"id":"96e16dd4-13b3-4445-8276-57aa20a4ba46","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasic","status":"ready","created_at":"2026-05-28T14:07:35.200069Z","updated_at":"2026-05-28T14:07:39.193406Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"93ac26bb-9ff1-423c-b95d-ff11c5ac91e2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasic","status":"ready","created_at":"2026-06-24T09:38:38.866269Z","updated_at":"2026-06-24T09:38:41.483263Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "429"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:39 GMT
+                - Wed, 24 Jun 2026 09:38:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 4b22fc7e-1541-4d3c-8ae8-8cbff9fb4d14
+                - c5854f28-d462-43fe-8caa-e940ed015d91
         status: 200 OK
         code: 200
-        duration: 44.92739ms
+        duration: 33.355921ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -681,28 +681,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/96e16dd4-13b3-4445-8276-57aa20a4ba46
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/93ac26bb-9ff1-423c-b95d-ff11c5ac91e2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 429
-        body: '{"id":"96e16dd4-13b3-4445-8276-57aa20a4ba46","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasic","status":"ready","created_at":"2026-05-28T14:07:35.200069Z","updated_at":"2026-05-28T14:07:39.193406Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"93ac26bb-9ff1-423c-b95d-ff11c5ac91e2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasic","status":"ready","created_at":"2026-06-24T09:38:38.866269Z","updated_at":"2026-06-24T09:38:41.483263Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "429"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:40 GMT
+                - Wed, 24 Jun 2026 09:38:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 0af012ea-d7d5-4d8a-b29d-bcb0b26e2906
+                - 1cb49bfc-01b4-4d76-8f4f-e9a39d1fdcc2
         status: 200 OK
         code: 200
-        duration: 33.006156ms
+        duration: 17.874216ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -716,7 +716,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/96e16dd4-13b3-4445-8276-57aa20a4ba46/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/93ac26bb-9ff1-423c-b95d-ff11c5ac91e2/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -730,14 +730,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:40 GMT
+                - Wed, 24 Jun 2026 09:38:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 20be3304-b32b-487d-9dee-fc7da77f78fb
+                - 338f7141-acad-4a2b-a314-0b0ac481d308
         status: 200 OK
         code: 200
-        duration: 48.069887ms
+        duration: 32.725852ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -748,28 +748,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/96e16dd4-13b3-4445-8276-57aa20a4ba46
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/93ac26bb-9ff1-423c-b95d-ff11c5ac91e2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 429
-        body: '{"id":"96e16dd4-13b3-4445-8276-57aa20a4ba46","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasic","status":"ready","created_at":"2026-05-28T14:07:35.200069Z","updated_at":"2026-05-28T14:07:39.193406Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"93ac26bb-9ff1-423c-b95d-ff11c5ac91e2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasic","status":"ready","created_at":"2026-06-24T09:38:38.866269Z","updated_at":"2026-06-24T09:38:41.483263Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "429"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:40 GMT
+                - Wed, 24 Jun 2026 09:38:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - b80523d6-5d83-49d7-a9ea-9b83603f641c
+                - 33955ce6-7e59-49a6-b42a-e854fd69d722
         status: 200 OK
         code: 200
-        duration: 50.075254ms
+        duration: 22.487868ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -783,7 +783,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/96e16dd4-13b3-4445-8276-57aa20a4ba46/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/93ac26bb-9ff1-423c-b95d-ff11c5ac91e2/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -797,14 +797,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:40 GMT
+                - Wed, 24 Jun 2026 09:38:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - e518e7af-3928-44eb-81ba-072856ebea33
+                - 144d6322-fc80-4a48-b42c-09937ac70cd3
         status: 200 OK
         code: 200
-        duration: 33.49346ms
+        duration: 25.512822ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -815,7 +815,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/96e16dd4-13b3-4445-8276-57aa20a4ba46
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/93ac26bb-9ff1-423c-b95d-ff11c5ac91e2
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -827,14 +827,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:41 GMT
+                - Wed, 24 Jun 2026 09:38:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - db96264b-6503-46a4-a388-59764dfde9cc
+                - 068deb48-41a3-4bdf-ae60-4a675452675d
         status: 204 No Content
         code: 204
-        duration: 60.845202ms
+        duration: 136.677489ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -845,25 +845,25 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/96e16dd4-13b3-4445-8276-57aa20a4ba46
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/93ac26bb-9ff1-423c-b95d-ff11c5ac91e2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 454
-        body: '{"id":"96e16dd4-13b3-4445-8276-57aa20a4ba46","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasic","status":"ready","created_at":"2026-05-28T14:07:35.200069Z","updated_at":"2026-05-28T14:07:39.193406Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-05-28T14:07:41.150018Z","key_id":null,"region":"fr-par"}'
+        body: '{"id":"93ac26bb-9ff1-423c-b95d-ff11c5ac91e2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"secretNameBasic","status":"ready","created_at":"2026-06-24T09:38:38.866269Z","updated_at":"2026-06-24T09:38:42.626825Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-06-24T09:38:42.626825Z","key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "454"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:41 GMT
+                - Wed, 24 Jun 2026 09:38:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 2531af8c-e82b-4788-a52a-e6ff81647632
+                - 63b95d11-750f-47a7-b3f5-33e8b9fcf1ad
         status: 200 OK
         code: 200
-        duration: 40.890037ms
+        duration: 17.701325ms

--- a/internal/services/secret/testdata/secret-path.cassette.yaml
+++ b/internal/services/secret/testdata/secret-path.cassette.yaml
@@ -21,21 +21,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 437
-        body: '{"id":"5aef25f5-7301-44b4-9e83-860066c6c9b0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-05-28T14:07:35.277739Z","updated_at":"2026-05-28T14:07:35.277739Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"547a210e-1b14-4d88-b602-a8ebfe1e0a1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-06-24T09:38:38.845335Z","updated_at":"2026-06-24T09:38:38.845335Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "437"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:35 GMT
+                - Wed, 24 Jun 2026 09:38:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 5c3804a5-efb4-4130-85d0-beff97b146f8
+                - 4f507ac7-8312-4d31-8645-b58367a8d9a3
         status: 200 OK
         code: 200
-        duration: 230.7522ms
+        duration: 329.077013ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -46,28 +46,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5aef25f5-7301-44b4-9e83-860066c6c9b0
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 437
-        body: '{"id":"5aef25f5-7301-44b4-9e83-860066c6c9b0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-05-28T14:07:35.277739Z","updated_at":"2026-05-28T14:07:35.277739Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"547a210e-1b14-4d88-b602-a8ebfe1e0a1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-06-24T09:38:38.845335Z","updated_at":"2026-06-24T09:38:38.845335Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "437"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:35 GMT
+                - Wed, 24 Jun 2026 09:38:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 557adb94-ec3c-4db5-a459-c5c221edff2f
+                - 8a1265e5-a2c5-47c5-ab16-83d37abfcbfa
         status: 200 OK
         code: 200
-        duration: 75.706091ms
+        duration: 104.260298ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -81,7 +81,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5aef25f5-7301-44b4-9e83-860066c6c9b0/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -95,14 +95,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:35 GMT
+                - Wed, 24 Jun 2026 09:38:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 2c6402f0-bda5-453d-bdb2-1c801f61d902
+                - bda98486-dc24-48e3-8c50-5f494730df10
         status: 200 OK
         code: 200
-        duration: 40.386231ms
+        duration: 103.10409ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -113,28 +113,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5aef25f5-7301-44b4-9e83-860066c6c9b0
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 437
-        body: '{"id":"5aef25f5-7301-44b4-9e83-860066c6c9b0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-05-28T14:07:35.277739Z","updated_at":"2026-05-28T14:07:35.277739Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"547a210e-1b14-4d88-b602-a8ebfe1e0a1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-06-24T09:38:38.845335Z","updated_at":"2026-06-24T09:38:38.845335Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "437"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:35 GMT
+                - Wed, 24 Jun 2026 09:38:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 0a1544d6-f16f-45e2-91a7-39be361c3d84
+                - 198c95e5-d508-4ed2-866f-22cee9f39c86
         status: 200 OK
         code: 200
-        duration: 50.950163ms
+        duration: 22.98388ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -145,28 +145,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5aef25f5-7301-44b4-9e83-860066c6c9b0
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 437
-        body: '{"id":"5aef25f5-7301-44b4-9e83-860066c6c9b0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-05-28T14:07:35.277739Z","updated_at":"2026-05-28T14:07:35.277739Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"547a210e-1b14-4d88-b602-a8ebfe1e0a1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-06-24T09:38:38.845335Z","updated_at":"2026-06-24T09:38:38.845335Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "437"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:36 GMT
+                - Wed, 24 Jun 2026 09:38:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 7e0666ce-e206-4467-9601-d290562679f3
+                - 3d8624e2-46c9-4609-9e63-d07087aee2fc
         status: 200 OK
         code: 200
-        duration: 48.222612ms
+        duration: 101.668545ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -180,7 +180,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5aef25f5-7301-44b4-9e83-860066c6c9b0/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -194,14 +194,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:36 GMT
+                - Wed, 24 Jun 2026 09:38:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 2fafded2-58f4-47cf-8ef9-b975c5733bfe
+                - 9ca10d82-1b71-498d-8e25-55bd895a6812
         status: 200 OK
         code: 200
-        duration: 36.651485ms
+        duration: 20.227401ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -212,28 +212,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5aef25f5-7301-44b4-9e83-860066c6c9b0
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 437
-        body: '{"id":"5aef25f5-7301-44b4-9e83-860066c6c9b0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-05-28T14:07:35.277739Z","updated_at":"2026-05-28T14:07:35.277739Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"547a210e-1b14-4d88-b602-a8ebfe1e0a1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-06-24T09:38:38.845335Z","updated_at":"2026-06-24T09:38:38.845335Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "437"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:36 GMT
+                - Wed, 24 Jun 2026 09:38:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 22957fae-a130-4fd9-8099-0c47c442784c
+                - dc9eb504-69ac-4bba-9142-41193bb2cb10
         status: 200 OK
         code: 200
-        duration: 32.368841ms
+        duration: 24.290788ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -247,7 +247,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5aef25f5-7301-44b4-9e83-860066c6c9b0/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -261,14 +261,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:36 GMT
+                - Wed, 24 Jun 2026 09:38:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 91abbf4d-aca1-40a4-a271-9c18588482de
+                - 4addb209-e17f-44f8-a78b-e5c85778bd7e
         status: 200 OK
         code: 200
-        duration: 59.616989ms
+        duration: 27.312405ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -282,28 +282,28 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5aef25f5-7301-44b4-9e83-860066c6c9b0
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f
         method: PATCH
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 453
-        body: '{"id":"5aef25f5-7301-44b4-9e83-860066c6c9b0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-05-28T14:07:35.277739Z","updated_at":"2026-05-28T14:07:37.440803Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"547a210e-1b14-4d88-b602-a8ebfe1e0a1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-06-24T09:38:38.845335Z","updated_at":"2026-06-24T09:38:40.262601Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "453"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:37 GMT
+                - Wed, 24 Jun 2026 09:38:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 27958f48-bc0d-4186-a7ba-25f4c6df5b4d
+                - 4f1b394f-05b7-4128-ae30-34e60781784a
         status: 200 OK
         code: 200
-        duration: 120.335724ms
+        duration: 132.414248ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -314,28 +314,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5aef25f5-7301-44b4-9e83-860066c6c9b0
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 453
-        body: '{"id":"5aef25f5-7301-44b4-9e83-860066c6c9b0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-05-28T14:07:35.277739Z","updated_at":"2026-05-28T14:07:37.440803Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"547a210e-1b14-4d88-b602-a8ebfe1e0a1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-06-24T09:38:38.845335Z","updated_at":"2026-06-24T09:38:40.262601Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "453"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:37 GMT
+                - Wed, 24 Jun 2026 09:38:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 2b17977a-47b6-4c8e-91a6-ea40481d7da0
+                - 6551bf44-bc79-4edf-a2ac-cadf629ae82b
         status: 200 OK
         code: 200
-        duration: 49.302877ms
+        duration: 119.946035ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -349,7 +349,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5aef25f5-7301-44b4-9e83-860066c6c9b0/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -363,14 +363,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:37 GMT
+                - Wed, 24 Jun 2026 09:38:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 3cf7cb3d-c5d1-4bd6-b8de-e016886717f3
+                - d108e4ff-e3ce-4e51-be37-f345a0c8d73a
         status: 200 OK
         code: 200
-        duration: 43.688718ms
+        duration: 111.707848ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -381,28 +381,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5aef25f5-7301-44b4-9e83-860066c6c9b0
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 453
-        body: '{"id":"5aef25f5-7301-44b4-9e83-860066c6c9b0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-05-28T14:07:35.277739Z","updated_at":"2026-05-28T14:07:37.440803Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"547a210e-1b14-4d88-b602-a8ebfe1e0a1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-06-24T09:38:38.845335Z","updated_at":"2026-06-24T09:38:40.262601Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "453"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:37 GMT
+                - Wed, 24 Jun 2026 09:38:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 4a548481-b176-48e6-b185-4308b3355d7e
+                - 004381dd-c2be-46bb-86cf-6c9aedbe6855
         status: 200 OK
         code: 200
-        duration: 37.688418ms
+        duration: 17.227375ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -413,28 +413,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5aef25f5-7301-44b4-9e83-860066c6c9b0
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 453
-        body: '{"id":"5aef25f5-7301-44b4-9e83-860066c6c9b0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-05-28T14:07:35.277739Z","updated_at":"2026-05-28T14:07:37.440803Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"547a210e-1b14-4d88-b602-a8ebfe1e0a1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-06-24T09:38:38.845335Z","updated_at":"2026-06-24T09:38:40.262601Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "453"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:38 GMT
+                - Wed, 24 Jun 2026 09:38:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 407b527e-852c-4712-80f0-c777cb8a1a13
+                - 8a41d6b0-7c6a-4fcb-9e74-ff08c50d75bd
         status: 200 OK
         code: 200
-        duration: 35.776857ms
+        duration: 100.786794ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -448,7 +448,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5aef25f5-7301-44b4-9e83-860066c6c9b0/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -462,14 +462,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:38 GMT
+                - Wed, 24 Jun 2026 09:38:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - c3659c7c-da06-46de-b677-362528bbb29e
+                - 9ac886e3-2769-4153-9a74-13f052f300cd
         status: 200 OK
         code: 200
-        duration: 47.847871ms
+        duration: 68.740525ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -480,28 +480,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5aef25f5-7301-44b4-9e83-860066c6c9b0
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 453
-        body: '{"id":"5aef25f5-7301-44b4-9e83-860066c6c9b0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-05-28T14:07:35.277739Z","updated_at":"2026-05-28T14:07:37.440803Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"547a210e-1b14-4d88-b602-a8ebfe1e0a1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-06-24T09:38:38.845335Z","updated_at":"2026-06-24T09:38:40.262601Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "453"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:39 GMT
+                - Wed, 24 Jun 2026 09:38:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 0668b669-00ff-4e9b-b25b-faa4b59c4398
+                - 8946ce63-91f0-41f6-925a-aafda679fdd8
         status: 200 OK
         code: 200
-        duration: 51.265044ms
+        duration: 22.640401ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -515,7 +515,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5aef25f5-7301-44b4-9e83-860066c6c9b0/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -529,14 +529,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:39 GMT
+                - Wed, 24 Jun 2026 09:38:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 433ac350-fde7-4b46-99c1-c8da4621c429
+                - 47c54600-a88d-402d-97f6-d2cf69dc37f5
         status: 200 OK
         code: 200
-        duration: 51.139387ms
+        duration: 24.466595ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -547,28 +547,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5aef25f5-7301-44b4-9e83-860066c6c9b0
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 453
-        body: '{"id":"5aef25f5-7301-44b4-9e83-860066c6c9b0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-05-28T14:07:35.277739Z","updated_at":"2026-05-28T14:07:37.440803Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"547a210e-1b14-4d88-b602-a8ebfe1e0a1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-06-24T09:38:38.845335Z","updated_at":"2026-06-24T09:38:40.262601Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-path","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "453"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:39 GMT
+                - Wed, 24 Jun 2026 09:38:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 5ab38549-6b7e-4003-a6d8-910ed99f9eb0
+                - de19128c-85dd-4af7-80bd-e78213fa16f3
         status: 200 OK
         code: 200
-        duration: 34.899363ms
+        duration: 32.708349ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -582,7 +582,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5aef25f5-7301-44b4-9e83-860066c6c9b0/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -596,14 +596,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:39 GMT
+                - Wed, 24 Jun 2026 09:38:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - ded8dc3e-a678-4e50-b72c-e5ea8707f78d
+                - c2d7727f-d2f9-4c76-be59-e8d5bed48da5
         status: 200 OK
         code: 200
-        duration: 41.029597ms
+        duration: 22.225636ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -617,28 +617,28 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5aef25f5-7301-44b4-9e83-860066c6c9b0
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f
         method: PATCH
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 460
-        body: '{"id":"5aef25f5-7301-44b4-9e83-860066c6c9b0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-05-28T14:07:35.277739Z","updated_at":"2026-05-28T14:07:40.111080Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-path-change","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"547a210e-1b14-4d88-b602-a8ebfe1e0a1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-06-24T09:38:38.845335Z","updated_at":"2026-06-24T09:38:42.135617Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-path-change","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "460"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:40 GMT
+                - Wed, 24 Jun 2026 09:38:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 0e44d740-a828-4641-9ccd-9419499232e0
+                - 7fb1e0f0-8bb7-4964-b2f6-8d1040d3ff10
         status: 200 OK
         code: 200
-        duration: 108.382381ms
+        duration: 165.620713ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -649,28 +649,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5aef25f5-7301-44b4-9e83-860066c6c9b0
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 460
-        body: '{"id":"5aef25f5-7301-44b4-9e83-860066c6c9b0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-05-28T14:07:35.277739Z","updated_at":"2026-05-28T14:07:40.111080Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-path-change","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"547a210e-1b14-4d88-b602-a8ebfe1e0a1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-06-24T09:38:38.845335Z","updated_at":"2026-06-24T09:38:42.135617Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-path-change","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "460"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:40 GMT
+                - Wed, 24 Jun 2026 09:38:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 4456cdcb-9501-4e85-bccd-586a8465bccd
+                - 1fe29752-fbcb-4d62-8c24-b180924bb02c
         status: 200 OK
         code: 200
-        duration: 40.899905ms
+        duration: 36.26825ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -684,7 +684,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5aef25f5-7301-44b4-9e83-860066c6c9b0/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -698,14 +698,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:40 GMT
+                - Wed, 24 Jun 2026 09:38:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - c89cb5bf-208a-45de-a509-8d51e0397298
+                - 00827b84-66fc-47ab-b92e-9f51aae7930c
         status: 200 OK
         code: 200
-        duration: 31.493792ms
+        duration: 19.13737ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -716,28 +716,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5aef25f5-7301-44b4-9e83-860066c6c9b0
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 460
-        body: '{"id":"5aef25f5-7301-44b4-9e83-860066c6c9b0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-05-28T14:07:35.277739Z","updated_at":"2026-05-28T14:07:40.111080Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-path-change","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"547a210e-1b14-4d88-b602-a8ebfe1e0a1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-06-24T09:38:38.845335Z","updated_at":"2026-06-24T09:38:42.135617Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-path-change","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "460"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:40 GMT
+                - Wed, 24 Jun 2026 09:38:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 80f7ca59-7873-4c37-9b2b-823611c1341e
+                - 25849092-bc38-4394-86a0-d8dda89b8f1d
         status: 200 OK
         code: 200
-        duration: 51.751465ms
+        duration: 26.264895ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -748,28 +748,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5aef25f5-7301-44b4-9e83-860066c6c9b0
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 460
-        body: '{"id":"5aef25f5-7301-44b4-9e83-860066c6c9b0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-05-28T14:07:35.277739Z","updated_at":"2026-05-28T14:07:40.111080Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-path-change","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"547a210e-1b14-4d88-b602-a8ebfe1e0a1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-06-24T09:38:38.845335Z","updated_at":"2026-06-24T09:38:42.135617Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-path-change","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "460"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:40 GMT
+                - Wed, 24 Jun 2026 09:38:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 138b397c-ee80-42ec-aa31-38b578dd331c
+                - df58c789-e283-463a-b803-665841257bce
         status: 200 OK
         code: 200
-        duration: 49.444943ms
+        duration: 24.576907ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -783,7 +783,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5aef25f5-7301-44b4-9e83-860066c6c9b0/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -797,14 +797,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:40 GMT
+                - Wed, 24 Jun 2026 09:38:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 909a1310-7bca-4db8-ad07-42b3b004546a
+                - c74a68af-a0b6-4ac5-aadd-5d007df6c27a
         status: 200 OK
         code: 200
-        duration: 43.66224ms
+        duration: 23.26008ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -815,28 +815,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5aef25f5-7301-44b4-9e83-860066c6c9b0
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 460
-        body: '{"id":"5aef25f5-7301-44b4-9e83-860066c6c9b0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-05-28T14:07:35.277739Z","updated_at":"2026-05-28T14:07:40.111080Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-path-change","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"547a210e-1b14-4d88-b602-a8ebfe1e0a1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-06-24T09:38:38.845335Z","updated_at":"2026-06-24T09:38:42.135617Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/test-secret-path-change","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "460"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:41 GMT
+                - Wed, 24 Jun 2026 09:38:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - ca03c762-c047-4197-992f-0da8c1f8aacf
+                - c97e8933-13b7-4a66-be3b-42aa5454301d
         status: 200 OK
         code: 200
-        duration: 48.654714ms
+        duration: 28.41437ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -850,7 +850,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5aef25f5-7301-44b4-9e83-860066c6c9b0/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -864,14 +864,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:41 GMT
+                - Wed, 24 Jun 2026 09:38:42 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 2e1cf020-5ec9-44e3-aa67-0d62c4770520
+                - 5dcce2b4-a43b-4581-b6c4-bac34da14309
         status: 200 OK
         code: 200
-        duration: 34.905685ms
+        duration: 53.030171ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -885,28 +885,28 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5aef25f5-7301-44b4-9e83-860066c6c9b0
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f
         method: PATCH
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 437
-        body: '{"id":"5aef25f5-7301-44b4-9e83-860066c6c9b0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-05-28T14:07:35.277739Z","updated_at":"2026-05-28T14:07:41.595935Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"547a210e-1b14-4d88-b602-a8ebfe1e0a1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-06-24T09:38:38.845335Z","updated_at":"2026-06-24T09:38:43.009903Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "437"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:41 GMT
+                - Wed, 24 Jun 2026 09:38:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 4a1a6d6e-3fc7-40d7-a1e7-69be17e36b05
+                - 5d52d11f-9745-41f3-9170-9fce7489833d
         status: 200 OK
         code: 200
-        duration: 130.147118ms
+        duration: 77.532555ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -917,28 +917,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5aef25f5-7301-44b4-9e83-860066c6c9b0
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 437
-        body: '{"id":"5aef25f5-7301-44b4-9e83-860066c6c9b0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-05-28T14:07:35.277739Z","updated_at":"2026-05-28T14:07:41.595935Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"547a210e-1b14-4d88-b602-a8ebfe1e0a1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-06-24T09:38:38.845335Z","updated_at":"2026-06-24T09:38:43.009903Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "437"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:41 GMT
+                - Wed, 24 Jun 2026 09:38:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - e878e682-1b75-402e-870f-c736338abe1d
+                - b64fd64e-31dd-4137-b885-e94f589c31d3
         status: 200 OK
         code: 200
-        duration: 33.710436ms
+        duration: 19.826001ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -952,7 +952,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5aef25f5-7301-44b4-9e83-860066c6c9b0/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -966,14 +966,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:41 GMT
+                - Wed, 24 Jun 2026 09:38:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - aa43a73b-8ced-4187-bc7a-f3dc698d47d0
+                - 5be164cd-b54c-4d6f-8900-3064b9625901
         status: 200 OK
         code: 200
-        duration: 36.24811ms
+        duration: 36.568726ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -984,28 +984,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5aef25f5-7301-44b4-9e83-860066c6c9b0
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 437
-        body: '{"id":"5aef25f5-7301-44b4-9e83-860066c6c9b0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-05-28T14:07:35.277739Z","updated_at":"2026-05-28T14:07:41.595935Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"547a210e-1b14-4d88-b602-a8ebfe1e0a1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-06-24T09:38:38.845335Z","updated_at":"2026-06-24T09:38:43.009903Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "437"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:41 GMT
+                - Wed, 24 Jun 2026 09:38:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - cf8f39d2-aab2-41be-87c8-ff019cd6f334
+                - 7c2fdcf4-8a04-4976-bb9a-9d452609cb8c
         status: 200 OK
         code: 200
-        duration: 37.006981ms
+        duration: 26.984266ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1016,28 +1016,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5aef25f5-7301-44b4-9e83-860066c6c9b0
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 437
-        body: '{"id":"5aef25f5-7301-44b4-9e83-860066c6c9b0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-05-28T14:07:35.277739Z","updated_at":"2026-05-28T14:07:41.595935Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"547a210e-1b14-4d88-b602-a8ebfe1e0a1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-06-24T09:38:38.845335Z","updated_at":"2026-06-24T09:38:43.009903Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "437"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:42 GMT
+                - Wed, 24 Jun 2026 09:38:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 6c9614e2-f39d-48f0-9e26-e8195931f8e7
+                - b16c5ac4-5e2f-4097-a21b-38dde29f3c78
         status: 200 OK
         code: 200
-        duration: 43.285965ms
+        duration: 36.315461ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1051,7 +1051,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5aef25f5-7301-44b4-9e83-860066c6c9b0/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -1065,14 +1065,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:42 GMT
+                - Wed, 24 Jun 2026 09:38:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 8e677db5-bbb0-49c7-a198-2d5fd772acfc
+                - 55a1edb0-3fbb-42da-8f07-21b5e4695271
         status: 200 OK
         code: 200
-        duration: 29.705383ms
+        duration: 35.759142ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1083,7 +1083,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5aef25f5-7301-44b4-9e83-860066c6c9b0
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1095,14 +1095,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:42 GMT
+                - Wed, 24 Jun 2026 09:38:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - e70196d4-bca9-4e9c-9356-004255e84372
+                - 283e35cb-74d2-403c-85e4-418d6beb397c
         status: 204 No Content
         code: 204
-        duration: 57.848088ms
+        duration: 121.93439ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1113,25 +1113,25 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/5aef25f5-7301-44b4-9e83-860066c6c9b0
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/547a210e-1b14-4d88-b602-a8ebfe1e0a1f
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 462
-        body: '{"id":"5aef25f5-7301-44b4-9e83-860066c6c9b0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-05-28T14:07:35.277739Z","updated_at":"2026-05-28T14:07:41.595935Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-05-28T14:07:42.554975Z","key_id":null,"region":"fr-par"}'
+        body: '{"id":"547a210e-1b14-4d88-b602-a8ebfe1e0a1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-path-secret","status":"ready","created_at":"2026-06-24T09:38:38.845335Z","updated_at":"2026-06-24T09:38:43.796133Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-06-24T09:38:43.796133Z","key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "462"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:42 GMT
+                - Wed, 24 Jun 2026 09:38:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 3e8608ea-af87-4572-9331-a7837f3ce8f4
+                - 4e79eb75-bc5b-4fdb-9956-2fcc1919b715
         status: 200 OK
         code: 200
-        duration: 33.618203ms
+        duration: 23.642955ms

--- a/internal/services/secret/testdata/secret-protected.cassette.yaml
+++ b/internal/services/secret/testdata/secret-protected.cassette.yaml
@@ -21,21 +21,21 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 441
-        body: '{"id":"202ce4b4-eaa4-4325-b024-4c1ab144ac0a","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-protected-secret","status":"ready","created_at":"2026-05-28T14:07:35.305670Z","updated_at":"2026-05-28T14:07:35.305670Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":true,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"7bdd4085-74b0-4037-889b-bf3266488a97","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-protected-secret","status":"ready","created_at":"2026-06-24T09:38:38.782934Z","updated_at":"2026-06-24T09:38:38.782934Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":true,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "441"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:35 GMT
+                - Wed, 24 Jun 2026 09:38:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 8dd03d5b-3116-4b22-9c38-d2f64de3b980
+                - a64024a8-7e55-455e-9a11-064c4353474c
         status: 200 OK
         code: 200
-        duration: 245.344448ms
+        duration: 258.120426ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -46,28 +46,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/202ce4b4-eaa4-4325-b024-4c1ab144ac0a
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/7bdd4085-74b0-4037-889b-bf3266488a97
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 441
-        body: '{"id":"202ce4b4-eaa4-4325-b024-4c1ab144ac0a","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-protected-secret","status":"ready","created_at":"2026-05-28T14:07:35.305670Z","updated_at":"2026-05-28T14:07:35.305670Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":true,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"7bdd4085-74b0-4037-889b-bf3266488a97","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-protected-secret","status":"ready","created_at":"2026-06-24T09:38:38.782934Z","updated_at":"2026-06-24T09:38:38.782934Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":true,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "441"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:35 GMT
+                - Wed, 24 Jun 2026 09:38:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 32f4c4af-826d-4dc5-97e7-79918cd824b2
+                - 8624f0a6-f6ed-48a4-8d23-e51a0aaeb7f8
         status: 200 OK
         code: 200
-        duration: 76.704501ms
+        duration: 93.336829ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -81,7 +81,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/202ce4b4-eaa4-4325-b024-4c1ab144ac0a/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/7bdd4085-74b0-4037-889b-bf3266488a97/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -95,14 +95,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:35 GMT
+                - Wed, 24 Jun 2026 09:38:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - e743da48-6dec-4771-929a-5382bc590744
+                - 4b54c8ff-8cee-43bc-b155-67de83b1f6b3
         status: 200 OK
         code: 200
-        duration: 83.533825ms
+        duration: 109.473401ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -113,28 +113,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/202ce4b4-eaa4-4325-b024-4c1ab144ac0a
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/7bdd4085-74b0-4037-889b-bf3266488a97
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 441
-        body: '{"id":"202ce4b4-eaa4-4325-b024-4c1ab144ac0a","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-protected-secret","status":"ready","created_at":"2026-05-28T14:07:35.305670Z","updated_at":"2026-05-28T14:07:35.305670Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":true,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"7bdd4085-74b0-4037-889b-bf3266488a97","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-protected-secret","status":"ready","created_at":"2026-06-24T09:38:38.782934Z","updated_at":"2026-06-24T09:38:38.782934Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":true,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "441"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:35 GMT
+                - Wed, 24 Jun 2026 09:38:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - b8c60e16-d253-4d03-ac1d-7a2eedd592ee
+                - c9cc92f5-0e07-407a-a18f-a78a05c47d35
         status: 200 OK
         code: 200
-        duration: 55.125876ms
+        duration: 18.364547ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -145,28 +145,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/202ce4b4-eaa4-4325-b024-4c1ab144ac0a
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/7bdd4085-74b0-4037-889b-bf3266488a97
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 441
-        body: '{"id":"202ce4b4-eaa4-4325-b024-4c1ab144ac0a","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-protected-secret","status":"ready","created_at":"2026-05-28T14:07:35.305670Z","updated_at":"2026-05-28T14:07:35.305670Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":true,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"7bdd4085-74b0-4037-889b-bf3266488a97","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-protected-secret","status":"ready","created_at":"2026-06-24T09:38:38.782934Z","updated_at":"2026-06-24T09:38:38.782934Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":true,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "441"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:36 GMT
+                - Wed, 24 Jun 2026 09:38:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 607a7acb-0f70-42b9-934b-d99be61c8099
+                - 4404edeb-9a38-4fec-a386-22adabceb730
         status: 200 OK
         code: 200
-        duration: 35.137097ms
+        duration: 23.267154ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -180,7 +180,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/202ce4b4-eaa4-4325-b024-4c1ab144ac0a/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/7bdd4085-74b0-4037-889b-bf3266488a97/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -194,14 +194,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:36 GMT
+                - Wed, 24 Jun 2026 09:38:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 355fd6cb-8256-463b-b028-e49de42ef17e
+                - d1cc6843-1e2a-41e0-8304-2ebd143c392f
         status: 200 OK
         code: 200
-        duration: 32.03188ms
+        duration: 35.177326ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -212,28 +212,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/202ce4b4-eaa4-4325-b024-4c1ab144ac0a
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/7bdd4085-74b0-4037-889b-bf3266488a97
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 441
-        body: '{"id":"202ce4b4-eaa4-4325-b024-4c1ab144ac0a","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-protected-secret","status":"ready","created_at":"2026-05-28T14:07:35.305670Z","updated_at":"2026-05-28T14:07:35.305670Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":true,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"7bdd4085-74b0-4037-889b-bf3266488a97","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-protected-secret","status":"ready","created_at":"2026-06-24T09:38:38.782934Z","updated_at":"2026-06-24T09:38:38.782934Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":true,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "441"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:36 GMT
+                - Wed, 24 Jun 2026 09:38:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 29ab130b-8613-454b-948e-4b20a6f59850
+                - 773f1684-8aca-4845-a53f-0780332c7818
         status: 200 OK
         code: 200
-        duration: 44.038354ms
+        duration: 96.951455ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -247,7 +247,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/202ce4b4-eaa4-4325-b024-4c1ab144ac0a/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/7bdd4085-74b0-4037-889b-bf3266488a97/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -261,14 +261,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:36 GMT
+                - Wed, 24 Jun 2026 09:38:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - c17ea008-46d5-4d3c-96e2-e0b81833707e
+                - 35b35711-071e-484b-9e81-1c10456cfd00
         status: 200 OK
         code: 200
-        duration: 50.278314ms
+        duration: 25.861551ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -279,7 +279,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/202ce4b4-eaa4-4325-b024-4c1ab144ac0a
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/7bdd4085-74b0-4037-889b-bf3266488a97
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -293,14 +293,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:37 GMT
+                - Wed, 24 Jun 2026 09:38:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 91a8f483-6a06-4df8-a0e5-8798a575e5b0
+                - 72d924a0-2a39-4723-b13f-b845e2179266
         status: 412 Precondition Failed
         code: 412
-        duration: 76.49011ms
+        duration: 153.940131ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -311,28 +311,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/202ce4b4-eaa4-4325-b024-4c1ab144ac0a
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/7bdd4085-74b0-4037-889b-bf3266488a97
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 441
-        body: '{"id":"202ce4b4-eaa4-4325-b024-4c1ab144ac0a","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-protected-secret","status":"ready","created_at":"2026-05-28T14:07:35.305670Z","updated_at":"2026-05-28T14:07:35.305670Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":true,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"7bdd4085-74b0-4037-889b-bf3266488a97","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-protected-secret","status":"ready","created_at":"2026-06-24T09:38:38.782934Z","updated_at":"2026-06-24T09:38:38.782934Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":true,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "441"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:37 GMT
+                - Wed, 24 Jun 2026 09:38:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - fc06a395-18ab-4e8f-baea-875b09702af7
+                - b78d1858-6381-453b-b7c8-e481f1e1ea87
         status: 200 OK
         code: 200
-        duration: 49.829844ms
+        duration: 104.513614ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -346,7 +346,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/202ce4b4-eaa4-4325-b024-4c1ab144ac0a/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/7bdd4085-74b0-4037-889b-bf3266488a97/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -360,14 +360,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:37 GMT
+                - Wed, 24 Jun 2026 09:38:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - e0579848-fa95-47e3-83e8-2b175af3e09c
+                - 004b6300-c656-49ee-90e8-759588029dcf
         status: 200 OK
         code: 200
-        duration: 39.308934ms
+        duration: 21.949184ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -378,28 +378,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/202ce4b4-eaa4-4325-b024-4c1ab144ac0a
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/7bdd4085-74b0-4037-889b-bf3266488a97
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 441
-        body: '{"id":"202ce4b4-eaa4-4325-b024-4c1ab144ac0a","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-protected-secret","status":"ready","created_at":"2026-05-28T14:07:35.305670Z","updated_at":"2026-05-28T14:07:35.305670Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":true,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"7bdd4085-74b0-4037-889b-bf3266488a97","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-protected-secret","status":"ready","created_at":"2026-06-24T09:38:38.782934Z","updated_at":"2026-06-24T09:38:38.782934Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":true,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "441"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:38 GMT
+                - Wed, 24 Jun 2026 09:38:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 39571e93-a9d8-4f70-835d-f9deaa8387e8
+                - 428a8d57-8673-4eb3-a0a6-46f03740558f
         status: 200 OK
         code: 200
-        duration: 51.341205ms
+        duration: 19.017149ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -413,28 +413,28 @@ interactions:
                 - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/202ce4b4-eaa4-4325-b024-4c1ab144ac0a/unprotect
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/7bdd4085-74b0-4037-889b-bf3266488a97/unprotect
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 442
-        body: '{"id":"202ce4b4-eaa4-4325-b024-4c1ab144ac0a","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-protected-secret","status":"ready","created_at":"2026-05-28T14:07:35.305670Z","updated_at":"2026-05-28T14:07:35.305670Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"7bdd4085-74b0-4037-889b-bf3266488a97","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-protected-secret","status":"ready","created_at":"2026-06-24T09:38:38.782934Z","updated_at":"2026-06-24T09:38:38.782934Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "442"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:38 GMT
+                - Wed, 24 Jun 2026 09:38:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 3d6297d3-3de3-4441-bd71-6d1c656dbb94
+                - 5b19b3cc-8b88-48a7-9fb9-3aab790db0ab
         status: 200 OK
         code: 200
-        duration: 104.431768ms
+        duration: 122.84143ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -445,28 +445,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/202ce4b4-eaa4-4325-b024-4c1ab144ac0a
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/7bdd4085-74b0-4037-889b-bf3266488a97
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 442
-        body: '{"id":"202ce4b4-eaa4-4325-b024-4c1ab144ac0a","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-protected-secret","status":"ready","created_at":"2026-05-28T14:07:35.305670Z","updated_at":"2026-05-28T14:07:35.305670Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"7bdd4085-74b0-4037-889b-bf3266488a97","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-protected-secret","status":"ready","created_at":"2026-06-24T09:38:38.782934Z","updated_at":"2026-06-24T09:38:38.782934Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "442"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:38 GMT
+                - Wed, 24 Jun 2026 09:38:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 17482c3c-7cb3-4cf8-9098-56c03ff708b9
+                - 21e3c0fe-aa50-4a41-9a6e-65fc53977f99
         status: 200 OK
         code: 200
-        duration: 46.605723ms
+        duration: 37.836929ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -480,7 +480,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/202ce4b4-eaa4-4325-b024-4c1ab144ac0a/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/7bdd4085-74b0-4037-889b-bf3266488a97/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -494,14 +494,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:38 GMT
+                - Wed, 24 Jun 2026 09:38:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - e4435e36-5d36-4606-8052-9ca63d9dadd5
+                - de2c821d-5b6e-45ba-a271-0194e3f8d723
         status: 200 OK
         code: 200
-        duration: 38.405391ms
+        duration: 21.187654ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -512,28 +512,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/202ce4b4-eaa4-4325-b024-4c1ab144ac0a
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/7bdd4085-74b0-4037-889b-bf3266488a97
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 442
-        body: '{"id":"202ce4b4-eaa4-4325-b024-4c1ab144ac0a","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-protected-secret","status":"ready","created_at":"2026-05-28T14:07:35.305670Z","updated_at":"2026-05-28T14:07:35.305670Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"7bdd4085-74b0-4037-889b-bf3266488a97","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-protected-secret","status":"ready","created_at":"2026-06-24T09:38:38.782934Z","updated_at":"2026-06-24T09:38:38.782934Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "442"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:38 GMT
+                - Wed, 24 Jun 2026 09:38:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 11f40ddf-cc0f-4a1b-ac30-e0975aedc8a1
+                - 3d9d9d10-17b9-4e41-801d-d3fee5074f60
         status: 200 OK
         code: 200
-        duration: 34.435383ms
+        duration: 19.037298ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -544,28 +544,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/202ce4b4-eaa4-4325-b024-4c1ab144ac0a
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/7bdd4085-74b0-4037-889b-bf3266488a97
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 442
-        body: '{"id":"202ce4b4-eaa4-4325-b024-4c1ab144ac0a","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-protected-secret","status":"ready","created_at":"2026-05-28T14:07:35.305670Z","updated_at":"2026-05-28T14:07:35.305670Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        body: '{"id":"7bdd4085-74b0-4037-889b-bf3266488a97","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-protected-secret","status":"ready","created_at":"2026-06-24T09:38:38.782934Z","updated_at":"2026-06-24T09:38:38.782934Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "442"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:39 GMT
+                - Wed, 24 Jun 2026 09:38:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 84ce5191-345d-4ec6-bc9d-3b84aa4aab4f
+                - ecc5d61d-204e-4df1-9519-903cb90a7a2c
         status: 200 OK
         code: 200
-        duration: 29.934822ms
+        duration: 22.247938ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -579,7 +579,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/202ce4b4-eaa4-4325-b024-4c1ab144ac0a/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/7bdd4085-74b0-4037-889b-bf3266488a97/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -593,14 +593,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:39 GMT
+                - Wed, 24 Jun 2026 09:38:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - bfeb1ccb-58df-40d0-a15f-90df78bd3dcf
+                - 8c417051-2059-4ded-b8c9-ef8af5a800ef
         status: 200 OK
         code: 200
-        duration: 52.59213ms
+        duration: 115.120657ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -611,7 +611,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/202ce4b4-eaa4-4325-b024-4c1ab144ac0a
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/7bdd4085-74b0-4037-889b-bf3266488a97
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -623,14 +623,14 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:39 GMT
+                - Wed, 24 Jun 2026 09:38:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 0c099400-696d-4f82-a40a-05426d585717
+                - 6ab20f98-51d6-4e45-a8bb-7da7810df03c
         status: 204 No Content
         code: 204
-        duration: 66.476251ms
+        duration: 124.150112ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -641,25 +641,25 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/202ce4b4-eaa4-4325-b024-4c1ab144ac0a
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/7bdd4085-74b0-4037-889b-bf3266488a97
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 467
-        body: '{"id":"202ce4b4-eaa4-4325-b024-4c1ab144ac0a","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-protected-secret","status":"ready","created_at":"2026-05-28T14:07:35.305670Z","updated_at":"2026-05-28T14:07:35.305670Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-05-28T14:07:39.752715Z","key_id":null,"region":"fr-par"}'
+        body: '{"id":"7bdd4085-74b0-4037-889b-bf3266488a97","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-protected-secret","status":"ready","created_at":"2026-06-24T09:38:38.782934Z","updated_at":"2026-06-24T09:38:41.771276Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-06-24T09:38:41.771276Z","key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
                 - "467"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 28 May 2026 14:07:39 GMT
+                - Wed, 24 Jun 2026 09:38:41 GMT
             Server:
-                - Scaleway API Gateway (fr-par-1;edge01)
+                - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - f636c270-1cbb-48f6-9b16-cb8ff7815d91
+                - 47f19f71-c465-4380-8150-b83552f0e250
         status: 200 OK
         code: 200
-        duration: 39.973809ms
+        duration: 88.841524ms

--- a/internal/services/secret/testdata/secret-with-versions.cassette.yaml
+++ b/internal/services/secret/testdata/secret-with-versions.cassette.yaml
@@ -6,9 +6,9 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 248
+        content_length: 149
         host: api.scaleway.com
-        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-policy-secret","tags":null,"type":"opaque","path":"/","ephemeral_policy":{"time_to_live":"1800.000000000s","expires_once_accessed":false,"action":"disable"},"protected":false}'
+        body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-resource-versions","tags":null,"type":"opaque","path":"/","protected":false}'
         headers:
             Content-Type:
                 - application/json
@@ -20,11 +20,11 @@ interactions:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 508
-        body: '{"id":"1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-policy-secret","status":"ready","created_at":"2026-06-24T09:38:38.825020Z","updated_at":"2026-06-24T09:38:38.825020Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":{"time_to_live":"1800s","expires_once_accessed":false,"action":"disable"},"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        content_length: 443
+        body: '{"id":"3630efdd-2523-4b3f-9a52-5dc510686b2b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-resource-versions","status":"ready","created_at":"2026-06-24T09:38:38.806136Z","updated_at":"2026-06-24T09:38:38.806136Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "508"
+                - "443"
             Content-Type:
                 - application/json
             Date:
@@ -32,10 +32,10 @@ interactions:
             Server:
                 - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 10c6ba3d-b8b4-4d7f-afb8-20fccccae381
+                - cfa00fac-93db-490f-a525-d6b5b00d8459
         status: 200 OK
         code: 200
-        duration: 293.097658ms
+        duration: 270.306257ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -46,17 +46,17 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3630efdd-2523-4b3f-9a52-5dc510686b2b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 508
-        body: '{"id":"1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-policy-secret","status":"ready","created_at":"2026-06-24T09:38:38.825020Z","updated_at":"2026-06-24T09:38:38.825020Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":{"time_to_live":"1800s","expires_once_accessed":false,"action":"disable"},"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        content_length: 443
+        body: '{"id":"3630efdd-2523-4b3f-9a52-5dc510686b2b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-resource-versions","status":"ready","created_at":"2026-06-24T09:38:38.806136Z","updated_at":"2026-06-24T09:38:38.806136Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "508"
+                - "443"
             Content-Type:
                 - application/json
             Date:
@@ -64,10 +64,10 @@ interactions:
             Server:
                 - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 071d2d6f-589e-414c-a744-23dcae887071
+                - 625d7364-7812-4029-b76c-f27b71756f98
         status: 200 OK
         code: 200
-        duration: 88.599399ms
+        duration: 140.028779ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -81,7 +81,7 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3630efdd-2523-4b3f-9a52-5dc510686b2b/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
@@ -99,31 +99,34 @@ interactions:
             Server:
                 - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 2ddb2ca4-2481-4b85-9ff6-191afc5377c1
+                - 30e98660-5cb7-4637-8ddc-5b66c7308295
         status: 200 OK
         code: 200
-        duration: 131.939217ms
+        duration: 138.437826ms
     - id: 3
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 27
         host: api.scaleway.com
+        body: '{"data":"dmVyc2lvbi1kYXRh"}'
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436
-        method: GET
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3630efdd-2523-4b3f-9a52-5dc510686b2b/versions
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 508
-        body: '{"id":"1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-policy-secret","status":"ready","created_at":"2026-06-24T09:38:38.825020Z","updated_at":"2026-06-24T09:38:38.825020Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":{"time_to_live":"1800s","expires_once_accessed":false,"action":"disable"},"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        content_length: 294
+        body: '{"revision":1,"secret_id":"3630efdd-2523-4b3f-9a52-5dc510686b2b","status":"enabled","created_at":"2026-06-24T09:38:39.446382Z","updated_at":"2026-06-24T09:38:39.446382Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "508"
+                - "294"
             Content-Type:
                 - application/json
             Date:
@@ -131,10 +134,10 @@ interactions:
             Server:
                 - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 6f200806-5592-48db-9202-484497e63ddb
+                - fe57e7c3-d498-4801-953c-2b017591bef2
         status: 200 OK
         code: 200
-        duration: 21.526715ms
+        duration: 357.764967ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -145,17 +148,17 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3630efdd-2523-4b3f-9a52-5dc510686b2b/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 508
-        body: '{"id":"1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-policy-secret","status":"ready","created_at":"2026-06-24T09:38:38.825020Z","updated_at":"2026-06-24T09:38:38.825020Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":{"time_to_live":"1800s","expires_once_accessed":false,"action":"disable"},"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        content_length: 294
+        body: '{"revision":1,"secret_id":"3630efdd-2523-4b3f-9a52-5dc510686b2b","status":"enabled","created_at":"2026-06-24T09:38:39.446382Z","updated_at":"2026-06-24T09:38:39.446382Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "508"
+                - "294"
             Content-Type:
                 - application/json
             Date:
@@ -163,34 +166,34 @@ interactions:
             Server:
                 - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 533c742a-a8b8-4165-864e-366af7a44fef
+                - 8c26ecfd-4be9-48a5-8ce8-6b8d33ee770b
         status: 200 OK
         code: 200
-        duration: 26.562917ms
+        duration: 18.282379ms
     - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 39
         host: api.scaleway.com
-        form:
-            page:
-                - "1"
+        body: '{"data":"dXBkYXRlZC12ZXJzaW9uLWRhdGE="}'
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436/versions?page=1
-        method: GET
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3630efdd-2523-4b3f-9a52-5dc510686b2b/versions
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 31
-        body: '{"versions":[],"total_count":0}'
+        content_length: 294
+        body: '{"revision":2,"secret_id":"3630efdd-2523-4b3f-9a52-5dc510686b2b","status":"enabled","created_at":"2026-06-24T09:38:39.651671Z","updated_at":"2026-06-24T09:38:39.651671Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "31"
+                - "294"
             Content-Type:
                 - application/json
             Date:
@@ -198,10 +201,10 @@ interactions:
             Server:
                 - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 3a6cc7c2-c3d3-4916-849b-f5e5c0abd897
+                - aec9fdfc-40e5-40c9-988b-e9c37fc5ab3f
         status: 200 OK
         code: 200
-        duration: 30.784658ms
+        duration: 561.449505ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -212,17 +215,17 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3630efdd-2523-4b3f-9a52-5dc510686b2b/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 508
-        body: '{"id":"1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-policy-secret","status":"ready","created_at":"2026-06-24T09:38:38.825020Z","updated_at":"2026-06-24T09:38:38.825020Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":{"time_to_live":"1800s","expires_once_accessed":false,"action":"disable"},"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        content_length: 294
+        body: '{"revision":2,"secret_id":"3630efdd-2523-4b3f-9a52-5dc510686b2b","status":"enabled","created_at":"2026-06-24T09:38:39.651671Z","updated_at":"2026-06-24T09:38:39.651671Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "508"
+                - "294"
             Content-Type:
                 - application/json
             Date:
@@ -230,10 +233,10 @@ interactions:
             Server:
                 - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - f91cb815-d9f5-42d2-8ca1-5c54ea99c695
+                - c095db93-8a9f-4150-b988-3645f10e7f50
         status: 200 OK
         code: 200
-        duration: 18.529624ms
+        duration: 21.276564ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -241,23 +244,20 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: api.scaleway.com
-        form:
-            page:
-                - "1"
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3630efdd-2523-4b3f-9a52-5dc510686b2b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 31
-        body: '{"versions":[],"total_count":0}'
+        content_length: 443
+        body: '{"id":"3630efdd-2523-4b3f-9a52-5dc510686b2b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-resource-versions","status":"ready","created_at":"2026-06-24T09:38:38.806136Z","updated_at":"2026-06-24T09:38:38.806136Z","tags":[],"version_count":2,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "31"
+                - "443"
             Content-Type:
                 - application/json
             Date:
@@ -265,46 +265,11 @@ interactions:
             Server:
                 - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 41d3cd85-213f-4db8-8302-9e8a3c735fff
+                - 0dd4dfbd-a6d2-4ae2-8896-810530af1b34
         status: 200 OK
         code: 200
-        duration: 114.587674ms
+        duration: 100.486457ms
     - id: 8
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 103
-        host: api.scaleway.com
-        body: '{"ephemeral_policy":{"time_to_live":"18000.000000000s","expires_once_accessed":true,"action":"delete"}}'
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436
-        method: PATCH
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 507
-        body: '{"id":"1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-policy-secret","status":"ready","created_at":"2026-06-24T09:38:38.825020Z","updated_at":"2026-06-24T09:38:40.268544Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":{"time_to_live":"18000s","expires_once_accessed":true,"action":"delete"},"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
-        headers:
-            Content-Length:
-                - "507"
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 24 Jun 2026 09:38:40 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            X-Request-Id:
-                - 60156ea9-00da-4dd3-8e64-5b4cc84c3e67
-        status: 200 OK
-        code: 200
-        duration: 113.236652ms
-    - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -314,17 +279,17 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3630efdd-2523-4b3f-9a52-5dc510686b2b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 507
-        body: '{"id":"1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-policy-secret","status":"ready","created_at":"2026-06-24T09:38:38.825020Z","updated_at":"2026-06-24T09:38:40.268544Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":{"time_to_live":"18000s","expires_once_accessed":true,"action":"delete"},"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        content_length: 443
+        body: '{"id":"3630efdd-2523-4b3f-9a52-5dc510686b2b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-resource-versions","status":"ready","created_at":"2026-06-24T09:38:38.806136Z","updated_at":"2026-06-24T09:38:38.806136Z","tags":[],"version_count":2,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "507"
+                - "443"
             Content-Type:
                 - application/json
             Date:
@@ -332,11 +297,11 @@ interactions:
             Server:
                 - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - c531e017-c512-425c-9162-33678e39a1d9
+                - afcf8c15-12ca-4ab8-b71d-9a15a1407dd2
         status: 200 OK
         code: 200
-        duration: 117.959212ms
-    - id: 10
+        duration: 18.771488ms
+    - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -349,17 +314,17 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3630efdd-2523-4b3f-9a52-5dc510686b2b/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 31
-        body: '{"versions":[],"total_count":0}'
+        content_length: 621
+        body: '{"versions":[{"revision":2,"secret_id":"3630efdd-2523-4b3f-9a52-5dc510686b2b","status":"enabled","created_at":"2026-06-24T09:38:39.651671Z","updated_at":"2026-06-24T09:38:39.651671Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"3630efdd-2523-4b3f-9a52-5dc510686b2b","status":"enabled","created_at":"2026-06-24T09:38:39.446382Z","updated_at":"2026-06-24T09:38:39.446382Z","deleted_at":null,"description":"","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":2}'
         headers:
             Content-Length:
-                - "31"
+                - "621"
             Content-Type:
                 - application/json
             Date:
@@ -367,10 +332,42 @@ interactions:
             Server:
                 - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - d5ae0666-1aaa-4b47-b275-b7b36653cd4f
+                - 3c308f67-de26-4167-a4c6-0e7a3db9685f
         status: 200 OK
         code: 200
-        duration: 93.063003ms
+        duration: 120.950673ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3630efdd-2523-4b3f-9a52-5dc510686b2b/versions/1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 295
+        body: '{"revision":1,"secret_id":"3630efdd-2523-4b3f-9a52-5dc510686b2b","status":"enabled","created_at":"2026-06-24T09:38:39.446382Z","updated_at":"2026-06-24T09:38:39.446382Z","deleted_at":null,"description":"","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
+        headers:
+            Content-Length:
+                - "295"
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:40 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            X-Request-Id:
+                - e66aa54c-7031-4260-b323-1abc45577264
+        status: 200 OK
+        code: 200
+        duration: 23.768305ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -381,17 +378,17 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3630efdd-2523-4b3f-9a52-5dc510686b2b/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 507
-        body: '{"id":"1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-policy-secret","status":"ready","created_at":"2026-06-24T09:38:38.825020Z","updated_at":"2026-06-24T09:38:40.268544Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":{"time_to_live":"18000s","expires_once_accessed":true,"action":"delete"},"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        content_length: 294
+        body: '{"revision":2,"secret_id":"3630efdd-2523-4b3f-9a52-5dc510686b2b","status":"enabled","created_at":"2026-06-24T09:38:39.651671Z","updated_at":"2026-06-24T09:38:39.651671Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "507"
+                - "294"
             Content-Type:
                 - application/json
             Date:
@@ -399,10 +396,10 @@ interactions:
             Server:
                 - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - fd0c4dde-2dcf-4bbc-8b8e-bc26f7cadfbc
+                - d58d80f2-46dc-40d1-a5ff-a096bd6da8a7
         status: 200 OK
         code: 200
-        duration: 22.621615ms
+        duration: 91.67496ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -413,17 +410,17 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3630efdd-2523-4b3f-9a52-5dc510686b2b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 507
-        body: '{"id":"1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-policy-secret","status":"ready","created_at":"2026-06-24T09:38:38.825020Z","updated_at":"2026-06-24T09:38:40.268544Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":{"time_to_live":"18000s","expires_once_accessed":true,"action":"delete"},"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        content_length: 443
+        body: '{"id":"3630efdd-2523-4b3f-9a52-5dc510686b2b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-resource-versions","status":"ready","created_at":"2026-06-24T09:38:38.806136Z","updated_at":"2026-06-24T09:38:38.806136Z","tags":[],"version_count":2,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "507"
+                - "443"
             Content-Type:
                 - application/json
             Date:
@@ -431,10 +428,10 @@ interactions:
             Server:
                 - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - e397306e-2c98-4d96-b470-280ae44f13bc
+                - bc9a2b1a-d813-4639-862d-e881d9e734a3
         status: 200 OK
         code: 200
-        duration: 22.604973ms
+        duration: 21.465808ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -448,17 +445,17 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3630efdd-2523-4b3f-9a52-5dc510686b2b/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 31
-        body: '{"versions":[],"total_count":0}'
+        content_length: 621
+        body: '{"versions":[{"revision":2,"secret_id":"3630efdd-2523-4b3f-9a52-5dc510686b2b","status":"enabled","created_at":"2026-06-24T09:38:39.651671Z","updated_at":"2026-06-24T09:38:39.651671Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"3630efdd-2523-4b3f-9a52-5dc510686b2b","status":"enabled","created_at":"2026-06-24T09:38:39.446382Z","updated_at":"2026-06-24T09:38:39.446382Z","deleted_at":null,"description":"","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":2}'
         headers:
             Content-Length:
-                - "31"
+                - "621"
             Content-Type:
                 - application/json
             Date:
@@ -466,10 +463,10 @@ interactions:
             Server:
                 - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 43ec3eff-9408-43f4-a1a2-a6bc508a2690
+                - 205b2031-f191-4adc-a2d0-d680bc76ef78
         status: 200 OK
         code: 200
-        duration: 25.601894ms
+        duration: 26.010057ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -480,28 +477,28 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3630efdd-2523-4b3f-9a52-5dc510686b2b/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 507
-        body: '{"id":"1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-policy-secret","status":"ready","created_at":"2026-06-24T09:38:38.825020Z","updated_at":"2026-06-24T09:38:40.268544Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":{"time_to_live":"18000s","expires_once_accessed":true,"action":"delete"},"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        content_length: 294
+        body: '{"revision":2,"secret_id":"3630efdd-2523-4b3f-9a52-5dc510686b2b","status":"enabled","created_at":"2026-06-24T09:38:39.651671Z","updated_at":"2026-06-24T09:38:39.651671Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "507"
+                - "294"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:41 GMT
+                - Wed, 24 Jun 2026 09:38:40 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - f8b37acd-49ea-41ef-841a-8db52cc6fc4b
+                - 0ea0cae7-bd96-48ae-99c4-edf06657c0ef
         status: 200 OK
         code: 200
-        duration: 15.437079ms
+        duration: 17.192427ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -509,69 +506,63 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: api.scaleway.com
-        form:
-            page:
-                - "1"
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3630efdd-2523-4b3f-9a52-5dc510686b2b/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 31
-        body: '{"versions":[],"total_count":0}'
+        content_length: 295
+        body: '{"revision":1,"secret_id":"3630efdd-2523-4b3f-9a52-5dc510686b2b","status":"enabled","created_at":"2026-06-24T09:38:39.446382Z","updated_at":"2026-06-24T09:38:39.446382Z","deleted_at":null,"description":"","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "31"
+                - "295"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:41 GMT
+                - Wed, 24 Jun 2026 09:38:40 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - e9cc5893-b64f-45df-87d1-a79780eb232b
+                - ab7c1854-7ab6-4638-8f05-e376720b5484
         status: 200 OK
         code: 200
-        duration: 21.980435ms
+        duration: 23.065897ms
     - id: 16
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 89
+        content_length: 0
         host: api.scaleway.com
-        body: '{"ephemeral_policy":{"time_to_live":null,"expires_once_accessed":true,"action":"delete"}}'
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436
-        method: PATCH
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3630efdd-2523-4b3f-9a52-5dc510686b2b
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 503
-        body: '{"id":"1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-policy-secret","status":"ready","created_at":"2026-06-24T09:38:38.825020Z","updated_at":"2026-06-24T09:38:41.500550Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":{"time_to_live":null,"expires_once_accessed":true,"action":"delete"},"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        content_length: 443
+        body: '{"id":"3630efdd-2523-4b3f-9a52-5dc510686b2b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-resource-versions","status":"ready","created_at":"2026-06-24T09:38:38.806136Z","updated_at":"2026-06-24T09:38:38.806136Z","tags":[],"version_count":2,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "503"
+                - "443"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:41 GMT
+                - Wed, 24 Jun 2026 09:38:40 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 39b31aa7-b46c-4aaa-87e7-8791886d2cc1
+                - dd935dd6-dc76-4e0c-bb10-0eb98be2da17
         status: 200 OK
         code: 200
-        duration: 105.169843ms
+        duration: 31.376083ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -582,17 +573,17 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3630efdd-2523-4b3f-9a52-5dc510686b2b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 503
-        body: '{"id":"1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-policy-secret","status":"ready","created_at":"2026-06-24T09:38:38.825020Z","updated_at":"2026-06-24T09:38:41.500550Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":{"time_to_live":null,"expires_once_accessed":true,"action":"delete"},"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        content_length: 443
+        body: '{"id":"3630efdd-2523-4b3f-9a52-5dc510686b2b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-resource-versions","status":"ready","created_at":"2026-06-24T09:38:38.806136Z","updated_at":"2026-06-24T09:38:38.806136Z","tags":[],"version_count":2,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "503"
+                - "443"
             Content-Type:
                 - application/json
             Date:
@@ -600,10 +591,10 @@ interactions:
             Server:
                 - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - ecfbe72f-db67-4d5f-a3f2-68e928870c89
+                - c5e942b4-30a2-4155-abbe-5cf2cf0ec8b0
         status: 200 OK
         code: 200
-        duration: 34.809661ms
+        duration: 17.195605ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -617,17 +608,17 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436/versions?page=1
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3630efdd-2523-4b3f-9a52-5dc510686b2b/versions?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 31
-        body: '{"versions":[],"total_count":0}'
+        content_length: 621
+        body: '{"versions":[{"revision":2,"secret_id":"3630efdd-2523-4b3f-9a52-5dc510686b2b","status":"enabled","created_at":"2026-06-24T09:38:39.651671Z","updated_at":"2026-06-24T09:38:39.651671Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"},{"revision":1,"secret_id":"3630efdd-2523-4b3f-9a52-5dc510686b2b","status":"enabled","created_at":"2026-06-24T09:38:39.446382Z","updated_at":"2026-06-24T09:38:39.446382Z","deleted_at":null,"description":"","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}],"total_count":2}'
         headers:
             Content-Length:
-                - "31"
+                - "621"
             Content-Type:
                 - application/json
             Date:
@@ -635,10 +626,10 @@ interactions:
             Server:
                 - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 7e964d38-9440-44ce-8513-25e24636b423
+                - febb86e3-04ff-4acb-99b4-158441d046cc
         status: 200 OK
         code: 200
-        duration: 29.957781ms
+        duration: 24.858367ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -649,17 +640,17 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3630efdd-2523-4b3f-9a52-5dc510686b2b/versions/2
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 503
-        body: '{"id":"1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-policy-secret","status":"ready","created_at":"2026-06-24T09:38:38.825020Z","updated_at":"2026-06-24T09:38:41.500550Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":{"time_to_live":null,"expires_once_accessed":true,"action":"delete"},"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        content_length: 294
+        body: '{"revision":2,"secret_id":"3630efdd-2523-4b3f-9a52-5dc510686b2b","status":"enabled","created_at":"2026-06-24T09:38:39.651671Z","updated_at":"2026-06-24T09:38:39.651671Z","deleted_at":null,"description":"","latest":true,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "503"
+                - "294"
             Content-Type:
                 - application/json
             Date:
@@ -667,10 +658,10 @@ interactions:
             Server:
                 - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 5234301d-3f3f-4631-92bd-7f099874c495
+                - 2882240c-0179-48d0-9fa0-fed569c21379
         status: 200 OK
         code: 200
-        duration: 21.2955ms
+        duration: 16.14045ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -681,17 +672,17 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3630efdd-2523-4b3f-9a52-5dc510686b2b/versions/1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 503
-        body: '{"id":"1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-policy-secret","status":"ready","created_at":"2026-06-24T09:38:38.825020Z","updated_at":"2026-06-24T09:38:41.500550Z","tags":[],"version_count":0,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":{"time_to_live":null,"expires_once_accessed":true,"action":"delete"},"used_by":[],"deletion_requested_at":null,"key_id":null,"region":"fr-par"}'
+        content_length: 295
+        body: '{"revision":1,"secret_id":"3630efdd-2523-4b3f-9a52-5dc510686b2b","status":"enabled","created_at":"2026-06-24T09:38:39.446382Z","updated_at":"2026-06-24T09:38:39.446382Z","deleted_at":null,"description":"","latest":false,"ephemeral_properties":null,"deletion_requested_at":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "503"
+                - "295"
             Content-Type:
                 - application/json
             Date:
@@ -699,10 +690,10 @@ interactions:
             Server:
                 - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 4f08b957-f2f0-44e3-b910-b9bc12e9cc08
+                - 0e53ea1f-78cd-4324-b0c5-98cbf614e605
         status: 200 OK
         code: 200
-        duration: 29.989763ms
+        duration: 22.781171ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -710,45 +701,10 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: api.scaleway.com
-        form:
-            page:
-                - "1"
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436/versions?page=1
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 31
-        body: '{"versions":[],"total_count":0}'
-        headers:
-            Content-Length:
-                - "31"
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 24 Jun 2026 09:38:42 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-3;edge02)
-            X-Request-Id:
-                - cf46978b-5ebd-4667-af7b-7d1a1defc016
-        status: 200 OK
-        code: 200
-        duration: 24.176619ms
-    - id: 22
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3630efdd-2523-4b3f-9a52-5dc510686b2b/versions/2
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -760,14 +716,44 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:42 GMT
+                - Wed, 24 Jun 2026 09:38:41 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 3dd56b6a-65f0-43c5-b096-593d5f2f40b6
+                - 27fce0c3-a678-4531-82f2-55d483b8e5db
         status: 204 No Content
         code: 204
-        duration: 57.20958ms
+        duration: 122.447004ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3630efdd-2523-4b3f-9a52-5dc510686b2b/versions/1
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:41 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            X-Request-Id:
+                - a8053a3e-0036-4994-b6d1-52f557ffe331
+        status: 204 No Content
+        code: 204
+        duration: 207.101814ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -778,25 +764,55 @@ interactions:
         headers:
             User-Agent:
                 - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
-        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3630efdd-2523-4b3f-9a52-5dc510686b2b
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Jun 2026 09:38:41 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-3;edge02)
+            X-Request-Id:
+                - 04d63212-2474-43bd-99f0-50a385f1fce5
+        status: 204 No Content
+        code: 204
+        duration: 41.87123ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.26.1; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/secret-manager/v1beta1/regions/fr-par/secrets/3630efdd-2523-4b3f-9a52-5dc510686b2b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 127
-        body: '{"message":"resource is not found","resource":"secret","resource_id":"1ae09ddb-a0f8-4f2c-8824-3ad9d39b3436","type":"not_found"}'
+        content_length: 468
+        body: '{"id":"3630efdd-2523-4b3f-9a52-5dc510686b2b","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-secret-resource-versions","status":"ready","created_at":"2026-06-24T09:38:38.806136Z","updated_at":"2026-06-24T09:38:41.890014Z","tags":[],"version_count":2,"description":"","managed":false,"type":"opaque","protected":false,"path":"/","ephemeral_policy":null,"used_by":[],"deletion_requested_at":"2026-06-24T09:38:41.890014Z","key_id":null,"region":"fr-par"}'
         headers:
             Content-Length:
-                - "127"
+                - "468"
             Content-Type:
                 - application/json
             Date:
-                - Wed, 24 Jun 2026 09:38:42 GMT
+                - Wed, 24 Jun 2026 09:38:41 GMT
             Server:
                 - Scaleway API Gateway (fr-par-3;edge02)
             X-Request-Id:
-                - 1ec913cb-6188-48df-939f-10f8b37e14b7
-        status: 404 Not Found
-        code: 404
-        duration: 21.713373ms
+                - 0b4a3833-1723-4ef4-838a-94860289d658
+        status: 200 OK
+        code: 200
+        duration: 26.23593ms


### PR DESCRIPTION
https://github.com/scaleway/terraform-provider-scaleway/issues/4125

Fix regression introduced by [this PR](https://github.com/scaleway/terraform-provider-scaleway/pull/4034/changes#diff-10be07124e5332a60323e408bea22a074d36cc11809ac54fec2d3bdfef2d1d18) which omitted populating versions and version_count in the setState func.