### PR TITLE
test(acctest): wait for IAM propagation in cockpit and RDB tests

### DIFF
--- a/internal/acctest/iam.go
+++ b/internal/acctest/iam.go
@@ -1,0 +1,63 @@
+package acctest
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/httperrors"
+)
+
+// iamPropagationBackoff waits up to ~62s to outlive IAM's ~60s permission cache.
+var iamPropagationBackoff = []time.Duration{
+	2 * time.Second,
+	4 * time.Second,
+	8 * time.Second,
+	16 * time.Second,
+	32 * time.Second,
+}
+
+// WaitForProjectIAM retries probe until it succeeds or a non-403 error is returned.
+// probe should perform the same API call that fails transiently while IAM permissions propagate.
+func WaitForProjectIAM(ctx context.Context, probe func(context.Context) error) error {
+	var lastErr error
+
+	for i, wait := range iamPropagationBackoff {
+		lastErr = probe(ctx)
+		if lastErr == nil {
+			return nil
+		}
+
+		if !httperrors.Is403(lastErr) {
+			return fmt.Errorf("waiting for IAM permissions: %w", lastErr)
+		}
+
+		if i == len(iamPropagationBackoff)-1 {
+			break
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(wait):
+		}
+	}
+
+	return fmt.Errorf("IAM permissions not propagated after retries: %w", lastErr)
+}
+
+// StoreResourceID saves a resource ID from state into id for use in later test steps.
+func StoreResourceID(resourceName string, id *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", resourceName)
+		}
+
+		*id = rs.Primary.ID
+
+		return nil
+	}
+}

--- a/internal/acctest/iam_probes.go
+++ b/internal/acctest/iam_probes.go
@@ -1,0 +1,109 @@
+package acctest
+
+import (
+	"context"
+	"fmt"
+
+	cockpitSDK "github.com/scaleway/scaleway-sdk-go/api/cockpit/v1"
+	rdbSDK "github.com/scaleway/scaleway-sdk-go/api/rdb/v1"
+	"github.com/scaleway/scaleway-sdk-go/scw"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/locality/regional"
+)
+
+// CockpitReadProbe checks that cockpit read permissions are available on projectID.
+func CockpitReadProbe(tt *TestTools, projectID string, region scw.Region) func(context.Context) error {
+	return func(ctx context.Context) error {
+		api := cockpitSDK.NewRegionalAPI(tt.Meta.ScwClient())
+
+		_, err := api.ListDataSources(&cockpitSDK.RegionalAPIListDataSourcesRequest{
+			Region:    region,
+			ProjectID: projectID,
+		}, scw.WithContext(ctx))
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+}
+
+// RDBReadProjectProbe checks that RDB list permissions are available on projectID.
+func RDBReadProjectProbe(tt *TestTools, projectID string, region scw.Region) func(context.Context) error {
+	return func(ctx context.Context) error {
+		api := rdbSDK.NewAPI(tt.Meta.ScwClient())
+
+		_, err := api.ListInstances(&rdbSDK.ListInstancesRequest{
+			Region:    region,
+			ProjectID: &projectID,
+		}, scw.WithContext(ctx))
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+}
+
+// RDBReadInstanceProbe checks that RDB read permissions are available on a created instance.
+func RDBReadInstanceProbe(tt *TestTools, regionalInstanceID string) func(context.Context) error {
+	return func(ctx context.Context) error {
+		region, instanceID, err := regional.ParseID(regionalInstanceID)
+		if err != nil {
+			return fmt.Errorf("parse instance id: %w", err)
+		}
+
+		api := rdbSDK.NewAPI(tt.Meta.ScwClient())
+
+		_, err = api.GetInstance(&rdbSDK.GetInstanceRequest{
+			Region:     region,
+			InstanceID: instanceID,
+		}, scw.WithContext(ctx))
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+}
+
+// PreCheckWaitForCockpitIAM waits for cockpit read permissions before creating cockpit resources.
+func PreCheckWaitForCockpitIAM(tt *TestTools, projectID string) func() {
+	return func() {
+		if projectID == "" {
+			tt.T.Fatal("projectID is empty: use StoreResourceID in the previous test step")
+		}
+
+		err := WaitForProjectIAM(tt.T.Context(), CockpitReadProbe(tt, projectID, scw.RegionFrPar))
+		if err != nil {
+			tt.T.Fatalf("wait for cockpit IAM on project %s: %v", projectID, err)
+		}
+	}
+}
+
+// PreCheckWaitForRDBProjectIAM waits for RDB list permissions on a new project.
+func PreCheckWaitForRDBProjectIAM(tt *TestTools, projectID string) func() {
+	return func() {
+		if projectID == "" {
+			tt.T.Fatal("projectID is empty: use StoreResourceID in the previous test step")
+		}
+
+		err := WaitForProjectIAM(tt.T.Context(), RDBReadProjectProbe(tt, projectID, scw.RegionFrPar))
+		if err != nil {
+			tt.T.Fatalf("wait for RDB IAM on project %s: %v", projectID, err)
+		}
+	}
+}
+
+// PreCheckWaitForRDBInstanceIAM waits for RDB read permissions on a created instance.
+func PreCheckWaitForRDBInstanceIAM(tt *TestTools, regionalInstanceID string) func() {
+	return func() {
+		if regionalInstanceID == "" {
+			tt.T.Fatal("instanceID is empty: use StoreResourceID in the previous test step")
+		}
+
+		err := WaitForProjectIAM(tt.T.Context(), RDBReadInstanceProbe(tt, regionalInstanceID))
+		if err != nil {
+			tt.T.Fatalf("wait for RDB IAM on instance %s: %v", regionalInstanceID, err)
+		}
+	}
+}

--- a/internal/acctest/iam_probes.go
+++ b/internal/acctest/iam_probes.go
@@ -67,43 +67,43 @@ func RDBReadInstanceProbe(tt *TestTools, regionalInstanceID string) func(context
 }
 
 // PreCheckWaitForCockpitIAM waits for cockpit read permissions before creating cockpit resources.
-func PreCheckWaitForCockpitIAM(tt *TestTools, projectID string) func() {
+func PreCheckWaitForCockpitIAM(tt *TestTools, projectID *string) func() {
 	return func() {
-		if projectID == "" {
+		if projectID == nil || *projectID == "" {
 			tt.T.Fatal("projectID is empty: use StoreResourceID in the previous test step")
 		}
 
-		err := WaitForProjectIAM(tt.T.Context(), CockpitReadProbe(tt, projectID, scw.RegionFrPar))
+		err := WaitForProjectIAM(tt.T.Context(), CockpitReadProbe(tt, *projectID, scw.RegionFrPar))
 		if err != nil {
-			tt.T.Fatalf("wait for cockpit IAM on project %s: %v", projectID, err)
+			tt.T.Fatalf("wait for cockpit IAM on project %s: %v", *projectID, err)
 		}
 	}
 }
 
 // PreCheckWaitForRDBProjectIAM waits for RDB list permissions on a new project.
-func PreCheckWaitForRDBProjectIAM(tt *TestTools, projectID string) func() {
+func PreCheckWaitForRDBProjectIAM(tt *TestTools, projectID *string) func() {
 	return func() {
-		if projectID == "" {
+		if projectID == nil || *projectID == "" {
 			tt.T.Fatal("projectID is empty: use StoreResourceID in the previous test step")
 		}
 
-		err := WaitForProjectIAM(tt.T.Context(), RDBReadProjectProbe(tt, projectID, scw.RegionFrPar))
+		err := WaitForProjectIAM(tt.T.Context(), RDBReadProjectProbe(tt, *projectID, scw.RegionFrPar))
 		if err != nil {
-			tt.T.Fatalf("wait for RDB IAM on project %s: %v", projectID, err)
+			tt.T.Fatalf("wait for RDB IAM on project %s: %v", *projectID, err)
 		}
 	}
 }
 
 // PreCheckWaitForRDBInstanceIAM waits for RDB read permissions on a created instance.
-func PreCheckWaitForRDBInstanceIAM(tt *TestTools, regionalInstanceID string) func() {
+func PreCheckWaitForRDBInstanceIAM(tt *TestTools, regionalInstanceID *string) func() {
 	return func() {
-		if regionalInstanceID == "" {
+		if regionalInstanceID == nil || *regionalInstanceID == "" {
 			tt.T.Fatal("instanceID is empty: use StoreResourceID in the previous test step")
 		}
 
-		err := WaitForProjectIAM(tt.T.Context(), RDBReadInstanceProbe(tt, regionalInstanceID))
+		err := WaitForProjectIAM(tt.T.Context(), RDBReadInstanceProbe(tt, *regionalInstanceID))
 		if err != nil {
-			tt.T.Fatalf("wait for RDB IAM on instance %s: %v", regionalInstanceID, err)
+			tt.T.Fatalf("wait for RDB IAM on instance %s: %v", *regionalInstanceID, err)
 		}
 	}
 }

--- a/internal/acctest/iam_test.go
+++ b/internal/acctest/iam_test.go
@@ -1,0 +1,81 @@
+package acctest_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/scaleway/scaleway-sdk-go/scw"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/acctest"
+)
+
+func TestWaitForProjectIAM(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	t.Run("succeeds after transient 403", func(t *testing.T) {
+		t.Parallel()
+
+		calls := 0
+
+		err := acctest.WaitForProjectIAM(ctx, func(context.Context) error {
+			calls++
+			if calls < 3 {
+				return &scw.ResponseError{StatusCode: http.StatusForbidden}
+			}
+
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		if calls != 3 {
+			t.Fatalf("expected 3 calls, got %d", calls)
+		}
+	})
+
+	t.Run("succeeds after permissions_denied", func(t *testing.T) {
+		t.Parallel()
+
+		calls := 0
+
+		err := acctest.WaitForProjectIAM(ctx, func(context.Context) error {
+			calls++
+			if calls < 2 {
+				return &scw.PermissionsDeniedError{}
+			}
+
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		if calls != 2 {
+			t.Fatalf("expected 2 calls, got %d", calls)
+		}
+	})
+
+	t.Run("returns non-403 error immediately", func(t *testing.T) {
+		t.Parallel()
+
+		calls := 0
+		expected := errors.New("boom")
+
+		err := acctest.WaitForProjectIAM(ctx, func(context.Context) error {
+			calls++
+
+			return expected
+		})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+
+		if calls != 1 {
+			t.Fatalf("expected 1 call, got %d", calls)
+		}
+	})
+}

--- a/internal/services/cockpit/cockpit_test.go
+++ b/internal/services/cockpit/cockpit_test.go
@@ -46,11 +46,22 @@ func TestAccCockpit_Basic(t *testing.T) {
 	tt := acctest.NewTestTools(t)
 	defer tt.Cleanup()
 
+	var projectID string
+
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: tt.ProviderFactories,
 		CheckDestroy:             isCockpitDestroyed(tt),
 		Steps: []resource.TestStep{
 			{
+				Config: `
+					resource "scaleway_account_project" "project" {
+						name = "tf_tests_cockpit_project_basic"
+				  	}
+				`,
+				Check: acctest.StoreResourceID("scaleway_account_project.project", &projectID),
+			},
+			{
+				PreConfig: acctest.PreCheckWaitForCockpitIAM(tt, projectID),
 				Config: `
 					resource "scaleway_account_project" "project" {
 						name = "tf_tests_cockpit_project_basic"

--- a/internal/services/cockpit/cockpit_test.go
+++ b/internal/services/cockpit/cockpit_test.go
@@ -61,7 +61,7 @@ func TestAccCockpit_Basic(t *testing.T) {
 				Check: acctest.StoreResourceID("scaleway_account_project.project", &projectID),
 			},
 			{
-				PreConfig: acctest.PreCheckWaitForCockpitIAM(tt, projectID),
+				PreConfig: acctest.PreCheckWaitForCockpitIAM(tt, &projectID),
 				Config: `
 					resource "scaleway_account_project" "project" {
 						name = "tf_tests_cockpit_project_basic"

--- a/internal/services/cockpit/source_test.go
+++ b/internal/services/cockpit/source_test.go
@@ -36,7 +36,7 @@ func TestAccCockpitSource_Basic_metrics(t *testing.T) {
 				Check: acctest.StoreResourceID("scaleway_account_project.project", &projectID),
 			},
 			{
-				PreConfig: acctest.PreCheckWaitForCockpitIAM(tt, projectID),
+				PreConfig: acctest.PreCheckWaitForCockpitIAM(tt, &projectID),
 				Config: `
 					resource "scaleway_account_project" "project" {
 						name = "tf_tests_cockpit_datasource_basic"
@@ -87,7 +87,7 @@ func TestAccCockpitSource_Basic_logs(t *testing.T) {
 				Check: acctest.StoreResourceID("scaleway_account_project.project", &projectID),
 			},
 			{
-				PreConfig: acctest.PreCheckWaitForCockpitIAM(tt, projectID),
+				PreConfig: acctest.PreCheckWaitForCockpitIAM(tt, &projectID),
 				Config: `
 					resource "scaleway_account_project" "project" {
 						name = "tf_tests_cockpit_datasource_basic"
@@ -138,7 +138,7 @@ func TestAccCockpitSource_retention_days(t *testing.T) {
 				Check: acctest.StoreResourceID("scaleway_account_project.project", &projectID),
 			},
 			{
-				PreConfig: acctest.PreCheckWaitForCockpitIAM(tt, projectID),
+				PreConfig: acctest.PreCheckWaitForCockpitIAM(tt, &projectID),
 				Config: `
 					resource "scaleway_account_project" "project" {
 						name = "tf_tests_cockpit_datasource_basic"

--- a/internal/services/cockpit/source_test.go
+++ b/internal/services/cockpit/source_test.go
@@ -21,11 +21,22 @@ func TestAccCockpitSource_Basic_metrics(t *testing.T) {
 	tt := acctest.NewTestTools(t)
 	defer tt.Cleanup()
 
+	var projectID string
+
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: tt.ProviderFactories,
 		CheckDestroy:             isSourceDestroyed(tt),
 		Steps: []resource.TestStep{
 			{
+				Config: `
+					resource "scaleway_account_project" "project" {
+						name = "tf_tests_cockpit_datasource_basic"
+				  	}
+				`,
+				Check: acctest.StoreResourceID("scaleway_account_project.project", &projectID),
+			},
+			{
+				PreConfig: acctest.PreCheckWaitForCockpitIAM(tt, projectID),
 				Config: `
 					resource "scaleway_account_project" "project" {
 						name = "tf_tests_cockpit_datasource_basic"
@@ -61,11 +72,22 @@ func TestAccCockpitSource_Basic_logs(t *testing.T) {
 	tt := acctest.NewTestTools(t)
 	defer tt.Cleanup()
 
+	var projectID string
+
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: tt.ProviderFactories,
 		CheckDestroy:             isSourceDestroyed(tt),
 		Steps: []resource.TestStep{
 			{
+				Config: `
+					resource "scaleway_account_project" "project" {
+						name = "tf_tests_cockpit_datasource_basic"
+				  	}
+				`,
+				Check: acctest.StoreResourceID("scaleway_account_project.project", &projectID),
+			},
+			{
+				PreConfig: acctest.PreCheckWaitForCockpitIAM(tt, projectID),
 				Config: `
 					resource "scaleway_account_project" "project" {
 						name = "tf_tests_cockpit_datasource_basic"
@@ -101,11 +123,22 @@ func TestAccCockpitSource_retention_days(t *testing.T) {
 	tt := acctest.NewTestTools(t)
 	defer tt.Cleanup()
 
+	var projectID string
+
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: tt.ProviderFactories,
 		CheckDestroy:             isSourceDestroyed(tt),
 		Steps: []resource.TestStep{
 			{
+				Config: `
+					resource "scaleway_account_project" "project" {
+						name = "tf_tests_cockpit_datasource_basic"
+				  	}
+				`,
+				Check: acctest.StoreResourceID("scaleway_account_project.project", &projectID),
+			},
+			{
+				PreConfig: acctest.PreCheckWaitForCockpitIAM(tt, projectID),
 				Config: `
 					resource "scaleway_account_project" "project" {
 						name = "tf_tests_cockpit_datasource_basic"

--- a/internal/services/cockpit/token_test.go
+++ b/internal/services/cockpit/token_test.go
@@ -34,7 +34,7 @@ func TestAccToken_Basic(t *testing.T) {
 				Check: acctest.StoreResourceID("scaleway_account_project.project", &projectID),
 			},
 			{
-				PreConfig: acctest.PreCheckWaitForCockpitIAM(tt, projectID),
+				PreConfig: acctest.PreCheckWaitForCockpitIAM(tt, &projectID),
 				Config: fmt.Sprintf(`
 					resource "scaleway_account_project" "project" {
 						name = "%[1]s"

--- a/internal/services/cockpit/token_test.go
+++ b/internal/services/cockpit/token_test.go
@@ -19,11 +19,22 @@ func TestAccToken_Basic(t *testing.T) {
 	projectName := "tf_tests_cockpit_token_basic"
 	tokenName := projectName
 
+	var projectID string
+
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: tt.ProviderFactories,
 		CheckDestroy:             isTokenDestroyed(tt),
 		Steps: []resource.TestStep{
 			{
+				Config: fmt.Sprintf(`
+					resource "scaleway_account_project" "project" {
+						name = "%[1]s"
+				  	}
+				`, projectName),
+				Check: acctest.StoreResourceID("scaleway_account_project.project", &projectID),
+			},
+			{
+				PreConfig: acctest.PreCheckWaitForCockpitIAM(tt, projectID),
 				Config: fmt.Sprintf(`
 					resource "scaleway_account_project" "project" {
 						name = "%[1]s"

--- a/internal/services/rdb/database_backup_list_test.go
+++ b/internal/services/rdb/database_backup_list_test.go
@@ -23,11 +23,20 @@ func TestAccListRDBDatabaseBackups_Basic(t *testing.T) {
 	instanceName := "tf-test-rdb-backup-list-4823616331525728375"
 	backupName := "tf_backup_list_2078923807392667811"
 
+	var projectID, instanceID string
+
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: tt.ProviderFactories,
 		CheckDestroy:             accounttestfuncs.IsProjectDestroyed(tt),
 		Steps: []resource.TestStep{
 			{
+				Config: `
+					resource "scaleway_account_project" "main" {}
+				`,
+				Check: acctest.StoreResourceID("scaleway_account_project.main", &projectID),
+			},
+			{
+				PreConfig: acctest.PreCheckWaitForRDBProjectIAM(tt, projectID),
 				Config: fmt.Sprintf(`
 					resource "scaleway_account_project" "main" {}
 
@@ -54,9 +63,11 @@ func TestAccListRDBDatabaseBackups_Basic(t *testing.T) {
 					  name          = "%s"
 					}
 				`, instanceName, latestEngineVersion, backupName),
+				Check: acctest.StoreResourceID("scaleway_rdb_instance.main", &instanceID),
 			},
 			{
-				Query: true,
+				PreConfig: acctest.PreCheckWaitForRDBInstanceIAM(tt, instanceID),
+				Query:     true,
 				Config: fmt.Sprintf(`
 					list "scaleway_rdb_database_backup" "by_instance" {
 					  provider = scaleway

--- a/internal/services/rdb/database_backup_list_test.go
+++ b/internal/services/rdb/database_backup_list_test.go
@@ -36,7 +36,7 @@ func TestAccListRDBDatabaseBackups_Basic(t *testing.T) {
 				Check: acctest.StoreResourceID("scaleway_account_project.main", &projectID),
 			},
 			{
-				PreConfig: acctest.PreCheckWaitForRDBProjectIAM(tt, projectID),
+				PreConfig: acctest.PreCheckWaitForRDBProjectIAM(tt, &projectID),
 				Config: fmt.Sprintf(`
 					resource "scaleway_account_project" "main" {}
 
@@ -66,7 +66,7 @@ func TestAccListRDBDatabaseBackups_Basic(t *testing.T) {
 				Check: acctest.StoreResourceID("scaleway_rdb_instance.main", &instanceID),
 			},
 			{
-				PreConfig: acctest.PreCheckWaitForRDBInstanceIAM(tt, instanceID),
+				PreConfig: acctest.PreCheckWaitForRDBInstanceIAM(tt, &instanceID),
 				Query:     true,
 				Config: fmt.Sprintf(`
 					list "scaleway_rdb_database_backup" "by_instance" {

--- a/internal/services/rdb/database_list_test.go
+++ b/internal/services/rdb/database_list_test.go
@@ -35,7 +35,7 @@ func TestAccListRDBDatabases_Basic(t *testing.T) {
 				Check: acctest.StoreResourceID("scaleway_account_project.main", &projectID),
 			},
 			{
-				PreConfig: acctest.PreCheckWaitForRDBProjectIAM(tt, projectID),
+				PreConfig: acctest.PreCheckWaitForRDBProjectIAM(tt, &projectID),
 				Config: fmt.Sprintf(`
 					resource "scaleway_account_project" "main" {}
 
@@ -59,7 +59,7 @@ func TestAccListRDBDatabases_Basic(t *testing.T) {
 				Check: acctest.StoreResourceID("scaleway_rdb_instance.main", &instanceID),
 			},
 			{
-				PreConfig: acctest.PreCheckWaitForRDBInstanceIAM(tt, instanceID),
+				PreConfig: acctest.PreCheckWaitForRDBInstanceIAM(tt, &instanceID),
 				Query:     true,
 				Config: `
 					list "scaleway_rdb_database" "by_instance" {

--- a/internal/services/rdb/database_list_test.go
+++ b/internal/services/rdb/database_list_test.go
@@ -22,11 +22,20 @@ func TestAccListRDBDatabases_Basic(t *testing.T) {
 	latestEngineVersion := rdbchecks.GetLatestEngineVersion(tt, postgreSQLEngineName)
 	instanceName := "tf-test-rdb-db-list-4823616331525728375"
 
+	var projectID, instanceID string
+
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: tt.ProviderFactories,
 		CheckDestroy:             accounttestfuncs.IsProjectDestroyed(tt),
 		Steps: []resource.TestStep{
 			{
+				Config: `
+					resource "scaleway_account_project" "main" {}
+				`,
+				Check: acctest.StoreResourceID("scaleway_account_project.main", &projectID),
+			},
+			{
+				PreConfig: acctest.PreCheckWaitForRDBProjectIAM(tt, projectID),
 				Config: fmt.Sprintf(`
 					resource "scaleway_account_project" "main" {}
 
@@ -47,9 +56,11 @@ func TestAccListRDBDatabases_Basic(t *testing.T) {
 					  name        = "tfdb_list_2078923807392667811"
 					}
 				`, instanceName, latestEngineVersion),
+				Check: acctest.StoreResourceID("scaleway_rdb_instance.main", &instanceID),
 			},
 			{
-				Query: true,
+				PreConfig: acctest.PreCheckWaitForRDBInstanceIAM(tt, instanceID),
+				Query:     true,
 				Config: `
 					list "scaleway_rdb_database" "by_instance" {
 					  provider = scaleway

--- a/internal/services/rdb/instance_list_test.go
+++ b/internal/services/rdb/instance_list_test.go
@@ -34,7 +34,7 @@ func TestAccListRDBInstances_Basic(t *testing.T) {
 				Check: acctest.StoreResourceID("scaleway_account_project.main", &projectID),
 			},
 			{
-				PreConfig: acctest.PreCheckWaitForRDBProjectIAM(tt, projectID),
+				PreConfig: acctest.PreCheckWaitForRDBProjectIAM(tt, &projectID),
 				Config: fmt.Sprintf(`
 					resource "scaleway_account_project" "main" {}
 
@@ -53,7 +53,7 @@ func TestAccListRDBInstances_Basic(t *testing.T) {
 				Check: acctest.StoreResourceID("scaleway_rdb_instance.main", &instanceID),
 			},
 			{
-				PreConfig: acctest.PreCheckWaitForRDBInstanceIAM(tt, instanceID),
+				PreConfig: acctest.PreCheckWaitForRDBInstanceIAM(tt, &instanceID),
 				Query:     true,
 				Config: `
 					list "scaleway_rdb_instance" "all" {

--- a/internal/services/rdb/instance_list_test.go
+++ b/internal/services/rdb/instance_list_test.go
@@ -21,11 +21,20 @@ func TestAccListRDBInstances_Basic(t *testing.T) {
 
 	latestEngineVersion := rdbchecks.GetLatestEngineVersion(tt, postgreSQLEngineName)
 
+	var projectID, instanceID string
+
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: tt.ProviderFactories,
 		CheckDestroy:             accounttestfuncs.IsProjectDestroyed(tt),
 		Steps: []resource.TestStep{
 			{
+				Config: `
+					resource "scaleway_account_project" "main" {}
+				`,
+				Check: acctest.StoreResourceID("scaleway_account_project.main", &projectID),
+			},
+			{
+				PreConfig: acctest.PreCheckWaitForRDBProjectIAM(tt, projectID),
 				Config: fmt.Sprintf(`
 					resource "scaleway_account_project" "main" {}
 
@@ -41,9 +50,11 @@ func TestAccListRDBInstances_Basic(t *testing.T) {
 					  tags            = ["list-test"]
 					}
 				`, latestEngineVersion),
+				Check: acctest.StoreResourceID("scaleway_rdb_instance.main", &instanceID),
 			},
 			{
-				Query: true,
+				PreConfig: acctest.PreCheckWaitForRDBInstanceIAM(tt, instanceID),
+				Query:     true,
 				Config: `
 					list "scaleway_rdb_instance" "all" {
 					  provider = scaleway


### PR DESCRIPTION
## Summary
- Add `WaitForProjectIAM` in acctest with exponential backoff (~62s) and service-specific probes
- Cockpit probe: `ListDataSources` on the new project before creating cockpit resources
- RDB probes: `ListInstances` on project before instance create, `GetInstance` before list query steps
- Wire probes into acceptance tests that create a new `scaleway_account_project`
