### PR TITLE
fix(rdb): fix missing identity after read when rdb privilege drifts

### DIFF
--- a/internal/services/rdb/privilege.go
+++ b/internal/services/rdb/privilege.go
@@ -258,7 +258,7 @@ func readPrivilegeIntoState(ctx context.Context, d *schema.ResourceData, m any) 
 
 func ResourceRdbPrivilegeRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	diags := readPrivilegeIntoState(ctx, d, m)
-	if diags != nil {
+	if diags.HasError() {
 		return diags
 	}
 


### PR DESCRIPTION
Hello !

This is quite similar to an issue raised previously: https://github.com/scaleway/terraform-provider-scaleway/issues/3957 but not quite the same.

When the warning for `custom` is triggered (because of doing `GRANT` outside the API), the Terraform generates a warning. However, this warning then prevents the provider from going further, and it breaks:

<img width="1144" height="191" alt="image" src="https://github.com/user-attachments/assets/99c1e81b-6c9f-47ff-af3c-0be154de9f75" />

It's quite annoying and has broken a repo on our end, because we intentionally use non-API managed privilege to improve granularity.

The fix is just to only quit if the `diag` is an error.

Thanks !