### PR TITLE
fix(k8s): remove default values for new autoscaler fields

### DIFF
--- a/docs/resources/k8s_cluster.md
+++ b/docs/resources/k8s_cluster.md
@@ -279,11 +279,11 @@ you can still set it now. In this case it will not destroy and recreate your clu
 
     - `max_graceful_termination_sec` - (Defaults to `600`) Maximum number of seconds the cluster autoscaler waits for pod termination when trying to scale down a node
 
-    - `skip_nodes_with_local_storage` - (Defaults to `true`) If set to true, the autoscaler will never delete nodes with pods with local storage, e.g. EmptyDir or HostPath.
+    - `skip_nodes_with_local_storage` - If set to true, the autoscaler will never delete nodes with pods with local storage, e.g. EmptyDir or HostPath.
 
     ~> **Important:** For now, it is not possible to change the value of `skip_nodes_with_local_storage` after creation. Changes to this field will recreate a new cluster resource.
 
-    - `log_level` - (Defaults to `2`) Autoscaler logging level expressed from 0 (least verbose) to 4 (most verbose).
+    - `log_level` - Autoscaler logging level expressed from 0 (least verbose) to 4 (most verbose).
     Check out the [autoscaler's FAQ](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-can-i-increase-the-information-that-the-ca-is-logging) for details.
 
     ~> **Important:** For now, it is not possible to change the value of `log_level` after creation. Changes to this field will recreate a new cluster resource.

--- a/internal/services/k8s/cluster.go
+++ b/internal/services/k8s/cluster.go
@@ -1094,14 +1094,12 @@ func autoscalerConfigSchema() *schema.Resource {
 			"skip_nodes_with_local_storage": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Default:     true,
 				ForceNew:    true,
 				Description: "If true, the autoscaler will never delete nodes with pods with local storage, e.g. EmptyDir or HostPath, defaults to true.",
 			},
 			"log_level": {
 				Type:        schema.TypeInt,
 				Optional:    true,
-				Default:     2,
 				ForceNew:    true,
 				Description: "Autoscaler logging level expressed from 0 to 4 (4 being the more verbose), defaults to 2.",
 			},

--- a/internal/services/k8s/cluster.go
+++ b/internal/services/k8s/cluster.go
@@ -1095,13 +1095,13 @@ func autoscalerConfigSchema() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				ForceNew:    true,
-				Description: "If true, the autoscaler will never delete nodes with pods with local storage, e.g. EmptyDir or HostPath, defaults to true.",
+				Description: "If true, the autoscaler will never delete nodes with pods with local storage, e.g. EmptyDir or HostPath.",
 			},
 			"log_level": {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				ForceNew:    true,
-				Description: "Autoscaler logging level expressed from 0 to 4 (4 being the more verbose), defaults to 2.",
+				Description: "Autoscaler logging level expressed from 0 to 4 (4 being the more verbose).",
 			},
 		},
 	}

--- a/templates/resources/k8s_cluster.md.tmpl
+++ b/templates/resources/k8s_cluster.md.tmpl
@@ -86,11 +86,11 @@ you can still set it now. In this case it will not destroy and recreate your clu
 
     - `max_graceful_termination_sec` - (Defaults to `600`) Maximum number of seconds the cluster autoscaler waits for pod termination when trying to scale down a node
 
-    - `skip_nodes_with_local_storage` - (Defaults to `true`) If set to true, the autoscaler will never delete nodes with pods with local storage, e.g. EmptyDir or HostPath.
+    - `skip_nodes_with_local_storage` - If set to true, the autoscaler will never delete nodes with pods with local storage, e.g. EmptyDir or HostPath.
 
     ~> **Important:** For now, it is not possible to change the value of `skip_nodes_with_local_storage` after creation. Changes to this field will recreate a new cluster resource.
 
-    - `log_level` - (Defaults to `2`) Autoscaler logging level expressed from 0 (least verbose) to 4 (most verbose).
+    - `log_level` - Autoscaler logging level expressed from 0 (least verbose) to 4 (most verbose).
     Check out the [autoscaler's FAQ](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-can-i-increase-the-information-that-the-ca-is-logging) for details.
 
     ~> **Important:** For now, it is not possible to change the value of `log_level` after creation. Changes to this field will recreate a new cluster resource.


### PR DESCRIPTION
It was reported that the default values that Terraform fills in for `skip_nodes_with_local_storage` and `log_level` do not always correspond to the default values from the API, which can cause unexpected changes (and Terraform wants to replace the resource since the attribute triggers a ForceNew).
To avoid this, this PR removes the default values from Terraform and lets the API decide.